### PR TITLE
CommandTimeoutError for HTTP 408

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -314,6 +314,8 @@ class SandboxClient:
             u = getattr(req, "url", "?")
             status = getattr(resp, "status_code", "?")
             text = getattr(resp, "text", "")
+            if status == 408:
+                raise CommandTimeoutError(sandbox_id, command, effective_timeout) from e
             raise APIError(f"HTTP {status} {method} {u}: {text}") from e
         except httpx.RequestError as e:
             req = getattr(e, "request", None)
@@ -686,6 +688,8 @@ class AsyncSandboxClient:
             u = getattr(req, "url", "?")
             status = getattr(resp, "status_code", "?")
             text = getattr(resp, "text", "")
+            if status == 408:
+                raise CommandTimeoutError(sandbox_id, command, effective_timeout) from e
             raise APIError(f"HTTP {status} {method} {u}: {text}") from e
         except httpx.RequestError as e:
             req = getattr(e, "request", None)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Treat HTTP 408 responses as CommandTimeoutError for both sync and async `execute_command` paths.
> 
> - **Error handling** in `packages/prime-sandboxes/src/prime_sandboxes/sandbox.py`:
>   - Map HTTP `408` in `SandboxClient.execute_command` to `CommandTimeoutError`.
>   - Map HTTP `408` in `AsyncSandboxClient.execute_command` to `CommandTimeoutError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76ff93f6d60e912ca5dde6d61cb4ce5010432dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->