### PR TITLE
Imp: Fix eval push env_id param. Add support for updating evals.

### DIFF
--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-evals"
-version = "0.1.2"
+version = "0.1.3"
 description = "Prime Intellect Evals SDK - Push and manage evaluations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -35,7 +35,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -117,15 +117,15 @@ class EvalsClient:
 
     def list_evaluations(
         self,
-        environment_id: Optional[str] = None,
+        env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
     ) -> Dict[str, Any]:
         """List evaluations with optional filters"""
         params: Dict[str, Any] = {"skip": skip, "limit": limit}
-        if environment_id:
-            params["environment_id"] = environment_id
+        if env_name:
+            params["environment_name"] = env_name
         if suite_id:
             params["suite_id"] = suite_id
 
@@ -157,11 +157,11 @@ class EvalsClient:
             "framework": framework,
             "task_type": task_type,
             "description": description,
-            "tags": tags,
+            "tags": tags if tags is not None else [],
             "metadata": metadata,
             "metrics": metrics,
         }
-        payload = {k: v for k, v in payload.items() if v is not None}
+        payload = {k: v for k, v in payload.items() if v is not None or k in ["tags"]}
 
         response = self.client.request("PUT", f"/evaluations/{evaluation_id}", json=payload)
         return response
@@ -331,11 +331,11 @@ class AsyncEvalsClient:
             "framework": framework,
             "task_type": task_type,
             "description": description,
-            "tags": tags,
+            "tags": tags if tags is not None else [],
             "metadata": metadata,
             "metrics": metrics,
         }
-        payload = {k: v for k, v in payload.items() if v is not None}
+        payload = {k: v for k, v in payload.items() if v is not None or k in ["tags"]}
 
         response = await self.client.request("PUT", f"/evaluations/{evaluation_id}", json=payload)
         return response

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -137,6 +137,35 @@ class EvalsClient:
         response = self.client.request("GET", f"/evaluations/{evaluation_id}")
         return response
 
