### PR TITLE
Teams list, whoami, filter delete --all by user id

### DIFF
--- a/src/prime_cli/commands/config.py
+++ b/src/prime_cli/commands/config.py
@@ -43,6 +43,13 @@ def view() -> None:
         team_label += " (from env var)"
     table.add_row("Team ID", team_label)
 
+    # Show User ID
+    user_id = settings.get("user_id")
+    user_label = user_id or "Not set"
+    if user_id and _env_set("PRIME_USER_ID"):
+        user_label += " (from env var)"
+    table.add_row("User ID", user_label)
+
     # Show base URL
     base_label = settings["base_url"]
     if _env_set("PRIME_API_BASE_URL", "PRIME_BASE_URL"):
@@ -130,6 +137,37 @@ def remove_team_id() -> None:
     config = Config()
     config.set_team_id(None)
     console.print("[green]Team ID removed. Using personal account.[/green]")
+
+
+@app.command()
+def set_user_id(
+    user_id: Optional[str] = typer.Argument(
+        None,
+        help="Your Prime Intellect user ID. Leave empty to clear.",
+    ),
+) -> None:
+    """Set your user ID for scoping operations (e.g., sandbox delete)."""
+    if user_id is None:
+        # Interactive mode with prompt
+        user_id = typer.prompt(
+            "Enter your Prime Intellect user ID (leave empty to clear)",
+            default="",
+        )
+
+    config = Config()
+    config.set_user_id(user_id)
+    if user_id:
+        console.print(f"[green]User ID '{user_id}' configured successfully![/green]")
+    else:
+        console.print("[green]User ID cleared.[/green]")
+
+
+@app.command()
+def remove_user_id() -> None:
+    """Remove user ID from config"""
+    config = Config()
+    config.set_user_id(None)
+    console.print("[green]User ID removed.[/green]")
 
 
 @app.command()

