### PR TITLE
fix envshub naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ prime pods ssh <pod-id>
 
 ### Evaluations
 
-Push and manage evaluation results to the Environment Hub. Supports verifiers format and JSON format.
+Push and manage evaluation results to the Environments hub. Supports verifiers format and JSON format.
 
 ```bash
 # Auto-discover and push evaluations from current directory

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -677,7 +677,7 @@ def push(
                 console.print(f"Wheel: {wheel_path.name}")
                 console.print(f"SHA256: {wheel_sha256}")
 
-                # Save environment hub metadata for future reference
+                # Save Environments hub metadata for future reference
                 try:
                     env_metadata = {
                         "environment_id": env_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes naming to “Environments hub” in README and a CLI comment for env push metadata.
> 
> - **Docs**:
>   - Update README evaluations section to say `Environments hub`.
> - **CLI** (`packages/prime/src/prime_cli/commands/env.py`):
>   - Update comment to refer to `Environments hub` when saving push metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c097b2f0e385dbe5430a5c68809210cecbb8865c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->