### PR TITLE
add timeout to `prime sandbox run`

### DIFF
--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -561,6 +561,12 @@ def run(
         "--env",
         help="Environment variables in KEY=VALUE format. Can be specified multiple times.",
     ),
+    timeout: Optional[int] = typer.Option(
+        None,
+        "-t",
+        "--timeout",
+        help="Request timeout in seconds (default 300)",
+    ),
 ) -> None:
     """Execute a command in a sandbox"""
     try:
@@ -586,13 +592,19 @@ def run(
         if env_vars:
             obfuscated_env = obfuscate_env_vars(env_vars)
             console.print(f"[bold blue]Environment:[/bold blue] {obfuscated_env}")
+        if timeout is not None:
+            console.print(f"[bold blue]Timeout:[/bold blue] {timeout}s")
 
         # Start timing
         start_time = time.perf_counter()
 
         with console.status("[bold blue]Running command...", spinner="dots"):
             result = sandbox_client.execute_command(
-                sandbox_id, command_str, working_dir, env_vars if env_vars else None
+                sandbox_id,
+                command_str,
+                working_dir=working_dir,
+                env=env_vars if env_vars else None,
+                timeout=timeout,
             )
 
         # End timing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional --timeout/-t (seconds) to `prime sandbox run`, display it when set, and pass `timeout` to `SandboxClient.execute_command`.
> 
> - **CLI (`src/prime_cli/commands/sandbox.py`)**:
>   - **Sandbox Run**:
>     - Add `--timeout`/`-t` option (seconds; default 300) to `prime sandbox run`.
>     - Print provided timeout in command pre-run summary.
>     - Update `SandboxClient.execute_command` call to use keyword args and pass `working_dir`, `env`, and new `timeout`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78b7cc2f31ab0c517704735442fe2a136bec8e83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->