### PR TITLE
Make startup 2.5x faster by only importing `verifiers` when needed

### DIFF
--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -14,7 +14,6 @@ import toml
 import typer
 from rich.console import Console
 from rich.table import Table
-from verifiers.scripts.init import init_environment
 
 from ..api.client import APIClient, APIError
 
@@ -535,6 +534,9 @@ def init(
 ) -> None:
     """Initialize a new verifier environment from template"""
     try:
+        # this import is slow, so we do it inside the command
+        from verifiers.scripts.init import init_environment
+
         created_path = init_environment(name, path, rewrite_readme)
 
         console.print(f"[green]✓ Created environment template in {created_path}/[/green]")


### PR DESCRIPTION
`verifiers` has a huge dep tree (`uv tree`) and importing it is very slow. Luckily, it's only needed for `prime env init`, so we can move the import into that command and get a big startup speed improvement elsewhere:

```
$ hyperfine --ignore-failure --warmup 1 \
  --command-name upstream \
  --prepare 'git checkout upstream/main' \
  "uv run prime" \
  --command-name fixed \
  --prepare "git checkout origin/main" \
  "uv run prime"
Benchmark 1: upstream
  Time (mean ± σ):      2.270 s ±  0.161 s    [User: 2.788 s, System: 0.167 s]
  Range (min … max):    2.163 s …  2.655 s    10 runs
 
Benchmark 2: fixed
  Time (mean ± σ):     785.5 ms ±  93.8 ms    [User: 716.7 ms, System: 65.5 ms]
  Range (min … max):   689.8 ms … 1009.4 ms    10 runs
 
Summary
  'fixed' ran
    2.89 ± 0.40 times faster than 'upstream'
```