### PR TITLE
fix sandbox timeout

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -242,14 +242,16 @@ class SandboxClient:
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/exec"
         headers = {"Authorization": f"Bearer {auth['token']}"}
+
+        effective_timeout = timeout if timeout is not None else 300
+
         payload = {
             "command": command,
             "working_dir": working_dir,
             "env": env or {},
             "sandbox_id": sandbox_id,
+            "timeout": effective_timeout,
         }
-
-        effective_timeout = timeout if timeout is not None else 300
 
         try:
             with httpx.Client(timeout=effective_timeout) as client:
@@ -487,14 +489,16 @@ class AsyncSandboxClient:
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/exec"
         headers = {"Authorization": f"Bearer {auth['token']}"}
+
+        effective_timeout = timeout if timeout is not None else 300
+
         payload = {
             "command": command,
             "working_dir": working_dir,
             "env": env or {},
             "sandbox_id": sandbox_id,
+            "timeout": effective_timeout,
         }
-
-        effective_timeout = timeout if timeout is not None else 300
 
         try:
             async with httpx.AsyncClient(timeout=effective_timeout) as client:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates an effective timeout to the gateway for exec commands (sync and async) and uses it for httpx timeouts.
> 
> - **Sandbox client (`packages/prime-sandboxes/src/prime_sandboxes/sandbox.py`)**:
>   - **Command execution (sync/async)**:
>     - Compute `effective_timeout` earlier and include it in request `payload` as `"timeout"` for `exec`.
>     - Use `effective_timeout` for `httpx` client timeouts.
>     - Minor refactor of payload construction/order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff56e8715f8cedf61a5c57d31717ea11d8cc985b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->