### PR TITLE
Imp: Fix prime-core issue in prime-evals

### DIFF
--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-evals"
-# Version is single-sourced from src/prime_sandboxes/__init__.py via Hatch
+# Version is single-sourced from src/prime_evals/__init__.py via Hatch
 dynamic = ["version"]
 description = "Prime Intellect Evals SDK - Push and manage evaluations"
 readme = "README.md"

--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "prime-evals"
-version = "0.1.3"
+# Version is single-sourced from src/prime_sandboxes/__init__.py via Hatch
+dynamic = ["version"]
 description = "Prime Intellect Evals SDK - Push and manage evaluations"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-core>=0.1.1",
+    "prime-core",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
 ]
@@ -44,6 +45,9 @@ prime-core = { workspace = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/prime_evals/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prime_evals"]

--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -35,7 +35,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __all__ = [
     # Core HTTP Client & Config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Single-source version via Hatch, unpin prime-core dependency, and bump prime-evals to 0.1.4.
> 
> - **Packaging (prime-evals)**:
>   - Single-sources `version` via Hatch (`[tool.hatch.version]`), switching `[project]` to `dynamic = ["version"]`.
>   - Unpins `prime-core` dependency (remove `>=0.1.1`).
>   - Bumps `__version__` in `src/prime_evals/__init__.py` to `0.1.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4aacf896421d55d226ffcff3fc11a2a007e82cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->