### PR TITLE
better file upload handling with non-blocking open, connection sharing

### DIFF
--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "prime-core",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
+    "aiofiles>=23.0.0",
 ]
 keywords = ["sandboxes", "remote-execution", "containers", "cloud", "sdk"]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,15 @@ dev = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1427,6 +1436,7 @@ provides-extras = ["dev"]
 name = "prime-sandboxes"
 source = { editable = "packages/prime-sandboxes" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "httpx" },
     { name = "prime-core" },
     { name = "pydantic" },
@@ -1441,6 +1451,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "prime-core", editable = "packages/prime-core" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors AsyncSandboxClient to use a shared httpx.AsyncClient with per‑request timeouts and aiofiles for non‑blocking upload/download, plus proper cleanup; adds aiofiles dependency.
> 
> - **Prime Sandboxes SDK**:
>   - **AsyncSandboxClient**:
>     - Introduces shared `httpx.AsyncClient` with connection pooling; timeouts set per request.
>     - Refactors `execute_command`, `upload_file`, and `download_file` to reuse the shared client.
>     - Uses `aiofiles` for non-blocking file reads/writes during upload/download.
>     - Ensures gateway client is closed in `aclose`.
> - **Dependencies**:
>   - Adds `aiofiles>=23.0.0` to `prime-sandboxes`; updates `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2996a979e353b0fdb0cbc21e3fa5187fc27e7bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->