### PR TITLE
simplify version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ uv run pytest packages/prime-sandboxes/tests
 
 All packages (prime-core, prime-sandboxes, prime) are installed in editable mode. Changes to code are immediately reflected.
 
+### Releasing
+
+This monorepo contains two independently versioned packages: `prime` (CLI + full SDK) and `prime-sandboxes` (lightweight SDK).
+
+Versions are single-sourced from each package's `__init__.py` file:
+- **prime**: `packages/prime/src/prime_cli/__init__.py`
+- **prime-sandboxes**: `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`
+
+#### To release a new version:
+
+1. Update the `__version__` string in the appropriate `__init__.py` file
+2. Commit and push the change
+
+Tagging and publishing to PyPI is handled automatically by CI.
+
+#### Version sync considerations:
+
+When releasing `prime`, consider whether `prime-sandboxes` should also be bumped, as `prime` depends on `prime-sandboxes`. The packages can be released independently or together depending on what changed.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "prime-sandboxes"
-version = "0.1.0"
+# Version is single-sourced from src/prime_sandboxes/__init__.py via Hatch
+dynamic = ["version"]
 description = "Prime Intellect Sandboxes SDK - Manage remote code execution environments"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -43,6 +44,9 @@ prime-core = { workspace = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/prime_sandboxes/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prime_sandboxes"]

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "prime"
-version = "0.4.2"
+# Version is single-sourced from src/prime_cli/__init__.py via Hatch
+dynamic = ["version"]
 description = "Prime Intellect CLI + SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -15,7 +15,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "APIClient",

--- a/uv.lock
+++ b/uv.lock
@@ -1550,7 +1550,6 @@ wheels = [
 
 [[package]]
 name = "prime"
-version = "0.4.2"
 source = { editable = "packages/prime" }
 dependencies = [
     { name = "build" },
@@ -1607,7 +1606,6 @@ requires-dist = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.1.0"
 source = { editable = "packages/prime-sandboxes" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch to Hatch-based single-sourced versions for `prime` and `prime-sandboxes`, bump `prime` to 0.4.3, and document the release process.
> 
> - **Versioning**:
>   - Switch `packages/prime/pyproject.toml` and `packages/prime-sandboxes/pyproject.toml` to Hatch dynamic `version` (single-sourced from `src/prime_cli/__init__.py` and `src/prime_sandboxes/__init__.py`).
>   - Add `[tool.hatch.version]` with `path` in `packages/prime-sandboxes/pyproject.toml`.
>   - Bump `__version__` in `packages/prime/src/prime_cli/__init__.py` to `0.4.3`.
> - **Docs**:
>   - Add README “Releasing” section detailing version sources, release steps, and CI-based tagging/publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ea283f8a30d89d33f248ff6649559a1b4d536ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->