### PR TITLE
add sandbox tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
         PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
-      run: uv run pytest tests/ -v
+      run: uv run pytest tests/ -v -n auto
 
   test-prime:
     runs-on: ubuntu-latest

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-xdist>=3.0.0",
     "ruff>=0.13.1",
 ]
 
@@ -52,6 +53,12 @@ path = "src/prime_sandboxes/__init__.py"
 packages = ["src/prime_sandboxes"]
 # Bundle prime-core directly at the prime_core import path for PyPI distribution
 force-include = { "../prime-core/src/prime_core" = "prime_core" }
+
+[tool.pytest.ini_options]
+# Run tests in parallel with pytest-xdist
+# Use -n auto to automatically detect CPU count, or specify number of workers
+addopts = "-v"
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 100

--- a/packages/prime-sandboxes/tests/conftest.py
+++ b/packages/prime-sandboxes/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest configuration and fixtures for sandbox tests"""
+
+import pytest
+
+from prime_sandboxes import APIClient, SandboxClient
+
+
+@pytest.fixture(scope="session")
+def sandbox_client():
+    """Create a shared sandbox client for all tests"""
+    client = APIClient()
+    return SandboxClient(client)

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -2,27 +2,16 @@
 
 import pytest
 
-from prime_sandboxes import (
-    APIClient,
-    CreateSandboxRequest,
-    SandboxClient,
-)
+from prime_sandboxes import CreateSandboxRequest
 from prime_sandboxes.exceptions import CommandTimeoutError
 
 
-@pytest.fixture
-def sandbox_client():
-    """Create a sandbox client for tests"""
-    client = APIClient()
-    return SandboxClient(client)
-
-
-@pytest.fixture
-def running_sandbox(sandbox_client):
-    """Create and setup a running sandbox for tests"""
+@pytest.fixture(scope="module")
+def shared_sandbox(sandbox_client):
+    """Create a sandbox for this test module"""
     sandbox = None
     try:
-        print("\nCreating sandbox...")
+        print("\n[SETUP] Creating sandbox for command execution tests...")
         sandbox = sandbox_client.create(
             CreateSandboxRequest(
                 name="test-cmd-exec",
@@ -32,34 +21,30 @@ def running_sandbox(sandbox_client):
                 timeout_minutes=60,
             )
         )
-        print(f"✓ Created: {sandbox.id}")
-
-        print("Waiting for sandbox to be ready...")
+        print(f"[SETUP] Created: {sandbox.id}")
         sandbox_client.wait_for_creation(sandbox.id)
-        print("✓ Sandbox is running!")
-
+        print("[SETUP] Sandbox ready!")
         yield sandbox
     finally:
         if sandbox and sandbox.id:
-            print(f"\nCleaning up sandbox {sandbox.id}...")
             try:
                 sandbox_client.delete(sandbox.id)
-                print(f"✓ Deleted sandbox {sandbox.id}")
+                print(f"[TEARDOWN] Deleted {sandbox.id}")
             except Exception as e:
-                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+                print(f"[TEARDOWN] Warning: {e}")
 
 
-def test_command_with_working_directory(sandbox_client, running_sandbox):
+def test_command_with_working_directory(sandbox_client, shared_sandbox):
     """Test executing command with working directory"""
     # Create a test directory
     sandbox_client.execute_command(
-        running_sandbox.id, "mkdir -p /tmp/workdir && echo 'test' > /tmp/workdir/file.txt"
+        shared_sandbox.id, "mkdir -p /tmp/workdir && echo 'test' > /tmp/workdir/file.txt"
     )
 
     # Execute command in working directory
     print("\nExecuting command with working_dir=/tmp/workdir...")
     result = sandbox_client.execute_command(
-        running_sandbox.id, "pwd && ls -la", working_dir="/tmp/workdir"
+        shared_sandbox.id, "pwd && ls -la", working_dir="/tmp/workdir"
     )
 
     assert result.exit_code == 0
@@ -68,7 +53,7 @@ def test_command_with_working_directory(sandbox_client, running_sandbox):
     print(f"✓ Command executed in working directory:\n{result.stdout}")
 
 
-def test_command_with_environment_variables(sandbox_client, running_sandbox):
+def test_command_with_environment_variables(sandbox_client, shared_sandbox):
     """Test executing command with custom environment variables"""
     env_vars = {
         "TEST_VAR": "hello_world",
@@ -78,7 +63,7 @@ def test_command_with_environment_variables(sandbox_client, running_sandbox):
 
     print("\nExecuting command with custom environment variables...")
     result = sandbox_client.execute_command(
-        running_sandbox.id,
+        shared_sandbox.id,
         "echo $TEST_VAR && echo $CUSTOM_VALUE && echo $PATH_APPEND",
         env=env_vars,
     )
@@ -90,26 +75,26 @@ def test_command_with_environment_variables(sandbox_client, running_sandbox):
     print(f"✓ Environment variables set correctly:\n{result.stdout}")
 
 
-def test_command_with_different_exit_codes(sandbox_client, running_sandbox):
+def test_command_with_different_exit_codes(sandbox_client, shared_sandbox):
     """Test commands that exit with different codes"""
     # Success (exit 0)
-    result = sandbox_client.execute_command(running_sandbox.id, "exit 0")
+    result = sandbox_client.execute_command(shared_sandbox.id, "exit 0")
     assert result.exit_code == 0
 
     # Various non-zero exit codes
     for exit_code in [1, 2, 127]:
         print(f"\nTesting exit code {exit_code}...")
-        result = sandbox_client.execute_command(running_sandbox.id, f"exit {exit_code}")
+        result = sandbox_client.execute_command(shared_sandbox.id, f"exit {exit_code}")
         assert result.exit_code == exit_code
         print(f"✓ Command exited with code {exit_code}")
 
 
-def test_command_stdout_stderr_separation(sandbox_client, running_sandbox):
+def test_command_stdout_stderr_separation(sandbox_client, shared_sandbox):
     """Test that stdout and stderr are properly separated"""
     command = "echo 'stdout message' && echo 'stderr message' >&2"
 
     print(f"\nExecuting command: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     assert "stdout message" in result.stdout
@@ -118,12 +103,12 @@ def test_command_stdout_stderr_separation(sandbox_client, running_sandbox):
     print(f"✓ stderr: {result.stderr.strip()}")
 
 
-def test_command_with_multiline_output(sandbox_client, running_sandbox):
+def test_command_with_multiline_output(sandbox_client, shared_sandbox):
     """Test command that produces multi-line output"""
     command = "for i in 1 2 3 4 5; do echo Line $i; done"
 
     print(f"\nExecuting command: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     lines = result.stdout.strip().split("\n")
@@ -133,47 +118,47 @@ def test_command_with_multiline_output(sandbox_client, running_sandbox):
     print(f"✓ Multi-line output received:\n{result.stdout}")
 
 
-def test_command_with_pipes_and_redirection(sandbox_client, running_sandbox):
+def test_command_with_pipes_and_redirection(sandbox_client, shared_sandbox):
     """Test command with pipes and redirection"""
     command = "echo 'hello world' | tr 'a-z' 'A-Z' | tee /tmp/output.txt"
 
     print(f"\nExecuting command: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     assert "HELLO WORLD" in result.stdout
 
     # Verify file was created
-    verify_result = sandbox_client.execute_command(running_sandbox.id, "cat /tmp/output.txt")
+    verify_result = sandbox_client.execute_command(shared_sandbox.id, "cat /tmp/output.txt")
     assert "HELLO WORLD" in verify_result.stdout
     print("✓ Pipes and redirection work correctly")
 
 
-def test_command_with_long_running_process(sandbox_client, running_sandbox):
+def test_command_with_long_running_process(sandbox_client, shared_sandbox):
     """Test command that runs for a few seconds"""
     command = "sleep 3 && echo 'completed'"
 
     print(f"\nExecuting long-running command: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command, timeout=10)
+    result = sandbox_client.execute_command(shared_sandbox.id, command, timeout=10)
 
     assert result.exit_code == 0
     assert "completed" in result.stdout
     print("✓ Long-running command completed successfully")
 
 
-def test_command_timeout_short(sandbox_client, running_sandbox):
+def test_command_timeout_short(sandbox_client, shared_sandbox):
     """Test that command timeout works correctly"""
     command = "sleep 30"
 
     print(f"\nExecuting command with short timeout: {command}")
     with pytest.raises(CommandTimeoutError) as exc_info:
-        sandbox_client.execute_command(running_sandbox.id, command, timeout=2)
+        sandbox_client.execute_command(shared_sandbox.id, command, timeout=2)
 
-    assert running_sandbox.id in str(exc_info.value)
+    assert shared_sandbox.id in str(exc_info.value)
     print(f"✓ Command correctly timed out: {exc_info.value}")
 
 
-def test_python_script_execution(sandbox_client, running_sandbox):
+def test_python_script_execution(sandbox_client, shared_sandbox):
     """Test executing Python code directly"""
     python_code = """
 import sys
