### PR TITLE
Release: Bump prime eval dependency

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 dependencies = [
     "prime-core",
     "prime-sandboxes>=0.1.0",
-    "prime-evals>=0.1.0",
+    "prime-evals>=0.1.1",
     "typer>=0.9.0",
     "rich>=13.3.1",
     "cryptography>=41.0.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -15,7 +15,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 
 __all__ = [
     "APIClient",

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-evals"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/prime-evals" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `prime-evals` dependency to 0.1.1 and updates the CLI package version to 0.4.8 (lockfile refreshed).
> 
> - **Versioning**:
>   - Update `__version__` in `packages/prime/src/prime_cli/__init__.py` from `0.4.7` to `0.4.8`.
> - **Dependencies**:
>   - Bump `prime-evals` in `packages/prime/pyproject.toml` from `>=0.1.0` to `>=0.1.1`.
>   - Refresh `uv.lock` to reflect `prime-evals` `0.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62d4ec29e4ad5f265f27aef52ccb13b59c066895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->