### PR TITLE
Add release workflow for prime-core

### DIFF
--- a/.github/workflows/release-prime-core.yml
+++ b/.github/workflows/release-prime-core.yml
@@ -1,0 +1,85 @@
+name: Release prime-core
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'packages/prime-core/**'
+      - '.github/workflows/release-prime-core.yml'
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Force release even if tag exists'
+        required: false
+        default: 'false'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        working-directory: packages/prime-core
+        run: |
+          VERSION=$(grep -E "^version\s*=" pyproject.toml | head -n1 | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check for existing tag
+        id: check_tag
+        run: |
+          TAG="prime-core-v${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag $TAG already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag $TAG does not exist"
+          fi
+
+      - name: Set up Python
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        working-directory: packages/prime-core
+        run: |
+          uv build --wheel --out-dir dist
+
+          # Install twine for publishing
+          uv venv
+          source .venv/bin/activate
+          uv pip install twine
+
+      - name: Create tag
+        if: steps.check_tag.outputs.exists != 'true'
+        run: |
+          TAG="prime-core-v${{ steps.version.outputs.version }}"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        working-directory: packages/prime-core
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          source .venv/bin/activate
+          twine upload dist/*

--- a/packages/prime-evals/build_for_pypi.sh
+++ b/packages/prime-evals/build_for_pypi.sh
@@ -1,34 +1,9 @@
 #!/bin/bash
 set -e
 
-cleanup() {
-    rm -rf src/prime_core
-    if [ -f pyproject.toml.backup ]; then
-        mv pyproject.toml.backup pyproject.toml
-    fi
-}
-
-trap cleanup EXIT
-
 echo "Building prime-evals for PyPI..."
-
-cp pyproject.toml pyproject.toml.backup
-
-echo "Copying prime-core into source tree..."
-rm -rf src/prime_core
-cp -r ../prime-core/src/prime_core src/prime_core
-
-# Remove prime-core from dependencies list only
-sed '/^    "prime-core",$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-# Remove the [tool.uv.sources] section
-sed '/^\[tool\.uv\.sources\]$/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-# Update the force-include path
-sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-
-echo "Building wheel..."
 uv build --wheel --out-dir dist
 
 echo "Build complete!"
 echo "Built files:"
 ls -la dist/
-

--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -51,8 +51,6 @@ path = "src/prime_evals/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prime_evals"]
-# Bundle prime-core directly at the prime_core import path for PyPI distribution
-force-include = { "../prime-core/src/prime_core" = "prime_core" }
 
 [tool.ruff]
 line-length = 100

--- a/packages/prime-sandboxes/build_for_pypi.sh
+++ b/packages/prime-sandboxes/build_for_pypi.sh
@@ -1,31 +1,7 @@
 #!/bin/bash
 set -e
 
-cleanup() {
-    rm -rf src/prime_core
-    if [ -f pyproject.toml.backup ]; then
-        mv pyproject.toml.backup pyproject.toml
-    fi
-}
-
-trap cleanup EXIT
-
 echo "Building prime-sandboxes for PyPI..."
-
-cp pyproject.toml pyproject.toml.backup
-
-echo "Copying prime-core into source tree..."
-rm -rf src/prime_core
-cp -r ../prime-core/src/prime_core src/prime_core
-
-# Remove prime-core from dependencies list only
-sed '/^    "prime-core",$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-# Remove the [tool.uv.sources] section
-sed '/^\[tool\.uv\.sources\]$/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-# Update the force-include path
-sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-
-echo "Building wheel..."
 uv build --wheel --out-dir dist
 
 echo "Build complete!"

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -52,8 +52,6 @@ path = "src/prime_sandboxes/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prime_sandboxes"]
-# Bundle prime-core directly at the prime_core import path for PyPI distribution
-force-include = { "../prime-core/src/prime_core" = "prime_core" }
 
 [tool.pytest.ini_options]
 # Run tests in parallel with pytest-xdist

--- a/packages/prime/build_for_pypi.sh
+++ b/packages/prime/build_for_pypi.sh
@@ -1,28 +1,7 @@
 #!/bin/bash
 set -e
 
-cleanup() {
-    rm -rf src/prime_core
-    if [ -f pyproject.toml.backup ]; then
-        mv pyproject.toml.backup pyproject.toml
-    fi
-}
-
-trap cleanup EXIT
-
 echo "Building prime for PyPI..."
-
-cp pyproject.toml pyproject.toml.backup
-
-echo "Copying prime-core into source tree..."
-rm -rf src/prime_core
-cp -r ../prime-core/src/prime_core src/prime_core
-
-sed '/^    "prime-core",/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-sed '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-sed 's|"../prime-core/src/prime_core"|"src/prime_core"|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
-
-echo "Building wheel..."
 uv build --wheel --out-dir dist
 
 echo "Build complete!"

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -68,8 +68,6 @@ path = "src/prime_cli/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prime_cli"]
-# Bundle prime-core directly at the prime_core import path for PyPI distribution
-force-include = { "../prime-core/src/prime_core" = "prime_core" }
 
 [tool.ruff]
 src = ["."]


### PR DESCRIPTION
## Summary
Adds GitHub Actions workflow to publish `prime-core` to PyPI.

Triggered by:
- Push to `main` with changes in `packages/prime-core/`
- Manual workflow dispatch

## Context
Follow-up to #225. Once `prime-core` is published to PyPI, we can remove the bundling from `prime`, `prime-sandboxes`, and `prime-evals`.

## Test plan
- [ ] Merge and verify workflow runs
- [ ] Check prime-core appears on PyPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to tag/build/publish prime-core to PyPI and removes bundled prime-core from other packages, simplifying their build scripts.
> 
> - **CI/Release**:
>   - Add `/.github/workflows/release-prime-core.yml` to build (`uv`), tag, and publish `prime-core` to PyPI with manual `force_release` support and tag-existence checks.
> - **Packaging/Build**:
>   - Remove `force-include` of `prime_core` from `packages/prime/pyproject.toml`, `packages/prime-sandboxes/pyproject.toml`, and `packages/prime-evals/pyproject.toml` to rely on `prime-core` dependency.
>   - Simplify `build_for_pypi.sh` in `packages/prime`, `packages/prime-sandboxes`, and `packages/prime-evals` to only run `uv build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc79aa5cd18f6869e79fc1d4d0255cabe13d2a87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->