### PR TITLE
default start command for sdk

### DIFF
--- a/src/prime_cli/api/sandbox.py
+++ b/src/prime_cli/api/sandbox.py
@@ -98,7 +98,7 @@ class CreateSandboxRequest(BaseModel):
 
     name: str
     docker_image: str
-    start_command: Optional[str] = None
+    start_command: Optional[str] = "tail -f /dev/null"
     cpu_cores: int = 1
     memory_gb: int = 2
     disk_size_gb: int = 5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets a default `start_command` of `"tail -f /dev/null"` in `CreateSandboxRequest` to keep sandboxes running by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f82789794d3ae7c3ffd446e3a1f44438a21b22bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->