### PR TITLE
Add Prime Inference models integration and prime env eval command

### DIFF
--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -4,6 +4,7 @@ import json
 from typing import Any, Dict, Iterable, Iterator, Optional
 
 import httpx
+
 from ..config import Config
 
 
@@ -43,7 +44,10 @@ class InferenceClient:
         if self.team_id:
             headers["X-Prime-Team-ID"] = self.team_id
 
-        self._client = httpx.Client(headers=headers, timeout=httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0))
+        self._client = httpx.Client(
+            headers=headers,
+            timeout=httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0),
+        )
 
     def list_models(self) -> Dict[str, Any]:
         url = f"{self.inference_url}/api/v1/models"
@@ -51,7 +55,9 @@ class InferenceClient:
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
-            raise InferenceAPIError(f"GET {url} failed: {e.response.status_code} {e.response.text}") from e
+            raise InferenceAPIError(
+                f"GET {url} failed: {e.response.status_code} {e.response.text}"
+            ) from e
         return resp.json()
 
     def chat_completion(

--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -72,12 +72,9 @@ class InferenceClient:
             # Treat common "unknown model" responses as a dedicated error
             if status in (400, 404, 422):
                 raise InferenceAPIError(
-                    f"Model '{model_id}' not found or unavailable "
-                    f"(GET {url} → {status})."
+                    f"Model '{model_id}' not found or unavailable (GET {url} → {status})."
                 ) from e
-            raise InferenceAPIError(
-                f"GET {url} failed: {status} {e.response.text}"
-            ) from e
+            raise InferenceAPIError(f"GET {url} failed: {status} {e.response.text}") from e
         return resp.json()
 
     def chat_completion(

--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -24,11 +24,11 @@ class InferenceClient:
         self,
         api_key: Optional[str] = None,
         team_id: Optional[str] = None,
+        inference_url: Optional[str] = None,
     ) -> None:
         # Load config
         self.config = Config()
 
-        self.inference_url = self.config.inference_url
         self.api_key = api_key or self.config.api_key
         if not self.api_key:
             raise InferenceAPIError(
@@ -36,6 +36,7 @@ class InferenceClient:
             )
 
         self.team_id = team_id if team_id is not None else self.config.team_id
+        self.inference_url = (inference_url or self.config.inference_url).rstrip("/")
 
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -51,7 +52,7 @@ class InferenceClient:
         )
 
     def list_models(self) -> Dict[str, Any]:
-        url = f"{self.inference_url}/api/v1/models"
+        url = f"{self.inference_url}/models"
         resp = self._client.get(url)
         try:
             resp.raise_for_status()
@@ -62,7 +63,7 @@ class InferenceClient:
         return resp.json()
 
     def retrieve_model(self, model_id: str) -> Dict[str, Any]:
-        url = f"{self.inference_url}/api/v1/models/{model_id}"
+        url = f"{self.inference_url}/models/{model_id}"
         resp = self._client.get(url)
         try:
             resp.raise_for_status()
@@ -82,7 +83,7 @@ class InferenceClient:
     def chat_completion(
         self, payload: Dict[str, Any], stream: bool = False
     ) -> Dict[str, Any] | Iterable[Dict[str, Any]]:
-        url = f"{self.inference_url}/api/v1/chat/completions"
+        url = f"{self.inference_url}/chat/completions"
 
         if not stream:
             resp = self._client.post(url, json=payload)

