### PR TITLE
Fix: Sandbox Command Execution Timeout Issue

### DIFF
--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -37,6 +37,7 @@ def test_command_timeout():
         assert result.stdout.strip() == "done"
         assert result.stderr.strip() == ""
     finally:
-        print("\nDeleting sandbox...")
-        sandbox_client.delete(sandbox.id)
-        print(f"✓ Deleted sandbox {sandbox.id}")
+        if sandbox and sandbox.id:
+            print("\nDeleting sandbox...")
+            sandbox_client.delete(sandbox.id)
+            print(f"✓ Deleted sandbox {sandbox.id}")

--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -6,6 +6,8 @@ from prime_sandboxes import (
 
 
 def test_command_timeout():
+    sandbox = None
+
     try:
         client = APIClient()
         sandbox_client = SandboxClient(client)

--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -1,0 +1,42 @@
+from prime_sandboxes import (
+    APIClient,
+    CreateSandboxRequest,
+    SandboxClient,
+)
+
+
+def test_command_timeout():
+    try:
+        client = APIClient()
+        sandbox_client = SandboxClient(client)
+
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-sandbox",
+                docker_image="python:3.11-slim",
+                cpu_cores=1,
+                memory_gb=2,
+                timeout_minutes=60,
+            )
+        )
+        print(f"✓ Created: {sandbox.id}")
+
+        print("\nWaiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id)
+        print("✓ Sandbox is running!")
+
+        print("\nExecuting command...")
+        command = "sleep 100 && echo 'done'"
+        result = sandbox_client.execute_command(
+            sandbox_id=sandbox.id, command=command, timeout=60 * 2
+        )
+        print(f"✓ Executed command: {command} with result: {result}")
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "done"
+        assert result.stderr.strip() == ""
+    finally:
+        print("\nDeleting sandbox...")
+        sandbox_client.delete(sandbox.id)
+        print(f"✓ Deleted sandbox {sandbox.id}")


### PR DESCRIPTION
# Fix: Sandbox Command Execution Timeout Issue

## Problem
The `execute_command` method was timing out prematurely when executing long-running commands. The server-side timeout was set to 90 seconds regardless of the client-specified timeout parameter, causing commands that needed more time to fail. The timeout was only set on `httpx.Client`.

## Solution
- Added a `timeout` item to the JSON payload sent to the server when executing a command as shown below
```python
effective_timeout = timeout if timeout is not None else 300

payload = {
    "command": command,
    "working_dir": working_dir,
    "env": env or {},
    "sandbox_id": sandbox_id,
    "timeout": effective_timeout, # <- Added
}

try:
    with httpx.Client(timeout=effective_timeout) as client:
        response = client.post(
            url,
            json=payload,
            headers=headers,
        )
```
- Applied the fix to both sync (`SandboxClient.execute_command`) and async (`AsyncSandboxClient.execute_command`) methods

## Testing
Added a simple test in `test_cmd_timeout.py`:
- Sync test: `test_command_timeout()`
- Test verifies that a 100-second sleep command completes successfully with a 120-second timeout
- Tests include proper cleanup (sandbox deletion) even on failure or interruption

**Test result before fix:**
```bash
=============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.13.5, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/13point5/projects/13point5-prime-cli/packages/prime-sandboxes
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, anyio-4.10.0, typeguard-4.4.4
collected 1 item                                                                                                                                                                                                  

tests/test_cmd_timeout.py F                                                                                                               [100%]

=================================================================== FAILURES ====================================================================
_____________________________________________________________ test_command_timeout ______________________________________________________________

self = <prime_sandboxes.sandbox.SandboxClient object at 0x104ff3b60>, sandbox_id = 'x7boyzk3kpqbliiyugqvrpdj'
command = "sleep 100 && echo 'done'", working_dir = None, env = None, timeout = 120

    def execute_command(
        self,
        sandbox_id: str,
        command: str,
        working_dir: Optional[str] = None,
        env: Optional[Dict[str, str]] = None,
        timeout: Optional[int] = None,
    ) -> CommandResponse:
        """Execute command directly via gateway"""
        auth = self._auth_cache.get_or_refresh(sandbox_id)
        gateway_url = auth["gateway_url"].rstrip("/")
        url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/exec"
        headers = {"Authorization": f"Bearer {auth['token']}"}
        effective_timeout = timeout if timeout is not None else 300
    
        payload = {
            "command": command,
            "working_dir": working_dir,
            "env": env or {},
            "sandbox_id": sandbox_id,
            # "timeout": effective_timeout,
        }
    
        try:
            with httpx.Client(timeout=effective_timeout) as client:
                response = client.post(
                    url,
                    json=payload,
                    headers=headers,
                )
>               response.raise_for_status()

src/prime_sandboxes/sandbox.py:275: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Response [500 Internal Server Error]>

    def raise_for_status(self) -> Response:
        """
        Raise the `HTTPStatusError` if one occurred.
        """
        request = self._request
        if request is None:
            raise RuntimeError(
                "Cannot call `raise_for_status` as the request "
                "instance has not been set on this response."
            )
    
        if self.is_success:
            return self
    
        if self.has_redirect_location:
            message = (
                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
                "Redirect location: '{0.headers[location]}'\n"
                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
            )
        else:
            message = (
                "{error_type} '{0.status_code} {0.reason_phrase}' for url '{0.url}'\n"
                "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/{0.status_code}"
            )
    
        status_class = self.status_code // 100
        error_types = {
            1: "Informational response",
            3: "Redirect response",
            4: "Client error",
            5: "Server error",
        }
        error_type = error_types.get(status_class, "Invalid status code")
        message = message.format(self, error_type=error_type)
>       raise HTTPStatusError(message, request=request, response=self)
E       httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'https://sandbox.pinfra.io/prod-box-cmbvin2kb0005969vhql6gqtn/x7boyzk3kpqbliiyugqvrpdj/exec'
E       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

/opt/anaconda3/lib/python3.13/site-packages/httpx/_models.py:829: HTTPStatusError

During handling of the above exception, another exception occurred:

    def test_command_timeout():
        try:
            client = APIClient()
            sandbox_client = SandboxClient(client)
    
            print("\nCreating sandbox...")
            sandbox = sandbox_client.create(
                CreateSandboxRequest(
                    name="test-sandbox",
                    docker_image="python:3.11-slim",
                    cpu_cores=1,
                    memory_gb=2,
                    timeout_minutes=60,
                )
            )
            print(f"✓ Created: {sandbox.id}")
    
            print("\nWaiting for sandbox to be ready...")
            sandbox_client.wait_for_creation(sandbox.id)
            print("✓ Sandbox is running!")
    
            print("\nExecuting command...")
            command = "sleep 100 && echo 'done'"
>           result = sandbox_client.execute_command(
                sandbox_id=sandbox.id, command=command, timeout=60 * 2
            )

tests/test_cmd_timeout.py:31: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <prime_sandboxes.sandbox.SandboxClient object at 0x104ff3b60>, sandbox_id = 'x7boyzk3kpqbliiyugqvrpdj'
command = "sleep 100 && echo 'done'", working_dir = None, env = None, timeout = 120

    def execute_command(
        self,
        sandbox_id: str,
        command: str,
        working_dir: Optional[str] = None,
        env: Optional[Dict[str, str]] = None,
        timeout: Optional[int] = None,
    ) -> CommandResponse:
        """Execute command directly via gateway"""
        auth = self._auth_cache.get_or_refresh(sandbox_id)
        gateway_url = auth["gateway_url"].rstrip("/")
        url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/exec"
        headers = {"Authorization": f"Bearer {auth['token']}"}
        effective_timeout = timeout if timeout is not None else 300
    
        payload = {
            "command": command,
            "working_dir": working_dir,
            "env": env or {},
            "sandbox_id": sandbox_id,
            # "timeout": effective_timeout,
        }
    
        try:
            with httpx.Client(timeout=effective_timeout) as client:
                response = client.post(
                    url,
                    json=payload,
                    headers=headers,
                )
                response.raise_for_status()
                return CommandResponse.model_validate(response.json())
        except httpx.TimeoutException:
            raise CommandTimeoutError(sandbox_id, command, effective_timeout)
        except httpx.HTTPStatusError as e:
>           raise APIError(f"HTTP {e.response.status_code}: {e.response.text}")
E           prime_core.client.APIError: HTTP 500: {"error":"Command execution failed: Command execution timed out after 90 seconds","timestamp":"2025-11-02T05:20:38.269068634Z"}

src/prime_sandboxes/sandbox.py:280: APIError
------------------------------------------------------------- Captured stdout call --------------------------------------------------------------

Creating sandbox...
✓ Created: x7boyzk3kpqbliiyugqvrpdj

Waiting for sandbox to be ready...
✓ Sandbox is running!

Executing command...

Deleting sandbox...
✓ Deleted sandbox x7boyzk3kpqbliiyugqvrpdj
============================================================ short test summary info ============================================================
FAILED tests/test_cmd_timeout.py::test_command_timeout - prime_core.client.APIError: HTTP 500: {"error":"Command execution failed: Command execution timed out after 90 seconds","timestamp":"2025-11...
========================================================= 1 failed in 147.18s (0:02:27) =========================================================
```

**Test result after fix:**
```bash
=============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.13.5, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/13point5/projects/13point5-prime-cli/packages/prime-sandboxes
configfile: pyproject.toml
plugins: jaxtyping-0.3.2, anyio-4.10.0, typeguard-4.4.4
collected 1 item                                                                                                                                                                                                  

tests/test_cmd_timeout.py .                                                                                                                                                                                 [100%]

========================================================================================== 1 passed in 106.30s (0:01:46) ==========================================================================================
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass the client-specified timeout in command execution payloads (sync/async) to prevent premature timeouts, and add a test verifying long-running commands complete within the provided timeout.
> 
> - **Sandbox client** (`src/prime_sandboxes/sandbox.py`):
>   - `SandboxClient.execute_command` and `AsyncSandboxClient.execute_command` now include `timeout` in the exec request payload and use an `effective_timeout` (default 300s) for both payload and HTTP client.
> - **Tests**:
>   - Add `tests/test_cmd_timeout.py` validating a 100s command succeeds with a 120s timeout and performs sandbox cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dc0aef6ac4fbd134dfe5dc1d15471dd7abb979d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->