### PR TITLE
chore: bump verifiers to 0.1.8.post1

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -57,7 +57,7 @@ class EvalsClient:
         except APIError as e:
             raise EvalsAPIError(
                 f"Environment '{env_name}' does not exist in the hub. "
-                f"Please push the environment first with: prime env push {env_name}"
+                f"Please push the environment first with: prime env push"
             ) from e
 
     def _resolve_environments(
@@ -272,7 +272,7 @@ class AsyncEvalsClient:
         except APIError as e:
             raise EvalsAPIError(
                 f"Environment '{env_name}' does not exist in the hub. "
-                f"Please push the environment first with: prime env push {env_name}"
+                f"Please push the environment first with: prime env push"
             ) from e
 
     async def _resolve_environments(

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -26,18 +26,29 @@ class EvalsClient:
 
     def _resolve_environment_id(self, env_name: str) -> str:
         """
-        Resolve environment ID to owner/name format.
+        Resolve environment ID from name or slug (owner/name format).
+
+        If env_name is in owner/name format, resolves by owner slug.
+        Otherwise, resolves by name for the authenticated user (get-or-create).
 
         Raises:
             EvalsAPIError: If the environment does not exist (404)
         """
+        owner_slug = None
+        name = env_name
+
+        # Check if it's in owner/name format
         if re.match(r"^[^/]+/[^/]+$", env_name):
-            env_name = env_name.split("/", 1)[1]
+            owner_slug, name = env_name.split("/", 1)
 
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name}
+            resolve_data: Dict[str, Any] = {"name": name}
 
-            if self.client.config.team_id:
+            if owner_slug:
+                # Full slug resolution - look up existing environment by owner
+                resolve_data["owner_slug"] = owner_slug
+            elif self.client.config.team_id:
+                # Use team_id for get-or-create behavior
                 resolve_data["team_id"] = self.client.config.team_id
 
             response = self.client.post("/environmentshub/resolve", json=resolve_data)
@@ -48,6 +59,32 @@ class EvalsClient:
                 f"Environment '{env_name}' does not exist in the hub. "
                 f"Please push the environment first with: prime env push {env_name}"
             ) from e
+
+    def _resolve_environments(
+        self, environments: List[Dict[str, str]]
+    ) -> List[Dict[str, str]]:
+        """
+        Resolve a list of environments from various identifier formats to database IDs.
+        """
+        resolved_environments = []
+        for env in environments:
+            resolved_env = env.copy()
+            # Handle different identifier types explicitly
+            # Check for explicit "slug" or "name" keys first
+            if "slug" in resolved_env:
+                # Owner/name format, resolve to database ID
+                resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("slug"))
+            elif "name" in resolved_env:
+                # Just a name, resolve to database ID (get-or-create)
+                resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
+            elif "id" in resolved_env:
+                # "id" key exists - it's already a database ID
+                pass
+            else:
+                # Skip environments without valid identifiers
+                continue
+            resolved_environments.append(resolved_env)
+        return resolved_environments
 
     def create_evaluation(
         self,
@@ -83,25 +120,7 @@ class EvalsClient:
 
         resolved_environments = None
         if environments:
-            # Initialize as empty list before resolution
-            resolved_environments = []
-            for env in environments:
-                resolved_env = env.copy()
-                # Handle different identifier types explicitly
-                # Check for explicit "slug" or "name" keys first
-                if "slug" in resolved_env:
-                    # Owner/name format, resolve to database ID
-                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("slug"))
-                elif "name" in resolved_env:
-                    # Just a name, resolve to database ID (get-or-create)
-                    resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
-                elif "id" in resolved_env:
-                    # "id" key exists - it's already a database ID
-                    pass
-                else:
-                    # Skip environments without valid identifiers
-                    continue
-                resolved_environments.append(resolved_env)
+            resolved_environments = self._resolve_environments(environments)
             
             # Validate that we have at least one resolved environment if run_id is not provided
             # This check happens AFTER resolution to catch cases where all environments were invalid
@@ -222,18 +241,29 @@ class AsyncEvalsClient:
 
     async def _resolve_environment_id(self, env_name: str) -> str:
         """
-        Resolve environment ID to owner/name format.
+        Resolve environment ID from name or slug (owner/name format).
+
+        If env_name is in owner/name format, resolves by owner slug.
+        Otherwise, resolves by name for the authenticated user (get-or-create).
 
         Raises:
             EvalsAPIError: If the environment does not exist (404)
         """
+        owner_slug = None
+        name = env_name
+
+        # Check if it's in owner/name format
         if re.match(r"^[^/]+/[^/]+$", env_name):
-            env_name = env_name.split("/", 1)[1]
+            owner_slug, name = env_name.split("/", 1)
 
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name}
+            resolve_data: Dict[str, Any] = {"name": name}
 
-            if self.client.config.team_id:
+            if owner_slug:
+                # Full slug resolution - look up existing environment by owner
+                resolve_data["owner_slug"] = owner_slug
+            elif self.client.config.team_id:
+                # Use team_id for get-or-create behavior
                 resolve_data["team_id"] = self.client.config.team_id
 
             response = await self.client.post("/environmentshub/resolve", json=resolve_data)
@@ -244,6 +274,40 @@ class AsyncEvalsClient:
                 f"Environment '{env_name}' does not exist in the hub. "
                 f"Please push the environment first with: prime env push {env_name}"
             ) from e
