### PR TITLE
Fix: Fix version extract for release workflows.

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         working-directory: packages/prime-evals
         run: |
-          VERSION=$(grep -E "^__version__\s*=" src/prime_evals/__init__.py | sed -E 's/__version__\s*=\s*"([^"]+)"/\1/')
+          VERSION=$(grep -E "^__version__\s*=\s*" src/prime_evals/__init__.py | sed -E 's/^__version__[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         working-directory: packages/prime-sandboxes
         run: |
-          VERSION=$(grep -E "^__version__\s*=" src/prime_sandboxes/__init__.py | sed -E 's/__version__\s*=\s*"([^"]+)"/\1/')
+          VERSION=$(grep -E "^__version__\s*=\s*" src/prime_sandboxes/__init__.py | sed -E 's/^__version__[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 


### PR DESCRIPTION
Fixed version extraction in release workflows by replacing non-portable \s regex with POSIX-compatible [[:space:]] and adding line anchors, which was causing releases to fail with the entire line __version__ = "0.1.4" instead of just 0.1.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes version parsing in evals and sandboxes release workflows by using anchored, POSIX-compliant grep/sed regex.
> 
> - **CI Workflows**:
>   - Update `release-evals.yml` and `release-sandboxes.yml`:
>     - Change `VERSION` extraction to use anchored, POSIX-compliant `grep`/`sed` regex to correctly parse `__version__`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c7a0016ba421ba0a591f90942b00d12fdb60fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->