--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+import httpx
+from ..config import Config
+
+
+class InferenceAPIError(Exception):
+    pass
+
+
+class InferenceClient:
+    """
+    Minimal client for the OpenAI-compatible Prime Inference API:
+      - GET /v1/models
+      - POST /v1/chat/completions
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> None:
+        # Load config
+        self.config = Config()
+
+        self.inference_url = self.config.inference_url
+        self.api_key = api_key or self.config.api_key
+        if not self.api_key:
+            raise InferenceAPIError(
+                "No API key. Run `prime config set-api-key` or set PRIME_API_KEY."
+            )
+
+        self.team_id = team_id if team_id is not None else self.config.team_id
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        if self.team_id:
+            headers["X-Prime-Team-ID"] = self.team_id
+
+        self._client = httpx.Client(headers=headers, timeout=httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0))
+
+    def list_models(self) -> Dict[str, Any]:
+        url = f"{self.inference_url}/api/v1/models"
+        resp = self._client.get(url)
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise InferenceAPIError(f"GET {url} failed: {e.response.status_code} {e.response.text}") from e
+        return resp.json()
+
+    def chat_completion(
+        self, payload: Dict[str, Any], stream: bool = False
+    ) -> Dict[str, Any] | Iterable[Dict[str, Any]]:
+        url = f"{self.inference_url}/api/v1/chat/completions"
+
+        if not stream:
+            resp = self._client.post(url, json=payload)
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                raise InferenceAPIError(
+                    f"POST {url} failed: {e.response.status_code} {e.response.text}"
+                ) from e
+            return resp.json()
+
+        # Streamed (SSE-style: lines prefixed with 'data: ')
+        def _stream() -> Iterator[Dict[str, Any]]:
+            with self._client.stream("POST", url, json=payload) as r:
+                r.raise_for_status()
+                for line in r.iter_lines():
+                    if not line:
+                        continue
+                    if line.startswith("data: "):
+                        data = line[6:].strip()
+                    else:
+                        # Some servers don't prefix; try parsing anyway
+                        data = line.strip()
+
+                    if not data or data == "[DONE]":
+                        if data == "[DONE]":
+                            return
+                        continue
+                    try:
+                        chunk = json.loads(data)
+                        yield chunk
+                    except json.JSONDecodeError:
+                        # Skip unparsable lines quietly
+                        continue
+
+        return _stream()

--- a/src/prime_cli/commands/availability.py
+++ b/src/prime_cli/commands/availability.py
@@ -11,7 +11,7 @@ from ..helper.short_id import generate_short_id
 from ..utils import output_data_as_json, status_color, validate_output_format
 from ..utils.display import STOCK_STATUS_COLORS
 
-app = typer.Typer(help="Check GPU availability and pricing")
+app = typer.Typer(help="Check GPU availability and pricing", no_args_is_help=True)
 console = Console()
 
 

--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -43,6 +43,9 @@ def view() -> None:
     # Show frontend URL
     table.add_row("Frontend URL", settings["frontend_url"])
 
+    # Show inference URL
+    table.add_row("Inference URL", settings["inference_url"])
+
     # Show SSH key path
     table.add_row("SSH Key Path", settings["ssh_key_path"])
 
@@ -155,6 +158,29 @@ def set_frontend_url(
     config = Config()
     config.set_frontend_url(url)
     console.print(f"[green]Frontend URL set to: {url}[/green]")
+
+
+@app.command()
+def set_inference_url(
+    url: Optional[str] = typer.Argument(
+        None,
+        help="Inference URL for Prime Inference API. If not provided, you'll be prompted.",
+    ),
+) -> None:
+    """Set the inference URL (prompts if not provided)"""
+    if not url:
+        config = Config()
+        url = typer.prompt(
+            "Enter the inference URL for Prime Inference API",
+            default=config.inference_url,
+        )
+        if not url:
+            console.print("[red]Inference URL is required[/red]")
+            return
+
+    config = Config()
+    config.set_inference_url(url)
+    console.print(f"[green]Inference URL set to: {url}[/green]")
 
 
 # Helper functions (not commands)

--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import typer
@@ -6,7 +7,7 @@ from rich.table import Table
 
 from ..config import Config
 
-app = typer.Typer(help="Configure the CLI")
+app = typer.Typer(help="Configure the CLI", no_args_is_help=True)
 console = Console()
 
 
@@ -20,14 +21,16 @@ def view() -> None:
     table.add_column("Setting", style="cyan")
     table.add_column("Value", style="green")
 
+    def _env_set(*names: str) -> bool:
+        return any(os.getenv(n) and os.getenv(n).strip() for n in names)
+
     # Show current environment
     table.add_row("Current Environment", settings["current_environment"])
 
     api_key = settings["api_key"]
     if api_key:
         masked_key = f"{api_key[:6]}...{api_key[-4:]}" if len(api_key) > 10 else "***"
-        config_key = config.config.get("api_key", "")
-        if not config_key:
+        if _env_set("PRIME_API_KEY"):
             masked_key += " (from env var)"
     else:
         masked_key = "Not set"
@@ -35,19 +38,34 @@ def view() -> None:
 
     # Show Team ID
     team_id = settings["team_id"]
-    table.add_row("Team ID", team_id or "Personal Account")
+    team_label = team_id or "Personal Account"
+    if team_id and _env_set("PRIME_TEAM_ID"):
+        team_label += " (from env var)"
+    table.add_row("Team ID", team_label)
 
     # Show base URL
-    table.add_row("Base URL", settings["base_url"])
+    base_label = settings["base_url"]
+    if _env_set("PRIME_API_BASE_URL", "PRIME_BASE_URL"):
+        base_label += " (from env var)"
+    table.add_row("Base URL", base_label)
 
     # Show frontend URL
-    table.add_row("Frontend URL", settings["frontend_url"])
+    front_label = settings["frontend_url"]
+    if _env_set("PRIME_FRONTEND_URL"):
+        front_label += " (from env var)"
+    table.add_row("Frontend URL", front_label)
 
     # Show inference URL
-    table.add_row("Inference URL", settings["inference_url"])
+    inf_label = settings["inference_url"]
+    if _env_set("PRIME_INFERENCE_URL"):
+        inf_label += " (from env var)"
+    table.add_row("Inference URL", inf_label)
 
     # Show SSH key path
-    table.add_row("SSH Key Path", settings["ssh_key_path"])
+    ssh_label = settings["ssh_key_path"]
+    if _env_set("PRIME_SSH_KEY_PATH"):
+        ssh_label += " (from env var)"
+    table.add_row("SSH Key Path", ssh_label)
 
     console.print(table)
 
@@ -238,7 +256,7 @@ def _list_environments() -> None:
     console.print(table)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def set_ssh_key_path(
     path: str = typer.Argument(
         ...,
@@ -268,7 +286,7 @@ def reset(
 
 
 # Environment commands
-@app.command(name="use")
+@app.command(name="use", no_args_is_help=True)
 def use_environment(
     env: str = typer.Argument(
         ..., help="Environment name: 'production' or a custom saved environment"
@@ -278,7 +296,7 @@ def use_environment(
     _set_environment(env)
 
 
-@app.command(name="save")
+@app.command(name="save", no_args_is_help=True)
 def save_env(name: str = typer.Argument(..., help="Name for the environment")) -> None:
     """Save current config as environment (including API key)"""
     _save_environment(name)

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1591,9 +1591,11 @@ def eval_env(
     # Always pass the selected model (since it's a required option)
     cmd += ["-m", model]
 
+    # Environment modificaiton may be necessary for passing in API key
+    env = os.environ.copy()
+
     # Set PRIME_API_KEY if user did not provider api key var
     if not _has_flag(("-k", "--api-key-var")):
-        env = os.environ.copy()
         env["PRIME_API_KEY"] = api_key
         cmd += ["-k", "PRIME_API_KEY"]
 

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1548,7 +1548,6 @@ def eval_env(
     Notes:
       • We add:  -b <Prime Inference base URL>  -k <Prime API Key>
       • All extra args are forwarded unchanged to vf-eval.
-      • We try 'vf-eval' first, then fall back to 'uv run vf-eval'.
     """
     config = Config()
     api_key = config.api_key

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ..api.client import APIClient, APIError
+from ..api.inference import InferenceAPIError, InferenceClient
 from ..config import Config
 from ..utils import output_data_as_json, validate_output_format
 
