### PR TITLE
add timeouts for sandbox creation and command excecution

### DIFF
--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -30,21 +30,10 @@ def main() -> None:
         print(f"✅ Created: {sandbox.name} ({sandbox.id})")
 
         # 3. Wait for sandbox to be running
-        import time
 
         print("\nWaiting for sandbox to be running...")
-        max_attempts = 30
-        for _ in range(max_attempts):
-            sandbox = sandbox_client.get(sandbox.id)
-            if sandbox.status == "RUNNING":
-                print("✅ Sandbox is running!")
-                # Give it a few extra seconds to be ready for commands
-                time.sleep(10)
-                break
-            elif sandbox.status in ["ERROR", "TERMINATED"]:
-                print(f"❌ Sandbox failed with status: {sandbox.status}")
-                return
-            time.sleep(2)
+        sandbox_client.wait_for_sandbox(sandbox.id, max_attempts=60)
+        print("✅ Sandbox is running!")
 
         # 4. Execute commands in the sandbox
         print("\nExecuting commands...")

--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -32,7 +32,7 @@ def main() -> None:
         # 3. Wait for sandbox to be running
 
         print("\nWaiting for sandbox to be running...")
-        sandbox_client.wait_for_sandbox(sandbox.id, max_attempts=60)
+        sandbox_client.wait_for_creation(sandbox.id, max_attempts=60)
         print("✅ Sandbox is running!")
 
         # 4. Execute commands in the sandbox

--- a/src/prime_cli/api/client.py
+++ b/src/prime_cli/api/client.py
@@ -23,6 +23,12 @@ class PaymentRequiredError(APIError):
     pass
 
 
+class TimeoutError(APIError):
+    """Raised when API request times out"""
+
+    pass
+
+
 class APIClient:
     def __init__(self, api_key: Optional[str] = None, require_auth: bool = True):
         # Load config
@@ -91,6 +97,8 @@ class APIClient:
                 pass
 
             raise APIError(f"HTTP {e.response.status_code}: {e.response.text or str(e)}")
+        except requests.exceptions.Timeout as e:
+            raise TimeoutError(f"Request timed out: {e}")
         except requests.exceptions.RequestException as e:
             raise APIError(f"Request failed: {e}")
 

--- a/src/prime_cli/api/client.py
+++ b/src/prime_cli/api/client.py
@@ -49,6 +49,7 @@ class APIClient:
         endpoint: str,
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Make a request to the API"""
         # Ensure endpoint starts with /api/v1/
@@ -60,7 +61,7 @@ class APIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            response = self.session.request(method, url, params=params, json=json)
+            response = self.session.request(method, url, params=params, json=json, timeout=timeout)
             response.raise_for_status()
 
             result = response.json()

--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -3,10 +3,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import requests
 from pydantic import BaseModel, ConfigDict, Field
 
-from prime_cli.api.client import APIClient
+from prime_cli.api.client import APIClient, TimeoutError
 
 
 class SandboxStatus(str, Enum):
@@ -225,7 +224,7 @@ class SandboxClient:
                 timeout=timeout,
             )
             return CommandResponse(**response)
-        except requests.exceptions.Timeout:
+        except TimeoutError:
             raise CommandTimeoutError(sandbox_id, command, timeout or 0)
 
     def wait_for_sandbox(self, sandbox_id: str, max_attempts: int = 60) -> None:

--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+import requests
 from pydantic import BaseModel, ConfigDict, Field
 
 from prime_cli.api.client import APIClient
@@ -24,6 +25,14 @@ class SandboxNotRunningError(RuntimeError):
 
     def __init__(self, sandbox_id: str, status: Optional[str] = None):
         msg = f"Sandbox {sandbox_id} is not running" + (f" (status={status})" if status else ".")
+        super().__init__(msg)
+
+
+class CommandTimeoutError(RuntimeError):
+    """Raised when a command execution times out."""
+
+    def __init__(self, sandbox_id: str, command: str, timeout: int):
+        msg = f"Command '{command}' timed out after {timeout}s in sandbox {sandbox_id}"
         super().__init__(msg)
 
 
@@ -193,15 +202,31 @@ class SandboxClient:
         command: str,
         working_dir: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
     ) -> CommandResponse:
-        """Execute a command in a sandbox"""
+        """Execute a command in a sandbox
+
+        Args:
+            sandbox_id: ID of the sandbox to execute the command in
+            command: Command to execute
+            working_dir: Working directory for the command
+            env: Environment variables for the command
+            timeout: Timeout in seconds for the command execution
+
+        Raises:
+            CommandTimeoutError: If the command execution times out
+        """
         request = CommandRequest(command=command, working_dir=working_dir, env=env)
-        response = self.client.request(
-            "POST",
-            f"/sandbox/{sandbox_id}/command",
-            json=request.model_dump(by_alias=False, exclude_none=True),
-        )
-        return CommandResponse(**response)
+        try:
+            response = self.client.request(
+                "POST",
+                f"/sandbox/{sandbox_id}/command",
+                json=request.model_dump(by_alias=False, exclude_none=True),
+                timeout=timeout,
+            )
+            return CommandResponse(**response)
+        except requests.exceptions.Timeout:
+            raise CommandTimeoutError(sandbox_id, command, timeout or 0)
 
     def wait_for_sandbox(self, sandbox_id: str, max_attempts: int = 60) -> None:
         for _ in range(max_attempts):
@@ -213,4 +238,4 @@ class SandboxClient:
             elif sandbox.status in ["ERROR", "TERMINATED"]:
                 raise SandboxNotRunningError(sandbox_id, sandbox.status)
             time.sleep(2)
-        raise SandboxNotRunningError(sandbox_id, "timeout")
+        raise SandboxNotRunningError(sandbox_id, "Timeout during sandbox creation")

--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -227,7 +227,7 @@ class SandboxClient:
         except TimeoutError:
             raise CommandTimeoutError(sandbox_id, command, timeout or 0)
 
-    def wait_for_sandbox(self, sandbox_id: str, max_attempts: int = 60) -> None:
+    def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
         for _ in range(max_attempts):
             sandbox = self.get(sandbox_id)
             if sandbox.status == "RUNNING":


### PR DESCRIPTION
added `wait_for_sandbox` to avoid boilerplate.

added timeout to `execute_command` so we can handle failures gracefully during training.