### PR TITLE
Add pricing columns to inference models table

### DIFF
--- a/src/prime_cli/commands/inference.py
+++ b/src/prime_cli/commands/inference.py
@@ -25,6 +25,16 @@ def _fmt_created(val: str) -> str:
     except Exception:
         return val or ""
 
+def _fmt_price(x) -> str:
+    """Format USD per 1M tokens (mtok) for display."""
+    if x is None:
+        return ""
+    try:
+        f = float(x)
+        return f"${f:.6f}".rstrip("0").rstrip(".")
+    except Exception:
+        return str(x)
+
 
 @app.command("models")
 def list_models(
@@ -54,14 +64,25 @@ def list_models(
             console.print("[yellow]No models returned.[/yellow]")
             return
 
-        table = Table(title="Prime Inference Available Models")
+        table = Table(title="Prime Inference — Models")
         table.add_column("id", style="cyan")
         table.add_column("created", style="magenta")
+        table.add_column("input $/1M tok", style="green", justify="right")
+        table.add_column("output $/1M tok", style="green", justify="right")
 
         for m in models:
             mid = str(m.get("id", ""))
             created = _fmt_created(str(m.get("created", "")))
-            table.add_row(mid, created)
+            pricing = m.get("pricing") or {}
+            pin = pricing.get("input_usd_per_mtok")
+            pout = pricing.get("output_usd_per_mtok")
+
+            table.add_row(
+                mid,
+                created,
+                _fmt_price(pin),
+                _fmt_price(pout),
+            )
 
         console.print(table)
 


### PR DESCRIPTION
## Summary
Always show pricing information (input/output $ per 1M tokens) in the inference models table output. No opt-in flag required.

## Changes
- Add `_fmt_price()` helper function for clean decimal formatting  
- Add two new columns: "input $/1M tok" and "output $/1M tok" (right-justified, green style)
- Update table title to "Prime Inference — Models" 
- Extract pricing data from `model.pricing.{input,output}_usd_per_mtok` fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Prime Inference support: new API client, `prime inference models` with pricing columns, `prime env eval` (beta), and configurable `inference_url`.
> 
> - **Prime Inference**:
>   - **API Client**: Add `InferenceClient` with `list_models`, `retrieve_model`, and `chat_completion` (incl. streaming) and `InferenceAPIError`.
>   - **CLI**: New `prime inference models` command showing model list with pricing columns (`input $/1M tok`, `output $/1M tok`) and improved timestamps; table titled "Prime Inference — Models".
> - **Environments**:
>   - **Eval (beta)**: Add `prime env eval` to run vf-eval via Prime Inference; validates model, forwards sampling/env args, supports API key var, and custom base URL.
> - **Configuration**:
>   - Add `inference_url` (default `https://api.pinference.ai/api/v1`) with getters/setters, include in `view`, and new `prime config set-inference-url`.
> - **CLI Wiring**:
>   - Register `inference` command group in `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff777f6a84274e83337eb8c7ee40c0edec1a224c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->