### PR TITLE
Handle TIMEOUT sandbox status in CLI

### DIFF
--- a/examples/sandbox_async_high_volume_demo.py
+++ b/examples/sandbox_async_high_volume_demo.py
@@ -100,7 +100,7 @@ async def main() -> None:
         # Wait for sandboxes using bulk wait function
         print("Waiting for sandboxes...")
         sandbox_ids = [s.id for s in sandboxes]
-        await client.bulk_wait_for_creation(sandbox_ids, max_attempts=180)
+        await client.bulk_wait_for_creation(sandbox_ids)
         print("Sandboxes ready\n")
 
         # Get auth for all sandboxes

--- a/examples/sandbox_async_high_volume_demo.py
+++ b/examples/sandbox_async_high_volume_demo.py
@@ -100,7 +100,7 @@ async def main() -> None:
         # Wait for sandboxes using bulk wait function
         print("Waiting for sandboxes...")
         sandbox_ids = [s.id for s in sandboxes]
-        await client.bulk_wait_for_creation(sandbox_ids)
+        await client.bulk_wait_for_creation(sandbox_ids, max_attempts=180)
         print("Sandboxes ready\n")
 
         # Get auth for all sandboxes

--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -272,14 +272,10 @@ def _check_sandbox_statuses(
 
     for sandbox in sandboxes:
         if sandbox.id in target_ids:
-            if sandbox.status == SandboxStatus.RUNNING.value:
+            if sandbox.status == "RUNNING":
                 running_count += 1
                 final_statuses[sandbox.id] = sandbox.status
-            elif sandbox.status in {
-                SandboxStatus.ERROR.value,
-                SandboxStatus.TERMINATED.value,
-                SandboxStatus.TIMEOUT.value,
-            }:
+            elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 failed_sandboxes.append((sandbox.id, sandbox.status))
                 final_statuses[sandbox.id] = sandbox.status
 
@@ -408,14 +404,10 @@ class SandboxClient:
     def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
         for attempt in range(max_attempts):
             sandbox = self.get(sandbox_id)
-            if sandbox.status == SandboxStatus.RUNNING.value:
+            if sandbox.status == "RUNNING":
                 if self._is_sandbox_reachable(sandbox_id):
                     return
-            elif sandbox.status in [
-                SandboxStatus.ERROR.value,
-                SandboxStatus.TERMINATED.value,
-                SandboxStatus.TIMEOUT.value,
-            ]:
+            elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 raise SandboxNotRunningError(sandbox_id, sandbox.status)
 
             # Aggressive polling for first 5 attempts (5 seconds), then back off
@@ -479,7 +471,7 @@ class SandboxClient:
             if total_running == len(sandbox_ids):
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
-                    if final_statuses.get(sandbox_id) == SandboxStatus.RUNNING.value:
+                    if final_statuses.get(sandbox_id) == "RUNNING":
                         if not self._is_sandbox_reachable(sandbox_id):
                             all_reachable = False
                             final_statuses.pop(sandbox_id, None)
@@ -494,7 +486,7 @@ class SandboxClient:
         # Timeout - mark remaining as timeout
         for sandbox_id in sandbox_id_set:
             if sandbox_id not in final_statuses:
-                final_statuses[sandbox_id] = SandboxStatus.TIMEOUT.value
+                final_statuses[sandbox_id] = "TIMEOUT"
 
         raise RuntimeError(f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}")
 
@@ -689,14 +681,10 @@ class AsyncSandboxClient:
 
         for attempt in range(max_attempts):
             sandbox = await self.get(sandbox_id)
-            if sandbox.status == SandboxStatus.RUNNING.value:
+            if sandbox.status == "RUNNING":
                 if await self._is_sandbox_reachable(sandbox_id):
                     return
-            elif sandbox.status in [
-                SandboxStatus.ERROR.value,
-                SandboxStatus.TERMINATED.value,
-                SandboxStatus.TIMEOUT.value,
-            ]:
+            elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 raise SandboxNotRunningError(sandbox_id, sandbox.status)
 
             # Aggressive polling for first 5 attempts (5 seconds), then back off
@@ -762,7 +750,7 @@ class AsyncSandboxClient:
             if total_running == len(sandbox_ids):
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
-                    if final_statuses.get(sandbox_id) == SandboxStatus.RUNNING.value:
+                    if final_statuses.get(sandbox_id) == "RUNNING":
                         if not await self._is_sandbox_reachable(sandbox_id):
                             all_reachable = False
                             final_statuses.pop(sandbox_id, None)
@@ -777,7 +765,7 @@ class AsyncSandboxClient:
         # Timeout - mark remaining as timeout
         for sandbox_id in sandbox_id_set:
             if sandbox_id not in final_statuses:
-                final_statuses[sandbox_id] = SandboxStatus.TIMEOUT.value
+                final_statuses[sandbox_id] = "TIMEOUT"
 
         raise RuntimeError(f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}")
 

--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -385,7 +385,9 @@ def delete(
                     page += 1
 
                 # Filter out already terminated sandboxes
-                active_sandboxes = [s for s in all_sandboxes if s.status != "TERMINATED"]
+                active_sandboxes = [
+                    s for s in all_sandboxes if s.status not in {"TERMINATED", "TIMEOUT"}
+                ]
                 sandbox_ids = [s.id for s in active_sandboxes]
 
                 if not sandbox_ids:

--- a/src/prime_cli/utils/display.py
+++ b/src/prime_cli/utils/display.py
@@ -50,6 +50,7 @@ SANDBOX_STATUS_COLORS = {
     "STOPPED": "blue",
     "ERROR": "red",
     "TERMINATED": "white",
+    "TIMEOUT": "white",
 }
 
 POD_STATUS_COLORS = {


### PR DESCRIPTION
## Summary
- add the TIMEOUT value to the CLI sandbox enum
- treat TIMEOUT like other terminal states in waits and delete helpers
- show TIMEOUT in status tables with a distinct colour

## Testing
- uv run ruff check src/prime_cli/api/sandbox.py src/prime_cli/commands/sandbox.py src/prime_cli/utils/display.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `TIMEOUT` sandbox status; handle it as a terminal state in waits and deletes, and display it with a color.
> 
> - **API/Client (`src/prime_cli/api/sandbox.py`)**:
>   - Add `TIMEOUT` to `SandboxStatus` enum.
>   - Treat `TIMEOUT` as a terminal failure in `_check_sandbox_statuses`, `wait_for_creation`, and `AsyncSandboxClient.wait_for_creation`.
> - **CLI (`src/prime_cli/commands/sandbox.py`)**:
>   - Bulk delete `--all` now excludes sandboxes with `TERMINATED` and `TIMEOUT` when determining active items.
> - **Display (`src/prime_cli/utils/display.py`)**:
>   - Map `TIMEOUT` status to `white` in `SANDBOX_STATUS_COLORS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3430317cb7d0c1cc54b8d989fad58bb0498792f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->