### PR TITLE
ENG-2194: Create `.env-metadata.json` on env pull

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 import sys
 from typing import Any, Dict, List, Optional
 

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -76,19 +76,24 @@ class EvalsClient:
             resolved_env = env.copy()
             # Handle different identifier types explicitly
             # Check for explicit "slug" or "name" keys first
-            if "slug" in resolved_env:
-                # Owner/name format, resolve to database ID
-                resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("slug"))
-            elif "name" in resolved_env:
-                # Just a name, resolve to database ID (get-or-create)
-                resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
-            elif "id" in resolved_env:
-                # "id" key exists - it's already a database ID
-                pass
-            else:
-                # Skip environments without valid identifiers
+            try:
+                if "slug" in resolved_env:
+                    # Owner/name format, resolve to database ID
+                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("slug"))
+                elif "name" in resolved_env:
+                    # Just a name, resolve to database ID (get-or-create)
+                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
+                elif "id" in resolved_env:
+                    # "id" key exists - it's already a database ID
+                    pass
+                else:
+                    # Skip environments without valid identifiers
+                    continue
+                resolved_environments.append(resolved_env)
+            except EvalsAPIError:
+                # Skip environments that don't exist in the hub
+                # Continue processing remaining environments
                 continue
-            resolved_environments.append(resolved_env)
         return resolved_environments
 
     def create_evaluation(
@@ -290,28 +295,33 @@ class AsyncEvalsClient:
             resolved_env = env.copy()
             # Handle different identifier types explicitly
             # Check for explicit "slug" or "name" keys first
-            if "slug" in resolved_env:
-                # Owner/name format, resolve to database ID
-                resolved_env["id"] = await self._resolve_environment_id(
-                    resolved_env.pop("slug")
-                )
-            elif "name" in resolved_env:
-                # Just a name, resolve to database ID (get-or-create)
-                resolved_env["id"] = await self._resolve_environment_id(
-                    resolved_env.pop("name")
-                )
-            elif "id" in resolved_env:
-                # "id" key exists - it's already a database ID
-                pass
-            else:
-                # Skip environments without valid identifiers
+            try:
+                if "slug" in resolved_env:
+                    # Owner/name format, resolve to database ID
+                    resolved_env["id"] = await self._resolve_environment_id(
+                        resolved_env.pop("slug")
+                    )
+                elif "name" in resolved_env:
+                    # Just a name, resolve to database ID (get-or-create)
+                    resolved_env["id"] = await self._resolve_environment_id(
+                        resolved_env.pop("name")
+                    )
+                elif "id" in resolved_env:
+                    # "id" key exists - it's already a database ID
+                    pass
+                else:
+                    # Skip environments without valid identifiers
+                    return None
+                return resolved_env
+            except EvalsAPIError:
+                # Skip environments that don't exist in the hub
+                # Return None to filter them out
                 return None
-            return resolved_env
 
         resolved_environments_list = await asyncio.gather(
             *[resolve_env(env) for env in environments]
         )
-        # Filter out None values (environments without valid identifiers)
+        # Filter out None values (environments without valid identifiers or resolution failures)
         return [env for env in resolved_environments_list if env is not None]
 
     async def create_evaluation(

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -360,7 +360,7 @@ class AsyncEvalsClient:
                     )
                 elif "id" in resolved_env:
                     # "id" key exists - validate it exists in the hub via lookup
-                    await self._lookup_environment_id(resolved_env["id"])
+                    resolved_env["id"] = await self._lookup_environment_id(resolved_env["id"])
                 else:
                     # Skip environments without valid identifiers
                     return None

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -68,6 +68,7 @@ class EvalsClient:
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         metrics: Optional[Dict[str, Any]] = None,
+        is_public: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Create a new evaluation
 
@@ -87,10 +88,33 @@ class EvalsClient:
 
         resolved_environments = None
         if environments:
-            resolved_environments = [
-                {**env, "id": self._resolve_environment_id(env["id"])} if "id" in env else env
-                for env in environments
-            ]
+            # Initialize as empty list before resolution
+            resolved_environments = []
+            for env in environments:
+                resolved_env = env.copy()
+                # Handle different identifier types explicitly
+                # Check for explicit "slug" or "name" keys first
+                if "slug" in resolved_env:
+                    # Owner/name format, resolve to database ID
+                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("slug"))
+                elif "name" in resolved_env:
+                    # Just a name, resolve to database ID (get-or-create)
+                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
+                elif "id" in resolved_env:
+                    # "id" key exists - it's already a database ID
+                    pass
+                else:
+                    # Skip environments without valid identifiers
+                    continue
+                resolved_environments.append(resolved_env)
+            
+            # Validate that we have at least one resolved environment if run_id is not provided
+            # This check happens AFTER resolution to catch cases where all environments were invalid
+            if not resolved_environments and not run_id:
+                raise InvalidEvaluationError(
+                    "All provided environments lack valid identifiers (slug, name, or id). "
+                    "Either provide valid environment identifiers or provide a 'run_id'. "
+                )
 
         payload = {
             "name": name,
@@ -106,6 +130,12 @@ class EvalsClient:
             "metadata": metadata,
             "metrics": metrics,
         }
+        # Include team_id from config if set (for team-owned evaluations)
+        if self.client.config.team_id:
+            payload["team_id"] = self.client.config.team_id
+        # Only include is_public if it's explicitly set (not None)
+        if is_public is not None:
+            payload["is_public"] = is_public
         payload = {k: v for k, v in payload.items() if v is not None or k in ["tags"]}
 
         response = self.client.request("POST", "/evaluations/", json=payload)