@@ -184,7 +169,7 @@ print(json.dumps(data))
 
     command = f"python3 -c '{python_code}'"
     print("\nExecuting Python code...")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     assert "python_version" in result.stdout
@@ -192,7 +177,7 @@ print(json.dumps(data))
     print(f"✓ Python code executed:\n{result.stdout}")
 
 
-def test_command_with_special_characters(sandbox_client, running_sandbox):
+def test_command_with_special_characters(sandbox_client, shared_sandbox):
     """Test command with special characters"""
     special_strings = [
         "hello & goodbye",
@@ -204,22 +189,22 @@ def test_command_with_special_characters(sandbox_client, running_sandbox):
     for special_str in special_strings:
         print(f"\nTesting string: {special_str}")
         # Use printf instead of echo to handle special characters better
-        result = sandbox_client.execute_command(running_sandbox.id, f"printf '%s' '{special_str}'")
+        result = sandbox_client.execute_command(shared_sandbox.id, f"printf '%s' '{special_str}'")
         assert result.exit_code == 0
         assert special_str in result.stdout
         print("✓ Special characters handled correctly")
 
 
-def test_command_with_combined_working_dir_and_env(sandbox_client, running_sandbox):
+def test_command_with_combined_working_dir_and_env(sandbox_client, shared_sandbox):
     """Test command with both working_dir and env parameters"""
     # Setup test directory
-    sandbox_client.execute_command(running_sandbox.id, "mkdir -p /tmp/env_test")
+    sandbox_client.execute_command(shared_sandbox.id, "mkdir -p /tmp/env_test")
 
     env_vars = {"MY_VAR": "test_value", "ANOTHER_VAR": "another_value"}
 
     print("\nExecuting command with both working_dir and env...")
     result = sandbox_client.execute_command(
-        running_sandbox.id,
+        shared_sandbox.id,
         "pwd && echo $MY_VAR && echo $ANOTHER_VAR",
         working_dir="/tmp/env_test",
         env=env_vars,
@@ -232,38 +217,38 @@ def test_command_with_combined_working_dir_and_env(sandbox_client, running_sandb
     print(f"✓ Both working_dir and env work together:\n{result.stdout}")
 
 
-def test_command_creates_and_reads_file(sandbox_client, running_sandbox):
+def test_command_creates_and_reads_file(sandbox_client, shared_sandbox):
     """Test command that creates a file and another reads it"""
     content = "This is test content for file operations"
 
     # Create file
     print("\nCreating file...")
     create_result = sandbox_client.execute_command(
-        running_sandbox.id, f"echo '{content}' > /tmp/test_file.txt"
+        shared_sandbox.id, f"echo '{content}' > /tmp/test_file.txt"
     )
     assert create_result.exit_code == 0
 
     # Read file
     print("Reading file...")
-    read_result = sandbox_client.execute_command(running_sandbox.id, "cat /tmp/test_file.txt")
+    read_result = sandbox_client.execute_command(shared_sandbox.id, "cat /tmp/test_file.txt")
     assert read_result.exit_code == 0
     assert content in read_result.stdout
     print(f"✓ File operations successful: {read_result.stdout.strip()}")
 
 
-def test_command_check_available_tools(sandbox_client, running_sandbox):
+def test_command_check_available_tools(sandbox_client, shared_sandbox):
     """Test that common tools are available in the sandbox"""
     tools = ["python3", "bash", "sh", "cat", "ls", "grep", "sed", "awk"]
 
     print("\nChecking available tools...")
     for tool in tools:
-        result = sandbox_client.execute_command(running_sandbox.id, f"which {tool}")
+        result = sandbox_client.execute_command(shared_sandbox.id, f"which {tool}")
         assert result.exit_code == 0
         assert tool in result.stdout or "/" in result.stdout
         print(f"✓ {tool} is available")
 
 
-def test_sequential_commands(sandbox_client, running_sandbox):
+def test_sequential_commands(sandbox_client, shared_sandbox):
     """Test executing multiple commands sequentially"""
     commands = [
         ("echo 'first'", "first"),
@@ -273,30 +258,30 @@ def test_sequential_commands(sandbox_client, running_sandbox):
 
     print("\nExecuting sequential commands...")
     for cmd, expected in commands:
-        result = sandbox_client.execute_command(running_sandbox.id, cmd)
+        result = sandbox_client.execute_command(shared_sandbox.id, cmd)
         assert result.exit_code == 0
         assert expected in result.stdout
         print(f"✓ Command '{cmd}' executed successfully")
 
 
-def test_command_with_numeric_output(sandbox_client, running_sandbox):
+def test_command_with_numeric_output(sandbox_client, shared_sandbox):
     """Test command that outputs numbers"""
     command = "expr 5 + 3"
 
     print(f"\nExecuting arithmetic command: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "8"
     print(f"✓ Arithmetic command result: {result.stdout.strip()}")
 
 
-def test_command_empty_output(sandbox_client, running_sandbox):
+def test_command_empty_output(sandbox_client, shared_sandbox):
     """Test command with no output"""
     command = "true"
 
     print(f"\nExecuting command with no output: {command}")
-    result = sandbox_client.execute_command(running_sandbox.id, command)
+    result = sandbox_client.execute_command(shared_sandbox.id, command)
 
     assert result.exit_code == 0
     assert result.stdout == ""

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -1,0 +1,304 @@
+"""Tests for advanced sandbox command execution"""
+
+import pytest
+
+from prime_sandboxes import (
+    APIClient,
+    CreateSandboxRequest,
+    SandboxClient,
+)
+from prime_sandboxes.exceptions import CommandTimeoutError
+
+
+@pytest.fixture
+def sandbox_client():
+    """Create a sandbox client for tests"""
+    client = APIClient()
+    return SandboxClient(client)
+
+
+@pytest.fixture
+def running_sandbox(sandbox_client):
+    """Create and setup a running sandbox for tests"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-cmd-exec",
+                docker_image="python:3.11-slim",
+                cpu_cores=1,
+                memory_gb=2,
+                timeout_minutes=60,
+            )
+        )
+        print(f"✓ Created: {sandbox.id}")
+
+        print("Waiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id)
+        print("✓ Sandbox is running!")
+
+        yield sandbox
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_command_with_working_directory(sandbox_client, running_sandbox):
+    """Test executing command with working directory"""
+    # Create a test directory
+    sandbox_client.execute_command(
+        running_sandbox.id, "mkdir -p /tmp/workdir && echo 'test' > /tmp/workdir/file.txt"
+    )
+
+    # Execute command in working directory
+    print("\nExecuting command with working_dir=/tmp/workdir...")
+    result = sandbox_client.execute_command(
+        running_sandbox.id, "pwd && ls -la", working_dir="/tmp/workdir"
+    )
+
+    assert result.exit_code == 0
+    assert "/tmp/workdir" in result.stdout
+    assert "file.txt" in result.stdout
+    print(f"✓ Command executed in working directory:\n{result.stdout}")
+
+
+def test_command_with_environment_variables(sandbox_client, running_sandbox):
+    """Test executing command with custom environment variables"""
+    env_vars = {
+        "TEST_VAR": "hello_world",
+        "CUSTOM_VALUE": "12345",
+        "PATH_APPEND": "/custom/path",
+    }
+
+    print("\nExecuting command with custom environment variables...")
+    result = sandbox_client.execute_command(
+        running_sandbox.id,
+        "echo $TEST_VAR && echo $CUSTOM_VALUE && echo $PATH_APPEND",
+        env=env_vars,
+    )
+
+    assert result.exit_code == 0
+    assert "hello_world" in result.stdout
+    assert "12345" in result.stdout
+    assert "/custom/path" in result.stdout
+    print(f"✓ Environment variables set correctly:\n{result.stdout}")
+
+
+def test_command_with_different_exit_codes(sandbox_client, running_sandbox):
+    """Test commands that exit with different codes"""
+    # Success (exit 0)
+    result = sandbox_client.execute_command(running_sandbox.id, "exit 0")
+    assert result.exit_code == 0
+
+    # Various non-zero exit codes
+    for exit_code in [1, 2, 127]:
+        print(f"\nTesting exit code {exit_code}...")
+        result = sandbox_client.execute_command(running_sandbox.id, f"exit {exit_code}")
+        assert result.exit_code == exit_code
+        print(f"✓ Command exited with code {exit_code}")
+
+
+def test_command_stdout_stderr_separation(sandbox_client, running_sandbox):
+    """Test that stdout and stderr are properly separated"""
+    command = "echo 'stdout message' && echo 'stderr message' >&2"
+
+    print(f"\nExecuting command: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    assert "stdout message" in result.stdout
+    assert "stderr message" in result.stderr
+    print(f"✓ stdout: {result.stdout.strip()}")
+    print(f"✓ stderr: {result.stderr.strip()}")
+
+
+def test_command_with_multiline_output(sandbox_client, running_sandbox):
+    """Test command that produces multi-line output"""
+    command = "for i in 1 2 3 4 5; do echo Line $i; done"
+
+    print(f"\nExecuting command: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    lines = result.stdout.strip().split("\n")
+    assert len(lines) == 5
+    for i in range(1, 6):
+        assert f"Line {i}" in result.stdout
+    print(f"✓ Multi-line output received:\n{result.stdout}")
+
+
+def test_command_with_pipes_and_redirection(sandbox_client, running_sandbox):
+    """Test command with pipes and redirection"""
+    command = "echo 'hello world' | tr 'a-z' 'A-Z' | tee /tmp/output.txt"
+
+    print(f"\nExecuting command: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    assert "HELLO WORLD" in result.stdout
+
+    # Verify file was created
+    verify_result = sandbox_client.execute_command(running_sandbox.id, "cat /tmp/output.txt")
+    assert "HELLO WORLD" in verify_result.stdout
+    print("✓ Pipes and redirection work correctly")
+
+
+def test_command_with_long_running_process(sandbox_client, running_sandbox):
+    """Test command that runs for a few seconds"""
+    command = "sleep 3 && echo 'completed'"
+
+    print(f"\nExecuting long-running command: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command, timeout=10)
+
+    assert result.exit_code == 0
+    assert "completed" in result.stdout
+    print("✓ Long-running command completed successfully")
+
+
+def test_command_timeout_short(sandbox_client, running_sandbox):
+    """Test that command timeout works correctly"""
+    command = "sleep 30"
+
+    print(f"\nExecuting command with short timeout: {command}")
+    with pytest.raises(CommandTimeoutError) as exc_info:
+        sandbox_client.execute_command(running_sandbox.id, command, timeout=2)
+
+    assert running_sandbox.id in str(exc_info.value)
+    print(f"✓ Command correctly timed out: {exc_info.value}")
+
+
+def test_python_script_execution(sandbox_client, running_sandbox):
+    """Test executing Python code directly"""
+    python_code = """
+import sys
+import json
+data = {'python_version': sys.version, 'platform': sys.platform}
+print(json.dumps(data))
+"""
+
+    command = f"python3 -c '{python_code}'"
+    print("\nExecuting Python code...")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    assert "python_version" in result.stdout
+    assert "platform" in result.stdout
+    print(f"✓ Python code executed:\n{result.stdout}")
+
+
+def test_command_with_special_characters(sandbox_client, running_sandbox):
+    """Test command with special characters"""
+    special_strings = [
+        "hello & goodbye",
+        "test | with | pipes",
+        "path/to/file.txt",
+        "quote'test'quote",
+    ]
+
+    for special_str in special_strings:
+        print(f"\nTesting string: {special_str}")
+        # Use printf instead of echo to handle special characters better
+        result = sandbox_client.execute_command(running_sandbox.id, f"printf '%s' '{special_str}'")
+        assert result.exit_code == 0
+        assert special_str in result.stdout
+        print("✓ Special characters handled correctly")
+
+
+def test_command_with_combined_working_dir_and_env(sandbox_client, running_sandbox):
+    """Test command with both working_dir and env parameters"""
+    # Setup test directory
+    sandbox_client.execute_command(running_sandbox.id, "mkdir -p /tmp/env_test")
+
+    env_vars = {"MY_VAR": "test_value", "ANOTHER_VAR": "another_value"}
+
+    print("\nExecuting command with both working_dir and env...")
+    result = sandbox_client.execute_command(
+        running_sandbox.id,
+        "pwd && echo $MY_VAR && echo $ANOTHER_VAR",
+        working_dir="/tmp/env_test",
+        env=env_vars,
+    )
+
+    assert result.exit_code == 0
+    assert "/tmp/env_test" in result.stdout
+    assert "test_value" in result.stdout
+    assert "another_value" in result.stdout
+    print(f"✓ Both working_dir and env work together:\n{result.stdout}")
+
+
+def test_command_creates_and_reads_file(sandbox_client, running_sandbox):
+    """Test command that creates a file and another reads it"""
+    content = "This is test content for file operations"
+
+    # Create file
+    print("\nCreating file...")
+    create_result = sandbox_client.execute_command(
+        running_sandbox.id, f"echo '{content}' > /tmp/test_file.txt"
+    )
+    assert create_result.exit_code == 0
+
+    # Read file
+    print("Reading file...")
+    read_result = sandbox_client.execute_command(running_sandbox.id, "cat /tmp/test_file.txt")
+    assert read_result.exit_code == 0
+    assert content in read_result.stdout
+    print(f"✓ File operations successful: {read_result.stdout.strip()}")
+
+
+def test_command_check_available_tools(sandbox_client, running_sandbox):
+    """Test that common tools are available in the sandbox"""
+    tools = ["python3", "bash", "sh", "cat", "ls", "grep", "sed", "awk"]
+
+    print("\nChecking available tools...")
+    for tool in tools:
+        result = sandbox_client.execute_command(running_sandbox.id, f"which {tool}")
+        assert result.exit_code == 0
+        assert tool in result.stdout or "/" in result.stdout
+        print(f"✓ {tool} is available")
+
+
+def test_sequential_commands(sandbox_client, running_sandbox):
+    """Test executing multiple commands sequentially"""
+    commands = [
+        ("echo 'first'", "first"),
+        ("echo 'second'", "second"),
+        ("echo 'third'", "third"),
+    ]
+
+    print("\nExecuting sequential commands...")
+    for cmd, expected in commands:
+        result = sandbox_client.execute_command(running_sandbox.id, cmd)
+        assert result.exit_code == 0
+        assert expected in result.stdout
+        print(f"✓ Command '{cmd}' executed successfully")
+
+
+def test_command_with_numeric_output(sandbox_client, running_sandbox):
+    """Test command that outputs numbers"""
+    command = "expr 5 + 3"
+
+    print(f"\nExecuting arithmetic command: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "8"
+    print(f"✓ Arithmetic command result: {result.stdout.strip()}")
+
+
+def test_command_empty_output(sandbox_client, running_sandbox):
+    """Test command with no output"""
+    command = "true"
+
+    print(f"\nExecuting command with no output: {command}")
+    result = sandbox_client.execute_command(running_sandbox.id, command)
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    print("✓ Command with empty output handled correctly")

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -158,43 +158,6 @@ def test_command_timeout_short(sandbox_client, shared_sandbox):
     print(f"✓ Command correctly timed out: {exc_info.value}")
 
 
-def test_python_script_execution(sandbox_client, shared_sandbox):
-    """Test executing Python code directly"""
-    python_code = """
-import sys
-import json
-data = {'python_version': sys.version, 'platform': sys.platform}
-print(json.dumps(data))
-"""
-
-    command = f"python3 -c '{python_code}'"
-    print("\nExecuting Python code...")
-    result = sandbox_client.execute_command(shared_sandbox.id, command)
-
-    assert result.exit_code == 0
-    assert "python_version" in result.stdout
-    assert "platform" in result.stdout
-    print(f"✓ Python code executed:\n{result.stdout}")
-
-
-def test_command_with_special_characters(sandbox_client, shared_sandbox):
-    """Test command with special characters"""
-    special_strings = [
-        "hello & goodbye",
-        "test | with | pipes",
-        "path/to/file.txt",
-        "quote'test'quote",
-    ]
-
-    for special_str in special_strings:
-        print(f"\nTesting string: {special_str}")
-        # Use printf instead of echo to handle special characters better
-        result = sandbox_client.execute_command(shared_sandbox.id, f"printf '%s' '{special_str}'")
-        assert result.exit_code == 0
-        assert special_str in result.stdout
-        print("✓ Special characters handled correctly")
-
-
 def test_command_with_combined_working_dir_and_env(sandbox_client, shared_sandbox):
     """Test command with both working_dir and env parameters"""
     # Setup test directory
@@ -234,56 +197,3 @@ def test_command_creates_and_reads_file(sandbox_client, shared_sandbox):
     assert read_result.exit_code == 0
     assert content in read_result.stdout
     print(f"✓ File operations successful: {read_result.stdout.strip()}")
-
-
-def test_command_check_available_tools(sandbox_client, shared_sandbox):
-    """Test that common tools are available in the sandbox"""
-    tools = ["python3", "bash", "sh", "cat", "ls", "grep", "sed", "awk"]
-
-    print("\nChecking available tools...")
-    for tool in tools:
-        result = sandbox_client.execute_command(shared_sandbox.id, f"which {tool}")
-        assert result.exit_code == 0
-        assert tool in result.stdout or "/" in result.stdout
-        print(f"✓ {tool} is available")
-
-
-def test_sequential_commands(sandbox_client, shared_sandbox):
-    """Test executing multiple commands sequentially"""
-    commands = [
-        ("echo 'first'", "first"),
-        ("echo 'second'", "second"),
-        ("echo 'third'", "third"),
-    ]
-
-    print("\nExecuting sequential commands...")
-    for cmd, expected in commands:
-        result = sandbox_client.execute_command(shared_sandbox.id, cmd)
-        assert result.exit_code == 0
-        assert expected in result.stdout
-        print(f"✓ Command '{cmd}' executed successfully")
-
-
-def test_command_with_numeric_output(sandbox_client, shared_sandbox):
-    """Test command that outputs numbers"""
-    command = "expr 5 + 3"
-
-    print(f"\nExecuting arithmetic command: {command}")
-    result = sandbox_client.execute_command(shared_sandbox.id, command)
-
-    assert result.exit_code == 0
-    assert result.stdout.strip() == "8"
-    print(f"✓ Arithmetic command result: {result.stdout.strip()}")
-
-
-def test_command_empty_output(sandbox_client, shared_sandbox):
-    """Test command with no output"""
-    command = "true"
-
-    print(f"\nExecuting command with no output: {command}")
-    result = sandbox_client.execute_command(shared_sandbox.id, command)
-
-    assert result.exit_code == 0
-    assert result.stdout == ""
-    assert result.stderr == ""
-    print("✓ Command with empty output handled correctly")

--- a/packages/prime-sandboxes/tests/test_file_operations.py
+++ b/packages/prime-sandboxes/tests/test_file_operations.py
@@ -1,0 +1,260 @@
+"""Tests for sandbox file operations (upload/download)"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from prime_sandboxes import (
+    APIClient,
+    CreateSandboxRequest,
+    SandboxClient,
+)
+
+
+@pytest.fixture
+def sandbox_client():
+    """Create a sandbox client for tests"""
+    client = APIClient()
+    return SandboxClient(client)
+
+
+@pytest.fixture
+def running_sandbox(sandbox_client):
+    """Create and setup a running sandbox for tests"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-file-ops",
+                docker_image="python:3.11-slim",
+                cpu_cores=1,
+                memory_gb=2,
+                timeout_minutes=60,
+            )
+        )
+        print(f"✓ Created: {sandbox.id}")
+
+        print("Waiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id)
+        print("✓ Sandbox is running!")
+
+        yield sandbox
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_upload_text_file(sandbox_client, running_sandbox):
+    """Test uploading a text file to sandbox"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        test_content = "Hello from test!\nLine 2\nLine 3"
+        f.write(test_content)
+        local_path = f.name
+
+    try:
+        # Upload file
+        remote_path = "/tmp/test_upload.txt"
+        print(f"\nUploading file to {remote_path}...")
+        result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+        print(f"✓ Upload result: {result}")
+
+        assert result.success is True
+        assert result.path == remote_path
+
+        # Verify file exists and has correct content
+        cmd_result = sandbox_client.execute_command(running_sandbox.id, f"cat {remote_path}")
+        assert cmd_result.exit_code == 0
+        assert cmd_result.stdout.strip() == test_content
+    finally:
+        Path(local_path).unlink(missing_ok=True)
+
+
+def test_upload_and_download_file(sandbox_client, running_sandbox):
+    """Test uploading and downloading a file"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        test_content = "Upload and download test\nMultiple lines\n123456"
+        f.write(test_content)
+        upload_path = f.name
+
+    download_path = None
+    try:
+        # Upload file
+        remote_path = "/tmp/test_roundtrip.txt"
+        print(f"\nUploading file to {remote_path}...")
+        upload_result = sandbox_client.upload_file(running_sandbox.id, remote_path, upload_path)
+        assert upload_result.success is True
+
+        # Download file
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            download_path = f.name
+
+        print(f"Downloading file from {remote_path}...")
+        sandbox_client.download_file(running_sandbox.id, remote_path, download_path)
+        print("✓ Download complete")
+
+        # Verify downloaded content matches uploaded content
+        with open(download_path, "r") as f:
+            downloaded_content = f.read()
+
+        assert downloaded_content == test_content
+    finally:
+        Path(upload_path).unlink(missing_ok=True)
+        if download_path:
+            Path(download_path).unlink(missing_ok=True)
+
+
+def test_upload_binary_file(sandbox_client, running_sandbox):
+    """Test uploading a binary file"""
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        binary_content = bytes(range(256))
+        f.write(binary_content)
+        local_path = f.name
+
+    try:
+        # Upload binary file
+        remote_path = "/tmp/test_binary.bin"
+        print(f"\nUploading binary file to {remote_path}...")
+        result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+        assert result.success is True
+
+        # Verify file exists and size is correct
+        cmd_result = sandbox_client.execute_command(running_sandbox.id, f"wc -c < {remote_path}")
+        assert cmd_result.exit_code == 0
+        assert int(cmd_result.stdout.strip()) == len(binary_content)
+    finally:
+        Path(local_path).unlink(missing_ok=True)
+
+
+def test_upload_to_nested_directory(sandbox_client, running_sandbox):
+    """Test uploading a file to a nested directory path"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Nested directory test")
+        local_path = f.name
+
+    try:
+        # Upload to nested path (directory may not exist)
+        remote_path = "/tmp/nested/dir/structure/test.txt"
+        print(f"\nUploading file to nested path {remote_path}...")
+
+        # First create the directory
+        sandbox_client.execute_command(running_sandbox.id, f"mkdir -p {Path(remote_path).parent}")
+
+        result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+        assert result.success is True
+
+        # Verify file exists
+        cmd_result = sandbox_client.execute_command(
+            running_sandbox.id, f"test -f {remote_path} && echo 'exists'"
+        )
+        assert cmd_result.exit_code == 0
+        assert "exists" in cmd_result.stdout
+    finally:
+        Path(local_path).unlink(missing_ok=True)
+
+
+def test_upload_multiple_files(sandbox_client, running_sandbox):
+    """Test uploading multiple files sequentially"""
+    files = []
+    try:
+        # Create multiple test files
+        for i in range(3):
+            with tempfile.NamedTemporaryFile(mode="w", suffix=f"_{i}.txt", delete=False) as f:
+                f.write(f"File {i} content")
+                files.append(f.name)
+
+        # Upload all files
+        remote_paths = []
+        for i, local_path in enumerate(files):
+            remote_path = f"/tmp/multi_file_{i}.txt"
+            remote_paths.append(remote_path)
+            print(f"\nUploading file {i} to {remote_path}...")
+            result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+            assert result.success is True
+
+        # Verify all files exist
+        cmd_result = sandbox_client.execute_command(
+            running_sandbox.id, f"ls -1 {' '.join(remote_paths)}"
+        )
+        assert cmd_result.exit_code == 0
+        for remote_path in remote_paths:
+            assert Path(remote_path).name in cmd_result.stdout
+    finally:
+        for f in files:
+            Path(f).unlink(missing_ok=True)
+
+
+def test_download_nonexistent_file(sandbox_client, running_sandbox):
+    """Test downloading a file that doesn't exist"""
+    from prime_core import APIError
+
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        download_path = f.name
+
+    try:
+        remote_path = "/tmp/nonexistent_file.txt"
+        print(f"\nAttempting to download nonexistent file {remote_path}...")
+
+        with pytest.raises(APIError):
+            sandbox_client.download_file(running_sandbox.id, remote_path, download_path)
+        print("✓ Correctly raised APIError for nonexistent file")
+    finally:
+        Path(download_path).unlink(missing_ok=True)
+
+
+def test_upload_large_file(sandbox_client, running_sandbox):
+    """Test uploading a larger file (1MB)"""
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        # Create 1MB file
+        large_content = "A" * (1024 * 1024)
+        f.write(large_content)
+        local_path = f.name
+
+    try:
+        remote_path = "/tmp/large_file.txt"
+        print(f"\nUploading 1MB file to {remote_path}...")
+        result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+        assert result.success is True
+
+        # Verify file size
+        cmd_result = sandbox_client.execute_command(running_sandbox.id, f"wc -c < {remote_path}")
+        assert cmd_result.exit_code == 0
+        assert int(cmd_result.stdout.strip()) == len(large_content)
+        print(f"✓ Verified file size: {len(large_content)} bytes")
+    finally:
+        Path(local_path).unlink(missing_ok=True)
+
+
+def test_upload_python_script_and_execute(sandbox_client, running_sandbox):
+    """Test uploading a Python script and executing it"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        script_content = """#!/usr/bin/env python3
+import sys
+print("Hello from uploaded script!")
+print(f"Python version: {sys.version}")
+"""
+        f.write(script_content)
+        local_path = f.name
+
+    try:
+        remote_path = "/tmp/test_script.py"
+        print(f"\nUploading Python script to {remote_path}...")
+        result = sandbox_client.upload_file(running_sandbox.id, remote_path, local_path)
+        assert result.success is True
+
+        # Make script executable and run it
+        sandbox_client.execute_command(running_sandbox.id, f"chmod +x {remote_path}")
+
+        cmd_result = sandbox_client.execute_command(running_sandbox.id, f"python3 {remote_path}")
+        assert cmd_result.exit_code == 0
+        assert "Hello from uploaded script!" in cmd_result.stdout
+        assert "Python version:" in cmd_result.stdout
+        print(f"✓ Script executed successfully:\n{cmd_result.stdout}")
+    finally:
+        Path(local_path).unlink(missing_ok=True)

--- a/packages/prime-sandboxes/tests/test_file_operations.py
+++ b/packages/prime-sandboxes/tests/test_file_operations.py
@@ -210,7 +210,7 @@ def test_download_nonexistent_file(sandbox_client, running_sandbox):
 
 def test_upload_large_file(sandbox_client, running_sandbox):
     """Test uploading a larger file (1MB)"""
-    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
         # Create 1MB file
         large_content = "A" * (1024 * 1024)
         f.write(large_content)

--- a/packages/prime-sandboxes/tests/test_sandbox_operations.py
+++ b/packages/prime-sandboxes/tests/test_sandbox_operations.py
@@ -1,0 +1,449 @@
+"""Tests for sandbox CRUD operations, listing, and bulk operations"""
+
+import pytest
+
+from prime_sandboxes import (
+    APIClient,
+    CreateSandboxRequest,
+    SandboxClient,
+)
+
+
+@pytest.fixture
+def sandbox_client():
+    """Create a sandbox client for tests"""
+    client = APIClient()
+    return SandboxClient(client)
+
+
+def test_create_sandbox_with_custom_config(sandbox_client):
+    """Test creating a sandbox with custom configuration"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox with custom configuration...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-custom-config",
+                docker_image="python:3.11-slim",
+                cpu_cores=2,
+                memory_gb=4,
+                disk_size_gb=10,
+                timeout_minutes=120,
+                labels=["test", "custom-config"],
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        assert sandbox.id is not None
+        assert sandbox.name == "test-custom-config"
+        assert sandbox.cpu_cores == 2
+        assert sandbox.memory_gb == 4
+        assert sandbox.disk_size_gb == 10
+        assert sandbox.timeout_minutes == 120
+        assert "test" in sandbox.labels
+        assert "custom-config" in sandbox.labels
+        print("✓ Sandbox configuration verified")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_get_sandbox(sandbox_client):
+    """Test getting sandbox details"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-get-sandbox",
+                docker_image="python:3.11-slim",
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        # Get sandbox details
+        print("Fetching sandbox details...")
+        retrieved = sandbox_client.get(sandbox.id)
+
+        assert retrieved.id == sandbox.id
+        assert retrieved.name == "test-get-sandbox"
+        assert retrieved.docker_image == "python:3.11-slim"
+        assert retrieved.status in ["PENDING", "RUNNING"]
+        print(f"✓ Retrieved sandbox details: status={retrieved.status}")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_list_sandboxes(sandbox_client):
+    """Test listing sandboxes"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-list-sandbox",
+                docker_image="python:3.11-slim",
+                labels=["test-list"],
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        # List all sandboxes
+        print("Listing sandboxes...")
+        list_response = sandbox_client.list(per_page=50)
+
+        assert list_response.sandboxes is not None
+        assert len(list_response.sandboxes) > 0
+        assert list_response.total >= 1
+
+        # Check our sandbox is in the list
+        found = False
+        for s in list_response.sandboxes:
+            if s.id == sandbox.id:
+                found = True
+                break
+
+        assert found, f"Created sandbox {sandbox.id} not found in list"
+        print(f"✓ Listed {len(list_response.sandboxes)} sandboxes")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_list_sandboxes_with_pagination(sandbox_client):
+    """Test listing sandboxes with pagination"""
+    print("\nListing sandboxes with pagination (page 1, 10 per page)...")
+    list_response = sandbox_client.list(page=1, per_page=10)
+
+    assert list_response.page == 1
+    assert list_response.per_page == 10
+    assert len(list_response.sandboxes) <= 10
+    print(f"✓ Page {list_response.page}: {len(list_response.sandboxes)} sandboxes")
+
+
+def test_list_sandboxes_with_status_filter(sandbox_client):
+    """Test listing sandboxes filtered by status"""
+    print("\nListing sandboxes with status=RUNNING...")
+    list_response = sandbox_client.list(status="RUNNING")
+
+    # All returned sandboxes should have RUNNING status
+    for sandbox in list_response.sandboxes:
+        assert sandbox.status == "RUNNING"
+
+    print(f"✓ Found {len(list_response.sandboxes)} RUNNING sandboxes")
+
+
+def test_list_sandboxes_with_label_filter(sandbox_client):
+    """Test listing sandboxes filtered by label"""
+    sandbox = None
+    test_label = "test-label-filter-unique"
+
+    try:
+        print(f"\nCreating sandbox with label '{test_label}'...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-label-filter",
+                docker_image="python:3.11-slim",
+                labels=[test_label],
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        # List sandboxes with this label
+        print(f"Listing sandboxes with label '{test_label}'...")
+        list_response = sandbox_client.list(labels=[test_label])
+
+        # Should find at least our sandbox
+        assert len(list_response.sandboxes) >= 1
+
+        # All sandboxes should have our label
+        found_our_sandbox = False
+        for s in list_response.sandboxes:
+            assert test_label in s.labels
+            if s.id == sandbox.id:
+                found_our_sandbox = True
+
+        assert found_our_sandbox
+        print(f"✓ Found {len(list_response.sandboxes)} sandbox(es) with label")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_delete_sandbox(sandbox_client):
+    """Test deleting a sandbox"""
+    print("\nCreating sandbox...")
+    sandbox = sandbox_client.create(
+        CreateSandboxRequest(
+            name="test-delete",
+            docker_image="python:3.11-slim",
+        )
+    )
+    sandbox_id = sandbox.id
+    print(f"✓ Created sandbox: {sandbox_id}")
+
+    # Delete sandbox
+    print(f"Deleting sandbox {sandbox_id}...")
+    result = sandbox_client.delete(sandbox_id)
+    print(f"✓ Delete result: {result}")
+
+    # Try to get the deleted sandbox - it should be gone or marked as TERMINATED
+    try:
+        deleted = sandbox_client.get(sandbox_id)
+        # If we can still get it, it should be terminated
+        assert deleted.status == "TERMINATED"
+        print("✓ Sandbox status is TERMINATED")
+    except Exception:
+        # Or it might be completely gone, which is also fine
+        print("✓ Sandbox completely removed")
+
+
+def test_bulk_delete_by_ids(sandbox_client):
+    """Test bulk deleting sandboxes by IDs"""
+    sandboxes = []
+    try:
+        # Create multiple sandboxes
+        print("\nCreating 3 sandboxes for bulk delete test...")
+        for i in range(3):
+            sandbox = sandbox_client.create(
+                CreateSandboxRequest(
+                    name=f"test-bulk-delete-{i}",
+                    docker_image="python:3.11-slim",
+                )
+            )
+            sandboxes.append(sandbox)
+            print(f"✓ Created sandbox {i + 1}: {sandbox.id}")
+
+        sandbox_ids = [s.id for s in sandboxes]
+
+        # Bulk delete
+        print(f"\nBulk deleting {len(sandbox_ids)} sandboxes...")
+        result = sandbox_client.bulk_delete(sandbox_ids=sandbox_ids)
+
+        assert result.deleted_count == len(sandbox_ids)
+        print(f"✓ Bulk deleted {result.deleted_count} sandboxes")
+
+        # Clear the list so we don't try to delete again in finally
+        sandboxes = []
+    finally:
+        # Clean up any remaining sandboxes
+        for sandbox in sandboxes:
+            try:
+                print(f"Cleaning up sandbox {sandbox.id}...")
+                sandbox_client.delete(sandbox.id)
+            except Exception as e:
+                print(f"Warning: Failed to delete {sandbox.id}: {e}")
+
+
+def test_bulk_delete_by_labels(sandbox_client):
+    """Test bulk deleting sandboxes by labels"""
+    test_label = "test-bulk-delete-label-unique"
+    sandboxes = []
+
+    try:
+        # Create sandboxes with specific label
+        print(f"\nCreating 2 sandboxes with label '{test_label}'...")
+        for i in range(2):
+            sandbox = sandbox_client.create(
+                CreateSandboxRequest(
+                    name=f"test-bulk-delete-label-{i}",
+                    docker_image="python:3.11-slim",
+                    labels=[test_label],
+                )
+            )
+            sandboxes.append(sandbox)
+            print(f"✓ Created sandbox {i + 1}: {sandbox.id}")
+
+        # Bulk delete by label
+        print(f"\nBulk deleting sandboxes with label '{test_label}'...")
+        result = sandbox_client.bulk_delete(labels=[test_label])
+
+        assert result.deleted_count >= 2
+        print(f"✓ Bulk deleted {result.deleted_count} sandboxes by label")
+
+        # Clear the list so we don't try to delete again in finally
+        sandboxes = []
+    finally:
+        # Clean up any remaining sandboxes
+        for sandbox in sandboxes:
+            try:
+                print(f"Cleaning up sandbox {sandbox.id}...")
+                sandbox_client.delete(sandbox.id)
+            except Exception as e:
+                print(f"Warning: Failed to delete {sandbox.id}: {e}")
+
+
+def test_get_logs(sandbox_client):
+    """Test getting sandbox logs"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-logs",
+                docker_image="python:3.11-slim",
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        print("Waiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id)
+
+        # Execute a command to generate some output
+        sandbox_client.execute_command(sandbox.id, "echo 'test log message'")
+
+        # Get logs
+        print("Fetching sandbox logs...")
+        logs = sandbox_client.get_logs(sandbox.id)
+
+        assert logs is not None
+        assert isinstance(logs, str)
+        print(f"✓ Retrieved logs ({len(logs)} chars)")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_wait_for_creation(sandbox_client):
+    """Test waiting for sandbox to be ready"""
+    sandbox = None
+    try:
+        print("\nCreating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-wait",
+                docker_image="python:3.11-slim",
+            )
+        )
+        print(f"✓ Created sandbox: {sandbox.id}")
+
+        # Wait for it to be ready
+        print("Waiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id, max_attempts=60)
+        print("✓ Sandbox is ready!")
+
+        # Verify it's actually running and reachable
+        retrieved = sandbox_client.get(sandbox.id)
+        assert retrieved.status == "RUNNING"
+
+        # Try executing a command to confirm it's reachable
+        result = sandbox_client.execute_command(sandbox.id, "echo 'ready'")
+        assert result.exit_code == 0
+        assert "ready" in result.stdout
+        print("✓ Sandbox is reachable and functional")
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
+
+
+def test_sandbox_with_different_docker_images(sandbox_client):
+    """Test creating sandboxes with different Docker images"""
+    images = [
+        "python:3.11-slim",
+        "python:3.12-slim",
+    ]
+    sandboxes = []
+
+    try:
+        for image in images:
+            print(f"\nCreating sandbox with image {image}...")
+            sandbox = sandbox_client.create(
+                CreateSandboxRequest(
+                    name=f"test-{image.replace(':', '-')}",
+                    docker_image=image,
+                )
+            )
+            sandboxes.append(sandbox)
+            print(f"✓ Created sandbox: {sandbox.id}")
+
+            # Verify the image is set correctly
+            retrieved = sandbox_client.get(sandbox.id)
+            assert retrieved.docker_image == image
+            print(f"✓ Verified docker_image: {retrieved.docker_image}")
+    finally:
+        for sandbox in sandboxes:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete {sandbox.id}: {e}")
+
+
+def test_sandbox_lifecycle(sandbox_client):
+    """Test complete sandbox lifecycle: create -> use -> delete"""
+    sandbox = None
+    try:
+        # Create
+        print("\n[LIFECYCLE] Creating sandbox...")
+        sandbox = sandbox_client.create(
+            CreateSandboxRequest(
+                name="test-lifecycle",
+                docker_image="python:3.11-slim",
+                labels=["lifecycle-test"],
+            )
+        )
+        print(f"✓ Created: {sandbox.id}")
+
+        # Wait for ready
+        print("[LIFECYCLE] Waiting for sandbox to be ready...")
+        sandbox_client.wait_for_creation(sandbox.id)
+        print("✓ Sandbox is ready")
+
+        # Use it
+        print("[LIFECYCLE] Using sandbox...")
+        result = sandbox_client.execute_command(sandbox.id, "echo 'lifecycle test'")
+        assert result.exit_code == 0
+        print("✓ Executed command successfully")
+
+        # Get details
+        print("[LIFECYCLE] Getting sandbox details...")
+        details = sandbox_client.get(sandbox.id)
+        assert details.status == "RUNNING"
+        print(f"✓ Status: {details.status}")
+
+        # Delete
+        print("[LIFECYCLE] Deleting sandbox...")
+        sandbox_client.delete(sandbox.id)
+        print("✓ Deleted successfully")
+
+        sandbox = None  # Don't try to delete again in finally
+    finally:
+        if sandbox and sandbox.id:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print(f"✓ Deleted sandbox {sandbox.id}")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")

--- a/packages/prime-sandboxes/tests/test_sandbox_operations.py
+++ b/packages/prime-sandboxes/tests/test_sandbox_operations.py
@@ -1,19 +1,6 @@
 """Tests for sandbox CRUD operations, listing, and bulk operations"""
 
-import pytest
-
-from prime_sandboxes import (
-    APIClient,
-    CreateSandboxRequest,
-    SandboxClient,
-)
-
-
-@pytest.fixture
-def sandbox_client():
-    """Create a sandbox client for tests"""
-    client = APIClient()
-    return SandboxClient(client)
+from prime_sandboxes import CreateSandboxRequest
 
 
 def test_create_sandbox_with_custom_config(sandbox_client):

--- a/uv.lock
+++ b/uv.lock
@@ -456,6 +456,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1426,6 +1435,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1435,6 +1445,7 @@ requires-dist = [
     { name = "prime-core", editable = "packages/prime-core" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
 ]
 provides-extras = ["dev"]
@@ -1731,6 +1742,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds extensive sandbox CRUD/exec/file integration tests and runs them in parallel via pytest-xdist and CI updates.
> 
> - **Tests (`packages/prime-sandboxes/tests/`)**:
>   - Add integration tests for sandbox lifecycle, listing/filtering, bulk delete, logs, readiness, and end-to-end lifecycle (`test_sandbox_operations.py`).
>   - Add command execution tests: working dirs, env vars, exit codes, stdout/stderr, pipelines, long-running, timeouts, file creation/read (`test_command_execution.py`).
>   - Add file operations tests: upload/download text/binary, nonexistent file error, upload-and-execute Python script (`test_file_operations.py`).
>   - Shared pytest fixture for `SandboxClient` (`conftest.py`).
> - **Tooling/Config**:
>   - Enable parallel testing in CI (`-n auto`) and add `pytest-xdist` dev dependency with pytest config in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e9df9caf4ed5be31136383896d6c34164fd08c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->