--- a/src/prime_cli/commands/sandbox.py
+++ b/src/prime_cli/commands/sandbox.py
@@ -388,10 +388,15 @@ def delete(
                         break
                     page += 1
 
-                # Filter out already terminated sandboxes
-                active_sandboxes = [
-                    s for s in all_sandboxes if s.status not in {"TERMINATED", "TIMEOUT"}
-                ]
+                # Filter to current user if configured, and exclude already terminated sandboxes
+                current_user_id = config.user_id
+                active_sandboxes = []
+                for s in all_sandboxes:
+                    if s.status in {"TERMINATED", "TIMEOUT"}:
+                        continue
+                    if current_user_id and s.user_id and s.user_id != current_user_id:
+                        continue
+                    active_sandboxes.append(s)
                 sandbox_ids = [s.id for s in active_sandboxes]
 
                 if not sandbox_ids:

--- a/src/prime_cli/commands/teams.py
+++ b/src/prime_cli/commands/teams.py
@@ -1,0 +1,53 @@
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..api.client import APIClient, APIError
+from ..utils import output_data_as_json, validate_output_format
+
+app = typer.Typer(help="List your teams", no_args_is_help=True)
+console = Console()
+
+
+@app.command(name="list")
+def list_teams(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List teams for the current user."""
+    validate_output_format(output, console)
+
+    try:
+        client = APIClient()
+        response = client.get("/user/teams")
+        data = response.get("data") if isinstance(response, dict) else []
+
+        if output == "json":
+            teams = data if isinstance(data, list) else []
+            output_data_as_json({"teams": teams, "total_count": len(teams)}, console)
+            return
+
+        teams = data if isinstance(data, list) else []
+        table = Table(title=f"Teams (Total: {len(teams)})", show_lines=True)
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Name", style="blue")
+        table.add_column("Slug", style="green")
+        table.add_column("Role", style="yellow")
+        table.add_column("Created", style="magenta")
+
+        for t in teams:
+            table.add_row(
+                str(t["teamId"]),
+                t["name"],
+                t["slug"],
+                t["role"],
+                str(t["createdAt"]),
+            )
+
+        console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)

--- a/src/prime_cli/commands/whoami.py
+++ b/src/prime_cli/commands/whoami.py
@@ -1,0 +1,49 @@
+from typing import Any, Dict
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..api.client import APIClient, APIError
+from ..config import Config
+
+app = typer.Typer(help="Show current authenticated user and update config", no_args_is_help=False)
+console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def whoami() -> None:
+    """Fetch identity from the API and set user_id in config."""
+    try:
+        client = APIClient()
+        response: Dict[str, Any] = client.get("/user/whoami")
+        data = response.get("data") if isinstance(response, dict) else None
+        if not isinstance(data, dict):
+            console.print("[red]Unexpected response from whoami endpoint[/red]")
+            raise typer.Exit(1)
+
+        user_id = data.get("id")
+        email = data.get("email")
+        name = data.get("name")
+
+        # Update config
+        config = Config()
+        if user_id:
+            config.set_user_id(user_id)
+            config.update_current_environment_file()
+
+        # Display table
+        table = Table(title="Current User")
+        table.add_column("Field", style="cyan")
+        table.add_column("Value", style="green")
+        table.add_row("User ID", user_id or "Unknown")
+        table.add_row("Name", name or "Unknown")
+        table.add_row("Email", email or "Unknown")
+        console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)

--- a/src/prime_cli/config.py
+++ b/src/prime_cli/config.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict
 class ConfigModel(BaseModel):
     api_key: str = ""
     team_id: str | None = None
+    user_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
     inference_url: str = "https://api.pinference.ai/api/v1"
@@ -46,6 +47,7 @@ class Config:
                 ConfigModel(
                     api_key="",
                     team_id=None,
+                    user_id=None,
                     base_url=self.DEFAULT_BASE_URL,
                     frontend_url=self.DEFAULT_FRONTEND_URL,
                     inference_url=self.DEFAULT_INFERENCE_URL,
@@ -88,6 +90,19 @@ class Config:
     def set_team_id(self, value: str | None) -> None:
         """Set team ID in config file"""
         self.config["team_id"] = value if value else None
+        self._save_config(self.config)
+
+    @property
+    def user_id(self) -> Optional[str]:
+        """Get user ID with precedence: env > file > None."""
+        user_id = os.getenv("PRIME_USER_ID")
+        if user_id is not None:
+            return user_id
+        return self.config.get("user_id") or None
+
+    def set_user_id(self, value: str | None) -> None:
+        """Set user ID in config file"""
+        self.config["user_id"] = value if value else None
         self._save_config(self.config)
 
     @property
@@ -174,6 +189,7 @@ class Config:
         return {
             "api_key": self.api_key,
             "team_id": self.team_id,
+            "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
             "inference_url": self.inference_url,
@@ -191,6 +207,7 @@ class Config:
         env_config = {
             "api_key": self.api_key,
             "team_id": self.team_id,
+            "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
             "inference_url": self.inference_url,
@@ -221,6 +238,8 @@ class Config:
                     self.set_api_key(env_config["api_key"])
                 # Set team_id from environment, defaulting to empty string
                 self.set_team_id(env_config.get("team_id", None))
+                # Set user_id from environment
+                self.set_user_id(env_config.get("user_id", None))
                 self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
                 self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
                 self.set_inference_url(env_config.get("inference_url", self.DEFAULT_INFERENCE_URL))
@@ -242,6 +261,7 @@ class Config:
                     env_config = {
                         "api_key": self.api_key,
                         "team_id": self.team_id,
+                        "user_id": self.user_id,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,
                         "inference_url": self.inference_url,

--- a/src/prime_cli/main.py
+++ b/src/prime_cli/main.py
@@ -9,6 +9,8 @@ from .commands.inference import app as inference_app
 from .commands.login import app as login_app
 from .commands.pods import app as pods_app
 from .commands.sandbox import app as sandbox_app
+from .commands.teams import app as teams_app
+from .commands.whoami import app as whoami_app
 
 __version__ = version("prime")
 
@@ -21,6 +23,8 @@ app.add_typer(sandbox_app, name="sandbox")
 app.add_typer(login_app, name="login")
 app.add_typer(env_app, name="env")
 app.add_typer(inference_app, name="inference")
+app.add_typer(whoami_app, name="whoami")
+app.add_typer(teams_app, name="teams")
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add whoami and teams listing commands, persist user_id in config (auto-set on login/set-api-key), and filter `sandbox delete --all` by current user when available.
> 
> - **CLI Commands**:
>   - `whoami`: Fetches `/user/whoami`, displays user info, and saves `user_id` to config.
>   - `teams list`: Lists teams for the current user (table/json).
> - **Config**:
>   - Add `user_id` to `ConfigModel`; getters/setters and env precedence (`PRIME_USER_ID`).
>   - Include `user_id` in `view`, environment save/load/update.
>   - `config view`: display `User ID`.
>   - `config set-api-key`: after setting key, call `/user/whoami` to store `user_id`.
> - **Login**:
>   - After successful auth, call `/user/whoami` to persist `user_id`; improve messages.
> - **Sandbox**:
>   - `sandbox delete --all`: filter to non-terminated sandboxes and, if configured, only those matching current `user_id`.
> - **App Wiring**:
>   - Register new subcommands `whoami` and `teams` in `main.py`.```
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07a7f5a58bc6b7543401474d77b3c3d3852ce341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->