@@ -234,6 +264,7 @@ class AsyncEvalsClient:
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         metrics: Optional[Dict[str, Any]] = None,
+        is_public: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Create a new evaluation
 
@@ -253,16 +284,44 @@ class AsyncEvalsClient:
 
         resolved_environments = None
         if environments:
+            # Initialize as empty list before resolution
+            resolved_environments = []
 
-            async def resolve_env(env: Dict[str, str]) -> Dict[str, str]:
+            async def resolve_env(env: Dict[str, str]) -> Optional[Dict[str, str]]:
                 resolved_env = env.copy()
-                if "id" in resolved_env:
-                    resolved_env["id"] = await self._resolve_environment_id(resolved_env["id"])
+                # Handle different identifier types explicitly
+                # Check for explicit "slug" or "name" keys first
+                if "slug" in resolved_env:
+                    # Owner/name format, resolve to database ID
+                    resolved_env["id"] = await self._resolve_environment_id(
+                        resolved_env.pop("slug")
+                    )
+                elif "name" in resolved_env:
+                    # Just a name, resolve to database ID (get-or-create)
+                    resolved_env["id"] = await self._resolve_environment_id(
+                        resolved_env.pop("name")
+                    )
+                elif "id" in resolved_env:
+                    # "id" key exists - it's already a database ID
+                    pass
+                else:
+                    # Skip environments without valid identifiers
+                    return None
                 return resolved_env
 
