### PR TITLE
Release: Bump prime evals pacakge to 0.1.2.

### DIFF
--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-evals"
-version = "0.1.1"
+version = "0.1.2"
 description = "Prime Intellect Evals SDK - Push and manage evaluations"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-core",
+    "prime-core>=0.1.1",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
 ]

--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -35,7 +35,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-core",
+    "prime-core>=0.1.1",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
 ]

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-core>=0.1.1",
+    "prime-core",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps prime-evals to 0.1.2 and sets prime-core dependency to >=0.1.1.
> 
> - **Packaging**:
>   - Bump `prime-evals` version to `0.1.2` in `pyproject.toml` and `prime_evals/__init__.py`.
>   - Set dependency floor `prime-core>=0.1.1` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eddcabcfc4b04a676af0a47869df15a0f424627f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->