### PR TITLE
Tweaked wording for `prime env init` logs

### DIFF
--- a/src/prime_cli/commands/env.py
+++ b/src/prime_cli/commands/env.py
@@ -621,7 +621,8 @@ def init(
         console.print(f"[green]✓ Created environment template in {created_path}/[/green]")
         console.print("\nNext steps:")
         console.print(f"  cd {created_path}")
-        console.print("  # Edit the environment file to implement your verifier")
+        filename = f"{name}.py".replace("-", "_")
+        console.print(f"  # Edit the {filename} file to implement your environment")
         console.print("  prime env push")
 
     except FileNotFoundError as e:
@@ -1608,8 +1609,7 @@ def eval_env(
     else:
         if not inference_base_url:
             console.print(
-                "[red]Inference URL not configured.[/red] "
-                "Check [bold]prime config view[/bold]."
+                "[red]Inference URL not configured.[/red] Check [bold]prime config view[/bold]."
             )
             raise typer.Exit(1)
         chosen_base = inference_base_url.rstrip("/")


### PR DESCRIPTION
Minor nitpick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies env init next steps by showing the exact Python filename and streamlines the inference URL missing error message.
> 
> - **CLI messages**:
>   - `prime env init`: Next steps now show the exact file to edit (`{name}.py` with dashes replaced by underscores) and refer to it as an environment file.
>   - `prime env eval`: Consolidates the "Inference URL not configured" error into a single concise line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c71b133ec9a2a3bf1285a575c9ba0e4db29889d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->