### PR TITLE
buildfix contd.

### DIFF
--- a/packages/prime-sandboxes/build_for_pypi.sh
+++ b/packages/prime-sandboxes/build_for_pypi.sh
@@ -23,6 +23,8 @@ sed '/\[tool\.uv\.sources\]/,/prime-core = { workspace = true }/d' pyproject.tom
 sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
 echo "Building wheel..."
-uv build --wheel
+uv build --wheel --out-dir dist
 
 echo "Build complete!"
+echo "Built files:"
+ls -la dist/

--- a/packages/prime/build_for_pypi.sh
+++ b/packages/prime/build_for_pypi.sh
@@ -23,6 +23,8 @@ sed '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv p
 sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
 echo "Building wheel..."
-uv build --wheel
+uv build --wheel --out-dir dist
 
 echo "Build complete!"
+echo "Built files:"
+ls -la dist/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Directs wheel builds to dist/ and lists built artifacts in both prime and prime-sandboxes build scripts.
> 
> - **Build scripts**:
>   - `packages/prime/build_for_pypi.sh` and `packages/prime-sandboxes/build_for_pypi.sh`:
>     - Output wheels to `dist/` via `uv build --wheel --out-dir dist`.
>     - Print built artifacts with `ls -la dist/` after build completes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b77cb0608931afac8704cae9baa72bdac28b2a52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->