### PR TITLE
readd timeout to run command in prime sandbox

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -651,6 +651,11 @@ def run(
         "--env",
         help="Environment variables in KEY=VALUE format. Can be specified multiple times.",
     ),
+    timeout: Optional[int] = typer.Option(
+        None,
+        "--timeout",
+        help="Timeout for the command in seconds",
+    ),
 ) -> None:
     """Execute a command in a sandbox"""
     try:
@@ -676,13 +681,18 @@ def run(
         if env_vars:
             obfuscated_env = obfuscate_env_vars(env_vars)
             console.print(f"[bold blue]Environment:[/bold blue] {obfuscated_env}")
+        if timeout is not None:
+            console.print(f"[bold blue]Timeout:[/bold blue] {timeout}s")
 
-        # Start timing
         start_time = time.perf_counter()
 
         with console.status("[bold blue]Running command...", spinner="dots"):
             result = sandbox_client.execute_command(
-                sandbox_id, command_str, working_dir, env_vars if env_vars else None
+                sandbox_id,
+                command_str,
+                working_dir,
+                env_vars if env_vars else None,
+                timeout=timeout,
             )
 
         # End timing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an optional per-command timeout (seconds) to `prime sandbox run`, displays it, and passes it through to the API for enforcement.
> 
> - **CLI (sandbox run)**:
>   - Add `--timeout` option (seconds) to `run` command.
>   - Echo selected timeout in console output.
>   - Pass `timeout` to `SandboxClient.execute_command` for enforcement.
>   - Maintain timing/outputs; no other behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c6b4205a9a207198a8f8c68797ef7e68f9483e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->