### PR TITLE
chore: bump versions for release (prime-sandboxes 0.2.5, prime 0.4.13)

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime-mcp-server/src/prime_mcp/__init__.py
+++ b/packages/prime-mcp-server/src/prime_mcp/__init__.py
@@ -2,7 +2,7 @@ from prime_mcp.client import make_prime_request
 from prime_mcp.mcp import mcp
 from prime_mcp.tools import availability, pods, ssh
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "mcp",

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -37,7 +37,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -1,12 +1,5 @@
 """Prime Intellect CLI."""
 
-from prime_cli.core import (
-    APIClient,
-    APIError,
-    APITimeoutError,
-    AsyncAPIClient,
-    Config,
-)
 from prime_sandboxes import (
     AsyncSandboxClient,
     CommandRequest,
@@ -18,6 +11,14 @@ from prime_sandboxes import (
     SandboxNotRunningError,
     SandboxStatus,
     UpdateSandboxRequest,
+)
+
+from prime_cli.core import (
+    APIClient,
+    APIError,
+    APITimeoutError,
+    AsyncAPIClient,
+    Config,
 )
 
 __version__ = "0.4.13"

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.4.13"
+__version__ = "0.5.0"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -1,5 +1,12 @@
 """Prime Intellect CLI."""
 
+from prime_cli.core import (
+    APIClient,
+    APIError,
+    APITimeoutError,
+    AsyncAPIClient,
+    Config,
+)
 from prime_sandboxes import (
     AsyncSandboxClient,
     CommandRequest,
@@ -13,15 +20,7 @@ from prime_sandboxes import (
     UpdateSandboxRequest,
 )
 
-from prime_cli.core import (
-    APIClient,
-    APIError,
-    APITimeoutError,
-    AsyncAPIClient,
-    Config,
-)
-
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bumps `prime-sandboxes` from 0.2.4 → 0.2.5
- Bumps `prime` CLI from 0.4.12 → 0.4.13

### Changes included in this release

**prime-sandboxes:**
- feat: add sandbox network isolation flags (#219)
- expose ports in sandbox pkg (#153)
- timeout buffer (#216)
- Add sandbox secret integration (#189)

**prime CLI:**
- feat: add sandbox network isolation flags (#219)
- expose ports in sandbox pkg (#153)
- Fix: pre-commit for local dev (#158)
- Feature: support multiple environment installations with `prime env install` (#164)
- Added support for push as .rc or .post (#214)
- Add sandbox secret integration (#189)
- fix envshub naming convention (#218)
- Feature: Add size limit warning for env tarballs (#209)

## Test plan
- [ ] CI passes
- [ ] Release workflows trigger on merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps versions for prime-evals, prime-mcp-server, prime-sandboxes, and prime CLI for release (0.1.5, 0.1.1, 0.2.5, 0.5.0).
> 
> - **Release: version bumps**
>   - `prime-evals`: `__version__` 0.1.4 → 0.1.5
>   - `prime-mcp-server`: `__version__` 0.1.0 → 0.1.1
>   - `prime-sandboxes`: `__version__` 0.2.4 → 0.2.5
>   - `prime CLI`: `__version__` 0.4.12 → 0.5.0
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eba80f0c5196950abb9a7a03ee1018f91b7e6c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->