### PR TITLE
Bump all package versions for release

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime-mcp-server/src/prime_mcp/__init__.py
+++ b/packages/prime-mcp-server/src/prime_mcp/__init__.py
@@ -2,7 +2,7 @@ from prime_mcp.client import make_prime_request
 from prime_mcp.mcp import mcp
 from prime_mcp.tools import availability, pods, ssh
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "mcp",

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -37,7 +37,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump versions after fixing uv build output directory issue:

- prime: 0.5.0 → 0.5.1
- prime-sandboxes: 0.2.5 → 0.2.6
- prime-evals: 0.1.5 → 0.1.6
- prime-mcp-server: 0.1.1 → 0.1.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps versions: prime 0.5.0→0.5.1, prime-sandboxes 0.2.5→0.2.6, prime-evals 0.1.5→0.1.6, prime-mcp-server 0.1.1→0.1.2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a5fc864a8fae3425427b6e21ce1b5d94613ff5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->