### PR TITLE
timeout buffer

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -297,7 +297,8 @@ class SandboxClient:
         }
 
         try:
-            with httpx.Client(timeout=effective_timeout) as client:
+            client_timeout = effective_timeout + 5
+            with httpx.Client(timeout=client_timeout) as client:
                 response = client.post(
                     url,
                     json=payload,
@@ -673,9 +674,10 @@ class AsyncSandboxClient:
         }
 
         try:
+            client_timeout = effective_timeout + 5
             gateway_client = self._get_gateway_client()
             response = await gateway_client.post(
-                url, json=payload, headers=headers, timeout=effective_timeout
+                url, json=payload, headers=headers, timeout=client_timeout
             )
             response.raise_for_status()
             return CommandResponse.model_validate(response.json())

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -297,7 +297,7 @@ class SandboxClient:
         }
 
         try:
-            client_timeout = effective_timeout + 5
+            client_timeout = effective_timeout + 2
             with httpx.Client(timeout=client_timeout) as client:
                 response = client.post(
                     url,
@@ -674,7 +674,7 @@ class AsyncSandboxClient:
         }
 
         try:
-            client_timeout = effective_timeout + 5
+            client_timeout = effective_timeout + 2
             gateway_client = self._get_gateway_client()
             response = await gateway_client.post(
                 url, json=payload, headers=headers, timeout=client_timeout


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a 2s buffer to HTTP client timeouts for sandbox command execution to prevent premature client timeouts.
> 
> - **Sandbox client timeouts**:
>   - `SandboxClient.execute_command`: wraps `httpx.Client` with `timeout = effective_timeout + 2` instead of `effective_timeout` in `packages/prime-sandboxes/src/prime_sandboxes/sandbox.py`.
>   - `AsyncSandboxClient.execute_command`: uses `timeout = effective_timeout + 2` for `gateway_client.post(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eff31460a6a259a5c4d1e5a9b04df914195334a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->