### PR TITLE
Feature: Add vf-eval stream option.

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1665,6 +1665,7 @@ def eval_env(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
     save_results: bool = typer.Option(True, "--save-results", "-s", help="Save results to disk"),
     save_every: int = typer.Option(1, "--save-every", "-f", help="Save dataset every n rollouts"),
+    stream: bool = typer.Option(False, "--stream", help="Stream results as they complete"),
     save_to_hf_hub: bool = typer.Option(False, "--save-to-hf-hub", "-H", help="Save to HF Hub"),
     hf_hub_dataset_name: Optional[str] = typer.Option(
         None, "--hf-hub-dataset-name", "-D", help="HF Hub dataset name"
@@ -1772,6 +1773,8 @@ def eval_env(
         cmd += ["-s"]
     if save_every is not None:
         cmd += ["-f", str(save_every)]
+    if stream:
+        cmd += ["--stream"]
     if save_to_hf_hub:
         cmd += ["-H"]
     if hf_hub_dataset_name:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `--stream` option to `prime env eval` to stream results as they complete and forwards the flag to `vf-eval`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a9f97485b6fef1bafa0d712e9d43baffcbc11b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->