### PR TITLE
Update inference prod domain and improve prime env eval parameters + help shows command are in beta

### DIFF
--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -35,7 +35,7 @@ class InferenceClient:
                 "No API key. Run `prime config set-api-key` or set PRIME_API_KEY."
             )
 
-        self.team_id = team_id or self.config.team_id
+        self.team_id = team_id if team_id is not None else self.config.team_id
         self.inference_url = (inference_url or self.config.inference_url).rstrip("/")
 
         headers = {

--- a/src/prime_cli/api/inference.py
+++ b/src/prime_cli/api/inference.py
@@ -24,18 +24,19 @@ class InferenceClient:
         self,
         api_key: Optional[str] = None,
         team_id: Optional[str] = None,
+        inference_url: Optional[str] = None,
     ) -> None:
         # Load config
         self.config = Config()
 
-        self.inference_url = self.config.inference_url
         self.api_key = api_key or self.config.api_key
         if not self.api_key:
             raise InferenceAPIError(
                 "No API key. Run `prime config set-api-key` or set PRIME_API_KEY."
             )
 
-        self.team_id = team_id if team_id is not None else self.config.team_id
+        self.team_id = team_id or self.config.team_id
+        self.inference_url = (inference_url or self.config.inference_url).rstrip("/")
 
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -51,7 +52,7 @@ class InferenceClient:
         )
 
     def list_models(self) -> Dict[str, Any]:
-        url = f"{self.inference_url}/api/v1/models"
+        url = f"{self.inference_url}/models"
         resp = self._client.get(url)
         try:
             resp.raise_for_status()
@@ -62,7 +63,7 @@ class InferenceClient:
         return resp.json()
 
     def retrieve_model(self, model_id: str) -> Dict[str, Any]:
-        url = f"{self.inference_url}/api/v1/models/{model_id}"
+        url = f"{self.inference_url}/models/{model_id}"
         resp = self._client.get(url)
         try:
             resp.raise_for_status()
@@ -82,7 +83,7 @@ class InferenceClient:
     def chat_completion(
         self, payload: Dict[str, Any], stream: bool = False
     ) -> Dict[str, Any] | Iterable[Dict[str, Any]]:
-        url = f"{self.inference_url}/api/v1/chat/completions"
+        url = f"{self.inference_url}/chat/completions"
 
         if not stream:
             resp = self._client.post(url, json=payload)

--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -10,8 +10,8 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
 app = typer.Typer(
-    help="Run and manage Prime Inference\n\n"
-    "Use `prime env eval` for environment evals with Prime Inference."
+    help="Run and manage Prime Inference (in beta, requires prime inference permissions)\n\n"
+    "Use `prime env eval (beta)` for environment evals with Prime Inference."
 )
 console = Console()
 

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -120,8 +120,6 @@ class Config:
     def set_inference_url(self, value: str) -> None:
         """Set frontend URL in config file"""
         value = value.rstrip("/")
-        if value.endswith("/api/v1"):
-            value = value[:-7]
         self.config["inference_url"] = value
         self._save_config(self.config)
 

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -12,7 +12,7 @@ class ConfigModel(BaseModel):
     team_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
-    inference_url: str = "https://inference.pinference.ai"
+    inference_url: str = "https://api.pinference.ai/api/v1"
     ssh_key_path: str = str(Path.home() / ".ssh" / "id_rsa")
     current_environment: str = "production"
 
@@ -22,7 +22,7 @@ class ConfigModel(BaseModel):
 class Config:
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
     DEFAULT_FRONTEND_URL: str = "https://app.primeintellect.ai"
-    DEFAULT_INFERENCE_URL: str = "https://inference.pinference.ai"
+    DEFAULT_INFERENCE_URL: str = "https://api.pinference.ai/api/v1"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
     def __init__(self) -> None:
@@ -112,7 +112,9 @@ class Config:
     @property
     def inference_url(self) -> str:
         """Get inference URL from config"""
-        inference_url: str = self.config.get("inference_url", self.DEFAULT_INFERENCE_URL)
+        inference_url: str = self.config.get(
+            "inference_url", self.DEFAULT_INFERENCE_URL
+        ).rstrip("/")
         return inference_url
 
     def set_inference_url(self, value: str) -> None:


### PR DESCRIPTION
## Summary
- Updated inference domain from `inference.pinference.ai` to `api.pinference.ai/api/v1` (this is consistent with how inference domains are usually specified in other tools, not using upto /v1 would be inconsistent with nearly every other tool)
- Enhanced prime env eval parameter handling with explicit CLI options
- Improved InferenceClient API URL construction
- Added beta warnings and better user guidance

## Changes Made

### Domain Update
- Changed default inference URL from `https://inference.pinference.ai` to `https://api.pinference.ai/api/v1`
- Updated all API endpoints to use correct domain structure

### Enhanced vf-eval Integration
- Added explicit CLI options for all vf-eval parameters instead of relying on context args
- Parameters include: `--num-examples`, `--rollouts-per-example`, `--max-concurrent`, `--max-tokens`, `--temperature`, `--sampling-args`, etc.
- Better error handling and parameter validation
- Clearer help text and examples

### API Improvements
- Fixed InferenceClient URL construction to avoid double `/api/v1` paths
- Added optional `inference_url` parameter to InferenceClient constructor
- Better URL normalization and trailing slash handling

### User Experience
- Added beta warnings to inference commands
- Updated help text to indicate beta status and permission requirements
- Improved error messages and guidance

## Test Plan
- [x] All existing tests pass
- [x] No linting issues
- [x] URL construction works correctly with new domain
- [x] vf-eval parameter forwarding works as expected

This update ensures the CLI works with the correct inference domain while providing a better user experience for the eval command.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates inference base URL and endpoint construction, adds explicit vf-eval CLI options and API overrides, and marks inference commands as beta.
> 
> - **Inference configuration and client**
>   - Default `inference_url` changed to `https://api.pinference.ai/api/v1` (config and constants), with normalization of trailing slashes.
>   - `InferenceClient` now accepts optional `inference_url`; endpoint paths updated from `/api/v1/...` to `/...` to rely on base including `/v1`.
> - **`prime env eval` (vf-eval integration, beta)**
>   - Adds explicit CLI options: `--num-examples`, `--rollouts-per-example`, `--max-concurrent`, `--max-tokens`, `--temperature`, `--sampling-args`, `--env-args`, verbosity and saving flags, HF Hub options, API key/base overrides.
>   - Constructs vf-eval command with selected base URL (`-b`), model (`-m`), and forwarded options; supports `--api-key-var` or injects `PRIME_API_KEY`.
>   - Removes auto-appending of `/api/v1`; uses chosen base as-is.
> - **CLI UX**
>   - Help text updated to indicate Prime Inference features are in beta and may require permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d54e99073409fdee97cce4cab62a01c4d6636542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->