### PR TITLE
Feature/sandbox byte streaming

### DIFF
--- a/packages/prime-core/src/prime_core/client.py
+++ b/packages/prime-core/src/prime_core/client.py
@@ -213,9 +213,6 @@ class AsyncAPIClient:
                 method, url, params=params, json=json, timeout=timeout
             )
 
-            # Temporary log to verify HTTP version used
-            print(f"[PRIME-CORE] Request to {url} using HTTP/{response.http_version}")
-
             response.raise_for_status()
 
             result = response.json()

--- a/packages/prime-core/src/prime_core/client.py
+++ b/packages/prime-core/src/prime_core/client.py
@@ -212,6 +212,10 @@ class AsyncAPIClient:
             response = await self.client.request(
                 method, url, params=params, json=json, timeout=timeout
             )
+
+            # Temporary log to verify HTTP version used
+            print(f"[PRIME-CORE] Request to {url} using HTTP/{response.http_version}")
+
             response.raise_for_status()
 
             result = response.json()

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -35,7 +35,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -386,6 +386,46 @@ class SandboxClient:
             except Exception as e:
                 raise APIError(f"Upload failed: {str(e)}")
 
+    def upload_bytes(
+        self,
+        sandbox_id: str,
+        file_path: str,
+        file_bytes: bytes,
+        filename: str,
+        timeout: Optional[int] = None,
+    ) -> FileUploadResponse:
+        """Upload bytes directly to sandbox via gateway without writing to disk
+
+        Args:
+            sandbox_id: The sandbox ID
+            file_path: Remote path in the sandbox where the file will be saved
+            file_bytes: The bytes content to upload
+            filename: Name for the file (used in multipart form)
+            timeout: Optional timeout in seconds
+        """
+        auth = self._auth_cache.get_or_refresh(sandbox_id)
+
+        url = f"{auth['gateway_url']}/{auth['user_ns']}/{auth['job_id']}/upload"
+        headers = {"Authorization": f"Bearer {auth['token']}"}
+
+        effective_timeout = timeout if timeout is not None else 300
+
+        files = {"file": (filename, file_bytes)}
+        params = {"path": file_path, "sandbox_id": sandbox_id}
+
+        try:
+            with httpx.Client(timeout=effective_timeout) as client:
+                response = client.post(url, files=files, params=params, headers=headers)
+                response.raise_for_status()
+                return FileUploadResponse.model_validate(response.json())
+        except httpx.TimeoutException:
+            raise UploadTimeoutError(sandbox_id, file_path, effective_timeout)
+        except httpx.HTTPStatusError as e:
+            error_details = f"HTTP {e.response.status_code}: {e.response.text}"
+            raise APIError(f"Upload failed: {error_details}")
+        except Exception as e:
+            raise APIError(f"Upload failed: {str(e)}")
+
     def download_file(
         self,
         sandbox_id: str,
@@ -697,6 +737,48 @@ class AsyncSandboxClient:
         try:
             gateway_client = self._get_gateway_client()
             files = {"file": (os.path.basename(local_file_path), file_content)}
+            response = await gateway_client.post(
+                url, files=files, params=params, headers=headers, timeout=effective_timeout
+            )
+            response.raise_for_status()
+            return FileUploadResponse.model_validate(response.json())
+        except httpx.TimeoutException:
+            raise UploadTimeoutError(sandbox_id, file_path, effective_timeout)
+        except httpx.HTTPStatusError as e:
+            error_details = f"HTTP {e.response.status_code}: {e.response.text}"
+            raise APIError(f"Upload failed: {error_details}")
+        except Exception as e:
+            raise APIError(f"Upload failed: {str(e)}")
+
+    async def upload_bytes(
+        self,
+        sandbox_id: str,
+        file_path: str,
+        file_bytes: bytes,
+        filename: str,
+        timeout: Optional[int] = None,
+    ) -> FileUploadResponse:
+        """Upload bytes directly to sandbox via gateway without writing to disk (async)
+
+        Args:
+            sandbox_id: The sandbox ID
+            file_path: Remote path in the sandbox where the file will be saved
+            file_bytes: The bytes content to upload
+            filename: Name for the file (used in multipart form)
+            timeout: Optional timeout in seconds
+        """
+        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+
+        gateway_url = auth["gateway_url"].rstrip("/")
+        url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/upload"
+        headers = {"Authorization": f"Bearer {auth['token']}"}
+        params = {"path": file_path, "sandbox_id": sandbox_id}
+
+        effective_timeout = timeout if timeout is not None else 300
+
+        try:
+            gateway_client = self._get_gateway_client()
+            files = {"file": (filename, file_bytes)}
             response = await gateway_client.post(
                 url, files=files, params=params, headers=headers, timeout=effective_timeout
             )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds sync and async `upload_bytes` to sandbox clients for direct in-memory file uploads, with tests; bumps SDK version and logs HTTP version in async core client.
> 
> - **Sandboxes**:
>   - **New APIs**: Add `SandboxClient.upload_bytes` and `AsyncSandboxClient.upload_bytes` to upload in-memory bytes via gateway (multipart) without writing to disk.
>   - Ensure gateway URLs are normalized with `rstrip("/")` in async paths.
> - **Tests**:
>   - Add `test_upload_bytes`, `test_upload_bytes_binary`, and `test_upload_bytes_json` in `packages/prime-sandboxes/tests/test_file_operations.py`.
> - **Core**:
>   - `AsyncAPIClient.request`: temporary log prints HTTP version used for requests.
> - **Version**:
>   - Bump `prime_sandboxes` `__version__` to `0.2.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e3397df30113c9b597a316179dbf4cc7ca980a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->