### PR TITLE
Remove `prime sandbox status`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,11 +9,13 @@ The `sandbox_demo.py` script demonstrates both programmatic and CLI usage of the
 ### Running the Demo
 
 1. **Interactive Demo** (recommended for first-time users):
+
    ```bash
    python examples/sandbox_demo.py
    ```
 
 2. **Programmatic Demo Only**:
+
    ```bash
    python examples/sandbox_demo.py --programmatic
    ```
@@ -32,6 +34,7 @@ The `sandbox_demo.py` script demonstrates both programmatic and CLI usage of the
 ### What the Demo Shows
 
 **Programmatic Usage:**
+
 - Creating sandboxes with custom configurations
 - Listing and filtering sandboxes
 - Getting detailed sandbox information
@@ -41,6 +44,7 @@ The `sandbox_demo.py` script demonstrates both programmatic and CLI usage of the
 - Error handling
 
 **CLI Usage Examples:**
+
 - All available sandbox commands
 - Common parameter combinations
 - Environment variable handling
@@ -95,14 +99,12 @@ prime sandbox delete SANDBOX_ID
 
 # Get logs
 prime sandbox logs SANDBOX_ID
-
-# Update status from Kubernetes
-prime sandbox status SANDBOX_ID
 ```
 
 ## Error Handling
 
 Both programmatic and CLI usage include proper error handling for:
+
 - API authentication errors
 - Network connectivity issues
 - Invalid parameters

--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -362,11 +362,6 @@ class SandboxClient:
         logs_response = SandboxLogsResponse.model_validate(response)
         return logs_response.logs
 
-    def update_status(self, sandbox_id: str) -> Sandbox:
-        """Update sandbox status from Kubernetes"""
-        response = self.client.request("POST", f"/sandbox/{sandbox_id}/status")
-        return Sandbox.model_validate(response)
-
     def execute_command(
         self,
         sandbox_id: str,
@@ -622,11 +617,6 @@ class AsyncSandboxClient:
         response = await self.client.request("GET", f"/sandbox/{sandbox_id}/logs")
         logs_response = SandboxLogsResponse.model_validate(response)
         return logs_response.logs
-
-    async def update_status(self, sandbox_id: str) -> Sandbox:
-        """Update sandbox status from Kubernetes"""
-        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/status")
-        return Sandbox.model_validate(response)
 
     async def execute_command(
         self,

--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -527,28 +527,6 @@ def logs(sandbox_id: str) -> None:
 
 
 @app.command(no_args_is_help=True)
-def status(sandbox_id: str) -> None:
-    """Update and get the current status of a sandbox from Kubernetes"""
-    try:
-        base_client = APIClient()
-        sandbox_client = SandboxClient(base_client)
-
-        with console.status("[bold blue]Updating status from Kubernetes...", spinner="dots"):
-            sandbox = sandbox_client.update_status(sandbox_id)
-
-        console.print(f"[green]Status updated for sandbox {sandbox.id}[/green]")
-        console.print(f"Current status: [bold]{sandbox.status}[/bold]")
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
-        console.print_exception(show_locals=True)
-        raise typer.Exit(1)
-
-
-@app.command(no_args_is_help=True)
 def run(
     sandbox_id: str,
     command: List[str] = typer.Argument(..., help="Command to execute"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the sandbox status CLI command and the sync/async API update_status methods, and updates docs accordingly.
> 
> - **CLI**:
>   - Remove `prime sandbox status` command from `src/prime_cli/commands/sandbox.py`.
> - **API**:
>   - Remove `SandboxClient.update_status` and `AsyncSandboxClient.update_status` from `src/prime_cli/api/sandbox.py`.
> - **Docs**:
>   - Update `examples/README.md` to remove `prime sandbox status` from CLI reference and tidy formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f882890db62c8d54a4bea65319a91fb016e9f514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->