### PR TITLE
Feature: Add size limit warning for env tarballs

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -24,6 +24,7 @@ from ..api.inference import InferenceAPIError, InferenceClient
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
 from ..utils.eval_push import push_eval_results_to_hub
+from ..utils.formatters import format_file_size
 
 app = typer.Typer(help="Manage verifiers environments", no_args_is_help=True)
 console = Console()
@@ -33,18 +34,6 @@ MAX_FILES_TO_SHOW = 10
 DEFAULT_HASH_LENGTH = 8
 DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 1 * 1024 * 1024 * 1024  # 1GB
-
-
-def format_file_size(size_bytes: int) -> str:
-    """Format file size in human-readable format."""
-    if size_bytes >= 1024 * 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
-    elif size_bytes >= 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    elif size_bytes >= 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    else:
-        return f"{size_bytes} bytes"
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -33,7 +33,7 @@ console = Console()
 MAX_FILES_TO_SHOW = 10
 DEFAULT_HASH_LENGTH = 8
 DEFAULT_LIST_LIMIT = 20
-MAX_TARBALL_SIZE_LIMIT = 1 * 1024 * 1024 * 1024  # 1GB
+MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -42,3 +42,15 @@ def format_resources(cpu_cores: int, memory_gb: int, gpu_count: int = 0) -> str:
 def format_gpu_spec(gpu_type: str, gpu_count: int) -> str:
     """Format GPU specification as 'Type x Count'."""
     return f"{gpu_type} x{gpu_count}"
+
+
+def format_file_size(size_bytes: int) -> str:
+    """Format file size in human-readable format."""
+    if size_bytes >= 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+    elif size_bytes >= 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    elif size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    else:
+        return f"{size_bytes} bytes"


### PR DESCRIPTION
<img width="1286" height="378" alt="CleanShot 2025-11-12 at 2  47 47@2x" src="https://github.com/user-attachments/assets/76742c9f-9c9a-475e-9399-2a4bf686b992" />

(For testing I set max size to 1KB) -> now back at 1GB

Closes ENG-2222

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays source archive size and warns if it exceeds 250MB when pushing environments, using a new format_file_size helper.
> 
> - **CLI (env push)**:
>   - After creating source archive in `prime_cli/commands/env.py`, display formatted size and warn if it exceeds `MAX_TARBALL_SIZE_LIMIT` (250MB) with guidance on reducing size.
> - **Utils**:
>   - Add `format_file_size(size_bytes)` in `prime_cli/utils/formatters.py` and use it to format sizes in push output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc15b68a0251f7506eeff04abfe41ad9daef7356. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->