### PR TITLE
upload and download timeouts

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -14,7 +14,12 @@ from prime_core import (
     UnauthorizedError,
 )
 
-from .exceptions import CommandTimeoutError, SandboxNotRunningError
+from .exceptions import (
+    CommandTimeoutError,
+    DownloadTimeoutError,
+    SandboxNotRunningError,
+    UploadTimeoutError,
+)
 from .models import (
     AdvancedConfigs,
     BulkDeleteSandboxRequest,
@@ -63,4 +68,6 @@ __all__ = [
     "TimeoutError",  # Deprecated alias
     "SandboxNotRunningError",
     "CommandTimeoutError",
+    "UploadTimeoutError",
+    "DownloadTimeoutError",
 ]

--- a/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
@@ -18,3 +18,19 @@ class CommandTimeoutError(RuntimeError):
     def __init__(self, sandbox_id: str, command: str, timeout: int):
         msg = f"Command '{command}' timed out after {timeout}s in sandbox {sandbox_id}"
         super().__init__(msg)
+
+
+class UploadTimeoutError(RuntimeError):
+    """Raised when a file upload times out."""
+
+    def __init__(self, sandbox_id: str, file_path: str, timeout: int):
+        msg = f"Upload to '{file_path}' timed out after {timeout}s in sandbox {sandbox_id}"
+        super().__init__(msg)
+
+
+class DownloadTimeoutError(RuntimeError):
+    """Raised when a file download times out."""
+
+    def __init__(self, sandbox_id: str, file_path: str, timeout: int):
+        msg = f"Download from '{file_path}' timed out after {timeout}s in sandbox {sandbox_id}"
+        super().__init__(msg)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional `timeout` to file upload/download (sync + async) and raises new `UploadTimeoutError`/`DownloadTimeoutError` on timeouts.
> 
> - **SDK (prime-sandboxes)**:
>   - **Timeouts**: Add optional `timeout` parameter to `SandboxClient.upload_file`/`download_file` and `AsyncSandboxClient.upload_file`/`download_file`; default to `300` seconds via `effective_timeout`.
>   - **Exceptions**: Introduce `UploadTimeoutError` and `DownloadTimeoutError`; raise on `httpx.TimeoutException` during file transfers.
>   - **Exports**: Expose new exceptions in `prime_sandboxes/__init__.py` `__all__`.
>   - **HTTP**: Use per-call `effective_timeout` for `httpx` clients in upload/download paths (sync + async).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ab96b48ca784c65b815fbab52355be70374bb50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->