### PR TITLE
Adding `-h` as a help shortcut

### DIFF
--- a/src/prime_cli/main.py
+++ b/src/prime_cli/main.py
@@ -14,7 +14,12 @@ from .commands.whoami import app as whoami_app
 
 __version__ = version("prime")
 
-app = typer.Typer(name="prime", help=f"Prime Intellect CLI (v{__version__})", no_args_is_help=True)
+app = typer.Typer(
+    name="prime",
+    help=f"Prime Intellect CLI (v{__version__})",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 app.add_typer(availability_app, name="availability")
 app.add_typer(config_app, name="config")


### PR DESCRIPTION
small PR to configure `-h` as a global help shortcut

tested locally:
<img width="895" height="179" alt="Screenshot 2025-10-07 at 10 03 25 PM" src="https://github.com/user-attachments/assets/bcdd4f8c-266d-46d9-a67c-cfe0439be871" />
<img width="763" height="197" alt="Screenshot 2025-10-07 at 10 03 40 PM" src="https://github.com/user-attachments/assets/fc912e8b-144a-4be5-b262-2f68631e5048" />

resolves https://github.com/PrimeIntellect-ai/prime-cli/issues/137