-            resolved_environments = await asyncio.gather(
+            resolved_environments_list = await asyncio.gather(
                 *[resolve_env(env) for env in environments]
             )
+            # Filter out None values (environments without valid identifiers)
+            resolved_environments = [env for env in resolved_environments_list if env is not None]
+            
+            # Validate that we have at least one resolved environment if run_id is not provided
+            # This check happens AFTER resolution to catch cases where all environments were invalid
+            if not resolved_environments and not run_id:
+                raise InvalidEvaluationError(
+                    "All provided environments lack valid identifiers (slug, name, or id). "
+                    "Either provide valid environment identifiers or provide a 'run_id'. "
+                )
 
         payload = {
             "name": name,
@@ -278,6 +337,12 @@ class AsyncEvalsClient:
             "metadata": metadata,
             "metrics": metrics,
         }
+        # Include team_id from config if set (for team-owned evaluations)
+        if self.client.config.team_id:
+            payload["team_id"] = self.client.config.team_id
+        # Only include is_public if it's explicitly set (not None)
+        if is_public is not None:
+            payload["is_public"] = is_public
         payload = {k: v for k, v in payload.items() if v is not None or k in ["tags"]}
 
         response = await self.client.request("POST", "/evaluations/", json=payload)

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -62,7 +62,7 @@ class EvalsClient:
         except APIError as e:
             raise EvalsAPIError(
                 f"Environment '{env_name}' does not exist in the hub. "
-                f"Please push the environment first with: prime env push {env_name}"
+                f"Please push the environment first with: prime env push"
             ) from e
 
     def _resolve_environments(
@@ -277,7 +277,7 @@ class AsyncEvalsClient:
         except APIError as e:
             raise EvalsAPIError(
                 f"Environment '{env_name}' does not exist in the hub. "
-                f"Please push the environment first with: prime env push {env_name}"
+                f"Please push the environment first with: prime env push"
             ) from e
 
     async def _resolve_environments(

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -107,6 +107,9 @@ class EvalsClient:
                 if "slug" in resolved_env:
                     # Owner/name format, lookup (does not create)
                     slug = resolved_env.pop("slug")
+                    if "/" not in slug:
+                        # Invalid slug format - skip this environment
+                        continue
                     owner_slug, name = slug.split("/", 1)
                     resolved_env["id"] = self._lookup_environment_by_slug(owner_slug, name)
                 elif "name" in resolved_env:
@@ -355,6 +358,9 @@ class AsyncEvalsClient:
                 if "slug" in resolved_env:
                     # Owner/name format, lookup (does not create)
                     slug = resolved_env.pop("slug")
+                    if "/" not in slug:
+                        # Invalid slug format - skip this environment
+                        return None
                     owner_slug, name = slug.split("/", 1)
                     resolved_env["id"] = await self._lookup_environment_by_slug(owner_slug, name)
                 elif "name" in resolved_env:

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from .core import APIError, AsyncAPIClient
 from .exceptions import EvalsAPIError, InvalidEvaluationError
@@ -88,7 +88,7 @@ class EvalsClient:
             ) from e
 
     def _resolve_environments(
-        self, environments: List[Dict[str, str]]
+        self, environments: List[Union[str, Dict[str, str]]]
     ) -> List[Dict[str, str]]:
         """
         Resolve a list of environments from various identifier formats to database IDs.
@@ -338,13 +338,17 @@ class AsyncEvalsClient:
             ) from e
 
     async def _resolve_environments(
-        self, environments: List[Dict[str, str]]
+        self, environments: List[Union[str, Dict[str, str]]]
     ) -> List[Dict[str, str]]:
         """
         Resolve a list of environments from various identifier formats to database IDs.
         """
-        async def resolve_env(env: Dict[str, str]) -> Optional[Dict[str, str]]:
-            resolved_env = env.copy()
+        async def resolve_env(env: Union[str, Dict[str, str]]) -> Optional[Dict[str, str]]:
+            # Handle string inputs (convert to dict format)
+            if isinstance(env, str):
+                env = {"slug": env} if "/" in env else {"name": env}
+            
+            resolved_env = env.copy() if isinstance(env, dict) else {}
             # Handle different identifier types explicitly
             # Check for explicit "slug" or "name" keys first
             try:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -18,6 +18,7 @@ import toml
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from prime_cli.core import Config
 
@@ -804,13 +805,13 @@ def push(
                         json.dump(env_metadata, f, indent=2)
                     
                     if existing_metadata:
-                        console.print(
-                            "[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]"
-                        )
+                        message = Text("Updated environment metadata in ", style="dim")
+                        message.append(str(metadata_path), style="dim")
+                        console.print(message)
                     else:
-                        console.print(
-                            "[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]"
-                        )
+                        message = Text("Saved environment metadata to ", style="dim")
+                        message.append(str(metadata_path), style="dim")
+                        console.print(message)
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -1013,7 +1014,9 @@ def pull(
             }
             with open(metadata_path, "w") as f:
                 json.dump(env_metadata, f, indent=2)
-            console.print("[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
+            message = Text("Created environment metadata at ", style="dim")
+            message.append(str(metadata_path), style="dim")
+            console.print(message)
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -68,7 +68,7 @@ def display_remote_environment_info(
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
-        console.print(f"Using remote environment {owner}/{env_name}\n")
+        console.print(f"[blue]Using remote environment {owner}/{env_name}[/blue]\n")
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -999,7 +999,12 @@ def pull(
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
-            extracted_files = list(target_dir.iterdir())
+            all_files = list(target_dir.iterdir())
+            # Filter out .prime directory and .env-metadata.json files (created locally, not extracted)
+            extracted_files = [
+                f for f in all_files
+                if f.name != ".prime" and f.name != ".env-metadata.json"
+            ]
             if extracted_files:
                 console.print("\nExtracted files:")
                 for file in extracted_files[:MAX_FILES_TO_SHOW]:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -38,7 +38,9 @@ DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
 
-def display_remote_environment_info(env_path: Optional[Path] = None, environment_name: Optional[str] = None) -> None:
+def display_remote_environment_info(
+    env_path: Optional[Path] = None, environment_name: Optional[str] = None
+) -> None:
     """Display the remote environment name if metadata exists.
     
     Checks the provided path (or current directory) for environment metadata
@@ -746,19 +748,22 @@ def push(
                     prime_dir.mkdir(exist_ok=True)
                     metadata_path = prime_dir / ".env-metadata.json"
                     
-                    # Backwards compatibility: Migrate .env-metadata.json from root to .prime/ if it exists
-                    # This handles environments that were pulled/pushed before we moved to .prime/ subfolder
+                    # Backwards compatibility: Migrate .env-metadata.json from root to .prime/
+                    # This handles environments that were pulled/pushed before we moved
+                    # to .prime/ subfolder
                     old_metadata_path = env_path / ".env-metadata.json"
                     if old_metadata_path.exists() and not metadata_path.exists():
                         try:
                             # Move the old file to the new location
                             old_metadata_path.rename(metadata_path)
                             console.print(
-                                f"[dim]Migrated environment metadata from root to .prime/ subfolder[/dim]"
+                                "[dim]Migrated environment metadata from root "
+                                "to .prime/ subfolder[/dim]"
                             )
                         except (OSError, IOError) as e:
                             console.print(
-                                f"[yellow]Warning: Could not migrate old .env-metadata.json file to .prime/ subfolder: {e}[/yellow]"
+                                f"[yellow]Warning: Could not migrate old .env-metadata.json "
+                                f"file to .prime/ subfolder: {e}[/yellow]"
                             )
                     elif old_metadata_path.exists() and metadata_path.exists():
                         # Both exist - prefer the one in .prime/ and remove the old one
@@ -790,9 +795,13 @@ def push(
                         json.dump(env_metadata, f, indent=2)
                     
                     if existing_metadata:
-                        console.print(f"[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]")
+                        console.print(
+                            "[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]"
+                        )
                     else:
-                        console.print(f"[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]")
+                        console.print(
+                            "[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]"
+                        )
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -923,7 +932,8 @@ def pull(
                     target_dir = Path.cwd() / f"{name}-{index}"
                     index += 1
                 console.print(
-                    f"[yellow]Directory {base_dir} already exists. Using {target_dir} instead.[/yellow]"
+                    f"[yellow]Directory {base_dir} already exists. "
+                    f"Using {target_dir} instead.[/yellow]"
                 )
 
         try:
@@ -994,13 +1004,14 @@ def pull(
             }
             with open(metadata_path, "w") as f:
                 json.dump(env_metadata, f, indent=2)
-            console.print(f"[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
+            console.print("[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
             all_files = list(target_dir.iterdir())
-            # Filter out .prime directory and .env-metadata.json files (created locally, not extracted)
+            # Filter out .prime directory and .env-metadata.json files
+            # (created locally, not extracted)
             extracted_files = [
                 f for f in all_files
                 if f.name != ".prime" and f.name != ".env-metadata.json"

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -913,7 +913,18 @@ def pull(
         if target:
             target_dir = Path(target)
         else:
-            target_dir = Path.cwd() / name
+            # Check if the base directory exists and add index suffix if needed
+            base_dir = Path.cwd() / name
+            target_dir = base_dir
+            if target_dir.exists():
+                # Find the next available directory with index suffix
+                index = 1
+                while target_dir.exists():
+                    target_dir = Path.cwd() / f"{name}-{index}"
+                    index += 1
+                console.print(
+                    f"[yellow]Directory {base_dir} already exists. Using {target_dir} instead.[/yellow]"
+                )
 
         try:
             target_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -771,7 +771,7 @@ def push(
                             old_metadata_path.unlink()
                         except (OSError, IOError):
                             console.print(
-                                "[yellow]Warning: Could not remove old .env-metadata.json "
+                                "[yellow]Warning: Could not remove old .env-metadata.json[/yellow]"
                             )
                     
                     # Read existing metadata if it exists

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -757,6 +757,7 @@ def push(
                     # This handles environments that were pulled/pushed before we moved
                     # to .prime/ subfolder
                     old_metadata_path = env_path / ".env-metadata.json"
+                    migration_failed = False
                     if old_metadata_path.exists() and not metadata_path.exists():
                         try:
                             # Move the old file to the new location
@@ -766,6 +767,7 @@ def push(
                                 "to .prime/ subfolder[/dim]"
                             )
                         except (OSError, IOError) as e:
+                            migration_failed = True
                             console.print(
                                 f"[yellow]Warning: Could not migrate old .env-metadata.json "
                                 f"file to .prime/ subfolder: {e}[/yellow]"
@@ -788,6 +790,17 @@ def push(
                         except (json.JSONDecodeError, IOError) as e:
                             console.print(
                                 f"[yellow]Warning: Could not read existing metadata: {e}[/yellow]"
+                            )
+                            existing_metadata = {}
+                    elif migration_failed and old_metadata_path.exists():
+                        # If migration failed, read from old location to preserve metadata
+                        try:
+                            with open(old_metadata_path, "r") as f:
+                                existing_metadata = json.load(f)
+                        except (json.JSONDecodeError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not read existing metadata from "
+                                f"old location: {e}[/yellow]"
                             )
                             existing_metadata = {}
                     

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -588,6 +588,10 @@ def push(
                         "[yellow]The content hash is based on your source files "
                         "(*.py, pyproject.toml, README.md).[/yellow]"
                     )
+                    console.print(
+                        "[dim]Alternatively, use the --auto-bump flag to push "
+                        "a new version without content changes[/dim]"
+                    )
                 else:
                     console.print(f"[red]Failed to prepare wheel upload: {e}[/red]")
                 raise typer.Exit(1)
@@ -699,6 +703,10 @@ def push(
                             console.print(
                                 "[yellow]The content hash is based on your source files "
                                 "(*.py, pyproject.toml, README.md).[/yellow]"
+                            )
+                            console.print(
+                                "[dim]Alternatively, use the --auto-bump flag to push "
+                                "a new version without content changes[/dim]"
                             )
                         else:
                             console.print(f"[red]Failed to prepare source upload: {e}[/red]")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -839,7 +839,7 @@ def pull(
         if target:
             target_dir = Path(target)
         else:
-            target_dir = Path.cwd() / f"{owner}-{name}-{version}"
+            target_dir = Path.cwd() / name
 
         try:
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -896,6 +896,20 @@ def pull(
                 Path(temp_file_path).unlink()
 
         console.print(f"[green]✓ Environment pulled to {target_dir}[/green]")
+
+        # Create .env-metadata.json for proper resolution
+        try:
+            metadata_path = target_dir / ".env-metadata.json"
+            env_metadata = {
+                "environment_id": details.get("id"),
+                "owner": owner,
+                "name": name,
+            }
+            with open(metadata_path, "w") as f:
+                json.dump(env_metadata, f, indent=2)
+            console.print(f"[dim]Created environment metadata at {metadata_path.name}[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
             extracted_files = list(target_dir.iterdir())

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -767,7 +767,12 @@ def push(
                             )
                     elif old_metadata_path.exists() and metadata_path.exists():
                         # Both exist - prefer the one in .prime/ and remove the old one
-                        old_metadata_path.unlink()
+                        try:
+                            old_metadata_path.unlink()
+                        except (OSError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not remove old .env-metadata.json "
+                            )
                     
                     # Read existing metadata if it exists
                     existing_metadata = {}

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -769,9 +769,9 @@ def push(
                         # Both exist - prefer the one in .prime/ and remove the old one
                         try:
                             old_metadata_path.unlink()
-                        except (OSError, IOError) as e:
+                        except (OSError, IOError):
                             console.print(
-                                f"[yellow]Warning: Could not remove old .env-metadata.json "
+                                "[yellow]Warning: Could not remove old .env-metadata.json "
                             )
                     
                     # Read existing metadata if it exists

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -72,7 +72,7 @@ def display_upstream_environment_info(
         console.print(f"[blue]Using upstream environment {owner}/{env_name}[/blue]\n")
         return True
     else:
-        console.print("[blue]No upstream environment found.\n")
+        console.print("[blue]No upstream environment found.[/blue]\n")
         return False
 
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -58,7 +58,7 @@ def should_include_directory_in_archive(dir_path: Path) -> bool:
     if not dir_path.is_dir():
         return False
 
-    # Skip hidden directories
+    # Skip hidden directories (includes .prime/, .git/, etc.)
     if dir_path.name.startswith("."):
         return False
 
@@ -705,20 +705,59 @@ def push(
                 console.print(f"Wheel: {wheel_path.name}")
                 console.print(f"SHA256: {wheel_sha256}")
 
-                # Save Environments hub metadata for future reference
+                # Save or update environment hub metadata for future reference
                 try:
+                    prime_dir = env_path / ".prime"
+                    prime_dir.mkdir(exist_ok=True)
+                    metadata_path = prime_dir / ".env-metadata.json"
+                    
+                    # Backwards compatibility: Migrate .env-metadata.json from root to .prime/ if it exists
+                    # This handles environments that were pulled/pushed before we moved to .prime/ subfolder
+                    old_metadata_path = env_path / ".env-metadata.json"
+                    if old_metadata_path.exists() and not metadata_path.exists():
+                        try:
+                            # Move the old file to the new location
+                            old_metadata_path.rename(metadata_path)
+                            console.print(
+                                f"[dim]Migrated environment metadata from root to .prime/ subfolder[/dim]"
+                            )
+                        except (OSError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not migrate old .env-metadata.json file to .prime/ subfolder: {e}[/yellow]"
+                            )
+                    elif old_metadata_path.exists() and metadata_path.exists():
+                        # Both exist - prefer the one in .prime/ and remove the old one
+                        old_metadata_path.unlink()
+                    
+                    # Read existing metadata if it exists
+                    existing_metadata = {}
+                    if metadata_path.exists():
+                        try:
+                            with open(metadata_path, "r") as f:
+                                existing_metadata = json.load(f)
+                        except (json.JSONDecodeError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not read existing metadata: {e}[/yellow]"
+                            )
+                            existing_metadata = {}
+                    
+                    # Merge existing metadata with new push information
                     env_metadata = {
+                        **existing_metadata,  # Preserve existing fields
                         "environment_id": env_id,
                         "owner": owner_name,
                         "name": env_name,
                         "pushed_at": datetime.now().isoformat(),
                         "wheel_sha256": wheel_sha256,
-                        "visibility": visibility,
                     }
-                    metadata_path = env_path / ".env-metadata.json"
+                    
                     with open(metadata_path, "w") as f:
                         json.dump(env_metadata, f, indent=2)
-                    console.print(f"[dim]Saved environment metadata to {metadata_path.name}[/dim]")
+                    
+                    if existing_metadata:
+                        console.print(f"[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]")
+                    else:
+                        console.print(f"[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]")
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -899,7 +938,9 @@ def pull(
 
         # Create .env-metadata.json for proper resolution
         try:
-            metadata_path = target_dir / ".env-metadata.json"
+            prime_dir = target_dir / ".prime"
+            prime_dir.mkdir(exist_ok=True)
+            metadata_path = prime_dir / ".env-metadata.json"
             env_metadata = {
                 "environment_id": details.get("id"),
                 "owner": owner,
@@ -907,7 +948,7 @@ def pull(
             }
             with open(metadata_path, "w") as f:
                 json.dump(env_metadata, f, indent=2)
-            console.print(f"[dim]Created environment metadata at {metadata_path.name}[/dim]")
+            console.print(f"[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -24,6 +24,7 @@ from prime_cli.core import Config
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
+from ..utils.env_metadata import get_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
 
@@ -35,6 +36,37 @@ MAX_FILES_TO_SHOW = 10
 DEFAULT_HASH_LENGTH = 8
 DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
+
+
+def display_remote_environment_info(env_path: Optional[Path] = None, environment_name: Optional[str] = None) -> None:
+    """Display the remote environment name if metadata exists.
+    
+    Checks the provided path (or current directory) for environment metadata
+    and displays "Using remote environment {owner}/{name}" if found.
+    
+    If environment_name is provided, also checks ./environments/{module_name} as a fallback.
+    
+    Args:
+        env_path: Path to check for metadata (defaults to current directory)
+        environment_name: Optional environment name to check in ./environments/{module_name}
+    """
+    if env_path is None:
+        env_path = Path.cwd()
+    
+    # Check the provided path first
+    env_metadata = get_environment_metadata(env_path)
+    
+    # If not found and environment_name is provided, check ./environments/{module_name}
+    if not env_metadata and environment_name:
+        current_dir = Path.cwd()
+        module_name = environment_name.replace("-", "_")
+        env_dir = current_dir / "environments" / module_name
+        env_metadata = get_environment_metadata(env_dir)
+    
+    if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
+        owner = env_metadata.get("owner")
+        env_name = env_metadata.get("name")
+        console.print(f"Using remote environment {owner}/{env_name}\n")
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:
@@ -257,6 +289,9 @@ def push(
 
     try:
         env_path = Path(path).resolve()
+
+        # Display remote environment info if metadata exists
+        display_remote_environment_info(env_path)
 
         # Validate basic structure
         pyproject_path = env_path / "pyproject.toml"
@@ -1893,6 +1928,9 @@ def eval_env(
        prime env eval meow -m meta-llama/llama-3.1-70b-instruct -n 2 -r 3 -t 1024 -T 0.7
        All extra args are forwarded unchanged to vf-eval.
     """
+    # Display remote environment info if metadata exists
+    display_remote_environment_info(environment_name=environment)
+    
     config = Config()
 
     api_key = config.api_key

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -38,13 +38,13 @@ DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
 
-def display_remote_environment_info(
+def display_upstream_environment_info(
     env_path: Optional[Path] = None, environment_name: Optional[str] = None
-) -> None:
-    """Display the remote environment name if metadata exists.
+) -> bool:
+    """Display the upstream environment name if metadata exists.
     
     Checks the provided path (or current directory) for environment metadata
-    and displays "Using remote environment {owner}/{name}" if found.
+    and displays "Using upstream environment {owner}/{name}" if found.
     
     If environment_name is provided, also checks ./environments/{module_name} as a fallback.
     
@@ -68,7 +68,11 @@ def display_remote_environment_info(
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
-        console.print(f"[blue]Using remote environment {owner}/{env_name}[/blue]\n")
+        console.print(f"[blue]Using upstream environment {owner}/{env_name}[/blue]\n")
+        return True
+    else:
+        console.print("[blue]No upstream environment found.\n")
+        return False
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:
@@ -292,8 +296,8 @@ def push(
     try:
         env_path = Path(path).resolve()
 
-        # Display remote environment info if metadata exists
-        display_remote_environment_info(env_path)
+        # Display upstream environment info if metadata exists
+        display_upstream_environment_info(env_path)
 
         # Validate basic structure
         pyproject_path = env_path / "pyproject.toml"
@@ -1960,8 +1964,8 @@ def eval_env(
        prime env eval meow -m meta-llama/llama-3.1-70b-instruct -n 2 -r 3 -t 1024 -T 0.7
        All extra args are forwarded unchanged to vf-eval.
     """
-    # Display remote environment info if metadata exists
-    display_remote_environment_info(environment_name=environment)
+    # Display upstream environment info if metadata exists
+    display_upstream_environment_info(environment_name=environment)
     
     config = Config()
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -260,14 +260,14 @@ def _push_single_eval(
 
     environments = None
     if env_slug and not run_id and not eval_id:
-    # Determine if env_slug is a slug (owner/name) or a name
-    # Use appropriate key so _resolve_environments can properly resolve it
-    if "/" in env_slug:
-        # It's a slug (owner/name format)
-        environments = [{"slug": env_slug}]
-    else:
-        # It's a name (will be resolved by _resolve_environments)
-        environments = [{"name": env_slug}]
+        # Determine if env_slug is a slug (owner/name) or a name
+        # Use appropriate key so _resolve_environments can properly resolve it
+        if "/" in env_slug:
+            # It's a slug (owner/name format)
+            environments = [{"slug": env_slug}]
+        else:
+            # It's a name (will be resolved by _resolve_environments)
+            environments = [{"name": env_slug}]
 
     console.print()
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -240,7 +240,7 @@ def _discover_eval_outputs() -> list[Path]:
 
 def _push_single_eval(
     config_path: str,
-    env_id: Optional[str],
+    env_slug: Optional[str],
     run_id: Optional[str],
     eval_id: Optional[str],
 ) -> str:
@@ -255,12 +255,19 @@ def _push_single_eval(
         console.print(f"[blue]✓ Loaded eval data (verifiers format):[/blue] {path}")
 
     detected_env = eval_data.get("env_id") or eval_data.get("env")
-    if not env_id and detected_env and not run_id and not eval_id:
-        env_id = detected_env
+    if not env_slug and detected_env and not run_id and not eval_id:
+        env_slug = detected_env
 
     environments = None
-    if env_id and not run_id and not eval_id:
-        environments = [{"id": env_id}]
+    if env_slug and not run_id and not eval_id:
+    # Determine if env_slug is a slug (owner/name) or a name
+    # Use appropriate key so _resolve_environments can properly resolve it
+    if "/" in env_slug:
+        # It's a slug (owner/name format)
+        environments = [{"slug": env_slug}]
+    else:
+        # It's a name (will be resolved by _resolve_environments)
+        environments = [{"name": env_slug}]
 
     console.print()
 

--- a/packages/prime/src/prime_cli/utils/env_metadata.py
+++ b/packages/prime/src/prime_cli/utils/env_metadata.py
@@ -10,6 +10,9 @@ def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
     Checks both the new location (.prime/.env-metadata.json) and old location
     (.env-metadata.json) for backwards compatibility.
     
+    This function only checks the provided path - it does not search multiple directories.
+    Use find_environment_metadata() if you need to search multiple locations.
+    
     Args:
         env_path: Path to the environment directory
         
@@ -30,4 +33,54 @@ def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
             return json.load(f)
     except (json.JSONDecodeError, IOError):
         return None
+
+
+def find_environment_metadata(
+    env_name: Optional[str] = None,
+    env_path: Optional[Path] = None,
+    module_name: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Search for environment metadata in multiple common locations.
+    
+    Searches directories in the following order:
+    1. env_path (if provided)
+    2. ./environments/{module_name} (if module_name provided)
+    3. ./environments/{env_name} (if env_name provided)
+    4. ./{env_name} (if env_name provided)
+    5. ./{module_name} (if module_name provided)
+    6. ./ (current directory)
+    
+    Args:
+        env_name: Environment name (e.g., "simpleqa")
+        env_path: Optional explicit path to check first
+        module_name: Optional module name (e.g., "simple_qa" for env_name "simpleqa")
+        
+    Returns:
+        Dictionary containing environment metadata from the first location found, or None
+    """
+    possible_env_dirs = []
+    
+    # 1. Check explicit path first if provided
+    if env_path:
+        possible_env_dirs.append(env_path)
+    
+    # 2-5. Check common locations based on provided names
+    if module_name:
+        possible_env_dirs.append(Path("./environments") / module_name)
+    if env_name:
+        possible_env_dirs.append(Path("./environments") / env_name)
+        possible_env_dirs.append(Path(".") / env_name)
+    if module_name:
+        possible_env_dirs.append(Path(".") / module_name)
+    
+    # 6. Check current directory last
+    possible_env_dirs.append(Path("."))
+    
+    # Search through directories and return first match
+    for env_dir in possible_env_dirs:
+        metadata = get_environment_metadata(env_dir)
+        if metadata:
+            return metadata
+    
+    return None
 

--- a/packages/prime/src/prime_cli/utils/env_metadata.py
+++ b/packages/prime/src/prime_cli/utils/env_metadata.py
@@ -1,0 +1,33 @@
+"""Utilities for reading and managing environment metadata."""
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
+    """Read environment metadata from .prime/.env-metadata.json with backwards compatibility.
+    
+    Checks both the new location (.prime/.env-metadata.json) and old location
+    (.env-metadata.json) for backwards compatibility.
+    
+    Args:
+        env_path: Path to the environment directory
+        
+    Returns:
+        Dictionary containing environment metadata, or None if not found
+    """
+    # Try new location first
+    metadata_path = env_path / ".prime" / ".env-metadata.json"
+    if not metadata_path.exists():
+        # Fall back to old location for backwards compatibility
+        metadata_path = env_path / ".env-metadata.json"
+    
+    if not metadata_path.exists():
+        return None
+    
+    try:
+        with open(metadata_path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -72,18 +72,29 @@ def push_eval_results_to_hub(
 
     console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
 
-    env_metadata_path = Path("./environments") / module_name / ".env-metadata.json"
+    # Backwards compatibility: Check both .prime/.env-metadata.json (new location) and
+    # .env-metadata.json (old location) for environments pulled/pushed before migration
+    env_dir = Path("./environments") / module_name
+    env_metadata_path = env_dir / ".prime" / ".env-metadata.json"
+    old_env_metadata_path = env_dir / ".env-metadata.json"
     resolved_env_slug = None
 
+    # Try new location first, then fall back to old location for backwards compatibility
+    metadata_path_to_use = None
     if env_metadata_path.exists():
+        metadata_path_to_use = env_metadata_path
+    elif old_env_metadata_path.exists():
+        metadata_path_to_use = old_env_metadata_path
+
+    if metadata_path_to_use:
         try:
-            with open(env_metadata_path, encoding="utf-8") as f:
+            with open(metadata_path_to_use, encoding="utf-8") as f:
                 hub_metadata = json.load(f)
                 if hub_metadata.get("owner") and hub_metadata.get("name"):
                     resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
                     console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
         except (json.JSONDecodeError, IOError, KeyError) as e:
-            console.print(f"[yellow]Warning: Could not load {env_metadata_path}: {e}[/yellow]")
+            console.print(f"[yellow]Warning: Could not load {metadata_path_to_use}: {e}[/yellow]")
             console.print(f"[blue]Using environment name:[/blue] {env_name}")
     else:
         console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -1,12 +1,13 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
 from prime_cli.core import APIClient
-from .env_metadata import get_environment_metadata
+from .env_metadata import find_environment_metadata
 
 console = Console()
 
@@ -15,6 +16,7 @@ def push_eval_results_to_hub(
     env_name: str,
     model: str,
     job_id: str,
+    env_path: Optional[Path] = None,
 ) -> None:
     """
     Push evaluation results to Prime Evals Hub after vf-eval completes.
@@ -27,12 +29,11 @@ def push_eval_results_to_hub(
     5. Creates evaluation, pushes samples, and finalizes
 
     Args:
-        environment: Environment name (e.g., "simpleqa")
+        env_name: Environment name (e.g., "simpleqa")
         model: Model identifier (e.g., "meta-llama/llama-3.1-70b-instruct")
         job_id: Unique job ID for tracking
+        env_path: Optional path to the environment directory (defaults to current directory)
     """
-    console.print("\n[blue]Pushing evaluation results to hub...[/blue]")
-
     # Step 1: Find the output directory
     module_name = env_name.replace("-", "_")
     model_name = model.replace("/", "--")
@@ -52,7 +53,6 @@ def push_eval_results_to_hub(
         raise FileNotFoundError(f"No evaluation results found in {base_evals_dir}")
 
     output_dir = max(subdirs, key=lambda d: d.stat().st_mtime)
-    console.print(f"[dim]Found results in: {output_dir}[/dim]")
 
     metadata_path = output_dir / "metadata.json"
     results_path = output_dir / "results.jsonl"
@@ -71,20 +71,63 @@ def push_eval_results_to_hub(
             if line.strip():
                 results_samples.append(json.loads(line))
 
-    console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
-
-    # Resolve environment slug from metadata if available
-    env_dir = Path("./environments") / module_name
-    hub_metadata = get_environment_metadata(env_dir)
+    # Search for environment metadata in multiple possible locations
+    hub_metadata = find_environment_metadata(
+        env_name=env_name,
+        env_path=env_path,
+        module_name=module_name,
+    )
+    
     resolved_env_slug = None
+    resolved_env_id = None
 
-    if hub_metadata and hub_metadata.get("owner") and hub_metadata.get("name"):
-        resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
-        console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
+    if hub_metadata:
+        try:
+            # Prefer database ID if available (no resolution needed)
+            if hub_metadata.get("environment_id"):
+                resolved_env_id = hub_metadata.get("environment_id")
+                owner = hub_metadata.get("owner")
+                name = hub_metadata.get("name")
+                resolved_env_slug = (
+                    f"{owner}/{name}" if owner and name else None
+                )
+            elif hub_metadata.get("owner") and hub_metadata.get("name"):
+                resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
+                resolved_env_id = None
+            else:
+                resolved_env_slug = None
+                resolved_env_id = None
+        except (KeyError, AttributeError) as e:
+            console.print(f"[yellow]Warning: Could not parse environment metadata: {e}[/yellow]")
+            resolved_env_slug = None
+            resolved_env_id = None
     else:
-        console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")
+        resolved_env_slug = None
+        resolved_env_id = None
 
-    environments = [{"id": resolved_env_slug or env_name}]
+    # Require accurate upstream for evaluation tracking
+    if not resolved_env_slug and not resolved_env_id:
+        console.print(
+            "[yellow]No upstream environment found. Cannot upload evaluation results "
+            "without specific environment identification.\nEnsure .prime/.env-metadata.json "
+            "exists in the environment directory or use --env-path to specify the "
+            "correct path.[/yellow]"
+        )
+        return None
+
+    env_identifier = resolved_env_slug or resolved_env_id
+    console.print(
+        f"\n[blue]Uploading evaluation results, "
+        f"using remote environment: {env_identifier}[/blue]"
+    )
+
+    if resolved_env_id:
+        environments = [{"id": resolved_env_id}]
+    elif resolved_env_slug:
+        environments = [{"slug": resolved_env_slug}]
+    else:
+        # This should never happen due to the check above, but keeping for safety
+        raise ValueError("No valid environment identifier found")
     metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
 
     eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
@@ -103,7 +146,6 @@ def push_eval_results_to_hub(
     api_client = APIClient()
     evals_client = EvalsClient(api_client)
 
-    console.print("[blue]Creating evaluation...[/blue]")
     create_response = evals_client.create_evaluation(
         name=eval_name,
         environments=environments,
@@ -113,27 +155,21 @@ def push_eval_results_to_hub(
         task_type=metadata.get("task_type"),
         metadata=eval_metadata,
         metrics=metrics,
+        is_public=False,  # Private by default - only visible to the user who created it
     )
 
     eval_id = create_response.get("evaluation_id")
     if not eval_id:
         raise EvalsAPIError("Failed to get evaluation ID from create_evaluation response")
 
-    console.print(f"[green]✓ Created evaluation:[/green] {eval_id}")
-
     if converted_results:
-        console.print(f"[blue]Pushing {len(converted_results)} samples...[/blue]")
         evals_client.push_samples(eval_id, converted_results)
-        console.print("[green]✓ Samples pushed successfully[/green]")
 
-    console.print("[blue]Finalizing evaluation...[/blue]")
     evals_client.finalize_evaluation(eval_id, metrics=metrics)
-    console.print("[green]✓ Evaluation finalized[/green]\n")
 
-    console.print("[green]✓ Successfully pushed to hub[/green]")
+    console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
-    if resolved_env_slug:
-        frontend_url = api_client.config.frontend_url
-        eval_url = f"{frontend_url}/dashboard/environments/{resolved_env_slug}/evals/{eval_id}"
-        console.print(f"[blue]View evaluation:[/blue] {eval_url}")
-        console.print()
+    frontend_url = api_client.config.frontend_url
+    eval_url = f"{frontend_url}/dashboard/evaluations/{eval_id}"
+    console.print("\n[green]View results at:[/green]")
+    console.print(eval_url)

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -7,6 +7,7 @@ from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
 from prime_cli.core import APIClient
+
 from .env_metadata import find_environment_metadata
 
 console = Console()

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -108,17 +108,17 @@ def push_eval_results_to_hub(
     # Require accurate upstream for evaluation tracking
     if not resolved_env_slug and not resolved_env_id:
         console.print(
-            "[yellow]No upstream environment found. Cannot upload evaluation results "
-            "without specific environment identification.\nEnsure .prime/.env-metadata.json "
-            "exists in the environment directory or use --env-path to specify the "
-            "correct path.[/yellow]"
+            "[yellow]No upstream environment found. Evaluation results will not be "
+            "uploaded or viewable on the platform. Use `prime env push` to set an "
+            "upstream, or use `--env-path` to specify the correct path to the "
+            "environment.[/yellow]"
         )
         return None
 
     env_identifier = resolved_env_slug or resolved_env_id
     console.print(
         f"\n[blue]Uploading evaluation results, "
-        f"using remote environment: {env_identifier}[/blue]"
+        f"using upstream: {env_identifier}[/blue]"
     )
 
     if resolved_env_id:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Creates and uses .prime/.env-metadata.json on pull/push, auto-uploads vf-eval results when an upstream is set, and adds robust environment resolution (id/slug/name) with team/is_public support.
> 
> - **CLI: Environments (`prime env`)**
>   - **Pull/Push metadata**: On pull, create `.prime/.env-metadata.json` with `environment_id`, `owner`, `name`. On push, save/update it under `.prime/` (migrates old root file), preserve existing fields, and report upstream changes.
>   - **Upstream detection**: New `display_upstream_environment_info()` using `find_environment_metadata()` to show/verify upstream; used in `push` and `eval`.
>   - **Eval command**: Replace `--push-to-hub` with `--skip-upload` and add `--env-path`; automatically upload results to hub if upstream is detected, otherwise warn/skip.
>   - **Pull UX**: Auto-select non-conflicting target dir names and exclude local metadata from extracted files list.
>   - **Upload tips**: Add guidance to use `--auto-bump` when content hash exists.
> - **Utils**:
>   - New `utils/env_metadata.py` with `get_environment_metadata()` and `find_environment_metadata()` for locating `.env-metadata.json` (supports old/new locations).
>   - `utils/eval_push.py`: Use metadata to resolve upstream by id or slug; require upstream to upload; set `is_public=False`; update success output and evaluation URL.
> - **Evals API client (`prime_evals/evals.py`)**
>   - Add environment resolution helpers: `*_lookup_environment_id`, `*_lookup_environment_by_slug`, and `*_resolve_environments` (supports string or dict inputs with `id`/`slug`/`name`).
>   - `create_evaluation`: include `team_id` when available and optional `is_public`; improved errors; mirror changes in async client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1df8edd4534c6c42ca70552b11ebcad196dea2c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->