### PR TITLE
Fix name collision between list command and Python's built-in list() function

### DIFF
--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -17,8 +17,8 @@ console = Console()
 config = Config()
 
 
-@app.command()
-def list(
+@app.command("list")
+def list_sandboxes_cmd(
     team_id: Optional[str] = typer.Option(None, help="Filter by team ID"),
     status: Optional[str] = typer.Option(None, help="Filter by status"),
     page: int = typer.Option(1, help="Page number"),


### PR DESCRIPTION
The 'list' command function was shadowing Python's built-in list() function,
causing tarfile.getmembers() to fail with HTTP 422 errors when it tried to
call list() internally.

Changes:
- Rename list() function to list_sandboxes_cmd()
- Use @app.command('list') to preserve CLI command name

Fixes: HTTP 422 error when using tarfile operations in CLI context

python script for testing:
```
#!/usr/bin/env python3
"""
Test script to demonstrate that the tarfile name collision issue is fixed.

This script tests that Python's built-in list() function works correctly
when the prime CLI is imported, which was previously broken due to a name
collision between the 'list' command function and Python's built-in list().
"""

import sys
import os
import tempfile
import tarfile
import io

# Add the src directory to the path so we can import prime_cli
sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))

def test_tarfile_with_prime_cli():
    """Test that tarfile works correctly when prime CLI is imported."""
    print("Testing tarfile functionality with prime CLI imported...")

    # Import prime CLI modules (this would previously cause the name collision)
    try:
        from prime_cli.commands import sandbox
        print("✓ Successfully imported prime_cli.commands.sandbox")
    except Exception as e:
        print(f"✗ Failed to import prime_cli.commands.sandbox: {e}")
        return False

    # Create a test tar file
    try:
        with tempfile.NamedTemporaryFile(suffix='.tar.gz', delete=False) as tmp_file:
            tmp_path = tmp_file.name

        # Create a simple tar.gz file
        with tarfile.open(tmp_path, 'w:gz') as tf:
            data = b'Hello, World!'
            tarinfo = tarfile.TarInfo(name='test.txt')
            tarinfo.size = len(data)
            tf.addfile(tarinfo, io.BytesIO(data))

        print("✓ Successfully created test tar file")

        # Try to read it back (this would previously fail with HTTP 422 error)
        with tarfile.open(tmp_path, 'r:gz') as tf:
            print("✓ Successfully opened tar file")

            # This call to list() was previously calling the CLI command instead of built-in list()
            members = list(tf.getmembers())
            print(f"✓ Successfully called list(tf.getmembers()), found {len(members)} members")

            for member in members:
                print(f"  - Member: {member.name}")

        # Clean up
        os.unlink(tmp_path)
        print("✓ Test completed successfully!")
        return True

    except Exception as e:
        print(f"✗ Test failed: {e}")
        import traceback
        traceback.print_exc()
        return False

if __name__ == "__main__":
    success = test_tarfile_with_prime_cli()
    sys.exit(0 if success else 1)

```
