### PR TITLE
Added support for push as .rc or .post

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -218,6 +218,7 @@ def list_cmd(
         console.print(f"[red]Unexpected error: {e}[/red]")
         raise typer.Exit(1)
 
+
 @app.command()
 def push(
     path: str = typer.Option(".", "--path", "-p", help="Path to environment directory"),

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -218,7 +218,6 @@ def list_cmd(
         console.print(f"[red]Unexpected error: {e}[/red]")
         raise typer.Exit(1)
 
-
 @app.command()
 def push(
     path: str = typer.Option(".", "--path", "-p", help="Path to environment directory"),
@@ -236,6 +235,12 @@ def push(
     ),
     auto_bump: bool = typer.Option(
         False, "--auto-bump", help="Automatically bump patch version before push"
+    ),
+    rc: bool = typer.Option(False, "--rc", help="Bump or create a .rc pre-release (rc0 -> rc1)"),
+    post: bool = typer.Option(
+        False,
+        "--post",
+        help="Bump or create a .post release (post0 -> post1)",
     ),
 ) -> None:
     """Push environment to registry"""
@@ -261,15 +266,27 @@ def push(
                 raise typer.Exit(1)
 
             # Auto-bump version if requested
-            if auto_bump:
+            if auto_bump or rc or post:
+                flags_set = sum(bool(x) for x in (auto_bump, rc, post))
+                if flags_set > 1:
+                    console.print(
+                        "[red]Error: --auto-bump, --rc, and --post are mutually exclusive[/red]"
+                    )
+                    raise typer.Exit(1)
                 current_version = project_info.get("version")
                 if not current_version:
                     console.print(
                         "[red]Error: No version found in pyproject.toml for auto-bump[/red]"
                     )
                     raise typer.Exit(1)
+                
+                if auto_bump:
+                    new_version = bump_version(current_version)
+                elif rc:
+                    new_version = bump_rc_version(current_version)
+                else:
+                    new_version = bump_post_version(current_version)
 
-                new_version = bump_version(current_version)
                 console.print(f"Auto-bumping version: {current_version} → {new_version}")
 
                 try:
@@ -934,6 +951,39 @@ def bump_version(version: str) -> str:
     else:
         return f"{version}.0.1"
 
+def bump_rc_version(version: str) -> str:
+    """
+    Bump or create an .post suffix.
+    Examples:
+      1.2.3 -> 1.2.3.post0
+      1.2.3.post0 -> 1.2.3.post1
+      1.2.3post2 -> 1.2.3post3
+    """
+    m = re.match(r"^(?P<base>.*?)(?:\.rc|rc)(?P<num>\d+)$", version)
+    if m:
+        base = m.group("base")
+        num = int(m.group("num"))
+        return f"{base}.rc{num + 1}"
+    else:
+        base = re.sub(r"([+-].*)$", "", version)
+        return f"{base}.rc0"
+    
+def bump_post_version(version: str) -> str:
+    """
+    Bump or create an .post suffix.
+    Examples:
+      1.2.3 -> 1.2.3.post0
+      1.2.3.post0 -> 1.2.3.post1
+      1.2.3post2 -> 1.2.3post3
+    """
+    m = re.match(r"^(?P<base>.*?)(?:\.post|post)(?P<num>\d+)$", version)
+    if m:
+        base = m.group("base")
+        num = int(m.group("num"))
+        return f"{base}.post{num + 1}"
+    else:
+        base = re.sub(r"([+-].*)$", "", version)
+        return f"{base}.post0"
 
 def update_pyproject_version(pyproject_path: Path, new_version: str) -> None:
     """Update version in pyproject.toml file."""


### PR DESCRIPTION
Fixes https://github.com/PrimeIntellect-ai/prime/issues/136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --rc and --post options to env push for prerelease/postrelease version bumps, enforcing mutual exclusivity with --auto-bump.
> 
> - **CLI (env push)**
>   - Add `--rc` and `--post` flags to bump/create `.rc` and `.post` versions.
>   - Enforce mutual exclusivity among `--auto-bump`, `--rc`, and `--post`.
>   - Select bump strategy based on flag and update `pyproject.toml` version accordingly.
> - **Versioning Utilities**
>   - Introduce `bump_rc_version(version)` and `bump_post_version(version)` helpers to increment or initialize `.rc`/`.post` suffixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6630e00707981a36c660cbc519e5abcf04f10380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->