### PR TITLE
fix sandbox release flow

### DIFF
--- a/packages/prime-sandboxes/build_for_pypi.sh
+++ b/packages/prime-sandboxes/build_for_pypi.sh
@@ -18,8 +18,11 @@ echo "Copying prime-core into source tree..."
 rm -rf src/prime_core
 cp -r ../prime-core/src/prime_core src/prime_core
 
-sed '/prime-core/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-sed '/\[tool\.uv\.sources\]/,/prime-core = { workspace = true }/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Remove prime-core from dependencies list only
+sed '/^    "prime-core",$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Remove the [tool.uv.sources] section
+sed '/^\[tool\.uv\.sources\]$/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Update the force-include path
 sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
 echo "Building wheel..."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens pyproject.toml edits in the build script to only remove the prime-core dependency, drop the [tool.uv.sources] section, update the force-include path, and build the wheel.
> 
> - **Build Script (`packages/prime-sandboxes/build_for_pypi.sh`)**:
>   - Precisely remove `prime-core` from dependencies only.
>   - Delete the entire `[tool.uv.sources]` section.
>   - Update `force-include` path to `src/prime_core`.
>   - Copy `prime_core` into `src` and build wheel with `uv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80497bca8068648b2c9333b09ed2225dedef556a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->