### PR TITLE
Fix: Fix release evals workflow.

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         working-directory: packages/prime-evals
         run: |
-          VERSION=$(grep -E "^version\s*=" pyproject.toml | sed -E 's/version\s*=\s*"([^"]+)"/\1/')
+          VERSION=$(grep -E "^__version__\s*=" src/prime_evals/__init__.py | sed -E 's/__version__\s*=\s*"([^"]+)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 


### PR DESCRIPTION
Closes ENG-2214

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update release-evals workflow to read version from `src/prime_evals/__init__.py` `__version__` instead of `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eebc1e177fad654512f9bea77db992a2d3d80736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->