### PR TITLE
Imp: Fix verifier path for prime env eval push

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -15,7 +15,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -71,7 +71,7 @@ def push_eval_results_to_hub(
 
     console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
 
-    env_metadata_path = Path("./environments") / env_name / ".env-metadata.json"
+    env_metadata_path = Path("./environments") / module_name / ".env-metadata.json"
     resolved_env_slug = None
 
     if env_metadata_path.exists():

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -32,11 +32,11 @@ def push_eval_results_to_hub(
     console.print("\n[blue]Pushing evaluation results to hub...[/blue]")
 
     # Step 1: Find the output directory
-    env_name = env_name.replace("-", "_")
+    module_name = env_name.replace("-", "_")
     model_name = model.replace("/", "--")
     env_model_str = f"{env_name}--{model_name}"
 
-    local_env_dir = Path("./environments") / env_name
+    local_env_dir = Path("./environments") / module_name
     if local_env_dir.exists():
         base_evals_dir = local_env_dir / "outputs" / "evals" / env_model_str
     else:
@@ -116,7 +116,6 @@ def push_eval_results_to_hub(
         task_type=metadata.get("task_type"),
         metadata=eval_metadata,
         metrics=metrics,
-        tags=[],
     )
 
     eval_id = create_response.get("evaluation_id")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Uses module-safe env names for local paths in eval push and removes the unused `tags` arg; bumps version to 0.4.7.
> 
> - **prime_cli/utils/eval_push.py**:
>   - Use module-safe `module_name = env_name.replace("-", "_")` for filesystem paths (`./environments/<module_name>`), updating `local_env_dir` and `.env-metadata.json` resolution.
>   - Keep `env_name` for dataset/env identifiers while fixing local path lookups.
>   - Remove `tags=[]` from `create_evaluation` call.
> - **prime_cli/__init__.py**:
>   - Bump `__version__` to `0.4.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbdd21313b49f5b0597748a9c55984ae51bff135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->