### PR TITLE
Imp: Remove env eval beta flag.

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -15,7 +15,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -10,8 +10,8 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import output_data_as_json, validate_output_format
 
 app = typer.Typer(
-    help="Run and manage Prime Inference (in beta, requires prime inference permissions)\n\n"
-    "Use `prime env eval` (beta) for environment evals with Prime Inference.",
+    help="Run and manage Prime Inference\n\n"
+    "Use `prime env eval` for environment evals with Prime Inference.",
     no_args_is_help=True,
 )
 console = Console()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove beta labels from inference CLI help and bump version to 0.4.11.
> 
> - **CLI**:
>   - Update `prime_cli/commands/inference.py` help text to remove beta labels for Prime Inference and `prime env eval`.
> - **Versioning**:
>   - Bump `prime_cli.__version__` to `0.4.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7732d6583b243c4192476c8d9472d463c49cefe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->