### PR TITLE
[ENG-2045] Add job_id header to prime env eval command

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1750,25 +1750,21 @@ def eval_env(
     if hf_hub_dataset_name:
         cmd += ["-D", hf_hub_dataset_name]
 
-    # Generate session_id and job_id for end-to-end tracing
+    # Generate job_id for end-to-end tracing of eval runs
     eval_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    session_uuid = str(uuid.uuid4())[:8]
-    session_id = f"eval_{eval_timestamp}_{session_uuid}"
-
-    # Create job_id from environment, model, and timestamp for grouping related eval runs
+    job_uuid = str(uuid.uuid4())[:8]
     sanitized_env = environment.replace("-", "_").replace("/", "_")
     sanitized_model = model.replace("/", "_").replace("-", "_")
-    job_id = f"{sanitized_env}_{sanitized_model}_{eval_timestamp}"
+    job_id = f"{sanitized_env}_{sanitized_model}_{eval_timestamp}_{job_uuid}"
 
-    # Pass tracking headers to vf-eval
-    cmd += ["--header", f"X-PI-Session-Id: {session_id}"]
+    # Pass tracking header to vf-eval
     cmd += ["--header", f"X-PI-Job-Id: {job_id}"]
 
     # If a team is configured, pass it to vf-eval via header
     if config.team_id:
         cmd += ["--header", f"X-Prime-Team-ID: {config.team_id}"]
 
-    console.print(f"[dim]Eval tracking - session_id: {session_id}, job_id: {job_id}[/dim]")
+    console.print(f"[dim]Eval job_id: {job_id}[/dim]")
 
     # Execute; stream output directly
     try:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -1749,9 +1750,25 @@ def eval_env(
     if hf_hub_dataset_name:
         cmd += ["-D", hf_hub_dataset_name]
 
+    # Generate session_id and job_id for end-to-end tracing
+    eval_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    session_uuid = str(uuid.uuid4())[:8]
+    session_id = f"eval_{eval_timestamp}_{session_uuid}"
+
+    # Create job_id from environment, model, and timestamp for grouping related eval runs
+    sanitized_env = environment.replace("-", "_").replace("/", "_")
+    sanitized_model = model.replace("/", "_").replace("-", "_")
+    job_id = f"{sanitized_env}_{sanitized_model}_{eval_timestamp}"
+
+    # Pass tracking headers to vf-eval
+    cmd += ["--header", f"X-PI-Session-Id: {session_id}"]
+    cmd += ["--header", f"X-PI-Job-Id: {job_id}"]
+
     # If a team is configured, pass it to vf-eval via header
     if config.team_id:
         cmd += ["--header", f"X-Prime-Team-ID: {config.team_id}"]
+
+    console.print(f"[dim]Eval tracking - session_id: {session_id}, job_id: {job_id}[/dim]")
 
     # Execute; stream output directly
     try:


### PR DESCRIPTION
**Linear:** https://linear.app/primeintellect/issue/ENG-2045

## Summary
Generate and pass job_id header in the prime-cli env eval command to enable end-to-end tracing of evaluation runs.

## Implementation
- Generate unique job_id for each eval run from environment + model + timestamp + uuid
- Pass job_id as header to vf-eval via `--header` flag
- Display job_id to user for reference

## Benefits
- Each eval run gets a unique job_id for tracing
- All requests within an eval run share the same job_id
- job_id is automatically forwarded to inference API for log correlation
- Works seamlessly with pi-inference tracking (ENG-2044)

## Usage
```bash
prime env eval gsm8k -m meta-llama/llama-3.1-70b-instruct
# Output: Eval job_id: gsm8k_meta_llama_llama_3_1_70b_instruct_20251010_120000_abc12345
```

## Changes
- Add uuid import for job ID generation
- Generate unique job_id for each eval run
- Pass job_id as `--header` flag to vf-eval
- Display job_id to user

## Related
- pi-inference PR: https://github.com/PrimeIntellect-ai/pi-inference/pull/36
- pi-inference ticket: ENG-2044

## Test plan
- [x] Syntax validation
- [x] Manual testing with eval command
- [x] Verify job_id appears in inference API logs