### PR TITLE
Will/vf init update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "rich>=13.3.1",  
     "pydantic>=2.0.0",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.2",
+    "verifiers>=0.1.2.post0",
     "build>=1.0.0",
     "toml>=0.10.0"
 ]

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -528,7 +528,7 @@ def init(
         "./environments", "--path", "-p", help="Path to environments directory"
     ),
     skip_vf_prefix: bool = typer.Option(
-        False, "--skip-vf-prefix", help="Skip the vf- prefix in the environment id"
+        False, "--rewrite-readme", help="Overwrite README.md with template if it already exists"
     ),
 ) -> None:
     """Initialize a new verifier environment from template"""

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -527,13 +527,13 @@ def init(
     path: str = typer.Option(
         "./environments", "--path", "-p", help="Path to environments directory"
     ),
-    skip_vf_prefix: bool = typer.Option(
+    rewrite_readme: bool = typer.Option(
         False, "--rewrite-readme", help="Overwrite README.md with template if it already exists"
     ),
 ) -> None:
     """Initialize a new verifier environment from template"""
     try:
-        created_path = init_environment(name, path, skip_vf_prefix)
+        created_path = init_environment(name, path, rewrite_readme)
 
         console.print(f"[green]✓ Created environment template in {created_path}/[/green]")
         console.print("\nNext steps:")


### PR DESCRIPTION
Bumping verifiers release version (`0.1.2` -> `0.1.2.post0`) + updating env CLI accordingly. 

`prime env init env-name --rewrite-readme` now overwrites with the current README template (everything else untouched).

deprecated `--skip-vf-prefix` flag, now not handled by CLI, up to user to add if desired.