### PR TITLE
Feature: support multiple environment installations with `prime env install`

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1189,6 +1189,9 @@ def install(
             console.print(f"[red]Error: {with_tool} is not installed.[/red]")
             raise typer.Exit(1)
 
+        # De-dup environment IDs just in case
+        env_ids = list(dict.fromkeys(env_ids))
+
         # Resolving and validating environments
         installable_envs = []
         failed_envs = []


### PR DESCRIPTION
resolves: https://github.com/PrimeIntellect-ai/prime-cli/issues/128

PR to add the ability to install multiple environments within a single `prime env install` command

## Testing
example outputs from testing locally:
- successful install of 3 environments
<img width="1045" height="609" alt="Screenshot 2025-10-20 at 9 43 15 PM" src="https://github.com/user-attachments/assets/d4031bc7-5f54-4271-b8b8-579b30cec4bb" />

- mix of a resolvable env, invalid format env, unresolvable env, and a private env
<img width="1151" height="372" alt="Screenshot 2025-10-20 at 9 45 10 PM" src="https://github.com/user-attachments/assets/4608c084-4270-4498-ae3c-72f85f92cfb1" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multi-environment support to `prime env install` with resolution/skip/fail summaries and shifts install errors to raise Exceptions for caller handling.
> 
> - **CLI — `prime env install`**:
>   - Accepts multiple `env_ids` and de-duplicates inputs; validates tool presence (`uv`/`pip`).
>   - Resolves each env (`owner/name[@version]`), categorizing into installable, skipped (invalid/private/no method), and failed (API/errors).
>   - Prefers simple index over wheel; generates per-env install commands; installs sequentially and prints per-env usage snippet.
>   - Outputs final summary sections for installed and failed environments.
> - **Install execution (`execute_install_command`)**:
>   - Simplifies subprocess handling and raises `Exception` on non-zero exit; caller handles and reports errors.
>   - Success output retained; removes internal Typer exits and generic catches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f845ce09b27b43f182eee2eb2a16cd8284509c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->