### PR TITLE
Feature: Add sandbox secret integration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -153,6 +153,7 @@ request = CreateSandboxRequest(
     gpu_count=0,
     timeout_minutes=60,
     environment_vars={"ENV": "production"},
+    secrets={"API_KEY": "your-secret-key"},
     team_id=None  # Use None for personal account
 )
 
@@ -168,6 +169,9 @@ prime sandbox list [--team_id TEAM] [--status STATUS] [--page N] [--per_page N]
 
 # Create sandbox
 prime sandbox create NAME --docker_image IMAGE [OPTIONS]
+
+# With environment variables and secrets:
+prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123
 
 # Get sandbox details
 prime sandbox get SANDBOX_ID

--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -33,6 +33,8 @@ def main() -> None:
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=120,  # 2 hours to avoid timeout during demo
+            environment_vars={"ENV": "demo", "DEBUG": "false"},
+            secrets={"API_KEY": "demo-secret-key-12345"},
         )
 
         print("Creating sandbox...")

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -88,6 +88,28 @@ The SDK looks for credentials in this order:
 
 ## Advanced Features
 
+### Environment Variables and Secrets
+
+```python
+# Create sandbox with environment variables and secrets
+request = CreateSandboxRequest(
+    name="my-sandbox",
+    docker_image="python:3.11-slim",
+    environment_vars={
+        "DEBUG": "true",
+        "LOG_LEVEL": "info"
+    },
+    secrets={
+        "API_KEY": "sk-secret-key-here",
+        "DATABASE_PASSWORD": "super-secret-password"
+    }
+)
+
+sandbox = sandbox_client.create(request)
+```
+
+**Note:** Secrets are never displayed in logs or outputs. When retrieving sandbox details, only the secret keys are shown with values masked as `***`.
+
 ### File Operations
 
 ```python

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -42,6 +42,7 @@ class Sandbox(BaseModel):
     status: str
     timeout_minutes: int = Field(..., alias="timeoutMinutes")
     environment_vars: Optional[Dict[str, Any]] = Field(None, alias="environmentVars")
+    secrets: Optional[Dict[str, Any]] = Field(None, alias="secrets")
     advanced_configs: Optional[AdvancedConfigs] = Field(None, alias="advancedConfigs")
     labels: List[str] = Field(default_factory=list)
     created_at: datetime = Field(..., alias="createdAt")
@@ -80,6 +81,7 @@ class CreateSandboxRequest(BaseModel):
     gpu_count: int = 0
     timeout_minutes: int = 60
     environment_vars: Optional[Dict[str, str]] = None
+    secrets: Optional[Dict[str, str]] = None
     labels: List[str] = Field(default_factory=list)
     team_id: Optional[str] = None
     advanced_configs: Optional[AdvancedConfigs] = None
@@ -97,6 +99,7 @@ class UpdateSandboxRequest(BaseModel):
     gpu_count: Optional[int] = None
     timeout_minutes: Optional[int] = None
     environment_vars: Optional[Dict[str, str]] = None
+    secrets: Optional[Dict[str, str]] = None
 
 
 class CommandRequest(BaseModel):

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -2,7 +2,13 @@
 
 # Re-export the most commonly used functions
 from .display import build_table, output_data_as_json, status_color, validate_output_format
-from .formatters import format_ip_display, format_price, format_resources, obfuscate_env_vars
+from .formatters import (
+    format_ip_display,
+    format_price,
+    format_resources,
+    obfuscate_env_vars,
+    obfuscate_secrets,
+)
 from .prompt import confirm_or_skip
 from .time_utils import human_age, iso_timestamp, sort_by_created
 
@@ -15,6 +21,7 @@ __all__ = [
     "iso_timestamp",
     "sort_by_created",
     "obfuscate_env_vars",
+    "obfuscate_secrets",
     "format_ip_display",
     "format_price",
     "format_resources",

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -15,6 +15,14 @@ def obfuscate_env_vars(env_vars: Dict[str, Any]) -> Dict[str, str]:
     return obfuscated
 
 
+def obfuscate_secrets(secrets: Dict[str, Any]) -> Dict[str, str]:
+    """Obfuscate secret values completely for display (keys only, all values as ***)."""
+    obfuscated: Dict[str, str] = {}
+    for key in secrets.keys():
+        obfuscated[key] = "***"
+    return obfuscated
+
+
 def format_ip_display(ip: Optional[Union[str, List[str]]]) -> str:
     """Format IP address(es) for display, handling both single and list cases."""
     if not ip:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add secrets support to sandboxes across SDK and CLI with a new --secret flag, model fields, secure masking, and updated docs/examples.
> 
> - **SDK (`prime-sandboxes`)**:
>   - Add `secrets` support to models: `Sandbox`, `CreateSandboxRequest`, `UpdateSandboxRequest`.
> - **CLI (`packages/prime/src/prime_cli/commands/sandbox.py`)**:
>   - Add `--secret KEY=VALUE` option to `sandbox create` and parse into request.
>   - Display masked `secrets` in `get` output and creation summary.
> - **Utils**:
>   - Implement and export `obfuscate_secrets` in `utils/formatters.py`; wire through `utils/__init__.py` and CLI.
> - **Docs & Examples**:
>   - Update `examples/README.md`, `sandbox_demo.py`, and `prime-sandboxes/README.md` to show secrets usage and note masking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 198fa918a43fd083605fb89978ce8246c26d82b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->