### PR TITLE
build multiple python versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       contents: write
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_created: ${{ steps.release_status.outputs.created }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -103,6 +106,13 @@ jobs:
           source .venv/bin/activate
           python -m build
 
+      - name: Upload build artifacts
+        if: steps.check_tag.outputs.exists != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
       # Create GitHub Release
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists != 'true'
@@ -122,25 +132,63 @@ jobs:
           source .venv/bin/activate
           twine upload dist/*
 
-      # Publish Docker image with the newly released CLI
+      - name: Set release status
+        id: release_status
+        run: |
+          if [ "${{ steps.check_tag.outputs.exists }}" = "true" ]; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  docker-images:
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
       - name: Log in to GitHub Container Registry
-        if: steps.check_tag.outputs.exists != 'true'
         env:
           CR_PAT: ${{ github.token }}
         run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
-        if: steps.check_tag.outputs.exists != 'true'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.tag-and-release.outputs.version }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
           REPOSITORY: ${{ github.repository }}
         run: |
           IMAGE_PATH=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/$IMAGE_PATH"
+          PY_TAG="py${PYTHON_VERSION}"
           docker build --build-arg PRIME_VERSION="$VERSION" \
-            -t "$IMAGE:$VERSION" \
-            -t "$IMAGE:v$VERSION" \
-            -t "$IMAGE:latest" .
-          docker push "$IMAGE:$VERSION"
-          docker push "$IMAGE:v$VERSION"
-          docker push "$IMAGE:latest"
+            --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
+            -t "$IMAGE:$VERSION-$PY_TAG" \
+            -t "$IMAGE:v$VERSION-$PY_TAG" \
+            -t "$IMAGE:$PY_TAG" .
+          docker push "$IMAGE:$VERSION-$PY_TAG"
+          docker push "$IMAGE:v$VERSION-$PY_TAG"
+          docker push "$IMAGE:$PY_TAG"
+          if [ "$PYTHON_VERSION" = "3.11" ]; then
+            docker tag "$IMAGE:$VERSION-$PY_TAG" "$IMAGE:$VERSION"
+            docker tag "$IMAGE:$VERSION-$PY_TAG" "$IMAGE:v$VERSION"
+            docker tag "$IMAGE:$VERSION-$PY_TAG" "$IMAGE:latest"
+            docker push "$IMAGE:$VERSION"
+            docker push "$IMAGE:v$VERSION"
+            docker push "$IMAGE:latest"
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # This image packages the released Prime CLI together with uv so it can be used in
 # automation scenarios.
 
-FROM python:3.11-slim AS runtime
+ARG PYTHON_VERSION=3.11
+
+FROM python:${PYTHON_VERSION}-slim AS runtime
 
 ARG PRIME_VERSION
 ENV PRIME_VERSION=${PRIME_VERSION}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Build/publish Docker images for Python 3.10–3.12 via a new matrix job using a parameterized Dockerfile, with artifact sharing and workflow outputs/conditions added.
> 
> - **CI/Release Workflow (`.github/workflows/release.yml`)**:
>   - Add job outputs `version` and `release_created`; introduce `Set release status` to control downstream jobs.
>   - Upload build artifacts (`dist/*`); new `docker-images` job runs only when a release is created.
>   - Split Docker build/publish into a matrix across Python versions `3.10`, `3.11`, `3.12`:
>     - Download `dist` artifact and use `needs.tag-and-release.outputs.version` for tagging.
>     - Tag images with version- and Python-specific tags (e.g., `:$VERSION-py3.10`, `:v$VERSION-py3.10`, `:py3.10`).
>     - For Python 3.11, also tag/push `:$VERSION`, `:v$VERSION`, and `:latest`.
> - **Dockerfile**:
>   - Parameterize base image via `ARG PYTHON_VERSION` (default 3.11) and use `python:${PYTHON_VERSION}-slim`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 065786cd495934b921d878728d6f1acea661c9eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->