### PR TITLE
Release: Bump prime-evals package to v0.1.1

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -35,7 +35,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Core HTTP Client & Config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `__version__` in `packages/prime-evals/src/prime_evals/__init__.py` from `0.1.0` to `0.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24fa39e5fd509f317ed810169ea6f7ee2068d74a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->