@@ -1562,6 +1563,17 @@ def eval_env(
         console.print(
             "[red]Inference URL not configured.[/red] "
             "Check [bold]prime config view[/bold]."
+        )
+        raise typer.Exit(1)
+
+    # Fast fail if the model doesn't exist
+    client = InferenceClient()
+    try:
+        client.retrieve_model(model)
+    except InferenceAPIError as e:
+        console.print(
+            f"[red]Invalid model:[/red] {e} \n\n"
+            f"[b]Use 'prime inference models' to see available models.[/b]"
         )
         raise typer.Exit(1)
 

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -22,7 +22,7 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..config import Config
 from ..utils import output_data_as_json, validate_output_format
 
-app = typer.Typer(help="Manage verifiers environments")
+app = typer.Typer(help="Manage verifiers environments", no_args_is_help=True)
 console = Console()
 
 # Constants
@@ -601,7 +601,7 @@ def push(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def init(
     name: str = typer.Argument(..., help="Name of the new environment"),
     path: str = typer.Option(
@@ -635,7 +635,7 @@ def init(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def pull(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name or owner/name@version)"),
     target: Optional[str] = typer.Option(None, "--target", "-t", help="Target directory"),
@@ -864,7 +864,7 @@ def get_install_command(tool: str, wheel_url: str) -> List[str]:
         raise ValueError(f"Unsupported package manager: {tool}. Use 'uv' or 'pip'.")
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def info(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name)"),
     version: str = typer.Option("latest", "--version", "-v", help="Version to show"),
@@ -1068,7 +1068,7 @@ def execute_install_command(cmd: List[str], env_id: str, version: str, tool: str
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def install(
     env_id: str = typer.Argument(..., help="Environment ID to install (owner/name)"),
     with_tool: str = typer.Option(
@@ -1264,7 +1264,7 @@ def execute_uninstall_command(cmd: List[str], env_name: str, tool: str) -> None:
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def uninstall(
     env_name: str = typer.Argument(..., help="Environment name to uninstall"),
     with_tool: str = typer.Option(
@@ -1324,11 +1324,11 @@ def uninstall(
         raise typer.Exit(1)
 
 
-version_app = typer.Typer(help="Manage environment versions")
+version_app = typer.Typer(help="Manage environment versions", no_args_is_help=True)
 app.add_typer(version_app, name="version")
 
 
-@version_app.command("list")
+@version_app.command("list", no_args_is_help=True)
 def list_versions(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name)"),
     full_hashes: bool = typer.Option(
@@ -1415,7 +1415,7 @@ def list_versions(
         raise typer.Exit(1)
 
 
-@version_app.command("delete")
+@version_app.command("delete", no_args_is_help=True)
 def delete_version(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name)"),
     content_hash: str = typer.Argument(..., help="Content hash of the version to delete"),
@@ -1481,7 +1481,7 @@ def delete_version(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def delete(
     env_id: str = typer.Argument(..., help="Environment ID to delete"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
@@ -1522,6 +1522,7 @@ def delete(
 
 @app.command(
     "eval",
+    no_args_is_help=True,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
 def eval_env(
@@ -1550,15 +1551,14 @@ def eval_env(
         32, "--max-concurrent", "-c", help="Max concurrent requests"
     ),
     max_tokens: Optional[int] = typer.Option(
-        None, "--max-tokens", "-t",
-        help="Max tokens to generate (unset → model default)"
+        None, "--max-tokens", "-t", help="Max tokens to generate (unset → model default)"
     ),
-    temperature: Optional[float] = typer.Option(
-        None, "--temperature", "-T", help="Temperature"
-    ),
+    temperature: Optional[float] = typer.Option(None, "--temperature", "-T", help="Temperature"),
     sampling_args: Optional[str] = typer.Option(
-        None, "--sampling-args", "-S",
-        help='Sampling args as JSON, e.g. \'{"enable_thinking": false, "max_tokens": 256}\''
+        None,
+        "--sampling-args",
+        "-S",
+        help='Sampling args as JSON, e.g. \'{"enable_thinking": false, "max_tokens": 256}\'',
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
     save_dataset: bool = typer.Option(False, "--save-dataset", "-s", help="Save dataset to disk"),
@@ -1567,19 +1567,19 @@ def eval_env(
         None, "--hf-hub-dataset-name", "-D", help="HF Hub dataset name"
     ),
     env_args: Optional[str] = typer.Option(
-        None, "--env-args", "-a",
-        help='Environment args as JSON, e.g. \'{"key":"value"}\''
+        None, "--env-args", "-a", help='Environment args as JSON, e.g. \'{"key":"value"}\''
     ),
     api_key_var: Optional[str] = typer.Option(
-        None, "--api-key-var", "-k",
-        help="override api key variable instead of using PRIME_API_KEY"
+        None, "--api-key-var", "-k", help="override api key variable instead of using PRIME_API_KEY"
     ),
     api_base_url: Optional[str] = typer.Option(
-        None, "--api-base-url", "-b",
+        None,
+        "--api-base-url",
+        "-b",
         help=(
             "override api base url variable instead of using prime inference url, "
             "should end in '/v1'"
-        )
+        ),
     ),
 ) -> None:
     """

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1591,10 +1591,11 @@ def eval_env(
     # Always pass the selected model (since it's a required option)
     cmd += ["-m", model]
 
-    # Set PRIME_API_KEY for the child process
-    env = os.environ.copy()
-    env["PRIME_API_KEY"] = api_key
-    cmd += ["-k", "PRIME_API_KEY"]
+    # Set PRIME_API_KEY if user did not provider api key var
+    if not _has_flag(("-k", "--api-key-var")):
+        env = os.environ.copy()
+        env["PRIME_API_KEY"] = api_key
+        cmd += ["-k", "PRIME_API_KEY"]
 
     # Forward everything else untouched
     cmd += user_args

--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -1,11 +1,11 @@
 import hashlib
+import os
 import re
 import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -10,8 +10,8 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
 app = typer.Typer(
-    help="Run and manage Prime Inference (in beta, requires prime inference permissions)\n\n"
-    "Use `prime env eval (beta)` for environment evals with Prime Inference."
+    help="Run and manage Prime Inference (in closed beta, requires prime inference permissions)\n\n"
+    "Use `prime env eval (closed beta)` for environment evals with Prime Inference."
 )
 console = Console()
 

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -10,8 +10,9 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
 app = typer.Typer(
-    help="Run and manage Prime Inference (in closed beta, requires prime inference permissions)\n\n"
-    "Use `prime env eval (closed beta)` for environment evals with Prime Inference."
+    help="Run and manage Prime Inference (in beta, requires prime inference permissions)\n\n"
+    "Use `prime env eval` (beta) for environment evals with Prime Inference.",
+    no_args_is_help=True,
 )
 console = Console()
 
@@ -92,4 +93,3 @@ def list_models(
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {e}")
         raise typer.Exit(1)
-

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -10,8 +10,8 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
 app = typer.Typer(
-    help="Run and manage Prime Inference\n\n"
-    "Use `prime env eval` for environment evals with Prime Inference."
+    help="Run and manage Prime Inference (in beta, requires prime inference permissions)\n\n"
+    "Use `prime env eval (beta)` for environment evals with Prime Inference."
 )
 console = Console()
 

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -9,7 +9,10 @@ from rich.table import Table
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
-app = typer.Typer(help="Run model inference")
+app = typer.Typer(
+    help="Run and manage Prime Inference\n\n"
+    "Use `prime env eval` for environment evals with Prime Inference."
+)
 console = Console()
 
 
@@ -51,16 +54,12 @@ def list_models(
             console.print("[yellow]No models returned.[/yellow]")
             return
 
-        table = Table(title="Prime Inference Models")
+        table = Table(title="Prime Inference Available Models")
         table.add_column("id", style="cyan")
-        # TODO: skip owned_by for now
-        # table.add_column("owned_by", style="green")
         table.add_column("created", style="magenta")
 
         for m in models:
             mid = str(m.get("id", ""))
-            # TODO: skip owned_by for now
-            # owned_by = str(m.get("owned_by", m.get("owner", "")) or "")
             created = _fmt_created(str(m.get("created", "")))
             table.add_row(mid, created)
 

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -25,6 +25,16 @@ def _fmt_created(val: str) -> str:
     except Exception:
         return val or ""
 
+def _fmt_price(x) -> str:
+    """Format USD per 1M tokens (mtok) for display."""
+    if x is None:
+        return ""
+    try:
+        f = float(x)
+        return f"${f:.6f}".rstrip("0").rstrip(".")
+    except Exception:
+        return str(x)
+
 
 @app.command("models")
 def list_models(
@@ -54,14 +64,25 @@ def list_models(
             console.print("[yellow]No models returned.[/yellow]")
             return
 
-        table = Table(title="Prime Inference Available Models")
+        table = Table(title="Prime Inference — Models")
         table.add_column("id", style="cyan")
         table.add_column("created", style="magenta")
+        table.add_column("input $/1M tok", style="green", justify="right")
+        table.add_column("output $/1M tok", style="green", justify="right")
 
         for m in models:
             mid = str(m.get("id", ""))
             created = _fmt_created(str(m.get("created", "")))
-            table.add_row(mid, created)
+            pricing = m.get("pricing") or {}
+            pin = pricing.get("input_usd_per_mtok")
+            pout = pricing.get("output_usd_per_mtok")
+
+            table.add_row(
+                mid,
+                created,
+                _fmt_price(pin),
+                _fmt_price(pout),
+            )
 
         console.print(table)
 

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import datetime as _dt
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..api.inference import InferenceAPIError, InferenceClient
+from ..utils import output_data_as_json, validate_output_format
+
+app = typer.Typer(help="Run model inference")
+console = Console()
+
+
+def _fmt_created(val: str) -> str:
+    """Format created timestamp for display"""
+    try:
+        # if epoch seconds
+        ts = int(val)
+        return _dt.datetime.fromtimestamp(ts, _dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return val or ""
+
+
+@app.command("models")
+def list_models(
+    output: str = typer.Option("table", "--output", "-o", help="table|json"),
+) -> None:
+    """List available models from Prime Inference (/v1/models)."""
+    validate_output_format(output, console)
+    try:
+        client = InferenceClient()
+        data = client.list_models()
+
+        # Expect OpenAI-style: {"object":"list","data":[{"id":..., ...}, ...]}
+        models = []
+        if isinstance(data, dict):
+            if "data" in data and isinstance(data["data"], list):
+                models = data["data"]
+            elif "models" in data and isinstance(data["models"], list):
+                models = data["models"]  # be liberal in what we accept
+        elif isinstance(data, list):
+            models = data
+
+        if output == "json":
+            output_data_as_json(data, console)
+            return
+
+        if not models:
+            console.print("[yellow]No models returned.[/yellow]")
+            return
+
+        table = Table(title="Prime Inference Models")
+        table.add_column("id", style="cyan")
+        # TODO: skip owned_by for now
+        # table.add_column("owned_by", style="green")
+        table.add_column("created", style="magenta")
+
+        for m in models:
+            mid = str(m.get("id", ""))
+            # TODO: skip owned_by for now
+            # owned_by = str(m.get("owned_by", m.get("owner", "")) or "")
+            created = _fmt_created(str(m.get("created", "")))
+            table.add_row(mid, created)
+
+        console.print(table)
+
+    except InferenceAPIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {e}")
+        raise typer.Exit(1)
+

--- a/src/prime_cli/commands/pods.py
+++ b/src/prime_cli/commands/pods.py
@@ -27,7 +27,7 @@ from ..utils import (
 )
 from ..utils.display import POD_STATUS_COLORS
 
-app = typer.Typer(help="Manage compute pods")
+app = typer.Typer(help="Manage compute pods", no_args_is_help=True)
 console = Console()
 config = Config()
 
@@ -253,7 +253,7 @@ def list(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def status(
     pod_id: str,
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
@@ -755,7 +755,7 @@ def create(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def terminate(
     pod_id: str,
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -786,8 +786,8 @@ def terminate(
         raise typer.Exit(1)
 
 
-@app.command(name="connect")
-@app.command(name="ssh")
+@app.command(name="connect", no_args_is_help=True)
+@app.command(name="ssh", no_args_is_help=True)
 def connect(pod_id: str) -> None:
     """SSH / connect to a pod using configured SSH key"""
     try:

--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -26,7 +27,7 @@ from ..utils import (
 )
 from ..utils.display import SANDBOX_STATUS_COLORS
 
-app = typer.Typer(help="Manage code sandboxes")
+app = typer.Typer(help="Manage code sandboxes", no_args_is_help=True)
 console = Console()
 
 
@@ -175,11 +176,12 @@ def list_sandboxes_cmd(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def get(
     sandbox_id: str,
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
@@ -245,11 +247,12 @@ def get(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def create(
     docker_image: str = typer.Argument(..., help="Docker image to run"),
     name: Optional[str] = typer.Option(
@@ -344,11 +347,12 @@ def create(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def delete(
     sandbox_ids: Optional[List[str]] = typer.Argument(
         None, help="Sandbox ID(s) to delete (space or comma-separated)"
@@ -490,11 +494,12 @@ def delete(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def logs(sandbox_id: str) -> None:
     """Get logs from a sandbox"""
     try:
@@ -506,19 +511,20 @@ def logs(sandbox_id: str) -> None:
 
         if logs:
             console.print(f"\n[bold]Logs for sandbox {sandbox_id}:[/bold]")
-            console.print(logs)
+            console.print(f"{escape(logs)}")
         else:
             console.print(f"[yellow]No logs available for sandbox {sandbox_id}[/yellow]")
 
     except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def status(sandbox_id: str) -> None:
     """Update and get the current status of a sandbox from Kubernetes"""
     try:
@@ -535,11 +541,12 @@ def status(sandbox_id: str) -> None:
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(no_args_is_help=True)
 def run(
     sandbox_id: str,
     command: List[str] = typer.Argument(..., help="Command to execute"),
@@ -609,11 +616,12 @@ def run(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command("upload")
+@app.command("upload", no_args_is_help=True)
 def upload_file(
     sandbox_id: str = typer.Argument(..., help="Sandbox ID to upload file to"),
     local_file: str = typer.Argument(..., help="Path to local file to upload"),
@@ -658,11 +666,12 @@ def upload_file(
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
-@app.command("download")
+@app.command("download", no_args_is_help=True)
 def download_file(
     sandbox_id: str = typer.Argument(..., help="Sandbox ID to download file from"),
     remote_path: str = typer.Argument(..., help="Path to file in sandbox"),
@@ -710,7 +719,8 @@ def download_file(
         console.print(f"[red]File not found:[/red] {str(e)}")
         raise typer.Exit(1)
     except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -12,6 +12,7 @@ class ConfigModel(BaseModel):
     team_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
+    inference_url: str = "https://inference.pinference.ai"
     ssh_key_path: str = str(Path.home() / ".ssh" / "id_rsa")
     current_environment: str = "production"
 
@@ -21,6 +22,7 @@ class ConfigModel(BaseModel):
 class Config:
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
     DEFAULT_FRONTEND_URL: str = "https://app.primeintellect.ai"
+    DEFAULT_INFERENCE_URL: str = "https://inference.pinference.ai"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
     def __init__(self) -> None:
@@ -41,6 +43,7 @@ class Config:
                     team_id=None,
                     base_url=self.DEFAULT_BASE_URL,
                     frontend_url=self.DEFAULT_FRONTEND_URL,
+                    inference_url=self.DEFAULT_INFERENCE_URL,
                     ssh_key_path=self.DEFAULT_SSH_KEY_PATH,
                     current_environment="production",
                 ).model_dump()
@@ -107,6 +110,20 @@ class Config:
         self._save_config(self.config)
 
     @property
+    def inference_url(self) -> str:
+        """Get inference URL from config"""
+        inference_url: str = self.config.get("inference_url", self.DEFAULT_INFERENCE_URL)
+        return inference_url
+
+    def set_inference_url(self, value: str) -> None:
+        """Set frontend URL in config file"""
+        value = value.rstrip("/")
+        if value.endswith("/api/v1"):
+            value = value[:-7]
+        self.config["inference_url"] = value
+        self._save_config(self.config)
+
+    @property
     def ssh_key_path(self) -> str:
         """Get SSH private key path from config file or environment"""
         return self.config.get("ssh_key_path", self.DEFAULT_SSH_KEY_PATH) or os.getenv(
@@ -147,6 +164,7 @@ class Config:
             "team_id": self.team_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
+            "inference_url": self.inference_url,
             "ssh_key_path": self.ssh_key_path,
             "current_environment": self.current_environment,
         }
@@ -163,6 +181,7 @@ class Config:
             "team_id": self.team_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
+            "inference_url": self.inference_url,
         }
         env_file.write_text(json.dumps(env_config, indent=2))
 
@@ -172,6 +191,7 @@ class Config:
             # Built-in production environment
             self.set_base_url(self.DEFAULT_BASE_URL)
             self.set_frontend_url(self.DEFAULT_FRONTEND_URL)
+            self.set_inference_url(self.DEFAULT_INFERENCE_URL)
             self.set_team_id(None)  # Production defaults to personal account
             self.set_current_environment("production")
             return True
@@ -191,6 +211,7 @@ class Config:
                 self.set_team_id(env_config.get("team_id", None))
                 self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
                 self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
+                self.set_inference_url(env_config.get("inference_url", self.DEFAULT_INFERENCE_URL))
                 self.set_current_environment(name)
                 return True
         except ValueError:
@@ -211,6 +232,7 @@ class Config:
                         "team_id": self.team_id,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,
+                        "inference_url": self.inference_url,
                     }
                     env_file.write_text(json.dumps(env_config, indent=2))
             except ValueError:

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -12,7 +12,7 @@ class ConfigModel(BaseModel):
     team_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
-    inference_url: str = "https://inference.pinference.ai"
+    inference_url: str = "https://api.pinference.ai/api/v1"
     ssh_key_path: str = str(Path.home() / ".ssh" / "id_rsa")
     current_environment: str = "production"
 
@@ -22,7 +22,7 @@ class ConfigModel(BaseModel):
 class Config:
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
     DEFAULT_FRONTEND_URL: str = "https://app.primeintellect.ai"
-    DEFAULT_INFERENCE_URL: str = "https://inference.pinference.ai"
+    DEFAULT_INFERENCE_URL: str = "https://api.pinference.ai/api/v1"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
     def __init__(self) -> None:
@@ -112,14 +112,14 @@ class Config:
     @property
     def inference_url(self) -> str:
         """Get inference URL from config"""
-        inference_url: str = self.config.get("inference_url", self.DEFAULT_INFERENCE_URL)
+        inference_url: str = self.config.get(
+            "inference_url", self.DEFAULT_INFERENCE_URL
+        ).rstrip("/")
         return inference_url
 
     def set_inference_url(self, value: str) -> None:
         """Set frontend URL in config file"""
         value = value.rstrip("/")
-        if value.endswith("/api/v1"):
-            value = value[:-7]
         self.config["inference_url"] = value
         self._save_config(self.config)
 

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -32,6 +32,11 @@ class Config:
         self._ensure_config_dir()
         self._load_config()
 
+    @staticmethod
+    def _strip_api_v1(url: str) -> str:
+        # make base_url consistent even if user passed a /api/v1 variant
+        return url.rstrip("/").removesuffix("/api/v1")
+
     def _ensure_config_dir(self) -> None:
         """Create config directory if it doesn't exist"""
         self.config_dir.mkdir(exist_ok=True)
@@ -64,8 +69,8 @@ class Config:
 
     @property
     def api_key(self) -> str:
-        """Get API key from config file or environment"""
-        return self.config.get("api_key", "") or os.getenv("PRIME_API_KEY", "")
+        """Get API key with precedence: env > file > empty."""
+        return os.getenv("PRIME_API_KEY") or self.config.get("api_key", "")
 
     def set_api_key(self, value: str) -> None:
         """Set API key in config file"""
@@ -74,9 +79,11 @@ class Config:
 
     @property
     def team_id(self) -> Optional[str]:
-        """Get team ID from config file or environment"""
-        team_id = self.config.get("team_id", None) or os.getenv("PRIME_TEAM_ID", None)
-        return team_id if team_id else None
+        """Get team ID with precedence: env > file > None."""
+        team_id = os.getenv("PRIME_TEAM_ID")
+        if team_id is not None:
+            return team_id
+        return self.config.get("team_id") or None
 
     def set_team_id(self, value: str | None) -> None:
         """Set team ID in config file"""
@@ -85,9 +92,11 @@ class Config:
 
     @property
     def base_url(self) -> str:
-        """Get API base URL from config"""
-        base_url: str = self.config.get("base_url", self.DEFAULT_BASE_URL)
-        return base_url
+        """Get API base URL with precedence: env > file > default."""
+        env_val = os.getenv("PRIME_API_BASE_URL") or os.getenv("PRIME_BASE_URL")
+        if env_val:
+            return self._strip_api_v1(env_val)
+        return self._strip_api_v1(self.config.get("base_url", self.DEFAULT_BASE_URL))
 
     def set_base_url(self, value: str) -> None:
         """Set API base URL in config file"""
@@ -99,9 +108,11 @@ class Config:
 
     @property
     def frontend_url(self) -> str:
-        """Get frontend URL from config"""
-        frontend_url: str = self.config.get("frontend_url", self.DEFAULT_FRONTEND_URL)
-        return frontend_url
+        """Get frontend URL with precedence: env > file > default."""
+        env_val = os.getenv("PRIME_FRONTEND_URL")
+        if env_val:
+            return env_val.rstrip("/")
+        return (self.config.get("frontend_url", self.DEFAULT_FRONTEND_URL)).rstrip("/")
 
     def set_frontend_url(self, value: str) -> None:
         """Set frontend URL in config file"""
@@ -111,24 +122,25 @@ class Config:
 
     @property
     def inference_url(self) -> str:
-        """Get inference URL from config"""
-        inference_url: str = self.config.get(
-            "inference_url", self.DEFAULT_INFERENCE_URL
-        ).rstrip("/")
-        return inference_url
+        """Get inference URL with precedence: env > file > default."""
+        env_val = os.getenv("PRIME_INFERENCE_URL")
+        if env_val:
+            return env_val.rstrip("/")
+        return self.config.get("inference_url", self.DEFAULT_INFERENCE_URL).rstrip("/")
 
     def set_inference_url(self, value: str) -> None:
-        """Set frontend URL in config file"""
+        """Set inference URL in config file"""
         value = value.rstrip("/")
         self.config["inference_url"] = value
         self._save_config(self.config)
 
     @property
     def ssh_key_path(self) -> str:
-        """Get SSH private key path from config file or environment"""
-        return self.config.get("ssh_key_path", self.DEFAULT_SSH_KEY_PATH) or os.getenv(
-            "PRIME_SSH_KEY_PATH", self.DEFAULT_SSH_KEY_PATH
-        )
+        """Get SSH private key path with precedence: env > file > default."""
+        env_val = os.getenv("PRIME_SSH_KEY_PATH")
+        if env_val:
+            return str(Path(env_val).expanduser())
+        return self.config.get("ssh_key_path", self.DEFAULT_SSH_KEY_PATH)
 
     def set_ssh_key_path(self, value: str) -> None:
         """Set SSH private key path in config file"""

--- a/src/prime_cli/main.py
+++ b/src/prime_cli/main.py
@@ -12,7 +12,7 @@ from .commands.sandbox import app as sandbox_app
 
 __version__ = version("prime")
 
-app = typer.Typer(name="prime", help=f"Prime Intellect CLI (v{__version__})")
+app = typer.Typer(name="prime", help=f"Prime Intellect CLI (v{__version__})", no_args_is_help=True)
 
 app.add_typer(availability_app, name="availability")
 app.add_typer(config_app, name="config")
@@ -32,8 +32,6 @@ def callback(
     if version_flag:
         typer.echo(f"Prime CLI version: {__version__}")
         raise typer.Exit()
-    if ctx.invoked_subcommand is None:
-        ctx.get_help()
 
 
 def run() -> None:

--- a/src/prime_cli/main.py
+++ b/src/prime_cli/main.py
@@ -8,6 +8,7 @@ from .commands.env import app as env_app
 from .commands.login import app as login_app
 from .commands.pods import app as pods_app
 from .commands.sandbox import app as sandbox_app
+from .commands.inference import app as inference_app
 
 __version__ = version("prime")
 
@@ -19,6 +20,7 @@ app.add_typer(pods_app, name="pods")
 app.add_typer(sandbox_app, name="sandbox")
 app.add_typer(login_app, name="login")
 app.add_typer(env_app, name="env")
+app.add_typer(inference_app, name="inference")
 
 
 @app.callback(invoke_without_command=True)

--- a/src/prime_cli/main.py
+++ b/src/prime_cli/main.py
@@ -5,10 +5,10 @@ import typer
 from .commands.availability import app as availability_app
 from .commands.config import app as config_app
 from .commands.env import app as env_app
+from .commands.inference import app as inference_app
 from .commands.login import app as login_app
 from .commands.pods import app as pods_app
 from .commands.sandbox import app as sandbox_app
-from .commands.inference import app as inference_app
 
 __version__ = version("prime")
 

--- a/uv.lock
+++ b/uv.lock
@@ -798,7 +798,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.100.2"
+version = "1.109.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -810,9 +810,27 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/36/e2e24d419438a5e66aa6445ec663194395226293d214bfe615df562b2253/openai-1.100.2.tar.gz", hash = "sha256:787b4c3c8a65895182c58c424f790c25c790cc9a0330e34f73d55b6ee5a00e32", size = 507954, upload-time = "2025-08-19T15:32:47.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/9f/d11cc7fb2d60af14a97dbef4e3c7b23917387995c257951fdc321d8efd0a/openai-1.109.0.tar.gz", hash = "sha256:701e26d13e3953524ba99f44cf5fbbda40eafd41ba15a8d85b76229a2693cfe5", size = 563971, upload-time = "2025-09-23T16:59:41.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/8d/9ab1599c7942b3d04784ac5473905dc543aeb30a1acce3591d0b425682db/openai-1.100.2-py3-none-any.whl", hash = "sha256:54d3457b2c8d7303a1bc002a058de46bdd8f37a8117751c7cf4ed4438051f151", size = 787755, upload-time = "2025-08-19T15:32:46.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d3/d65e318e8d3b5845afaa5960d8da779988b4cb9f4e1ca82e588fed9c6a9d/openai-1.109.0-py3-none-any.whl", hash = "sha256:8c0910bdd4ee1274d5ff0354786bdd0bc79e68c158d5d2c19e24208b412e5792", size = 948421, upload-time = "2025-09-23T16:59:39.516Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/9f/dafa9f80653778179822e1abf77c7f0d9da5a16806c96b5bb9e0e46bd747/openai_agents-0.3.2.tar.gz", hash = "sha256:b71ac04ee9f502f1bc0f4d142407df4ec69db4442db86c4da252b4558fa90cd5", size = 1727988, upload-time = "2025-09-23T20:37:20.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/7e/6a8437f9f40937bb473ceb120a65e1b37bc87bcee6da67be4c05b25c6a89/openai_agents-0.3.2-py3-none-any.whl", hash = "sha256:55e02c57f2aaf3170ff0aa0ab7c337c28fd06b43b3bb9edc28b77ffd8142b425", size = 194221, upload-time = "2025-09-23T20:37:19.121Z" },
 ]
 
 [[package]]
@@ -906,6 +924,10 @@ wheels = [
 
 [[package]]
 name = "prime"
+<<<<<<< HEAD
+=======
+version = "0.3.34"
+>>>>>>> c360ff8 (fix comment)
 source = { editable = "." }
 dependencies = [
     { name = "build" },
@@ -1524,15 +1546,25 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
+<<<<<<< HEAD
 version = "0.36.0"
+=======
+version = "0.37.0"
+>>>>>>> c360ff8 (fix comment)
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
+<<<<<<< HEAD
 sdist = { url = "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz", hash = "sha256:527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9", size = 80032, upload-time = "2025-09-20T01:07:14.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/06/5cc0542b47c0338c1cb676b348e24a1c29acabc81000bced518231dded6f/uvicorn-0.36.0-py3-none-any.whl", hash = "sha256:6bb4ba67f16024883af8adf13aba3a9919e415358604ce46780d3f9bdc36d731", size = 67675, upload-time = "2025-09-20T01:07:12.984Z" },
+=======
+sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
+>>>>>>> c360ff8 (fix comment)
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -798,7 +798,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.109.0"
+version = "1.100.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -810,27 +810,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/9f/d11cc7fb2d60af14a97dbef4e3c7b23917387995c257951fdc321d8efd0a/openai-1.109.0.tar.gz", hash = "sha256:701e26d13e3953524ba99f44cf5fbbda40eafd41ba15a8d85b76229a2693cfe5", size = 563971, upload-time = "2025-09-23T16:59:41.508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/36/e2e24d419438a5e66aa6445ec663194395226293d214bfe615df562b2253/openai-1.100.2.tar.gz", hash = "sha256:787b4c3c8a65895182c58c424f790c25c790cc9a0330e34f73d55b6ee5a00e32", size = 507954, upload-time = "2025-08-19T15:32:47.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/d3/d65e318e8d3b5845afaa5960d8da779988b4cb9f4e1ca82e588fed9c6a9d/openai-1.109.0-py3-none-any.whl", hash = "sha256:8c0910bdd4ee1274d5ff0354786bdd0bc79e68c158d5d2c19e24208b412e5792", size = 948421, upload-time = "2025-09-23T16:59:39.516Z" },
-]
-
-[[package]]
-name = "openai-agents"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe" },
-    { name = "mcp" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/9f/dafa9f80653778179822e1abf77c7f0d9da5a16806c96b5bb9e0e46bd747/openai_agents-0.3.2.tar.gz", hash = "sha256:b71ac04ee9f502f1bc0f4d142407df4ec69db4442db86c4da252b4558fa90cd5", size = 1727988, upload-time = "2025-09-23T20:37:20.7Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/7e/6a8437f9f40937bb473ceb120a65e1b37bc87bcee6da67be4c05b25c6a89/openai_agents-0.3.2-py3-none-any.whl", hash = "sha256:55e02c57f2aaf3170ff0aa0ab7c337c28fd06b43b3bb9edc28b77ffd8142b425", size = 194221, upload-time = "2025-09-23T20:37:19.121Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/9ab1599c7942b3d04784ac5473905dc543aeb30a1acce3591d0b425682db/openai-1.100.2-py3-none-any.whl", hash = "sha256:54d3457b2c8d7303a1bc002a058de46bdd8f37a8117751c7cf4ed4438051f151", size = 787755, upload-time = "2025-08-19T15:32:46.252Z" },
 ]
 
 [[package]]
@@ -924,10 +906,6 @@ wheels = [
 
 [[package]]
 name = "prime"
-<<<<<<< HEAD
-=======
-version = "0.3.34"
->>>>>>> c360ff8 (fix comment)
 source = { editable = "." }
 dependencies = [
     { name = "build" },
@@ -1546,25 +1524,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-<<<<<<< HEAD
 version = "0.36.0"
-=======
-version = "0.37.0"
->>>>>>> c360ff8 (fix comment)
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-<<<<<<< HEAD
 sdist = { url = "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz", hash = "sha256:527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9", size = 80032, upload-time = "2025-09-20T01:07:14.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/06/5cc0542b47c0338c1cb676b348e24a1c29acabc81000bced518231dded6f/uvicorn-0.36.0-py3-none-any.whl", hash = "sha256:6bb4ba67f16024883af8adf13aba3a9919e415358604ce46780d3f9bdc36d731", size = 67675, upload-time = "2025-09-20T01:07:12.984Z" },
-=======
-sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
->>>>>>> c360ff8 (fix comment)
 ]
 
 [[package]]


### PR DESCRIPTION
prime inference models and prime env eval, could be much clearer if we share the args from verifiers (after some refactoring)

## Summary
• Add Prime Inference API client and `/v1/models` endpoint
• Add `prime env eval` command that wraps verifiers' `vf-eval` with automatic credential injection
• Add `prime config set-inference-url` command for configuring inference endpoints
• Improve model listing with readable timestamp formatting

## Key Features
**Prime Inference Integration**
- New `prime inference models` command to list available models
- InferenceClient class for OpenAI-compatible API calls
- Proper error handling and credential management

**vf-eval Wrapper (`prime env eval`)**
- Automatically injects Prime Inference base URL and API key
- Forwards all user arguments unchanged to `vf-eval`
- Handles both direct `vf-eval` and `uv run vf-eval` execution
- Required model parameter with help text pointing to available models

**Enhanced Configuration**
- `prime config set-inference-url` command for endpoint management
- Improved timestamp display (epoch → `2025-09-20 06:13:47`)

## Usage Examples
```bash
# List available models
prime inference models

# Run evaluation with automatic credential injection  
prime env eval hard-wordle -m meta-llama/llama-3.1-70b-instruct -n 5

# All vf-eval flags work unchanged
prime env eval myenv -m qwen/qwen-2.5-7b-instruct -r 3 -t 2048 --sampling-args '{"reasoning_effort":"low"}'
```

## Test Plan
- [x] `prime inference models` lists models with formatted timestamps
- [x] `prime env eval --help` shows correct usage and required model parameter
- [x] Credential injection working (tested with debug output)
- [x] Environment installation and evaluation flow tested with `tnmy/hard-wordle`
- [x] All ruff linting checks pass
- [x] Existing functionality unchanged

## Technical Details
- Uses `context_settings={"allow_extra_args": True, "ignore_unknown_options": True}` for flexible argument forwarding
- Checks for existing `-b`/`--base-url` and `-k`/`--api-key` flags to avoid overriding user values
- Graceful fallback from `vf-eval` to `uv run vf-eval`
- Proper timezone handling in timestamp formatting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Prime Inference integration (client + `prime inference models`) and a `prime env eval` wrapper, adds `inference_url` config, and polishes CLI UX.
> 
> - **Inference (beta)**:
>   - **Client**: Add `InferenceClient` for OpenAI-compatible `/v1/models`, `/v1/models/{id}`, and `/v1/chat/completions` (incl. streaming, robust errors).
>   - **CLI**: New `prime inference models` to list models with readable timestamps and pricing.
>   - **Env eval**: New `prime env eval` to run `vf-eval` using Prime Inference (injects API key/base URL, optional overrides, model pre-check, forwards flags).
> - **Config**:
>   - Add `inference_url` (default + env precedence), getters/setters, and show env-var sources in `config view`.
>   - New `prime config set-inference-url`; include `inference_url` in env save/load; normalize `base_url` (strip `/api/v1`).
> - **CLI/UX**:
>   - Register `inference` subcommand; set `no_args_is_help=True` for main and many subcommands.
>   - Sandbox: escape logs/errors and print rich exceptions for better diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519d65df58ab3c762cf8e4741192341c8c8a5141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->