### PR TITLE
test: add prime env eval E2E tests

### DIFF
--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -54,11 +54,12 @@ def test_env_eval_single_turn_math(install_math_env):
                 "-m",
                 TEST_MODEL,
                 "-n",
-                "1",  # Only 1 example
+                "3",  # 3 examples
                 "-r",
-                "1",  # Only 1 rollout
+                "1",  # 1 rollout each
                 "-c",
                 "1",  # Max 1 concurrent request
+                "-v",  # Verbose output
             ],
             capture_output=True,
             text=True,

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -62,7 +62,7 @@ def test_env_eval_single_turn_math(install_math_env):
             ],
             capture_output=True,
             text=True,
-            timeout=180,  # 3 minute timeout
+            timeout=300,  # 5 minute timeout
             cwd=tmpdir,
             env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
         )

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -91,7 +91,7 @@ def test_env_eval_invalid_model(install_math_env):
             ],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=120,
             cwd=tmpdir,
             env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
         )
@@ -123,7 +123,7 @@ def test_env_eval_missing_environment():
             ],
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=120,
             cwd=tmpdir,
             env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
         )

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -54,16 +54,13 @@ def test_env_eval_single_turn_math(install_math_env):
                 "-m",
                 TEST_MODEL,
                 "-n",
-                "3",  # 3 examples
+                "1",  # 1 example
                 "-r",
-                "1",  # 1 rollout each
-                "-c",
-                "1",  # Max 1 concurrent request
-                "-v",  # Verbose output
+                "1",  # 1 rollout
             ],
             capture_output=True,
             text=True,
-            timeout=300,  # 5 minute timeout
+            timeout=600,  # 10 minute timeout
             cwd=tmpdir,
             env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
         )

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -10,19 +10,6 @@ import pytest
 TEST_MODEL = "deepseek/deepseek-chat"
 
 
-def has_inference_access() -> bool:
-    """Check if we have access to Prime Inference API"""
-    result = subprocess.run(
-        ["uv", "run", "prime", "inference", "models"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
-    )
-    # If we get 401 or can't list models, we don't have inference access
-    return result.returncode == 0 and "401" not in result.stdout
-
-
 @pytest.fixture(scope="module")
 def install_math_env():
     """Install the single-turn-math environment for testing"""
@@ -48,14 +35,7 @@ def install_math_env():
     )
 
 
