### PR TITLE
Feature: Add eval push to env hub.

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -32,13 +32,7 @@ class EvalsClient:
                 resolve_data["team_id"] = self.client.config.team_id
 
             response = self.client.post("/environmentshub/resolve", json=resolve_data)
-
-            if "data" in response:
-                resolve_response = response["data"]
-            else:
-                resolve_response = response
-
-            return resolve_response["id"]
+            return response["data"]["id"]
 
         except APIError as e:
             raise EvalsAPIError(
@@ -175,13 +169,7 @@ class AsyncEvalsClient:
                 resolve_data["team_id"] = self.client.config.team_id
 
             response = await self.client.post("/environmentshub/resolve", json=resolve_data)
-
-            if "data" in response:
-                resolve_response = response["data"]
-            else:
-                resolve_response = response
-
-            return resolve_response["id"]
+            return response["data"]["id"]
 
         except APIError as e:
             raise EvalsAPIError(

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -1,8 +1,10 @@
+import asyncio
+import re
 from typing import Any, Dict, List, Optional
 
-from prime_core import APIClient, AsyncAPIClient
+from prime_core import APIClient, APIError, AsyncAPIClient
 
-from .exceptions import InvalidEvaluationError
+from .exceptions import EvalsAPIError, InvalidEvaluationError
 
 
 class EvalsClient:
@@ -12,6 +14,37 @@ class EvalsClient:
 
     def __init__(self, api_client: APIClient) -> None:
         self.client = api_client
+
+    def _resolve_environment_id(self, env_name: str) -> str:
+        """
+        Resolve environment ID to owner/name format.
+
+        Raises:
+            EvalsAPIError: If the environment does not exist (404)
+        """
+        if re.match(r"^[^/]+/[^/]+$", env_name):
+            env_name = env_name.split("/", 1)[1]
+
+        try:
+            resolve_data: Dict[str, Any] = {"name": env_name, "visibility": "PUBLIC"}
+
+            if self.client.config.team_id:
+                resolve_data["team_id"] = self.client.config.team_id
+
+            response = self.client.post("/environmentshub/resolve", json=resolve_data)
+
+            if "data" in response:
+                resolve_response = response["data"]
+            else:
+                resolve_response = response
+
+            return resolve_response["id"]
+
+        except APIError as e:
+            raise EvalsAPIError(
+                f"Environment '{env_name}' does not exist in the hub. "
+                f"Please push the environment first with: prime env push {env_name}"
+            ) from e
 
     def create_evaluation(
         self,
@@ -32,7 +65,8 @@ class EvalsClient:
 
         Either run_id or environments must be provided.
         Environments should be a list of dicts with 'id' and optional 'version_id'.
-        Example: [{"id": "env-123", "version_id": "v1"}]
+
+        Example: [{"id": "simpleqa", "version_id": "v1"}]
 
         Raises:
             InvalidEvaluationError: If neither run_id nor environments is provided
@@ -43,9 +77,16 @@ class EvalsClient:
                 "For environment evals, provide environments=[{'id': 'env-id', 'version_id': 'v1'}]"
             )
 
+        resolved_environments = None
+        if environments:
+            resolved_environments = [
+                {**env, "id": self._resolve_environment_id(env["id"])} if "id" in env else env
+                for env in environments
+            ]
+
         payload = {
             "name": name,
-            "environments": environments,
+            "environments": resolved_environments,
             "suite_id": suite_id,
             "run_id": run_id,
             "model_name": model_name,
@@ -117,6 +158,37 @@ class AsyncEvalsClient:
     def __init__(self, api_key: Optional[str] = None) -> None:
         self.client = AsyncAPIClient(api_key=api_key)
 
+    async def _resolve_environment_id(self, env_name: str) -> str:
+        """
+        Resolve environment ID to owner/name format.
+
+        Raises:
+            EvalsAPIError: If the environment does not exist (404)
+        """
+        if re.match(r"^[^/]+/[^/]+$", env_name):
+            env_name = env_name.split("/", 1)[1]
+
+        try:
+            resolve_data: Dict[str, Any] = {"name": env_name, "visibility": "PUBLIC"}
+
+            if self.client.config.team_id:
+                resolve_data["team_id"] = self.client.config.team_id
+
+            response = await self.client.post("/environmentshub/resolve", json=resolve_data)
+
+            if "data" in response:
+                resolve_response = response["data"]
+            else:
+                resolve_response = response
+
+            return resolve_response["id"]
+
+        except APIError as e:
+            raise EvalsAPIError(
+                f"Environment '{env_name}' does not exist in the hub. "
+                f"Please push the environment first with: prime env push {env_name}"
+            ) from e
+
     async def create_evaluation(
         self,
         name: str,
@@ -136,7 +208,8 @@ class AsyncEvalsClient:
 
         Either run_id or environments must be provided.
         Environments should be a list of dicts with 'id' and optional 'version_id'.
-        Example: [{"id": "env-123", "version_id": "v1"}]
+
+        Example: [{"id": "simpleqa", "version_id": "v1"}]
 
         Raises:
             InvalidEvaluationError: If neither run_id nor environments is provided
@@ -147,9 +220,22 @@ class AsyncEvalsClient:
                 "For environment evals, provide environments=[{'id': 'env-id', 'version_id': 'v1'}]"
             )
 
+        resolved_environments = None
+        if environments:
+
+            async def resolve_env(env: Dict[str, str]) -> Dict[str, str]:
+                resolved_env = env.copy()
+                if "id" in resolved_env:
+                    resolved_env["id"] = await self._resolve_environment_id(resolved_env["id"])
+                return resolved_env
+
+            resolved_environments = await asyncio.gather(
+                *[resolve_env(env) for env in environments]
+            )
+
         payload = {
             "name": name,
-            "environments": environments,
+            "environments": resolved_environments,
             "suite_id": suite_id,
             "run_id": run_id,
             "model_name": model_name,

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -1,0 +1,143 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from prime_core import APIClient
+from prime_evals import EvalsAPIError, EvalsClient
+from rich.console import Console
+
+console = Console()
+
+
+def push_eval_results_to_hub(
+    env_name: str,
+    model: str,
+    job_id: str,
+) -> None:
+    """
+    Push evaluation results to Prime Evals Hub after vf-eval completes.
+
+    This function:
+    1. Locates the most recent vf-eval output directory
+    2. Reads and parses metadata.json and results.jsonl
+    3. Resolves environment ID (from metadata or by name)
+    4. Converts results to Prime Evals API format
+    5. Creates evaluation, pushes samples, and finalizes
+
+    Args:
+        environment: Environment name (e.g., "simpleqa")
+        model: Model identifier (e.g., "meta-llama/llama-3.1-70b-instruct")
+        job_id: Unique job ID for tracking
+    """
+    console.print("\n[blue]Pushing evaluation results to hub...[/blue]")
+
+    # Step 1: Find the output directory
+    env_name = env_name.replace("-", "_")
+    model_name = model.replace("/", "--")
+    env_model_str = f"{env_name}--{model_name}"
+
+    local_env_dir = Path("./environments") / env_name
+    if local_env_dir.exists():
+        base_evals_dir = local_env_dir / "outputs" / "evals" / env_model_str
+    else:
+        base_evals_dir = Path("./outputs") / "evals" / env_model_str
+
+    if not base_evals_dir.exists():
+        raise FileNotFoundError(f"Evaluation output directory not found: {base_evals_dir}")
+
+    subdirs = [d for d in base_evals_dir.iterdir() if d.is_dir()]
+    if not subdirs:
+        raise FileNotFoundError(f"No evaluation results found in {base_evals_dir}")
+
+    output_dir = max(subdirs, key=lambda d: d.stat().st_mtime)
+    console.print(f"[dim]Found results in: {output_dir}[/dim]")
+
+    metadata_path = output_dir / "metadata.json"
+    results_path = output_dir / "results.jsonl"
+
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"metadata.json not found in {output_dir}")
+    if not results_path.exists():
+        raise FileNotFoundError(f"results.jsonl not found in {output_dir}")
+
+    with open(metadata_path, encoding="utf-8") as f:
+        metadata = json.load(f)
+
+    results_samples = []
+    with open(results_path, encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                results_samples.append(json.loads(line))
+
+    console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
+
+    env_metadata_path = Path("./environments") / env_name / ".env-metadata.json"
+    resolved_env_slug = None
+
+    if env_metadata_path.exists():
+        try:
+            with open(env_metadata_path, encoding="utf-8") as f:
+                hub_metadata = json.load(f)
+                if hub_metadata.get("owner") and hub_metadata.get("name"):
+                    resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
+                    console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
+        except (json.JSONDecodeError, IOError, KeyError) as e:
+            console.print(f"[yellow]Warning: Could not load {env_metadata_path}: {e}[/yellow]")
+            console.print(f"[blue]Using environment name:[/blue] {env_name}")
+    else:
+        console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")
+
+    environments = [{"id": resolved_env_slug or env_name}]
+    metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
+
+    eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
+
+    converted_results = [
+        {
+            "example_id": sample.get("id", 0),
+            "reward": sample.get("reward", 0.0),
+            **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
+        }
+        for sample in results_samples
+    ]
+
+    eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+    api_client = APIClient()
+    evals_client = EvalsClient(api_client)
+
+    console.print("[blue]Creating evaluation...[/blue]")
+    create_response = evals_client.create_evaluation(
+        name=eval_name,
+        environments=environments,
+        model_name=model,
+        dataset=env_name,
+        framework="verifiers",
+        task_type=metadata.get("task_type"),
+        metadata=eval_metadata,
+        metrics=metrics,
+        tags=[],
+    )
+
+    eval_id = create_response.get("evaluation_id")
+    if not eval_id:
+        raise EvalsAPIError("Failed to get evaluation ID from create_evaluation response")
+
+    console.print(f"[green]✓ Created evaluation:[/green] {eval_id}")
+
+    if converted_results:
+        console.print(f"[blue]Pushing {len(converted_results)} samples...[/blue]")
+        evals_client.push_samples(eval_id, converted_results)
+        console.print("[green]✓ Samples pushed successfully[/green]")
+
+    console.print("[blue]Finalizing evaluation...[/blue]")
+    evals_client.finalize_evaluation(eval_id, metrics=metrics)
+    console.print("[green]✓ Evaluation finalized[/green]\n")
+
+    console.print("[green]✓ Successfully pushed to hub[/green]")
+
+    if resolved_env_slug:
+        frontend_url = api_client.config.frontend_url
+        eval_url = f"{frontend_url}/dashboard/environments/{resolved_env_slug}/evals/{eval_id}"
+        console.print(f"[blue]View evaluation:[/blue] {eval_url}")
+        console.print()


### PR DESCRIPTION
Closes ENG-2132

Adds support for `--push-to-hub` flag for Environment Hub

Example command:

`prime env eval gsm8k -m meta-llama/llama-3.1-70b-instruct -n 2 -r 1 --push-to-hub`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a --push-to-hub flag to `prime env eval` to upload vf-eval results to Prime Evals Hub, including environment ID resolution and async support in evals client.
> 
> - **CLI**:
>   - `packages/prime/src/prime_cli/commands/env.py`
>     - Add `--push-to-hub` (`-P`) to `prime env eval`; on success, pushes results via helper.
>     - Wire in `push_eval_results_to_hub(environment, model, job_id)` and handle errors.
> - **Utility**:
>   - `packages/prime/src/prime_cli/utils/eval_push.py` (new)
>     - Parse latest vf-eval outputs (`metadata.json`, `results.jsonl`), resolve environment, convert samples, create evaluation, push samples, and finalize via `EvalsClient`.
>     - Prints hub URL when available.
> - **SDK (prime-evals)**:
>   - `packages/prime-evals/src/prime_evals/evals.py`
>     - Add environment resolution via `/environmentshub/resolve`; raise `EvalsAPIError` on missing env.
>     - Resolve environment IDs in `create_evaluation` (sync/async; async uses `asyncio.gather`).
>     - Import `APIError`; expose new `EvalsAPIError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9985fd60edab8cdcb87000e610f63fb398b3d250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->