### PR TITLE
fix: monkeypatch env var

### DIFF
--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -10,6 +10,9 @@ from typer.testing import CliRunner
 
 @pytest.fixture
 def mock_api_client(monkeypatch: pytest.MonkeyPatch) -> APIClient:
+    # Set the environment variable
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+
     # Get the absolute path to the test data file
     test_dir = os.path.dirname(os.path.abspath(__file__))
     data_file = os.path.join(test_dir, "data", "availability_response.json")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Monkeypatches PRIME_API_KEY to a dummy value in the availability test fixture to satisfy CLI auth expectations.
> 
> - **Tests**:
>   - In `tests/test_availability.py`, set env var `PRIME_API_KEY` via `monkeypatch.setenv` in the `mock_api_client` fixture to provide a dummy API key during CLI tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 797a53bf6d144340d47089588aaa957e2af76415. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->