### PR TITLE
Prepare prime-core for PyPI publishing

### DIFF
--- a/packages/prime-core/README.md
+++ b/packages/prime-core/README.md
@@ -1,23 +1,36 @@
 # prime-core
 
-**Internal development package - NOT published to PyPI**
+Shared HTTP client and configuration for Prime Intellect packages.
 
-This package contains shared HTTP client and configuration code used by both `prime-sandboxes` and `prime` packages during development.
+This is a core package used by:
+- [prime](https://pypi.org/project/prime/) - Prime Intellect CLI + SDK
+- [prime-sandboxes](https://pypi.org/project/prime-sandboxes/) - Sandboxes SDK
+- [prime-evals](https://pypi.org/project/prime-evals/) - Evals SDK
 
-## Purpose
+## Installation
 
-- **Single source of truth** for `APIClient` and `Config` during development
-- **Used via uv workspace** - packages reference this locally
-- **Not published** - published packages include their own copies of this code
+```bash
+pip install prime-core
+```
 
-## Contents
+## Usage
 
-- `client.py` - HTTP client with error handling
-- `config.py` - Configuration management
+```python
+from prime_core import APIClient, Config
 
-## Development
+# Uses PRIME_API_KEY env var or ~/.prime/config.json
+client = APIClient()
+response = client.get("/some/endpoint")
+```
 
-When making changes to core functionality:
-1. Edit files in `prime-core`
-2. Changes are immediately available to all workspace packages
-3. Before releasing, ensure changes are synced to published packages
+## Configuration
+
+Set your API key:
+```bash
+export PRIME_API_KEY=your-api-key
+```
+
+Or use the CLI:
+```bash
+prime login
+```

--- a/packages/prime-core/pyproject.toml
+++ b/packages/prime-core/pyproject.toml
@@ -1,15 +1,31 @@
 [project]
 name = "prime-core"
-version = "0.1.1"
-description = "Prime Intellect Core - Shared HTTP client and configuration (internal package)"
+version = "0.1.2"
+description = "Prime Intellect Core - Shared HTTP client and configuration"
+readme = "README.md"
 requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [
+    { name = "Prime Intellect", email = "contact@primeintellect.ai" }
+]
 dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
 ]
 classifiers = [
-    "Private :: Do Not Upload",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
+
+[project.urls]
+Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
+Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.2
- Remove 'Private :: Do Not Upload' classifier  
- Add proper metadata (license, authors, classifiers, URLs)
- Update README for public package

## Context
This is the first step to fix the bundling issues where `prime`, `prime-sandboxes`, and `prime-evals` each bundle their own copy of `prime_core`, causing version conflicts when installed together.

After this is merged and `prime-core` is published to PyPI, a follow-up PR will remove the `force-include` directives from the other packages so they use the PyPI dependency instead.

## Test plan
- [ ] Build with `uv build` in `packages/prime-core`
- [ ] Publish to PyPI with `uv publish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preps `prime-core` for PyPI by updating packaging metadata to v0.1.2 and rewriting the README for public installation/usage.
> 
> - **Packaging (`packages/prime-core/pyproject.toml`)**:
>   - Bump version to `0.1.2` and update `description`, `readme`, `license`, and `authors`.
>   - Replace private classifier with public classifiers (status, audience, license, OS, Python 3.10–3.12).
>   - Add project URLs (`Homepage`, `Repository`).
> - **Docs (`packages/prime-core/README.md`)**:
>   - Rewrite for public use with installation, usage example (`APIClient`, `Config`), and configuration via `PRIME_API_KEY` or `prime login`.
>   - Clarify package purpose and relations to `prime`, `prime-sandboxes`, and `prime-evals`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5254efb3fe8cc629d0181bd7aea29de9002c1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->