### PR TITLE
show token permissions in whoami view

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -5,10 +5,11 @@ import time
 from typing import Any, Dict, List, Optional
 
 import typer
-from prime_core import APIError, Config
 from prime_sandboxes import (
     APIClient,
+    APIError,
     BulkDeleteSandboxResponse,
+    Config,
     CreateSandboxRequest,
     Sandbox,
     SandboxClient,

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -23,6 +23,7 @@ def whoami() -> None:
         user_id = data.get("id")
         email = data.get("email")
         name = data.get("name")
+        scope = data.get("scope", {})
 
         # Update config
         config = Config()
@@ -30,7 +31,7 @@ def whoami() -> None:
             config.set_user_id(user_id)
             config.update_current_environment_file()
 
-        # Display table
+        # Display user info table
         table = Table(title="Current User")
         table.add_column("Field", style="cyan")
         table.add_column("Value", style="green")
@@ -38,6 +39,24 @@ def whoami() -> None:
         table.add_row("Name", name or "Unknown")
         table.add_row("Email", email or "Unknown")
         console.print(table)
+
+        # Display permissions table
+        if scope:
+            console.print()
+            perms_table = Table(title="Token Permissions")
+            perms_table.add_column("Scope", style="cyan")
+            perms_table.add_column("Read", style="magenta", justify="center")
+            perms_table.add_column("Write", style="magenta", justify="center")
+
+            for scope_name, permissions in scope.items():
+                if permissions is None:
+                    perms_table.add_row(scope_name, "-", "-")
+                else:
+                    read_val = "✓" if permissions.get("read", False) else "✗"
+                    write_val = "✓" if permissions.get("write", False) else "✗"
+                    perms_table.add_row(scope_name, read_val, write_val)
+
+            console.print(perms_table)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Display token scope read/write permissions in whoami output and source APIError/Config from prime_sandboxes in sandbox commands.
> 
> - **CLI**:
>   - **whoami**:
>     - Parse `scope` from `/user/whoami` and render a "Token Permissions" table with read/write indicators.
>     - Retains existing user info display and config update.
>   - **sandbox**:
>     - Switch imports to use `APIError` and `Config` from `prime_sandboxes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c1dbb78f1d7b5ccbebeeafd7cd8b3bd87f39c14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->