### PR TITLE
Imp: Bump prime-eval package version. Remove unused visibility flag.

### DIFF
--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-evals"
-version = "0.1.0"
+version = "0.1.1"
 description = "Prime Intellect Evals SDK - Push and manage evaluations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -26,7 +26,7 @@ class EvalsClient:
             env_name = env_name.split("/", 1)[1]
 
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name, "visibility": "PUBLIC"}
+            resolve_data: Dict[str, Any] = {"name": env_name}
 
             if self.client.config.team_id:
                 resolve_data["team_id"] = self.client.config.team_id
@@ -163,7 +163,7 @@ class AsyncEvalsClient:
             env_name = env_name.split("/", 1)[1]
 
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name, "visibility": "PUBLIC"}
+            resolve_data: Dict[str, Any] = {"name": env_name}
 
             if self.client.config.team_id:
                 resolve_data["team_id"] = self.client.config.team_id


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps prime-evals to 0.1.1 and removes the visibility field from environment resolution requests in both sync and async clients.
> 
> - **SDK (`packages/prime-evals`)**:
>   - **Environment resolve**: Drop `visibility` from resolve payload in `EvalsClient._resolve_environment_id` and `AsyncEvalsClient._resolve_environment_id` (`src/prime_evals/evals.py`).
>   - **Version**: Bump `project.version` to `0.1.1` (`pyproject.toml`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88c03064cd0aebde32556438dd3d34aacf5a50a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->