### PR TITLE
bump verifiers version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "rich>=13.3.1",  
     "pydantic>=2.0.0",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.4",
+    "verifiers>=0.1.5",
     "build>=1.0.0",
     "toml>=0.10.0"
 ]


### PR DESCRIPTION
v0.1.4 -> v0.1.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `verifiers` dependency from `0.1.4` to `0.1.5` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6e39003f6848ad69789f51dea84ba736bb04c68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->