### PR TITLE
fix: prevent non-json output in pods list

### DIFF
--- a/src/prime_cli/commands/pods.py
+++ b/src/prime_cli/commands/pods.py
@@ -210,22 +210,21 @@ def list(
 
                     console.print(table)
 
-                # Update hash after displaying
+                    if not watch:
+                        console.print(
+                            "\n[blue]Use 'prime pods status <pod-id>' to "
+                            "see detailed information about a specific pod[/blue]"
+                        )
+
+                        # If there are more pods, show a message
+                        if pods_list.total_count > offset + limit:
+                            remaining = pods_list.total_count - (offset + limit)
+                            console.print(
+                                f"\n[yellow]Showing {limit} of {pods_list.total_count} pods. "
+                                f"Use --offset {offset + limit} to see the next "
+                                f"{min(limit, remaining)} pods.[/yellow]"
+                            )
             if not watch:
-                console.print(
-                    "\n[blue]Use 'prime pods status <pod-id>' to "
-                    "see detailed information about a specific pod[/blue]"
-                )
-
-                # If there are more pods, show a message
-                if pods_list.total_count > offset + limit:
-                    remaining = pods_list.total_count - (offset + limit)
-                    console.print(
-                        f"\n[yellow]Showing {limit} of {pods_list.total_count} pods. "
-                        f"Use --offset {offset + limit} to see the next "
-                        f"{min(limit, remaining)} pods.[/yellow]"
-                    )
-
                 break
             else:
                 # Only print the message when we're not repeating due to unchanged data


### PR DESCRIPTION
This PR addresses a bug where running `prime pods list --output json` would append extra, non-JSON text to the output. The fix moves this informational text to only display for the default table view.

### Current behavior:

```console
ob1@pop-os:~/prime-cli$ prime pods list --output json | jq '.limit'
100
parse error: Invalid numeric literal at line 8, column 4
```

### After fix:

```console
ob1@pop-os:~/prime-cli$ uv pip freeze | grep prime
-e file:///home/ob1/Desktop/envs/prime-cli
ob1@pop-os:~/prime-cli$ prime pods list --output json | jq '.limit'
100
```