### PR TITLE
use nonblocking aiofiles for sandbox auth cache

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -35,7 +35,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch async sandbox auth cache to use nonblocking aiofiles and wire async cache checks/saves; bump version to 0.2.3.
> 
> - **SDK (`prime_sandboxes`)**:
>   - **Auth cache (async)**:
>     - Add `SandboxAuthCache._save_cache_async` and `_check_cached_auth_async` using `aiofiles`.
>     - Update `get_or_refresh_async` to use async cache methods and persist with `_save_cache_async`.
> - **Version**:
>   - Bump `__version__` to `0.2.3` in `prime_sandboxes/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2bd7a7918fc072d2263e93972c2a54d5e5dbb8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->