### PR TITLE
source inclusion in build

### DIFF
--- a/packages/prime-sandboxes/build_for_pypi.sh
+++ b/packages/prime-sandboxes/build_for_pypi.sh
@@ -1,26 +1,21 @@
 #!/bin/bash
-# Build script for creating PyPI-ready wheels
-# This script bundles prime-core code and removes it from dependencies
-
 set -e
 
-echo "🔨 Building prime-sandboxes for PyPI..."
+echo "Building prime-sandboxes for PyPI..."
 
-# Store original pyproject.toml
 cp pyproject.toml pyproject.toml.backup
 
-# Remove prime-core from dependencies using sed
-# This creates a version without the workspace dependency
+echo "Copying prime-core into source tree..."
+cp -r ../prime-core/src/prime_core src/prime_core
+
 sed '/prime-core/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-
-# Remove the workspace source declaration
 sed '/\[tool\.uv\.sources\]/,/prime-core = { workspace = true }/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
-echo "📦 Building wheel (prime-core code will be bundled via force-include)..."
-uv build
+echo "Building wheel..."
+uv build --wheel
 
-# Restore original pyproject.toml
+rm -rf src/prime_core
 mv pyproject.toml.backup pyproject.toml
 
-echo "✅ Build complete! Wheel in dist/ includes bundled prime-core code"
-echo "   Users installing from PyPI will get a self-contained package"
+echo "Build complete!"

--- a/packages/prime-sandboxes/build_for_pypi.sh
+++ b/packages/prime-sandboxes/build_for_pypi.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+    rm -rf src/prime_core
+    if [ -f pyproject.toml.backup ]; then
+        mv pyproject.toml.backup pyproject.toml
+    fi
+}
+
+trap cleanup EXIT
+
 echo "Building prime-sandboxes for PyPI..."
 
 cp pyproject.toml pyproject.toml.backup
 
 echo "Copying prime-core into source tree..."
+rm -rf src/prime_core
 cp -r ../prime-core/src/prime_core src/prime_core
 
 sed '/prime-core/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
@@ -14,8 +24,5 @@ sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproj
 
 echo "Building wheel..."
 uv build --wheel
-
-rm -rf src/prime_core
-mv pyproject.toml.backup pyproject.toml
 
 echo "Build complete!"

--- a/packages/prime/build_for_pypi.sh
+++ b/packages/prime/build_for_pypi.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+    rm -rf src/prime_core
+    if [ -f pyproject.toml.backup ]; then
+        mv pyproject.toml.backup pyproject.toml
+    fi
+}
+
+trap cleanup EXIT
+
 echo "Building prime for PyPI..."
 
 cp pyproject.toml pyproject.toml.backup
 
 echo "Copying prime-core into source tree..."
+rm -rf src/prime_core
 cp -r ../prime-core/src/prime_core src/prime_core
 
 sed '/^    "prime-core",/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
@@ -14,8 +24,5 @@ sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproj
 
 echo "Building wheel..."
 uv build --wheel
-
-rm -rf src/prime_core
-mv pyproject.toml.backup pyproject.toml
 
 echo "Build complete!"

--- a/packages/prime/build_for_pypi.sh
+++ b/packages/prime/build_for_pypi.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
-# Build script for creating PyPI-ready wheels
-# This script bundles prime-core code and removes it from dependencies
-
 set -e
 
-echo "🔨 Building prime for PyPI..."
+echo "Building prime for PyPI..."
 
-# Store original pyproject.toml
 cp pyproject.toml pyproject.toml.backup
 
-# Remove prime-core from dependencies (keep prime-sandboxes as-is)
+echo "Copying prime-core into source tree..."
+cp -r ../prime-core/src/prime_core src/prime_core
+
 sed '/^    "prime-core",/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-
-# Remove the entire [tool.uv.sources] section (not needed for build, causes issues)
 sed '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
-echo "📦 Building wheel (prime-core code will be bundled via force-include)..."
-uv build
+echo "Building wheel..."
+uv build --wheel
 
-# Restore original pyproject.toml
+rm -rf src/prime_core
 mv pyproject.toml.backup pyproject.toml
 
-echo "✅ Build complete! Wheel in dist/ includes bundled prime-core code"
-echo "   Users installing from PyPI will get:"
-echo "   - prime (with bundled prime-core)"
-echo "   - prime-sandboxes from PyPI (as dependency)"
+echo "Build complete!"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates build scripts to copy `prime-core` into `src/prime_core`, adjust `pyproject.toml`, add cleanup trap, and build wheels with `uv build --wheel`.
> 
> - **Build scripts**:
>   - `packages/prime/build_for_pypi.sh` and `packages/prime-sandboxes/build_for_pypi.sh`:
>     - Bundle `prime-core` by copying `../prime-core/src/prime_core` into `src/prime_core`.
>     - Modify `pyproject.toml` to remove `prime-core` dependency and workspace source; rewrite force-include path to `"src/prime_core"`.
>     - Add `cleanup` function with `trap EXIT` to remove `src/prime_core` and restore `pyproject.toml`.
>     - Switch to `uv build --wheel` and simplify output messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24432830c820f62f24c8f1e1049da491fd09607b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->