### PR TITLE
add url where to create API key to prompt message

### DIFF
--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -43,7 +43,7 @@ def view() -> None:
 def set_api_key(
     api_key: str = typer.Option(
         ...,
-        prompt="Enter your API key",
+        prompt="you can create an API key at https://app.primeintellect.ai/dashboard/tokens\nEnter your API key",  # noqa: E501
         help="Your Prime Intellect API key",
         hide_input=True,
     ),


### PR DESCRIPTION
suggestions to make the prime-cli more helpful when generating an API key (like the huggingface-cli)

<img width="711" alt="image" src="https://github.com/user-attachments/assets/7ed861c9-387c-4097-a79c-3dd497764186" />
