### PR TITLE
Release: Bump prime cli version to 0.4.10

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 dependencies = [
     "prime-core",
     "prime-sandboxes>=0.1.0",
-    "prime-evals>=0.1.2",
+    "prime-evals>=0.1.3",
     "typer>=0.9.0",
     "rich>=13.3.1",
     "cryptography>=41.0.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -15,7 +15,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 __all__ = [
     "APIClient",

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ requires-dist = [
 
 [[package]]
 name = "prime-evals"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/prime-evals" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps the CLI package version to 0.4.10 and updates `prime-evals` dependency to 0.1.3, with lockfile refresh.
> 
> - **Release**:
>   - Update `packages/prime/src/prime_cli/__init__.py` `__version__` to `0.4.10`.
> - **Dependencies**:
>   - Bump `prime-evals` from `0.1.2` to `0.1.3` in `packages/prime/pyproject.toml`.
>   - Refresh `uv.lock` to reflect `prime-evals@0.1.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e701e0e5acf8d66b44db16ea29d2d4a8cb29e775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->