### PR TITLE
Imp: Require api key check on request, not on init for prime-cli

### DIFF
--- a/packages/prime-core/pyproject.toml
+++ b/packages/prime-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Prime Intellect Core - Shared HTTP client and configuration (internal package)"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/prime-core/src/prime_core/__init__.py
+++ b/packages/prime-core/src/prime_core/__init__.py
@@ -10,7 +10,7 @@ from .client import (
 )
 from .config import Config
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "APIClient",

--- a/packages/prime-core/src/prime_core/client.py
+++ b/packages/prime-core/src/prime_core/client.py
@@ -44,10 +44,9 @@ class APIClient:
 
         # Use provided API key or fall back to config
         self.api_key = api_key or self.config.api_key
-        if require_auth and not self.api_key:
-            raise APIError(
-                "No API key configured. Use command 'prime login' to configure your API key.",
-            )
+
+        # Store require_auth for lazy validation on request
+        self.require_auth = require_auth
 
         # Setup client
         self.base_url = self.config.base_url
@@ -61,6 +60,12 @@ class APIClient:
             timeout=httpx.Timeout(30.0, connect=10.0),
         )
 
+    def _check_auth_required(self) -> None:
+        if self.require_auth and not self.api_key:
+            raise APIError(
+                "No API key configured. Use command 'prime login' to configure your API key.",
+            )
+
     def request(
         self,
         method: str,
@@ -70,6 +75,8 @@ class APIClient:
         timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Make a request to the API"""
+        self._check_auth_required()
+
         # Ensure endpoint starts with /api/v1/
         if not endpoint.startswith("/"):
             endpoint = f"/api/v1/{endpoint}"
@@ -160,10 +167,9 @@ class AsyncAPIClient:
 
         # Use provided API key or fall back to config
         self.api_key = api_key or self.config.api_key
-        if require_auth and not self.api_key:
-            raise APIError(
-                "No API key configured. Use command 'prime login' to configure your API key.",
-            )
+
+        # Store require_auth for lazy validation on request
+        self.require_auth = require_auth
 
         # Setup client
         self.base_url = self.config.base_url
@@ -177,6 +183,12 @@ class AsyncAPIClient:
             timeout=httpx.Timeout(30.0, connect=10.0),
         )
 
+    def _check_auth_required(self) -> None:
+        if self.require_auth and not self.api_key:
+            raise APIError(
+                "No API key configured. Use command 'prime login' to configure your API key.",
+            )
+
     async def request(
         self,
         method: str,
@@ -186,6 +198,8 @@ class AsyncAPIClient:
         timeout: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Make an async request to the API"""
+        self._check_auth_required()
+
         # Ensure endpoint starts with /api/v1/
         if not endpoint.startswith("/"):
             endpoint = f"/api/v1/{endpoint}"


### PR DESCRIPTION
Closes ENG-2147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers API key checks to per-request for both sync and async clients and bumps version to 0.1.1.
> 
> - **Core Clients (`prime_core/client.py`)**:
>   - Defer API key validation to request time via `_check_auth_required()`; remove init-time check.
>   - Apply change to both `APIClient` and `AsyncAPIClient`; store `require_auth` for lazy validation.
> - **Versioning**:
>   - Bump package and `__version__` to `0.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05281b0191e3f5cefc9d526be45389ebe6ff5f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->