### PR TITLE
fix test setup

### DIFF
--- a/packages/prime-sandboxes/tests/conftest.py
+++ b/packages/prime-sandboxes/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared pytest configuration and fixtures for sandbox tests"""
 
+import os
 import uuid
+from unittest.mock import patch
 
 import pytest
 
@@ -8,10 +10,16 @@ from prime_sandboxes import APIClient, SandboxClient
 
 
 @pytest.fixture(scope="session")
-def sandbox_client():
-    """Create a shared sandbox client for all tests"""
-    client = APIClient()
-    return SandboxClient(client)
+def sandbox_client(tmp_path_factory):
+    """Create a shared sandbox client for all tests with isolated config per worker"""
+    # Create a unique config directory for this test worker to avoid file collisions
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    config_dir = tmp_path_factory.mktemp(f"prime_config_{worker_id}", numbered=False)
+
+    # Patch Path.home() to return our isolated config directory for this worker
+    with patch("pathlib.Path.home", return_value=config_dir):
+        client = APIClient()
+        yield SandboxClient(client)
 
 
 @pytest.fixture

--- a/packages/prime-sandboxes/tests/conftest.py
+++ b/packages/prime-sandboxes/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared pytest configuration and fixtures for sandbox tests"""
 
+import uuid
+
 import pytest
 
 from prime_sandboxes import APIClient, SandboxClient
@@ -10,3 +12,9 @@ def sandbox_client():
     """Create a shared sandbox client for all tests"""
     client = APIClient()
     return SandboxClient(client)
+
+
+@pytest.fixture
+def unique_id():
+    """Generate a unique ID for each test to avoid collisions in parallel runs"""
+    return str(uuid.uuid4())[:8]

--- a/packages/prime-sandboxes/tests/test_sandbox_operations.py
+++ b/packages/prime-sandboxes/tests/test_sandbox_operations.py
@@ -113,16 +113,16 @@ def test_list_sandboxes(sandbox_client):
                 print(f"Warning: Failed to delete sandbox {sandbox.id}: {e}")
 
 
-def test_list_sandboxes_with_label_filter(sandbox_client):
+def test_list_sandboxes_with_label_filter(sandbox_client, unique_id):
     """Test listing sandboxes filtered by label"""
     sandbox = None
-    test_label = "test-label-filter-unique"
+    test_label = f"test-label-filter-{unique_id}"
 
     try:
         print(f"\nCreating sandbox with label '{test_label}'...")
         sandbox = sandbox_client.create(
             CreateSandboxRequest(
-                name="test-label-filter",
+                name=f"test-label-filter-{unique_id}",
                 docker_image="python:3.11-slim",
                 labels=[test_label],
             )
@@ -220,9 +220,9 @@ def test_bulk_delete_by_ids(sandbox_client):
                 print(f"Warning: Failed to delete {sandbox.id}: {e}")
 
 
-def test_bulk_delete_by_labels(sandbox_client):
+def test_bulk_delete_by_labels(sandbox_client, unique_id):
     """Test bulk deleting sandboxes by labels"""
-    test_label = "test-bulk-delete-label-unique"
+    test_label = f"test-bulk-delete-{unique_id}"
     sandboxes = []
 
     try:
@@ -231,7 +231,7 @@ def test_bulk_delete_by_labels(sandbox_client):
         for i in range(2):
             sandbox = sandbox_client.create(
                 CreateSandboxRequest(
-                    name=f"test-bulk-delete-label-{i}",
+                    name=f"test-bulk-delete-label-{unique_id}-{i}",
                     docker_image="python:3.11-slim",
                     labels=[test_label],
                 )

--- a/packages/prime-sandboxes/tests/test_sandbox_operations.py
+++ b/packages/prime-sandboxes/tests/test_sandbox_operations.py
@@ -60,7 +60,7 @@ def test_get_sandbox(sandbox_client):
         assert retrieved.id == sandbox.id
         assert retrieved.name == "test-get-sandbox"
         assert retrieved.docker_image == "python:3.11-slim"
-        assert retrieved.status in ["PENDING", "RUNNING"]
+        assert retrieved.status in ["PENDING", "PROVISIONING", "RUNNING"]
         print(f"✓ Retrieved sandbox details: status={retrieved.status}")
     finally:
         if sandbox and sandbox.id:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make tests parallel-safe by isolating config per worker and using unique IDs, and update status assertions to include PROVISIONING.
> 
> - **Tests**:
>   - **Pytest fixtures**:
>     - Update `tests/conftest.py` `sandbox_client` to use a per-worker temp config dir via `tmp_path_factory` and patch `Path.home()`.
>     - Add `unique_id` fixture generating short UUIDs for test isolation.
>   - **Sandbox operations tests** (`tests/test_sandbox_operations.py`):
>     - Extend status assertions to include `"PROVISIONING"` in `test_get_sandbox`.
>     - Use `unique_id` to de-conflict labels and names in label-based list and bulk-delete tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5854bd6ceda49e8645ff5141d3ae5a62c9f0699f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->