### PR TITLE
Add uninstall command + clarify `prime env delete` docs

### DIFF
--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1220,11 +1220,11 @@ def uninstall(
             console.print(f"[red]Error: {cmd_parts[0]} is not installed.[/red]")
             raise typer.Exit(1)
 
-        # Execute installation
+        # Execute uninstall
         execute_uninstall_command(cmd_parts, env_name, with_tool)
 
     except KeyboardInterrupt:
-        console.print("\n[yellow]Installation cancelled by user[/yellow]")
+        console.print("\n[yellow]Uninstall cancelled by user[/yellow]")
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error: {e}[/red]")

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1132,7 +1132,7 @@ def execute_uninstall_command(cmd: List[str], env_name: str, tool: str) -> None:
         tool: Tool name for display
 
     Raises:
-        typer.Exit: If installation fails
+        typer.Exit: If uninstall fails
     """
 
     console.print(f"\n[cyan]Uninstalling {env_name} with {tool}...[/cyan]")


### PR DESCRIPTION
* Adds `prime env uninstall` to uninstall an environment from the local venv
* Clarifies that `prime env delete` deletes the environment from the hub, not the local venv

(...Environmental storytelling...)