-@pytest.fixture(scope="module")
-def check_inference_access():
-    """Skip tests if we don't have inference access"""
-    if not has_inference_access():
-        pytest.skip("No access to Prime Inference API (API key may not have inference permissions)")
-
-
-def test_env_eval_single_turn_math(install_math_env, check_inference_access):
+def test_env_eval_single_turn_math(install_math_env):
     """Test running prime env eval with single_turn_math environment
 
     This test runs a minimal evaluation (1 example, 1 rollout) against

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -1,0 +1,134 @@
+"""Tests for prime env eval command with Prime Inference"""
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+# Use a small/fast model for testing
+TEST_MODEL = "deepseek/deepseek-chat"
+
+
+@pytest.fixture(scope="module")
+def install_math_env():
+    """Install the single-turn-math environment for testing"""
+    result = subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "single_turn_math",
+            "--extra-index-url",
+            "https://hub.primeintellect.ai/primeintellect/simple/",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Failed to install single_turn_math: {result.stderr}")
+    yield
+    # Cleanup: uninstall after tests
+    subprocess.run(
+        ["uv", "pip", "uninstall", "single_turn_math", "-y"],
+        capture_output=True,
+    )
+
+
+def test_env_eval_single_turn_math(install_math_env):
+    """Test running prime env eval with single_turn_math environment
+
+    This test runs a minimal evaluation (1 example, 1 rollout) against
+    Prime Inference to verify the end-to-end eval pipeline works.
+    """
+    # Run from a temp directory to avoid polluting the source tree with results
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "prime",
+                "env",
+                "eval",
+                "single_turn_math",
+                "-m",
+                TEST_MODEL,
+                "-n",
+                "1",  # Only 1 example
+                "-r",
+                "1",  # Only 1 rollout
+                "-c",
+                "1",  # Max 1 concurrent request
+            ],
+            capture_output=True,
+            text=True,
+            timeout=180,  # 3 minute timeout
+            cwd=tmpdir,
+            env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
+        )
+
+        print(f"stdout: {result.stdout}")
+        print(f"stderr: {result.stderr}")
+
+        assert result.returncode == 0, f"Eval failed: {result.stderr}\n{result.stdout}"
+
+
+def test_env_eval_invalid_model(install_math_env):
+    """Test that prime env eval fails gracefully with invalid model"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "prime",
+                "env",
+                "eval",
+                "single_turn_math",
+                "-m",
+                "nonexistent/fake-model-12345",
+                "-n",
+                "1",
+                "-r",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=tmpdir,
+            env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
+        )
+
+        # Should fail with non-zero exit code
+        assert result.returncode != 0, f"Expected failure but got: {result.stdout}"
+        # Should show error about invalid model
+        output = result.stdout.lower() + result.stderr.lower()
+        assert "invalid model" in output or "not found" in output
+
+
+def test_env_eval_missing_environment():
+    """Test that prime env eval fails gracefully with missing environment"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "prime",
+                "env",
+                "eval",
+                "nonexistent_env_xyz_12345",
+                "-m",
+                TEST_MODEL,
+                "-n",
+                "1",
+                "-r",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=tmpdir,
+            env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
+        )
+
+        # Should fail with non-zero exit code
+        assert result.returncode != 0, f"Expected failure but got: {result.stdout}\n{result.stderr}"

--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -10,6 +10,19 @@ import pytest
 TEST_MODEL = "deepseek/deepseek-chat"
 
 
+def has_inference_access() -> bool:
+    """Check if we have access to Prime Inference API"""
+    result = subprocess.run(
+        ["uv", "run", "prime", "inference", "models"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", "")},
+    )
+    # If we get 401 or can't list models, we don't have inference access
+    return result.returncode == 0 and "401" not in result.stdout
+
+
 @pytest.fixture(scope="module")
 def install_math_env():
     """Install the single-turn-math environment for testing"""
@@ -35,7 +48,14 @@ def install_math_env():
     )
 
 
-def test_env_eval_single_turn_math(install_math_env):
+@pytest.fixture(scope="module")
+def check_inference_access():
+    """Skip tests if we don't have inference access"""
+    if not has_inference_access():
+        pytest.skip("No access to Prime Inference API (API key may not have inference permissions)")
+
+
+def test_env_eval_single_turn_math(install_math_env, check_inference_access):
     """Test running prime env eval with single_turn_math environment
 
     This test runs a minimal evaluation (1 example, 1 rollout) against


### PR DESCRIPTION
## Summary
- Adds E2E tests for `prime env eval` command
- Tests run against Prime Inference with the `single_turn_math` environment
- Tests include:
  - Successful evaluation with 1 example/1 rollout
  - Error handling for invalid model names
  - Error handling for missing environments

## Test plan
- Tests require `PRIME_API_KEY` environment secret (already configured in CI)
- Run with: `uv run pytest packages/prime/tests/test_env_eval.py -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds E2E tests for `prime env eval` covering a successful run and graceful failures for invalid model and missing environment.
> 
> - **Tests**:
>   - **E2E for `prime env eval`** in `packages/prime/tests/test_env_eval.py`:
>     - Installs `single_turn_math` test environment via `uv pip` (with cleanup).
>     - Verifies successful eval against `single_turn_math` using model `deepseek/deepseek-chat` (1 example, 1 rollout).
>     - Asserts failure with informative output for invalid model names.
>     - Asserts failure when the specified environment is missing.
>     - Runs in isolated temp directories and forwards `PRIME_API_KEY` from environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d353d77917d9bcb65732579d1fa8c5b84277bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->