### PR TITLE
Fix: pre-commit for local dev

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -47,8 +47,7 @@ dev = [
     "pytest>=7.0.0",
     "ruff>=0.13.1",
     "ty>=0.0.0a6",
-    "types-toml>=0.10.0",
-    "pre-commit>=3.5.0"
+    "types-toml>=0.10.0"
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ dev-dependencies = [
     "pytest>=7.0.0",
     "ruff>=0.13.1",
     "ty>=0.0.1a21",
+    "pre-commit>=3.5.0"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
 
 [manifest.dependency-groups]
 dev = [
+    { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.13.1" },
     { name = "ty", specifier = ">=0.0.1a21" },
@@ -1564,7 +1565,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -1575,7 +1575,6 @@ dev = [
 requires-dist = [
     { name = "build", specifier = ">=1.0.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "prime-core", editable = "packages/prime-core" },
     { name = "prime-sandboxes", editable = "packages/prime-sandboxes" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
when starting a fresh virtualenv, `pre-commit` won't actually get installed after running `uv sync` since it's not in the the root `pyproject.toml`:

```bash
prime-cli ❯ git commit -m "test commit"
/Users/minh/repos/eexwhyzee/prime-cli/.venv/bin/python3: No module named pre_commit
```

so this PR just moves (i don't think it actually still needs to be in the `packages/prime/pyproject.toml` anymore) the `pre-commit` dependency into the root `pyproject.toml` to make sure it gets installed when you run `uv sync` per the README instructions for local development


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `pre-commit` from `packages/prime` dev extras to root `pyproject.toml` dev-dependencies and updates `uv.lock` accordingly.
> 
> - **Workspace / Tooling**:
>   - Add `pre-commit>=3.5.0` to root `pyproject.toml` under `tool.uv.dev-dependencies`.
> - **Package (`packages/prime`)**:
>   - Remove `pre-commit` from `project.optional-dependencies.dev`.
> - **Lockfile (`uv.lock`)**:
>   - Add `pre-commit` to `[manifest.dependency-groups.dev]`.
>   - Remove `pre-commit` entries from `[package.optional-dependencies]` and `[package.metadata.requires-dist]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e49ad3e538582617c085dadd79532904303e15d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->