### PR TITLE
Add support for the XDG specification on Linux.

### DIFF
--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -28,7 +28,6 @@ class Config:
         else:
             self.config_dir = Path.home() / ".prime"
 
-
         self.config_file = self.config_dir / "config.json"
         self._ensure_config_dir()
         self._load_config()


### PR DESCRIPTION
This adds support for the XDG specification, moving .prime from $HOME to not clutter the user's home folder.
Mac also has something similar (Claude says it's at ~/Library/Application Support) but i'm not familiar with the specifics so i would appreciate someone chiming in.