+
+    async def _resolve_environments(
+        self, environments: List[Dict[str, str]]
+    ) -> List[Dict[str, str]]:
+        """
+        Resolve a list of environments from various identifier formats to database IDs.
+        """
+        async def resolve_env(env: Dict[str, str]) -> Optional[Dict[str, str]]:
+            resolved_env = env.copy()
+            # Handle different identifier types explicitly
+            # Check for explicit "slug" or "name" keys first
+            if "slug" in resolved_env:
+                # Owner/name format, resolve to database ID
+                resolved_env["id"] = await self._resolve_environment_id(
+                    resolved_env.pop("slug")
+                )
+            elif "name" in resolved_env:
+                # Just a name, resolve to database ID (get-or-create)
+                resolved_env["id"] = await self._resolve_environment_id(
+                    resolved_env.pop("name")
+                )
+            elif "id" in resolved_env:
+                # "id" key exists - it's already a database ID
+                pass
+            else:
+                # Skip environments without valid identifiers
+                return None
+            return resolved_env
+
+        resolved_environments_list = await asyncio.gather(
+            *[resolve_env(env) for env in environments]
+        )
+        # Filter out None values (environments without valid identifiers)
+        return [env for env in resolved_environments_list if env is not None]
 
     async def create_evaluation(
         self,
@@ -279,36 +343,7 @@ class AsyncEvalsClient:
 
         resolved_environments = None
         if environments:
-            # Initialize as empty list before resolution
-            resolved_environments = []
-
-            async def resolve_env(env: Dict[str, str]) -> Optional[Dict[str, str]]:
-                resolved_env = env.copy()
-                # Handle different identifier types explicitly
-                # Check for explicit "slug" or "name" keys first
-                if "slug" in resolved_env:
-                    # Owner/name format, resolve to database ID
-                    resolved_env["id"] = await self._resolve_environment_id(
-                        resolved_env.pop("slug")
-                    )
-                elif "name" in resolved_env:
-                    # Just a name, resolve to database ID (get-or-create)
-                    resolved_env["id"] = await self._resolve_environment_id(
-                        resolved_env.pop("name")
-                    )
-                elif "id" in resolved_env:
-                    # "id" key exists - it's already a database ID
-                    pass
-                else:
-                    # Skip environments without valid identifiers
-                    return None
-                return resolved_env
-
-            resolved_environments_list = await asyncio.gather(
-                *[resolve_env(env) for env in environments]
-            )
-            # Filter out None values (environments without valid identifiers)
-            resolved_environments = [env for env in resolved_environments_list if env is not None]
+            resolved_environments = await self._resolve_environments(environments)
             
             # Validate that we have at least one resolved environment if run_id is not provided
             # This check happens AFTER resolution to catch cases where all environments were invalid

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -24,7 +24,7 @@ from rich.text import Text
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
-from ..utils.env_metadata import get_environment_metadata
+from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
 
@@ -52,18 +52,17 @@ def display_upstream_environment_info(
         env_path: Path to check for metadata (defaults to current directory)
         environment_name: Optional environment name to check in ./environments/{module_name}
     """
-    if env_path is None:
-        env_path = Path.cwd()
-    
-    # Check the provided path first
-    env_metadata = get_environment_metadata(env_path)
-    
-    # If not found and environment_name is provided, check ./environments/{module_name}
-    if not env_metadata and environment_name:
-        current_dir = Path.cwd()
+    # Determine module_name if environment_name is provided
+    module_name = None
+    if environment_name:
         module_name = environment_name.replace("-", "_")
-        env_dir = current_dir / "environments" / module_name
-        env_metadata = get_environment_metadata(env_dir)
+    
+    # Search for environment metadata in common locations
+    env_metadata = find_environment_metadata(
+        env_name=environment_name,
+        env_path=env_path,
+        module_name=module_name,
+    )
     
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
@@ -1956,8 +1955,18 @@ def eval_env(
             "should end in '/v1'"
         ),
     ),
-    push_to_hub: bool = typer.Option(
-        False, "--push-to-hub", "-P", help="Push results to Prime Evals Hub"
+    skip_upload: bool = typer.Option(
+        False,
+        "--skip-upload",
+        help="Skip uploading results to Prime Evals Hub (results are uploaded by default)",
+    ),
+    env_path: Optional[str] = typer.Option(
+        None,
+        "--env-path",
+        help=(
+            "Path to the environment directory "
+            "(used to locate .prime/.env-metadata.json for upstream resolution)"
+        ),
     ),
 ) -> None:
     """
@@ -1967,9 +1976,19 @@ def eval_env(
        prime env eval meow -m meta-llama/llama-3.1-70b-instruct -n 2 -r 3 -t 1024 -T 0.7
        All extra args are forwarded unchanged to vf-eval.
     """
+
+    # Determine the path to check for upstream metadata
+    check_path = Path(env_path) if env_path else Path.cwd()
     # Display upstream environment info if metadata exists
-    display_upstream_environment_info(environment_name=environment)
-    
+    is_resolved = display_upstream_environment_info(
+        env_path=check_path, environment_name=environment
+    )
+    if not is_resolved:
+        console.print(
+            "[yellow]Evaluation results will not be uploaded or viewable on the platform "
+            "without a specified upstream environment.[/yellow]"
+        )
+
     config = Config()
 
     api_key = config.api_key
@@ -2079,13 +2098,14 @@ def eval_env(
         console.print("[red]Failed to start vf-eval process.[/red]")
         raise typer.Exit(1)
 
-    # Push to hub if requested and eval succeeded
-    if push_to_hub:
+    # Automatically push to hub after successful eval (unless --skip-upload is used)
+    if not skip_upload and is_resolved:
         try:
             push_eval_results_to_hub(
                 env_name=environment,
                 model=model,
                 job_id=job_id,
+                env_path=check_path,
             )
         except Exception as e:
             console.print(f"[red]Failed to push results to hub:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -67,7 +67,7 @@ def display_remote_environment_info(
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
-        console.print(f"Using remote environment {owner}/{env_name}\n")
+        console.print(f"[blue]Using remote environment {owner}/{env_name}[/blue]\n")
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -578,6 +578,10 @@ def push(
                         "[yellow]The content hash is based on your source files "
                         "(*.py, pyproject.toml, README.md).[/yellow]"
                     )
+                    console.print(
+                        "[dim]Alternatively, use the --auto-bump flag to push "
+                        "a new version without content changes[/dim]"
+                    )
                 else:
                     console.print(f"[red]Failed to prepare wheel upload: {e}[/red]")
                 raise typer.Exit(1)
@@ -689,6 +693,10 @@ def push(
                             console.print(
                                 "[yellow]The content hash is based on your source files "
                                 "(*.py, pyproject.toml, README.md).[/yellow]"
+                            )
+                            console.print(
+                                "[dim]Alternatively, use the --auto-bump flag to push "
+                                "a new version without content changes[/dim]"
                             )
                         else:
                             console.print(f"[red]Failed to prepare source upload: {e}[/red]")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -759,9 +759,9 @@ def push(
                         # Both exist - prefer the one in .prime/ and remove the old one
                         try:
                             old_metadata_path.unlink()
-                        except (OSError, IOError) as e:
+                        except (OSError, IOError):
                             console.print(
-                                f"[yellow]Warning: Could not remove old .env-metadata.json "
+                                "[yellow]Warning: Could not remove old .env-metadata.json "
                             )
                     
                     # Read existing metadata if it exists

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -989,7 +989,12 @@ def pull(
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
-            extracted_files = list(target_dir.iterdir())
+            all_files = list(target_dir.iterdir())
+            # Filter out .prime directory and .env-metadata.json files (created locally, not extracted)
+            extracted_files = [
+                f for f in all_files
+                if f.name != ".prime" and f.name != ".env-metadata.json"
+            ]
             if extracted_files:
                 console.print("\nExtracted files:")
                 for file in extracted_files[:MAX_FILES_TO_SHOW]:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -19,6 +19,7 @@ import typer
 from prime_core import Config
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..client import APIClient, APIError
@@ -794,13 +795,13 @@ def push(
                         json.dump(env_metadata, f, indent=2)
                     
                     if existing_metadata:
-                        console.print(
-                            "[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]"
-                        )
+                        message = Text("Updated environment metadata in ", style="dim")
+                        message.append(str(metadata_path), style="dim")
+                        console.print(message)
                     else:
-                        console.print(
-                            "[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]"
-                        )
+                        message = Text("Saved environment metadata to ", style="dim")
+                        message.append(str(metadata_path), style="dim")
+                        console.print(message)
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -1003,7 +1004,9 @@ def pull(
             }
             with open(metadata_path, "w") as f:
                 json.dump(env_metadata, f, indent=2)
-            console.print("[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
+            message = Text("Created environment metadata at ", style="dim")
+            message.append(str(metadata_path), style="dim")
+            console.print(message)
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -37,7 +37,9 @@ DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
 
-def display_remote_environment_info(env_path: Optional[Path] = None, environment_name: Optional[str] = None) -> None:
+def display_remote_environment_info(
+    env_path: Optional[Path] = None, environment_name: Optional[str] = None
+) -> None:
     """Display the remote environment name if metadata exists.
     
     Checks the provided path (or current directory) for environment metadata
@@ -736,19 +738,22 @@ def push(
                     prime_dir.mkdir(exist_ok=True)
                     metadata_path = prime_dir / ".env-metadata.json"
                     
-                    # Backwards compatibility: Migrate .env-metadata.json from root to .prime/ if it exists
-                    # This handles environments that were pulled/pushed before we moved to .prime/ subfolder
+                    # Backwards compatibility: Migrate .env-metadata.json from root to .prime/
+                    # This handles environments that were pulled/pushed before we moved
+                    # to .prime/ subfolder
                     old_metadata_path = env_path / ".env-metadata.json"
                     if old_metadata_path.exists() and not metadata_path.exists():
                         try:
                             # Move the old file to the new location
                             old_metadata_path.rename(metadata_path)
                             console.print(
-                                f"[dim]Migrated environment metadata from root to .prime/ subfolder[/dim]"
+                                "[dim]Migrated environment metadata from root "
+                                "to .prime/ subfolder[/dim]"
                             )
                         except (OSError, IOError) as e:
                             console.print(
-                                f"[yellow]Warning: Could not migrate old .env-metadata.json file to .prime/ subfolder: {e}[/yellow]"
+                                f"[yellow]Warning: Could not migrate old .env-metadata.json "
+                                f"file to .prime/ subfolder: {e}[/yellow]"
                             )
                     elif old_metadata_path.exists() and metadata_path.exists():
                         # Both exist - prefer the one in .prime/ and remove the old one
@@ -780,9 +785,13 @@ def push(
                         json.dump(env_metadata, f, indent=2)
                     
                     if existing_metadata:
-                        console.print(f"[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]")
+                        console.print(
+                            "[dim]Updated environment metadata in .prime/.env-metadata.json[/dim]"
+                        )
                     else:
-                        console.print(f"[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]")
+                        console.print(
+                            "[dim]Saved environment metadata to .prime/.env-metadata.json[/dim]"
+                        )
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -913,7 +922,8 @@ def pull(
                     target_dir = Path.cwd() / f"{name}-{index}"
                     index += 1
                 console.print(
-                    f"[yellow]Directory {base_dir} already exists. Using {target_dir} instead.[/yellow]"
+                    f"[yellow]Directory {base_dir} already exists. "
+                    f"Using {target_dir} instead.[/yellow]"
                 )
 
         try:
@@ -984,13 +994,14 @@ def pull(
             }
             with open(metadata_path, "w") as f:
                 json.dump(env_metadata, f, indent=2)
-            console.print(f"[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
+            console.print("[dim]Created environment metadata at .prime/.env-metadata.json[/dim]")
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
             all_files = list(target_dir.iterdir())
-            # Filter out .prime directory and .env-metadata.json files (created locally, not extracted)
+            # Filter out .prime directory and .env-metadata.json files
+            # (created locally, not extracted)
             extracted_files = [
                 f for f in all_files
                 if f.name != ".prime" and f.name != ".env-metadata.json"

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -829,7 +829,7 @@ def pull(
         if target:
             target_dir = Path(target)
         else:
-            target_dir = Path.cwd() / f"{owner}-{name}-{version}"
+            target_dir = Path.cwd() / name
 
         try:
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -886,6 +886,20 @@ def pull(
                 Path(temp_file_path).unlink()
 
         console.print(f"[green]✓ Environment pulled to {target_dir}[/green]")
+
+        # Create .env-metadata.json for proper resolution
+        try:
+            metadata_path = target_dir / ".env-metadata.json"
+            env_metadata = {
+                "environment_id": details.get("id"),
+                "owner": owner,
+                "name": name,
+            }
+            with open(metadata_path, "w") as f:
+                json.dump(env_metadata, f, indent=2)
+            console.print(f"[dim]Created environment metadata at {metadata_path.name}[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]Warning: Could not create metadata file: {e}[/yellow]")
 
         try:
             extracted_files = list(target_dir.iterdir())

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -37,13 +37,13 @@ DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
 
-def display_remote_environment_info(
+def display_upstream_environment_info(
     env_path: Optional[Path] = None, environment_name: Optional[str] = None
-) -> None:
-    """Display the remote environment name if metadata exists.
+) -> bool:
+    """Display the upstream environment name if metadata exists.
     
     Checks the provided path (or current directory) for environment metadata
-    and displays "Using remote environment {owner}/{name}" if found.
+    and displays "Using upstream environment {owner}/{name}" if found.
     
     If environment_name is provided, also checks ./environments/{module_name} as a fallback.
     
@@ -67,7 +67,11 @@ def display_remote_environment_info(
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
-        console.print(f"[blue]Using remote environment {owner}/{env_name}[/blue]\n")
+        console.print(f"[blue]Using upstream environment {owner}/{env_name}[/blue]\n")
+        return True
+    else:
+        console.print("[blue]No upstream environment found.\n")
+        return False
 
 
 def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:
@@ -285,8 +289,8 @@ def push(
     try:
         env_path = Path(path).resolve()
 
-        # Display remote environment info if metadata exists
-        display_remote_environment_info(env_path)
+        # Display upstream environment info if metadata exists
+        display_upstream_environment_info(env_path)
 
         # Validate basic structure
         pyproject_path = env_path / "pyproject.toml"
@@ -1947,8 +1951,8 @@ def eval_env(
        prime env eval meow -m meta-llama/llama-3.1-70b-instruct -n 2 -r 3 -t 1024 -T 0.7
        All extra args are forwarded unchanged to vf-eval.
     """
-    # Display remote environment info if metadata exists
-    display_remote_environment_info(environment_name=environment)
+    # Display upstream environment info if metadata exists
+    display_upstream_environment_info(environment_name=environment)
     
     config = Config()
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -903,7 +903,18 @@ def pull(
         if target:
             target_dir = Path(target)
         else:
-            target_dir = Path.cwd() / name
+            # Check if the base directory exists and add index suffix if needed
+            base_dir = Path.cwd() / name
+            target_dir = base_dir
+            if target_dir.exists():
+                # Find the next available directory with index suffix
+                index = 1
+                while target_dir.exists():
+                    target_dir = Path.cwd() / f"{name}-{index}"
+                    index += 1
+                console.print(
+                    f"[yellow]Directory {base_dir} already exists. Using {target_dir} instead.[/yellow]"
+                )
 
         try:
             target_dir.mkdir(parents=True, exist_ok=True)

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -71,7 +71,7 @@ def display_upstream_environment_info(
         console.print(f"[blue]Using upstream environment {owner}/{env_name}[/blue]\n")
         return True
     else:
-        console.print("[blue]No upstream environment found.\n")
+        console.print("[blue]No upstream environment found.[/blue]\n")
         return False
 
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -747,6 +747,7 @@ def push(
                     # This handles environments that were pulled/pushed before we moved
                     # to .prime/ subfolder
                     old_metadata_path = env_path / ".env-metadata.json"
+                    migration_failed = False
                     if old_metadata_path.exists() and not metadata_path.exists():
                         try:
                             # Move the old file to the new location
@@ -756,6 +757,7 @@ def push(
                                 "to .prime/ subfolder[/dim]"
                             )
                         except (OSError, IOError) as e:
+                            migration_failed = True
                             console.print(
                                 f"[yellow]Warning: Could not migrate old .env-metadata.json "
                                 f"file to .prime/ subfolder: {e}[/yellow]"
@@ -778,6 +780,17 @@ def push(
                         except (json.JSONDecodeError, IOError) as e:
                             console.print(
                                 f"[yellow]Warning: Could not read existing metadata: {e}[/yellow]"
+                            )
+                            existing_metadata = {}
+                    elif migration_failed and old_metadata_path.exists():
+                        # If migration failed, read from old location to preserve metadata
+                        try:
+                            with open(old_metadata_path, "r") as f:
+                                existing_metadata = json.load(f)
+                        except (json.JSONDecodeError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not read existing metadata from "
+                                f"old location: {e}[/yellow]"
                             )
                             existing_metadata = {}
                     

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -67,10 +67,10 @@ def display_upstream_environment_info(
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
-        console.print(f"[blue]Using upstream environment {owner}/{env_name}[/blue]\n")
+        console.print(f"[dim]Using upstream environment {owner}/{env_name}[/dim]\n")
         return True
     else:
-        console.print("[blue]No upstream environment found.[/blue]\n")
+        console.print("[dim]No upstream environment found.[/dim]\n")
         return False
 
 
@@ -793,6 +793,13 @@ def push(
                             )
                             existing_metadata = {}
                     
+                    # Check if upstream (owner/name) changed
+                    old_owner = existing_metadata.get("owner")
+                    old_name = existing_metadata.get("name")
+                    upstream_changed = False
+                    if existing_metadata and (old_owner != owner_name or old_name != env_name):
+                        upstream_changed = True
+                    
                     # Merge existing metadata with new push information
                     env_metadata = {
                         **existing_metadata,  # Preserve existing fields
@@ -814,6 +821,12 @@ def push(
                         message = Text("Saved environment metadata to ", style="dim")
                         message.append(str(metadata_path), style="dim")
                         console.print(message)
+                    
+                    # Report upstream change if it occurred
+                    if upstream_changed:
+                        upstream_message = Text("Upstream set to ", style="dim")
+                        upstream_message.append(f"{owner_name}/{env_name}", style="dim")
+                        console.print(upstream_message)
                 except Exception as e:
                     console.print(
                         f"[yellow]Warning: Could not save environment metadata: {e}[/yellow]"
@@ -1986,7 +1999,8 @@ def eval_env(
     if not is_resolved:
         console.print(
             "[yellow]Evaluation results will not be uploaded or viewable on the platform "
-            "without a specified upstream environment.[/yellow]"
+            "without a specified upstream environment. Use `prime env push` "
+            "to set an upstream.[/yellow]"
         )
 
     config = Config()
@@ -2111,3 +2125,10 @@ def eval_env(
             console.print(f"[red]Failed to push results to hub:[/red] {e}")
             console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
             raise typer.Exit(1)
+    else:
+        console.print(
+            "[dim]No upstream environment found. Skipped uploading evaluation "
+            "results to platform.\nUse `prime env push` to set an "
+            "upstream, or use `--env-path` to specify the correct path to the "
+            "environment if it's not the current directory.[/dim]"
+        )

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -761,7 +761,7 @@ def push(
                             old_metadata_path.unlink()
                         except (OSError, IOError):
                             console.print(
-                                "[yellow]Warning: Could not remove old .env-metadata.json "
+                                "[yellow]Warning: Could not remove old .env-metadata.json[/yellow]"
                             )
                     
                     # Read existing metadata if it exists

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2004,7 +2004,7 @@ def eval_env(
     is_resolved = display_upstream_environment_info(
         env_path=check_path, environment_name=environment
     )
-    if not is_resolved:
+    if not is_resolved and not skip_upload:
         console.print(
             "[yellow]Evaluation results will not be uploaded or viewable on the platform "
             "without a specified upstream environment. Use `prime env push` "
@@ -2121,22 +2121,27 @@ def eval_env(
         raise typer.Exit(1)
 
     # Automatically push to hub after successful eval (unless --skip-upload is used)
-    if not skip_upload and is_resolved:
-        try:
-            push_eval_results_to_hub(
-                env_name=environment,
-                model=model,
-                job_id=job_id,
-                env_path=check_path,
+    if not skip_upload:
+        if is_resolved:
+            try:
+                push_eval_results_to_hub(
+                    env_name=environment,
+                    model=model,
+                    job_id=job_id,
+                    env_path=check_path,
+                )
+            except Exception as e:
+                console.print(f"[red]Failed to push results to hub:[/red] {e}")
+                console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
+                raise typer.Exit(1)
+        else:
+            console.print(
+                "[dim]No upstream environment found. Skipped uploading evaluation "
+                "results to platform.\nUse `prime env push` to set an "
+                "upstream, or use `--env-path` to specify the correct path to the "
+                "environment if it's not the current directory.[/dim]"
             )
-        except Exception as e:
-            console.print(f"[red]Failed to push results to hub:[/red] {e}")
-            console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
-            raise typer.Exit(1)
     else:
         console.print(
-            "[dim]No upstream environment found. Skipped uploading evaluation "
-            "results to platform.\nUse `prime env push` to set an "
-            "upstream, or use `--env-path` to specify the correct path to the "
-            "environment if it's not the current directory.[/dim]"
+            "[dim]Skipped uploading evaluation results[/dim]"
         )

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -757,7 +757,12 @@ def push(
                             )
                     elif old_metadata_path.exists() and metadata_path.exists():
                         # Both exist - prefer the one in .prime/ and remove the old one
-                        old_metadata_path.unlink()
+                        try:
+                            old_metadata_path.unlink()
+                        except (OSError, IOError) as e:
+                            console.print(
+                                f"[yellow]Warning: Could not remove old .env-metadata.json "
+                            )
                     
                     # Read existing metadata if it exists
                     existing_metadata = {}

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -260,14 +260,14 @@ def _push_single_eval(
 
     environments = None
     if env_slug and not run_id and not eval_id:
-    # Determine if env_slug is a slug (owner/name) or a name
-    # Use appropriate key so _resolve_environments can properly resolve it
-    if "/" in env_slug:
-        # It's a slug (owner/name format)
-        environments = [{"slug": env_slug}]
-    else:
-        # It's a name (will be resolved by _resolve_environments)
-        environments = [{"name": env_slug}]
+        # Determine if env_slug is a slug (owner/name) or a name
+        # Use appropriate key so _resolve_environments can properly resolve it
+        if "/" in env_slug:
+            # It's a slug (owner/name format)
+            environments = [{"slug": env_slug}]
+        else:
+            # It's a name (will be resolved by _resolve_environments)
+            environments = [{"name": env_slug}]
 
     console.print()
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -240,7 +240,7 @@ def _discover_eval_outputs() -> list[Path]:
 
 def _push_single_eval(
     config_path: str,
-    env_id: Optional[str],
+    env_slug: Optional[str],
     run_id: Optional[str],
     eval_id: Optional[str],
 ) -> str:
@@ -255,12 +255,19 @@ def _push_single_eval(
         console.print(f"[blue]✓ Loaded eval data (verifiers format):[/blue] {path}")
 
     detected_env = eval_data.get("env_id") or eval_data.get("env")
-    if not env_id and detected_env and not run_id and not eval_id:
-        env_id = detected_env
+    if not env_slug and detected_env and not run_id and not eval_id:
+        env_slug = detected_env
 
     environments = None
-    if env_id and not run_id and not eval_id:
-        environments = [{"id": env_id}]
+    if env_slug and not run_id and not eval_id:
+    # Determine if env_slug is a slug (owner/name) or a name
+    # Use appropriate key so _resolve_environments can properly resolve it
+    if "/" in env_slug:
+        # It's a slug (owner/name format)
+        environments = [{"slug": env_slug}]
+    else:
+        # It's a name (will be resolved by _resolve_environments)
+        environments = [{"name": env_slug}]
 
     console.print()
 

--- a/packages/prime/src/prime_cli/utils/env_metadata.py
+++ b/packages/prime/src/prime_cli/utils/env_metadata.py
@@ -10,6 +10,9 @@ def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
     Checks both the new location (.prime/.env-metadata.json) and old location
     (.env-metadata.json) for backwards compatibility.
     
+    This function only checks the provided path - it does not search multiple directories.
+    Use find_environment_metadata() if you need to search multiple locations.
+    
     Args:
         env_path: Path to the environment directory
         
@@ -30,4 +33,54 @@ def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
             return json.load(f)
     except (json.JSONDecodeError, IOError):
         return None
+
+
+def find_environment_metadata(
+    env_name: Optional[str] = None,
+    env_path: Optional[Path] = None,
+    module_name: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Search for environment metadata in multiple common locations.
+    
+    Searches directories in the following order:
+    1. env_path (if provided)
+    2. ./environments/{module_name} (if module_name provided)
+    3. ./environments/{env_name} (if env_name provided)
+    4. ./{env_name} (if env_name provided)
+    5. ./{module_name} (if module_name provided)
+    6. ./ (current directory)
+    
+    Args:
+        env_name: Environment name (e.g., "simpleqa")
+        env_path: Optional explicit path to check first
+        module_name: Optional module name (e.g., "simple_qa" for env_name "simpleqa")
+        
+    Returns:
+        Dictionary containing environment metadata from the first location found, or None
+    """
+    possible_env_dirs = []
+    
+    # 1. Check explicit path first if provided
+    if env_path:
+        possible_env_dirs.append(env_path)
+    
+    # 2-5. Check common locations based on provided names
+    if module_name:
+        possible_env_dirs.append(Path("./environments") / module_name)
+    if env_name:
+        possible_env_dirs.append(Path("./environments") / env_name)
+        possible_env_dirs.append(Path(".") / env_name)
+    if module_name:
+        possible_env_dirs.append(Path(".") / module_name)
+    
+    # 6. Check current directory last
+    possible_env_dirs.append(Path("."))
+    
+    # Search through directories and return first match
+    for env_dir in possible_env_dirs:
+        metadata = get_environment_metadata(env_dir)
+        if metadata:
+            return metadata
+    
+    return None
 

--- a/packages/prime/src/prime_cli/utils/env_metadata.py
+++ b/packages/prime/src/prime_cli/utils/env_metadata.py
@@ -1,0 +1,33 @@
+"""Utilities for reading and managing environment metadata."""
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def get_environment_metadata(env_path: Path) -> Optional[Dict[str, Any]]:
+    """Read environment metadata from .prime/.env-metadata.json with backwards compatibility.
+    
+    Checks both the new location (.prime/.env-metadata.json) and old location
+    (.env-metadata.json) for backwards compatibility.
+    
+    Args:
+        env_path: Path to the environment directory
+        
+    Returns:
+        Dictionary containing environment metadata, or None if not found
+    """
+    # Try new location first
+    metadata_path = env_path / ".prime" / ".env-metadata.json"
+    if not metadata_path.exists():
+        # Fall back to old location for backwards compatibility
+        metadata_path = env_path / ".env-metadata.json"
+    
+    if not metadata_path.exists():
+        return None
+    
+    try:
+        with open(metadata_path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -1,12 +1,13 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from prime_core import APIClient
 from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
-from .env_metadata import get_environment_metadata
+from .env_metadata import find_environment_metadata
 
 console = Console()
 
@@ -15,6 +16,7 @@ def push_eval_results_to_hub(
     env_name: str,
     model: str,
     job_id: str,
+    env_path: Optional[Path] = None,
 ) -> None:
     """
     Push evaluation results to Prime Evals Hub after vf-eval completes.
@@ -27,12 +29,11 @@ def push_eval_results_to_hub(
     5. Creates evaluation, pushes samples, and finalizes
 
     Args:
-        environment: Environment name (e.g., "simpleqa")
+        env_name: Environment name (e.g., "simpleqa")
         model: Model identifier (e.g., "meta-llama/llama-3.1-70b-instruct")
         job_id: Unique job ID for tracking
+        env_path: Optional path to the environment directory (defaults to current directory)
     """
-    console.print("\n[blue]Pushing evaluation results to hub...[/blue]")
-
     # Step 1: Find the output directory
     module_name = env_name.replace("-", "_")
     model_name = model.replace("/", "--")
@@ -52,7 +53,6 @@ def push_eval_results_to_hub(
         raise FileNotFoundError(f"No evaluation results found in {base_evals_dir}")
 
     output_dir = max(subdirs, key=lambda d: d.stat().st_mtime)
-    console.print(f"[dim]Found results in: {output_dir}[/dim]")
 
     metadata_path = output_dir / "metadata.json"
     results_path = output_dir / "results.jsonl"
@@ -71,20 +71,63 @@ def push_eval_results_to_hub(
             if line.strip():
                 results_samples.append(json.loads(line))
 
-    console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
-
-    # Resolve environment slug from metadata if available
-    env_dir = Path("./environments") / module_name
-    hub_metadata = get_environment_metadata(env_dir)
+    # Search for environment metadata in multiple possible locations
+    hub_metadata = find_environment_metadata(
+        env_name=env_name,
+        env_path=env_path,
+        module_name=module_name,
+    )
+    
     resolved_env_slug = None
+    resolved_env_id = None
 
-    if hub_metadata and hub_metadata.get("owner") and hub_metadata.get("name"):
-        resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
-        console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
+    if hub_metadata:
+        try:
+            # Prefer database ID if available (no resolution needed)
+            if hub_metadata.get("environment_id"):
+                resolved_env_id = hub_metadata.get("environment_id")
+                owner = hub_metadata.get("owner")
+                name = hub_metadata.get("name")
+                resolved_env_slug = (
+                    f"{owner}/{name}" if owner and name else None
+                )
+            elif hub_metadata.get("owner") and hub_metadata.get("name"):
+                resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
+                resolved_env_id = None
+            else:
+                resolved_env_slug = None
+                resolved_env_id = None
+        except (KeyError, AttributeError) as e:
+            console.print(f"[yellow]Warning: Could not parse environment metadata: {e}[/yellow]")
+            resolved_env_slug = None
+            resolved_env_id = None
     else:
-        console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")
+        resolved_env_slug = None
+        resolved_env_id = None
 
-    environments = [{"id": resolved_env_slug or env_name}]
+    # Require accurate upstream for evaluation tracking
+    if not resolved_env_slug and not resolved_env_id:
+        console.print(
+            "[yellow]No upstream environment found. Cannot upload evaluation results "
+            "without specific environment identification.\nEnsure .prime/.env-metadata.json "
+            "exists in the environment directory or use --env-path to specify the "
+            "correct path.[/yellow]"
+        )
+        return None
+
+    env_identifier = resolved_env_slug or resolved_env_id
+    console.print(
+        f"\n[blue]Uploading evaluation results, "
+        f"using remote environment: {env_identifier}[/blue]"
+    )
+
+    if resolved_env_id:
+        environments = [{"id": resolved_env_id}]
+    elif resolved_env_slug:
+        environments = [{"slug": resolved_env_slug}]
+    else:
+        # This should never happen due to the check above, but keeping for safety
+        raise ValueError("No valid environment identifier found")
     metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
 
     eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
@@ -103,7 +146,6 @@ def push_eval_results_to_hub(
     api_client = APIClient()
     evals_client = EvalsClient(api_client)
 
-    console.print("[blue]Creating evaluation...[/blue]")
     create_response = evals_client.create_evaluation(
         name=eval_name,
         environments=environments,
@@ -113,27 +155,21 @@ def push_eval_results_to_hub(
         task_type=metadata.get("task_type"),
         metadata=eval_metadata,
         metrics=metrics,
+        is_public=False,  # Private by default - only visible to the user who created it
     )
 
     eval_id = create_response.get("evaluation_id")
     if not eval_id:
         raise EvalsAPIError("Failed to get evaluation ID from create_evaluation response")
 
-    console.print(f"[green]✓ Created evaluation:[/green] {eval_id}")
-
     if converted_results:
-        console.print(f"[blue]Pushing {len(converted_results)} samples...[/blue]")
         evals_client.push_samples(eval_id, converted_results)
-        console.print("[green]✓ Samples pushed successfully[/green]")
 
-    console.print("[blue]Finalizing evaluation...[/blue]")
     evals_client.finalize_evaluation(eval_id, metrics=metrics)
-    console.print("[green]✓ Evaluation finalized[/green]\n")
 
-    console.print("[green]✓ Successfully pushed to hub[/green]")
+    console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
-    if resolved_env_slug:
-        frontend_url = api_client.config.frontend_url
-        eval_url = f"{frontend_url}/dashboard/environments/{resolved_env_slug}/evals/{eval_id}"
-        console.print(f"[blue]View evaluation:[/blue] {eval_url}")
-        console.print()
+    frontend_url = api_client.config.frontend_url
+    eval_url = f"{frontend_url}/dashboard/evaluations/{eval_id}"
+    console.print("\n[green]View results at:[/green]")
+    console.print(eval_url)

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -108,17 +108,17 @@ def push_eval_results_to_hub(
     # Require accurate upstream for evaluation tracking
     if not resolved_env_slug and not resolved_env_id:
         console.print(
-            "[yellow]No upstream environment found. Cannot upload evaluation results "
-            "without specific environment identification.\nEnsure .prime/.env-metadata.json "
-            "exists in the environment directory or use --env-path to specify the "
-            "correct path.[/yellow]"
+            "[yellow]No upstream environment found. Evaluation results will not be "
+            "uploaded or viewable on the platform. Use `prime env push` to set an "
+            "upstream, or use `--env-path` to specify the correct path to the "
+            "environment.[/yellow]"
         )
         return None
 
     env_identifier = resolved_env_slug or resolved_env_id
     console.print(
         f"\n[blue]Uploading evaluation results, "
-        f"using remote environment: {env_identifier}[/blue]"
+        f"using upstream: {env_identifier}[/blue]"
     )
 
     if resolved_env_id:

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -6,6 +6,8 @@ from prime_core import APIClient
 from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
+from .env_metadata import get_environment_metadata
+
 console = Console()
 
 
@@ -71,30 +73,14 @@ def push_eval_results_to_hub(
 
     console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
 
-    # Backwards compatibility: Check both .prime/.env-metadata.json (new location) and
-    # .env-metadata.json (old location) for environments pulled/pushed before migration
+    # Resolve environment slug from metadata if available
     env_dir = Path("./environments") / module_name
-    env_metadata_path = env_dir / ".prime" / ".env-metadata.json"
-    old_env_metadata_path = env_dir / ".env-metadata.json"
+    hub_metadata = get_environment_metadata(env_dir)
     resolved_env_slug = None
 
-    # Try new location first, then fall back to old location for backwards compatibility
-    metadata_path_to_use = None
-    if env_metadata_path.exists():
-        metadata_path_to_use = env_metadata_path
-    elif old_env_metadata_path.exists():
-        metadata_path_to_use = old_env_metadata_path
-
-    if metadata_path_to_use:
-        try:
-            with open(metadata_path_to_use, encoding="utf-8") as f:
-                hub_metadata = json.load(f)
-                if hub_metadata.get("owner") and hub_metadata.get("name"):
-                    resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
-                    console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
-        except (json.JSONDecodeError, IOError, KeyError) as e:
-            console.print(f"[yellow]Warning: Could not load {metadata_path_to_use}: {e}[/yellow]")
-            console.print(f"[blue]Using environment name:[/blue] {env_name}")
+    if hub_metadata and hub_metadata.get("owner") and hub_metadata.get("name"):
+        resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
+        console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
     else:
         console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")
 

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -71,18 +71,29 @@ def push_eval_results_to_hub(
 
     console.print(f"[dim]Loaded {len(results_samples)} samples[/dim]")
 
-    env_metadata_path = Path("./environments") / module_name / ".env-metadata.json"
+    # Backwards compatibility: Check both .prime/.env-metadata.json (new location) and
+    # .env-metadata.json (old location) for environments pulled/pushed before migration
+    env_dir = Path("./environments") / module_name
+    env_metadata_path = env_dir / ".prime" / ".env-metadata.json"
+    old_env_metadata_path = env_dir / ".env-metadata.json"
     resolved_env_slug = None
 
+    # Try new location first, then fall back to old location for backwards compatibility
+    metadata_path_to_use = None
     if env_metadata_path.exists():
+        metadata_path_to_use = env_metadata_path
+    elif old_env_metadata_path.exists():
+        metadata_path_to_use = old_env_metadata_path
+
+    if metadata_path_to_use:
         try:
-            with open(env_metadata_path, encoding="utf-8") as f:
+            with open(metadata_path_to_use, encoding="utf-8") as f:
                 hub_metadata = json.load(f)
                 if hub_metadata.get("owner") and hub_metadata.get("name"):
                     resolved_env_slug = f"{hub_metadata.get('owner')}/{hub_metadata.get('name')}"
                     console.print(f"[blue]✓ Found environment:[/blue] {env_name}")
         except (json.JSONDecodeError, IOError, KeyError) as e:
-            console.print(f"[yellow]Warning: Could not load {env_metadata_path}: {e}[/yellow]")
+            console.print(f"[yellow]Warning: Could not load {metadata_path_to_use}: {e}[/yellow]")
             console.print(f"[blue]Using environment name:[/blue] {env_name}")
     else:
         console.print(f"[blue]Using environment name:[/blue] {env_name} (will be resolved)")

--- a/uv.lock
+++ b/uv.lock
@@ -2694,7 +2694,7 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.6"
+version = "0.1.8.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
@@ -2707,10 +2707,13 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "textual" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "wget" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/47/d2e916c7009faca66466a4ffcd9f07f87b54215c0b82bdc2fc9a3bd04471/verifiers-0.1.6.tar.gz", hash = "sha256:1ee2f3eae39d894da2e67822c586f2314d6a9e840032b5e2dfe34ef4f614b1c6", size = 124961, upload-time = "2025-10-21T01:06:32.239Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8f/8ab2a095cdc7db4cbbb8b21c8bb208aa7043cc6dfc99b65f24fd235f8bfd/verifiers-0.1.8.post1.tar.gz", hash = "sha256:8be547ecfdac8464128798b083601ca576061a3bdf522920c57dc0dc71ae649f", size = 117959, upload-time = "2025-11-26T07:50:29.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/3e/6115fcb03ee63316d4f1e866758aad135ecdc3392c35981635f46526687b/verifiers-0.1.6-py3-none-any.whl", hash = "sha256:e07203a78a95d877461affd242e2a29786fac8676c683bcfa69d307ba81abaa7", size = 115453, upload-time = "2025-10-21T01:06:30.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0a/38a238f53de3aedd46a4cf36f06e8bce9a68e314d4b61ab6c7b8acd03dca/verifiers-0.1.8.post1-py3-none-any.whl", hash = "sha256:8ea9e536f3c1a40f28f000bc7196a84afd5d51bb497aae1262ab7852ccc19f9d", size = 106975, upload-time = "2025-11-26T07:50:28.157Z" },
 ]
 
 [[package]]
@@ -2786,6 +2789,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
+
+[[package]]
+name = "wget"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061", size = 10857, upload-time = "2015-10-22T15:26:37.51Z" }
 
 [[package]]
 name = "xxhash"


### PR DESCRIPTION
## Summary
- Bumps verifiers dependency from 0.1.6 to 0.1.8.post1

## Test plan
- CI should pass with updated dependency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds upstream environment metadata discovery and migration, auto-uploads vf-eval results by default, and enhances environment resolution (slug/name/id) with team and visibility options.
> 
> - **Prime Evals client (`prime_evals/evals.py`)**:
>   - Resolve environments from `slug` (`owner/name`) or `name`; new `_resolve_environments` (sync/async) utilities.
>   - Include `team_id` in create payloads; support `is_public`; improved validation when environments are missing/invalid.
> - **CLI: environments (`prime_cli/commands/env.py`)**:
>   - Display upstream env info via new metadata utilities; create/migrate `.prime/.env-metadata.json` on push/pull (with backwards compatibility) and dim notices.
>   - Eval command now uploads results to hub by default; adds `--skip-upload` and `--env-path`; warns/skips when no upstream.
>   - Pull: smarter default target dir (avoids collisions); exclude local metadata from extracted files list.
>   - Push: clearer tips for content-hash conflicts (`--auto-bump`).
> - **CLI: evals (`prime_cli/commands/evals.py`)**:
>   - Accept `env` as slug or name; pass as `slug`/`name` so the client resolves IDs.
> - **Utils**:
>   - New `utils/env_metadata.py` to read/find upstream metadata.
>   - `utils/eval_push.py` uses metadata finder, prefers env `id` if present, requires upstream, sets evaluations private by default, and updates result URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a938d00ed32571f04571ae76ef281f81b3626750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->