### PR TITLE
Fix: Fix build script for evals.

### DIFF
--- a/packages/prime-evals/build_for_pypi.sh
+++ b/packages/prime-evals/build_for_pypi.sh
@@ -18,8 +18,11 @@ echo "Copying prime-core into source tree..."
 rm -rf src/prime_core
 cp -r ../prime-core/src/prime_core src/prime_core
 
-sed '/prime-core/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-sed '/\[tool\.uv\.sources\]/,/prime-core = { workspace = true }/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Remove prime-core from dependencies list only
+sed '/^    "prime-core",$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Remove the [tool.uv.sources] section
+sed '/^\[tool\.uv\.sources\]$/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+# Update the force-include path
 sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
 
 echo "Building wheel..."


### PR DESCRIPTION
Corrected the prime-evals build script to safely preserve [tool.hatch.version] config (preventing builds from defaulting to 0.0.0).

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates build script to vendor `prime_core`, remove `prime-core` dependency and `[tool.uv.sources]` block, and fix force-include path before building the wheel.
> 
> - **Build script (`packages/prime-evals/build_for_pypi.sh`)**:
>   - Vendors `prime_core` by copying from `../prime-core/src/prime_core` into `src/prime_core`.
>   - Removes only the `"prime-core"` dependency line from `pyproject.toml`.
>   - Deletes the entire `[tool.uv.sources]` section from `pyproject.toml`.
>   - Updates `force-include` path from `"../prime-core/src/prime_core"` to `"src/prime_core"`.
>   - Keeps backup/restore of `pyproject.toml` and builds wheel via `uv build --wheel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11c75b9b14b838e5afc934810dec18f3186a1b64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->