### PR TITLE
Support setting env vars during pod creation

### DIFF
--- a/src/prime_cli/api/client.py
+++ b/src/prime_cli/api/client.py
@@ -82,7 +82,7 @@ class APIClient:
                     "Payment required. Please check your billing status at "
                     "https://app.primeintellect.ai/dashboard/billing"
                 )
-            raise APIError(f"API request failed: {e}")
+            raise e
         except requests.exceptions.RequestException as e:
             raise APIError(f"Request failed: {e}")
 

--- a/src/prime_cli/api/pods.py
+++ b/src/prime_cli/api/pods.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -159,7 +160,11 @@ class PodsClient:
             return Pod(**response)
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to create pod: {e.response.text}")
+                error_text = e.response.text
+                error_json = json.loads(error_text)
+                if "detail" in error_json:
+                    error_text = error_json["detail"]
+                raise APIError(f"Failed to create pod: {error_text}")
             raise APIError(f"Failed to create pod: {str(e)}")
 
     def delete(self, pod_id: str) -> None:

--- a/src/prime_cli/commands/pods.py
+++ b/src/prime_cli/commands/pods.py
@@ -281,8 +281,19 @@ def create(
     ),
     custom_template_id: Optional[str] = typer.Option(None, help="Custom template ID"),
     team_id: Optional[str] = typer.Option(None, help="Team ID to use for the pod"),
+    env: Optional[List[str]] = typer.Option(
+        None,
+        help="Environment variables to set in the pod. Can be specified multiple times "
+        "using --env KEY=value --env KEY2=value2",
+    ),
 ) -> None:
     """Create a new pod with an interactive setup process"""
+    env_vars = []
+    if env:
+        for env_var in env:
+            key, value = env_var.split("=")
+            env_vars.append({"key": key, "value": value})
+
     try:
         # Validate custom template usage
         if custom_template_id and not image == "custom_template":
@@ -577,6 +588,7 @@ def create(
                 "jupyterPassword": None,
                 "autoRestart": False,
                 "customTemplateId": custom_template_id,
+                "envVars": env_vars,
             },
             "provider": {"type": selected_gpu.provider}
             if selected_gpu.provider


### PR DESCRIPTION
You can now set env vars using `prime pods create --env KEY=VALUE --env KEY2=VALUE2`