### PR TITLE
imp: support saving environments and setting FE url

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ prime config set-ssh-key-path
 prime config view
 ```
 
+### Environment Management
+```bash
+# Save current config as an environment (includes API key)
+prime config save develop
+
+# Switch between environments
+prime config use production
+prime config use develop
+
+# List available environments
+prime config envs
+```
+
 ### GPU Resources
 ```bash
 # List all available GPUs
@@ -180,15 +193,26 @@ We use semantic versioning. Releases are automatically created when changes are 
    uv pip install -e ".[dev]"
    pre-commit install
    ```
-4. Run code quality checks:
+4. Set up your development environment:
+   ```bash
+   # Save your local development config
+   prime config set-base-url http://localhost:8000
+   prime config set-frontend-url http://localhost:3000
+   prime config save local
+   
+   # Switch between environments as needed
+   prime config use local       # For development
+   prime config use production  # For testing against prod
+   ```
+5. Run code quality checks:
    ```bash
    uv run ruff format .
    uv run ruff check .
    uv run pytest
    ```
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+6. Commit your changes (`git commit -m 'Add amazing feature'`)
+7. Push to the branch (`git push origin feature/amazing-feature`)
+8. Open a Pull Request
 
 ## 📝 License
 

--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -121,13 +121,17 @@ def set_environment(
     config = Config()
 
     # Try to load the environment (handles both built-in and custom)
-    if config.load_environment(env):
-        console.print(f"[green]Switched to environment '{env}'![/green]")
-    else:
-        console.print(f"[red]Unknown environment: {env}[/red]")
-        console.print("[yellow]Available environments:[/yellow]")
-        for env_name in config.list_environments():
-            console.print(f"  - {env_name}")
+    try:
+        if config.load_environment(env):
+            console.print(f"[green]Switched to environment '{env}'![/green]")
+        else:
+            console.print(f"[red]Unknown environment: {env}[/red]")
+            console.print("[yellow]Available environments:[/yellow]")
+            for env_name in config.list_environments():
+                console.print(f"  - {env_name}")
+            raise typer.Exit(1)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
 
     console.print("[blue]Run 'prime config view' to see the current configuration[/blue]")
@@ -141,11 +145,15 @@ def save_environment(
     ),
 ) -> None:
     """Save current configuration as a named environment (including API key)"""
-    config = Config()
-    config.save_environment(name)
-    console.print(f"[green]Saved current configuration as environment '{name}'![/green]")
-    console.print("[yellow]Note: This includes your API key[/yellow]")
-    console.print(f"[blue]Use 'prime config use {name}' to load it later[/blue]")
+    try:
+        config = Config()
+        config.save_environment(name)
+        console.print(f"[green]Saved current configuration as environment '{name}'![/green]")
+        console.print("[yellow]Note: This includes your API key and team ID[/yellow]")
+        console.print(f"[blue]Use 'prime config use {name}' to load it later[/blue]")
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
 
 
 @app.command(name="list-environments")
@@ -189,6 +197,7 @@ def reset() -> None:
         config.set_base_url(Config.DEFAULT_BASE_URL)
         config.set_frontend_url(Config.DEFAULT_FRONTEND_URL)
         config.set_ssh_key_path(Config.DEFAULT_SSH_KEY_PATH)
+        config.set_current_environment("production")
         console.print("[green]Configuration reset to defaults![/green]")
 
 

--- a/src/prime_cli/commands/login.py
+++ b/src/prime_cli/commands/login.py
@@ -89,7 +89,7 @@ def login() -> None:
 
         challenge_code = challenge_response["challenge"]
         challenge_url = (
-            f"https://app.primeintellect.ai/dashboard/tokens/challenge?code={challenge_code}"
+            f"{settings['frontend_url']}/dashboard/tokens/challenge?code={challenge_code}"
         )
 
         console.print("\n[bold blue]🔐 Login Required[/bold blue]")
@@ -136,6 +136,8 @@ def login() -> None:
                     if decrypted_result:
                         # Update config with decrypted token
                         config.set_api_key(decrypted_result.decode())
+                        # Also update the current environment's saved file
+                        config.update_current_environment_file()
                         console.print("[green]Successfully logged in![/green]")
                     else:
                         console.print("[red]Failed to decrypt authentication token[/red]")

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -9,31 +9,38 @@ class ConfigModel(BaseModel):
     api_key: str = ""
     team_id: str = ""
     base_url: str = "https://api.primeintellect.ai"
+    frontend_url: str = "https://app.primeintellect.ai"
     ssh_key_path: str = str(Path.home() / ".ssh" / "id_rsa")
+    current_environment: str = "production"
 
     model_config = ConfigDict(populate_by_name=True)
 
 
 class Config:
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
+    DEFAULT_FRONTEND_URL: str = "https://app.primeintellect.ai"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
     def __init__(self) -> None:
         self.config_dir = Path.home() / ".prime"
         self.config_file = self.config_dir / "config.json"
+        self.environments_dir = self.config_dir / "environments"
         self._ensure_config_dir()
         self._load_config()
 
     def _ensure_config_dir(self) -> None:
         """Create config directory if it doesn't exist"""
         self.config_dir.mkdir(exist_ok=True)
+        self.environments_dir.mkdir(exist_ok=True)
         if not self.config_file.exists():
             self._save_config(
                 ConfigModel(
                     api_key="",
                     team_id="",
                     base_url=self.DEFAULT_BASE_URL,
+                    frontend_url=self.DEFAULT_FRONTEND_URL,
                     ssh_key_path=self.DEFAULT_SSH_KEY_PATH,
+                    current_environment="production",
                 ).model_dump()
             )
 
@@ -85,6 +92,18 @@ class Config:
         self._save_config(self.config)
 
     @property
+    def frontend_url(self) -> str:
+        """Get frontend URL from config"""
+        frontend_url: str = self.config.get("frontend_url", self.DEFAULT_FRONTEND_URL)
+        return frontend_url
+
+    def set_frontend_url(self, value: str) -> None:
+        """Set frontend URL in config file"""
+        value = value.rstrip("/")
+        self.config["frontend_url"] = value
+        self._save_config(self.config)
+
+    @property
     def ssh_key_path(self) -> str:
         """Get SSH private key path from environment or config file"""
         return os.getenv("PRIME_SSH_KEY_PATH") or self.config.get(
@@ -96,11 +115,75 @@ class Config:
         self.config["ssh_key_path"] = str(Path(value).expanduser().resolve())
         self._save_config(self.config)
 
+    @property
+    def current_environment(self) -> str:
+        """Get current environment name"""
+        current_env: str = self.config.get("current_environment", "production")
+        return current_env
+
+    def set_current_environment(self, value: str) -> None:
+        """Set current environment name"""
+        self.config["current_environment"] = value
+        self._save_config(self.config)
+
     def view(self) -> dict:
         """Get all config values"""
         return {
             "api_key": self.api_key,
             "team_id": self.team_id,
             "base_url": self.base_url,
+            "frontend_url": self.frontend_url,
             "ssh_key_path": self.ssh_key_path,
+            "current_environment": self.current_environment,
         }
+
+    def save_environment(self, name: str) -> None:
+        """Save current configuration as a named environment"""
+        env_file = self.environments_dir / f"{name}.json"
+        env_config = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "frontend_url": self.frontend_url,
+        }
+        env_file.write_text(json.dumps(env_config, indent=2))
+
+    def load_environment(self, name: str) -> bool:
+        """Load a named environment configuration"""
+        if name.lower() == "production":
+            # Built-in production environment
+            self.set_base_url(self.DEFAULT_BASE_URL)
+            self.set_frontend_url(self.DEFAULT_FRONTEND_URL)
+            self.set_current_environment("production")
+            return True
+
+        env_file = self.environments_dir / f"{name}.json"
+        if env_file.exists():
+            env_config = json.loads(env_file.read_text())
+            if "api_key" in env_config:
+                self.set_api_key(env_config["api_key"])
+            self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
+            self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
+            self.set_current_environment(name)
+            return True
+        return False
+
+    def update_current_environment_file(self) -> None:
+        """Update the current environment's saved file with current config"""
+        if self.current_environment != "production":
+            # Only update custom environments, not the built-in production
+            env_file = self.environments_dir / f"{self.current_environment}.json"
+            if env_file.exists():
+                env_config = {
+                    "api_key": self.api_key,
+                    "base_url": self.base_url,
+                    "frontend_url": self.frontend_url,
+                }
+                env_file.write_text(json.dumps(env_config, indent=2))
+
+    def list_environments(self) -> list[str]:
+        """List all saved environment names"""
+        environments = ["production"]  # Built-in environment
+        if self.environments_dir.exists():
+            for env_file in self.environments_dir.glob("*.json"):
+                environments.append(env_file.stem)
+        return environments

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "prime-cli"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "build" },

--- a/uv.lock
+++ b/uv.lock
@@ -112,25 +112,25 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.2.2.post1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701 }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950 },
+    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382 },
 ]
 
 [[package]]
 name = "certifi"
-version = "2025.7.14"
+version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722 },
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216 },
 ]
 
 [[package]]
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "prime-cli"
-version = "0.2.12"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "build" },
@@ -1233,16 +1233,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.32.0"
+version = "20.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/96/0834f30fa08dca3738614e6a9d42752b6420ee94e58971d702118f7cfd30/virtualenv-20.32.0.tar.gz", hash = "sha256:886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0", size = 6076970 }
+sdist = { url = "https://files.pythonhosted.org/packages/db/2e/8a70dcbe8bf15213a08f9b0325ede04faca5d362922ae0d62ef0fa4b069d/virtualenv-20.33.0.tar.gz", hash = "sha256:47e0c0d2ef1801fce721708ccdf2a28b9403fa2307c3268aebd03225976f61d2", size = 6082069 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/c6/f8f28009920a736d0df434b52e9feebfb4d702ba942f15338cb4a83eafc1/virtualenv-20.32.0-py3-none-any.whl", hash = "sha256:2c310aecb62e5aa1b06103ed7c2977b81e042695de2697d01017ff0f1034af56", size = 6057761 },
+    { url = "https://files.pythonhosted.org/packages/43/87/b22cf40cdf7e2b2bf83f38a94d2c90c5ad6c304896e5a12d0c08a602eb59/virtualenv-20.33.0-py3-none-any.whl", hash = "sha256:106b6baa8ab1b526d5a9b71165c85c456fbd49b16976c88e2bc9352ee3bc5d3f", size = 6060205 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds support for saving configurations which makes development a lot easier. 
```
prime config 
│ use                 Switch to a different environment (alias for set-environment)                                                                                                      │
│ save                Save current config as environment (alias for save-environment)                                                                                                    │
│ envs                List available environments (alias for list-environments)     
``` 

I've additionally added support to set the frontend URL which is used when running `prime login`. 