### PR TITLE
improve env var handling in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ prime config view
 
 **Security Note**: When using the non-interactive mode, be aware that the API key may be visible in your shell history. For enhanced security:
 - Use the interactive mode (no arguments) which hides your input
-- Use environment variables (`PRIME_API_KEY`)
+- Use environment variables (`PRIME_API_KEY`) as fallback if no CLI config is set
 - Clear your shell history after setting sensitive values
+
+**Configuration Priority**: CLI config takes precedence over environment variables. If you set an API key via `prime auth login`, it will override any `PRIME_API_KEY` environment variable.
 
 ### Environment Management
 ```bash

--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -23,10 +23,12 @@ def view() -> None:
     # Show current environment
     table.add_row("Current Environment", settings["current_environment"])
 
-    # Show API key (partially hidden)
     api_key = settings["api_key"]
     if api_key:
         masked_key = f"{api_key[:6]}...{api_key[-4:]}" if len(api_key) > 10 else "***"
+        config_key = config.config.get("api_key", "")
+        if not config_key:
+            masked_key += " (from env var)"
     else:
         masked_key = "Not set"
     table.add_row("API Key", masked_key)

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -60,8 +60,8 @@ class Config:
 
     @property
     def api_key(self) -> str:
-        """Get API key from environment or config file"""
-        return os.getenv("PRIME_API_KEY") or self.config.get("api_key", "")
+        """Get API key from config file or environment"""
+        return self.config.get("api_key", "") or os.getenv("PRIME_API_KEY", "")
 
     def set_api_key(self, value: str) -> None:
         """Set API key in config file"""

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -70,8 +70,8 @@ class Config:
 
     @property
     def team_id(self) -> str:
-        """Get team ID from environment or config file"""
-        return os.getenv("PRIME_TEAM_ID") or self.config.get("team_id", "")
+        """Get team ID from config file or environment"""
+        return self.config.get("team_id", "") or os.getenv("PRIME_TEAM_ID", "")
 
     def set_team_id(self, value: str) -> None:
         """Set team ID in config file"""
@@ -106,9 +106,9 @@ class Config:
 
     @property
     def ssh_key_path(self) -> str:
-        """Get SSH private key path from environment or config file"""
-        return os.getenv("PRIME_SSH_KEY_PATH") or self.config.get(
-            "ssh_key_path", self.DEFAULT_SSH_KEY_PATH
+        """Get SSH private key path from config file or environment"""
+        return self.config.get("ssh_key_path", self.DEFAULT_SSH_KEY_PATH) or os.getenv(
+            "PRIME_SSH_KEY_PATH", self.DEFAULT_SSH_KEY_PATH
         )
 
     def set_ssh_key_path(self, value: str) -> None:


### PR DESCRIPTION
The env var api key previously had higher prio than the config. This PR switches this confusing behvaior.