### PR TITLE
feat: add team ID validation to set-team-id command

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -10,8 +10,8 @@ from rich.table import Table
 app = typer.Typer(help="Configure the CLI", no_args_is_help=True)
 console = Console()
 
-# Team ID validation pattern: 25 alphanumeric characters
-TEAM_ID_PATTERN = re.compile(r"^[a-zA-Z0-9]{25}$")
+# Team ID validation pattern: CUID (v1)
+TEAM_ID_PATTERN = re.compile(r"^c[a-z0-9]{24}$")
 
 
 def validate_team_id(team_id: str) -> bool:
@@ -158,7 +158,8 @@ def set_team_id(
     if not validate_team_id(team_id):
         console.print(
             "[red]Error: Invalid team ID format. "
-            "Team ID must be exactly 25 alphanumeric characters.[/red]"
+            "Team ID must be a CUID v1 (start with 'c' followed by 24 lowercase "
+            "alphanumeric characters).[/red]"
         )
         raise typer.Exit(code=1)
 

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Optional
 
 import typer
@@ -8,6 +9,23 @@ from rich.table import Table
 
 app = typer.Typer(help="Configure the CLI", no_args_is_help=True)
 console = Console()
+
+# Team ID validation pattern: 25 alphanumeric characters
+TEAM_ID_PATTERN = re.compile(r"^[a-zA-Z0-9]{25}$")
+
+
+def validate_team_id(team_id: str) -> bool:
+    """Validate team ID format.
+    
+    Args:
+        team_id: The team ID to validate
+        
+    Returns:
+        True if valid, False otherwise
+    """
+    if not team_id:  # Empty string is valid (means personal account)
+        return True
+    return bool(TEAM_ID_PATTERN.match(team_id))
 
 
 @app.command()
@@ -135,6 +153,14 @@ def set_team_id(
             "Enter your Prime Intellect team ID (leave empty for personal account)",
             default="",
         )
+
+    # Validate team ID format
+    if not validate_team_id(team_id):
+        console.print(
+            "[red]Error: Invalid team ID format. "
+            "Team ID must be exactly 25 alphanumeric characters.[/red]"
+        )
+        raise typer.Exit(code=1)
 
     config = Config()
     config.set_team_id(team_id)

--- a/packages/prime/tests/test_config.py
+++ b/packages/prime/tests/test_config.py
@@ -9,15 +9,20 @@ class TestTeamIdValidation:
         valid_id = "cmf0ohr9s0026ilerf3w68s6n"
         assert validate_team_id(valid_id) is True
 
-    def test_valid_team_id_with_uppercase(self) -> None:
-        """Test that team IDs with uppercase letters are valid."""
-        valid_id = "CMF0OHR9S0026ILERF3W68S6N"
-        assert validate_team_id(valid_id) is True
+    def test_invalid_team_id_with_uppercase(self) -> None:
+        """Test that team IDs with uppercase letters are invalid (CUID v1 is lowercase only)."""
+        invalid_id = "CMF0OHR9S0026ILERF3W68S6N"
+        assert validate_team_id(invalid_id) is False
 
-    def test_valid_team_id_mixed_case(self) -> None:
-        """Test that team IDs with mixed case are valid."""
-        valid_id = "CmF0OhR9s0026IlErF3w68S6n"
-        assert validate_team_id(valid_id) is True
+    def test_invalid_team_id_mixed_case(self) -> None:
+        """Test that team IDs with mixed case are invalid (CUID v1 is lowercase only)."""
+        invalid_id = "CmF0OhR9s0026IlErF3w68S6n"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_not_starting_with_c(self) -> None:
+        """Test that team IDs not starting with 'c' are invalid (CUID v1 requirement)."""
+        invalid_id = "amf0ohr9s0026ilerf3w68s6n"
+        assert validate_team_id(invalid_id) is False
 
     def test_empty_string_is_valid(self) -> None:
         """Test that empty string is valid (personal account)."""

--- a/packages/prime/tests/test_config.py
+++ b/packages/prime/tests/test_config.py
@@ -1,0 +1,54 @@
+from prime_cli.commands.config import validate_team_id
+
+
+class TestTeamIdValidation:
+    """Test team ID validation logic."""
+
+    def test_valid_team_id(self) -> None:
+        """Test that valid team IDs pass validation."""
+        valid_id = "cmf0ohr9s0026ilerf3w68s6n"
+        assert validate_team_id(valid_id) is True
+
+    def test_valid_team_id_with_uppercase(self) -> None:
+        """Test that team IDs with uppercase letters are valid."""
+        valid_id = "CMF0OHR9S0026ILERF3W68S6N"
+        assert validate_team_id(valid_id) is True
+
+    def test_valid_team_id_mixed_case(self) -> None:
+        """Test that team IDs with mixed case are valid."""
+        valid_id = "CmF0OhR9s0026IlErF3w68S6n"
+        assert validate_team_id(valid_id) is True
+
+    def test_empty_string_is_valid(self) -> None:
+        """Test that empty string is valid (personal account)."""
+        assert validate_team_id("") is True
+
+    def test_invalid_team_id_too_short(self) -> None:
+        """Test that team IDs shorter than 25 characters are invalid."""
+        invalid_id = "cmf0ohr9s0026ilerf3w68s6"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_too_long(self) -> None:
+        """Test that team IDs longer than 25 characters are invalid."""
+        invalid_id = "cmf0ohr9s0026ilerf3w68s6nn"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_with_special_chars(self) -> None:
+        """Test that team IDs with special characters are invalid."""
+        invalid_id = "cmf0ohr9s0026ilerf3w68s-n"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_with_spaces(self) -> None:
+        """Test that team IDs with spaces are invalid."""
+        invalid_id = "cmf0ohr9s0026ilerf3w68s n"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_word(self) -> None:
+        """Test that regular words are invalid."""
+        invalid_id = "intertwine"
+        assert validate_team_id(invalid_id) is False
+
+    def test_invalid_team_id_with_underscore(self) -> None:
+        """Test that team IDs with underscores are invalid."""
+        invalid_id = "cmf0ohr9s0026ilerf3w68s_n"
+        assert validate_team_id(invalid_id) is False


### PR DESCRIPTION
# Add Team ID Validation to set-team-id Command

## Summary

Adds input validation to the `prime config set-team-id` command to ensure team IDs match the expected format before saving to configuration.

## Changes

### Implementation

- **Added validation function** (`validate_team_id()`) that checks team IDs match the pattern `^[a-zA-Z0-9]{25}$`
- **Updated `set_team_id` command** to validate input before persisting to config file
- **Clear error messaging** when invalid team ID format is provided
- **Preserves existing behavior** for empty strings (personal account mode)

### Testing

- **Created comprehensive test suite** (`test_config.py`) with 10 test cases covering:
  - Valid team IDs (lowercase, uppercase, mixed case)
  - Empty string handling (personal account)
  - Invalid formats (wrong length, special characters, spaces, etc.)
- **All tests passing** (12/12 including existing tests)

## Validation Rules

### ✅ Accepted Formats

- Exactly 25 alphanumeric characters (a-z, A-Z, 0-9)
- Example: `cmf0ohr9s0026testf3w68s5a`
- Empty string `""` (clears team ID for personal account)

### ❌ Rejected Formats

- Strings not exactly 25 characters long
- Strings containing special characters, spaces, or underscores
- Example: `intertest` (wrong length and format)

## Manual and Automated Testing

### Manual Testing

```bash
# Valid team ID - succeeds
uv run prime config set-team-id cmf0ohr9s0026testf3w68s5a
# Output: Team ID 'cmf0ohr9s0026testf3w68s5a' configured successfully!

# Invalid team ID - fails with clear error
uv run prime config set-team-id intertest
# Output: Error: Invalid team ID format. Team ID must be exactly 25 alphanumeric characters.

# Clear team ID - succeeds
uv run prime config set-team-id ""
# Output: Team ID cleared. Using personal account.
```

### Automated Tests

```bash
uv run pytest tests/test_config.py -v
# All 10 validation tests pass
```

## Files Changed

- `packages/prime/src/prime_cli/commands/config.py` - Added validation logic
- `packages/prime/tests/test_config.py` - New test file with comprehensive coverage

## Checklist

- [x] Code follows project style guidelines
- [x] Added comprehensive tests
- [x] All tests passing
- [x] Error messages are clear and helpful
- [x] Backward compatible (empty string still works)
- [x] No breaking changes to existing functionality


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CUID v1-based validation for team IDs in the CLI and introduces tests covering valid/invalid cases.
> 
> - **CLI**:
>   - Add `TEAM_ID_PATTERN` and `validate_team_id()` in `packages/prime/src/prime_cli/commands/config.py` to enforce CUID v1 format (`^c[a-z0-9]{24}$`), allowing empty string.
>   - Integrate validation into `set_team_id` with clear error messaging and non-zero exit on invalid input.
> - **Tests**:
>   - New `packages/prime/tests/test_config.py` validating accepted empty string and rejecting uppercase, mixed case, wrong prefix, wrong length, spaces, special chars, and underscores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d0a1dbd73d3fdb0943b0f7a238674e2c2f0982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->