### PR TITLE
fix version extraction in ci

### DIFF
--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         working-directory: packages/prime-sandboxes
         run: |
-          VERSION=$(grep -E "^version\s*=" pyproject.toml | sed -E 's/version\s*=\s*"([^"]+)"/\1/')
+          VERSION=$(grep -E "^__version__\s*=" src/prime_sandboxes/__init__.py | sed -E 's/__version__\s*=\s*"([^"]+)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update release workflow to read `prime-sandboxes` version from `src/prime_sandboxes/__init__.py` (`__version__`) instead of `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a412aab08d56e9afbdeb58d292c8b43f91df93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->