+    def update_evaluation(
+        self,
+        evaluation_id: str,
+        name: Optional[str] = None,
+        model_name: Optional[str] = None,
+        dataset: Optional[str] = None,
+        framework: Optional[str] = None,
+        task_type: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "name": name,
+            "model_name": model_name,
+            "dataset": dataset,
+            "framework": framework,
+            "task_type": task_type,
+            "description": description,
+            "tags": tags,
+            "metadata": metadata,
+            "metrics": metrics,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        response = self.client.request("PUT", f"/evaluations/{evaluation_id}", json=payload)
+        return response
+
     def get_samples(self, evaluation_id: str, page: int = 1, limit: int = 100) -> Dict[str, Any]:
         """Get samples for an evaluation"""
         params: Dict[str, Any] = {"page": page, "limit": limit}
@@ -280,6 +309,35 @@ class AsyncEvalsClient:
     async def get_evaluation(self, evaluation_id: str) -> Dict[str, Any]:
         """Get evaluation details by ID"""
         response = await self.client.request("GET", f"/evaluations/{evaluation_id}")
+        return response
+
+    async def update_evaluation(
+        self,
+        evaluation_id: str,
+        name: Optional[str] = None,
+        model_name: Optional[str] = None,
+        dataset: Optional[str] = None,
+        framework: Optional[str] = None,
+        task_type: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "name": name,
+            "model_name": model_name,
+            "dataset": dataset,
+            "framework": framework,
+            "task_type": task_type,
+            "description": description,
+            "tags": tags,
+            "metadata": metadata,
+            "metrics": metrics,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        response = await self.client.request("PUT", f"/evaluations/{evaluation_id}", json=payload)
         return response
 
     async def get_samples(

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -291,15 +291,15 @@ class AsyncEvalsClient:
 
     async def list_evaluations(
         self,
-        environment_id: Optional[str] = None,
+        env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
     ) -> Dict[str, Any]:
         """List evaluations with optional filters"""
         params: Dict[str, Any] = {"skip": skip, "limit": limit}
-        if environment_id:
-            params["environment_id"] = environment_id
+        if env_name:
+            params["environment_name"] = env_name
         if suite_id:
             params["suite_id"] = suite_id
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -57,6 +57,13 @@ def list_evals(
     output: str = typer.Option("table", "--output", "-o", help="table|json"),
     skip: int = typer.Option(0, "--skip", help="Number of records to skip"),
     limit: int = typer.Option(50, "--limit", help="Maximum number of records to return"),
+    env: Optional[str] = typer.Option(
+        None,
+        "--env",
+        "--env-id",
+        "-e",
+        help="Filter by environment (e.g., 'gsm8k' or 'owner/gsm8k')",
+    ),
 ) -> None:
     """List evaluations."""
     _validate_output_format(output, ["table", "json"])
@@ -64,7 +71,13 @@ def list_evals(
     try:
         api_client = APIClient()
         client = EvalsClient(api_client)
+
+        environment_id = None
+        if env:
+            environment_id = client._resolve_environment_id(env)
+
         data = client.list_evaluations(
+            environment_id=environment_id,
             skip=skip,
             limit=limit,
         )
@@ -160,9 +173,10 @@ def _load_verifiers_format(directory: Path) -> dict:
     with open(directory / "metadata.json") as f:
         metadata = json.load(f)
 
-    if "env" not in metadata or "model" not in metadata:
+    env_field = metadata.get("env_id") or metadata.get("env")
+    if not env_field or "model" not in metadata:
         raise ValueError(
-            f"Missing required 'env' or 'model' field in {directory / 'metadata.json'}"
+            f"Missing required 'env_id' or 'model' field in {directory / 'metadata.json'}"
         )
 
     results = []
@@ -187,9 +201,9 @@ def _load_verifiers_format(directory: Path) -> dict:
             metadata_copy[key] = value
 
     return {
-        "eval_name": f"{metadata['env']}-{metadata['model']}",
+        "eval_name": f"{env_field}-{metadata['model']}",
         "model_name": metadata["model"],
-        "env": metadata["env"],
+        "env": env_field,
         "metrics": metrics,
         "metadata": metadata_copy,
         "results": results,
@@ -232,6 +246,7 @@ def _push_single_eval(
     config_path: str,
     env_id: Optional[str],
     run_id: Optional[str],
+    eval_id: Optional[str],
 ) -> str:
     format_type, path = _detect_format(config_path)
 
@@ -243,12 +258,12 @@ def _push_single_eval(
         eval_data = _load_verifiers_format(path)
         console.print(f"[blue]✓ Loaded eval data (verifiers format):[/blue] {path}")
 
-    detected_env = eval_data.get("env")
-    if not env_id and detected_env and not run_id:
+    detected_env = eval_data.get("env_id") or eval_data.get("env")
+    if not env_id and detected_env and not run_id and not eval_id:
         env_id = detected_env
 
     environments = None
-    if env_id and not run_id:
+    if env_id and not run_id and not eval_id:
         environments = [{"id": env_id}]
 
     console.print()
@@ -256,25 +271,48 @@ def _push_single_eval(
     api_client = APIClient()
     client = EvalsClient(api_client)
 
-    console.print("[blue]Creating evaluation...[/blue]")
-    create_response = client.create_evaluation(
-        name=eval_data["eval_name"],
-        environments=environments,
-        run_id=run_id,
-        model_name=eval_data.get("model_name"),
-        framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
-        task_type=eval_data.get("metadata", {}).get("task_type"),
-        metadata=eval_data.get("metadata"),
-        metrics=eval_data.get("metrics"),
-        tags=eval_data.get("tags", []),
-    )
+    if eval_id:
+        console.print(f"[blue]Checking evaluation:[/blue] {eval_id}")
+        try:
+            client.get_evaluation(eval_id)
+            console.print("[green]✓ Found existing evaluation[/green]")
 
-    eval_id = create_response.get("evaluation_id")
-    if not eval_id:
-        raise ValueError("Failed to get evaluation ID from response")
+            console.print("[blue]Updating evaluation...[/blue]")
+            client.update_evaluation(
+                evaluation_id=eval_id,
+                name=eval_data.get("eval_name"),
+                model_name=eval_data.get("model_name"),
+                framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
+                task_type=eval_data.get("metadata", {}).get("task_type"),
+                metadata=eval_data.get("metadata"),
+                metrics=eval_data.get("metrics"),
+                tags=eval_data.get("tags", []),
+            )
+            console.print(f"[green]✓ Updated evaluation:[/green] {eval_id}")
+        except Exception as e:
+            console.print(f"[red]Error:[/red] Could not update evaluation {eval_id}: {e}")
+            raise
+        console.print()
+    else:
+        console.print("[blue]Creating evaluation...[/blue]")
+        create_response = client.create_evaluation(
+            name=eval_data["eval_name"],
+            environments=environments,
+            run_id=run_id,
+            model_name=eval_data.get("model_name"),
+            framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
+            task_type=eval_data.get("metadata", {}).get("task_type"),
+            metadata=eval_data.get("metadata"),
+            metrics=eval_data.get("metrics"),
+            tags=eval_data.get("tags", []),
+        )
 
-    console.print(f"[green]✓ Created evaluation:[/green] {eval_id}")
-    console.print()
+        eval_id = create_response.get("evaluation_id")
+        if not eval_id:
+            raise ValueError("Failed to get evaluation ID from response")
+
+        console.print(f"[green]✓ Created evaluation:[/green] {eval_id}")
+        console.print()
 
     results = eval_data.get("results", [])
     if results:
@@ -311,14 +349,20 @@ def push_eval(
     env_id: Optional[str] = typer.Option(
         None,
         "--env",
+        "--env-id",
         "-e",
-        help="Environment name (e.g., 'gsm8k' or 'd42me/gsm8k')",
+        help="Environment name (e.g., 'gsm8k' or 'owner/gsm8k')",
     ),
     run_id: Optional[str] = typer.Option(
         None,
         "--run-id",
         "-r",
         help="Link to existing training run id",
+    ),
+    eval_id: Optional[str] = typer.Option(
+        None,
+        "--eval-id",
+        help="Push to existing evaluation id",
     ),
     output: str = typer.Option("pretty", "--output", "-o", help="json|pretty"),
 ) -> None:
@@ -329,16 +373,18 @@ def push_eval(
     Examples:
         prime eval push                                    # Push current dir or auto-discover
         prime eval push outputs/evals/gsm8k--gpt-4/abc123  # Push specific directory
-        prime eval push eval.json --run-id abc123          # Push JSON file
+        prime eval push eval.json --run-id abc123          # Push JSON file with run_id
+        prime eval push eval.json --eval-id xyz789         # Push to existing evaluation
+        prime eval push --env gsm8k                        # Push with environment
     """
     try:
         if config_path is None:
             current_dir = Path(".")
             if _has_verifiers_files(current_dir):
-                eval_id = _push_single_eval(".", env_id, run_id)
+                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id)
                 if output == "json":
                     console.print()
-                    output_data_as_json({"evaluation_id": eval_id}, console)
+                    output_data_as_json({"evaluation_id": result_eval_id}, console)
                 return
 
             eval_dirs = _discover_eval_outputs()
@@ -358,8 +404,10 @@ def push_eval(
             results = []
             for eval_dir in eval_dirs:
                 try:
-                    eval_id = _push_single_eval(str(eval_dir), env_id, run_id)
-                    results.append({"path": str(eval_dir), "eval_id": eval_id, "status": "success"})
+                    result_eval_id = _push_single_eval(str(eval_dir), env_id, run_id, eval_id)
+                    results.append(
+                        {"path": str(eval_dir), "eval_id": result_eval_id, "status": "success"}
+                    )
                 except Exception as e:
                     console.print(f"[red]Failed to push {eval_dir}:[/red] {e}")
                     results.append({"path": str(eval_dir), "error": str(e), "status": "failed"})
@@ -379,11 +427,11 @@ def push_eval(
 
             return
 
-        eval_id = _push_single_eval(config_path, env_id, run_id)
+        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id)
 
         if output == "json":
             console.print()
-            output_data_as_json({"evaluation_id": eval_id}, console)
+            output_data_as_json({"evaluation_id": result_eval_id}, console)
 
     except FileNotFoundError as e:
         console.print(f"[red]Error:[/red] {e}")
@@ -395,8 +443,9 @@ def push_eval(
         console.print(f"[red]Error:[/red] {e}")
         console.print()
         console.print("[yellow]Tip:[/yellow] You must provide one of:")
-        console.print("  --run-id <run_id>  (to link to an existing training run)")
-        console.print("  --env <env>        (environment name, e.g., 'gsm8k' or 'd42me/gsm8k')")
+        console.print("  --eval-id <eval_id>  (to update an existing evaluation)")
+        console.print("  --run-id <run_id>    (to link to an existing training run)")
+        console.print("  --env <env>          (environment name, e.g., 'gsm8k' or 'owner/gsm8k')")
         console.print("  [or use verifiers format with 'env' in metadata.json for auto-detection]")
         raise typer.Exit(1)
     except KeyError as e:

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "prime-core"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/prime-core" }
 dependencies = [
     { name = "httpx" },
@@ -1390,7 +1390,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-evals"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packages/prime-evals" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Update evals via prime eval push --eval-id (needed for hosted evals)
- Fix verifiers support by updating env to env_id


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds eval update support via SDK and `prime eval push --eval-id`, switches list filtering to environment name, and fixes verifiers format to use `env_id`.
> 
> - **prime-evals SDK** (`packages/prime-evals`):
>   - Add `update_evaluation` (sync/async) to update eval metadata via `PUT /evaluations/{id}`.
>   - Change `list_evaluations` filter from `environment_id` to `env_name` (query `environment_name`).
>   - Bump version to `0.1.3`.
> - **CLI** (`packages/prime/src/prime_cli/commands/evals.py`):
>   - `list`: add `--env|--env-name|-e` to filter by environment name; pass `env_name` to SDK.
>   - `push`:
>     - Add `--eval|--eval-id` to update an existing evaluation; prevent use with auto-discovery; surface resulting `evaluation_id`.
>     - Update flow to call SDK `update_evaluation` when `--eval-id` is provided; otherwise create as before.
>   - Verifiers format: support `env_id` (fallback to `env`); use it in `eval_name`, payload, and validation messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dc49975c3ff63e246ee91bdf03a650358419608. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->