### PR TITLE
sandbox: remove kubernetes job id from sandbox detail

### DIFF
--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -136,7 +136,6 @@ def get(sandbox_id: str) -> None:
 
         table.add_row("User ID", sandbox.user_id or "N/A")
         table.add_row("Team ID", sandbox.team_id or "Personal")
-        table.add_row("Kubernetes Job ID", sandbox.kubernetes_job_id or "N/A")
 
         if sandbox.environment_vars:
             env_vars = json.dumps(sandbox.environment_vars, indent=2)


### PR DESCRIPTION
k8s is just implementation detail and our user can't do anything with that info too
