### PR TITLE
Auto-inject team ID header in prime env eval

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1749,6 +1749,10 @@ def eval_env(
     if hf_hub_dataset_name:
         cmd += ["-D", hf_hub_dataset_name]
 
+    # If a team is configured, pass it to vf-eval via header
+    if config.team_id:
+        cmd += ["--header", f"X-Prime-Team-ID: {config.team_id}"]
+
     # Execute; stream output directly
     try:
         result = subprocess.run(cmd, env=env)


### PR DESCRIPTION
## Summary
Automatically adds `--header "X-Prime-Team-ID: <team_id>"` to vf-eval commands when a team is configured via `PRIME_TEAM_ID` environment variable or config file.

## Changes
- When running `prime env eval`, if a team ID is configured, the CLI now automatically passes it to vf-eval via the `--header` flag
- This enables team-scoped inference API usage during evaluation runs

## Testing
Tested with real credentials:
```bash
PRIME_API_KEY=... PRIME_TEAM_ID="" \
  prime env eval llm-writing-detection -m qwen/qwen-2.5-72b-instruct -n 2 -r 1
```

Verified the command includes: `--header X-Prime-Team-ID:`

## Technical Details
- Location: `packages/prime/src/prime_cli/commands/env.py` lines 1752-1754
- Only adds the header if `config.team_id` is set
- Clean, minimal change on top of latest main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically adds `--header "X-Prime-Team-ID: <team_id>"` to `vf-eval` invocations in `prime env eval` when a team is configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5037ffa977cb9c87b93d77c370406489635eeff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->