### PR TITLE
feat(sandbox): -- separator support for run command

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -679,7 +679,11 @@ def logs(sandbox_id: str) -> None:
 @app.command(no_args_is_help=True)
 def run(
     sandbox_id: str,
-    command: List[str] = typer.Argument(..., help="Command to execute"),
+    command: List[str] = typer.Argument(
+        ...,
+        help="Command to execute. Use -- before commands with options "
+        "(e.g., -- bash -c 'echo hello')",
+    ),
     working_dir: Optional[str] = typer.Option(
         None, "-w", "--working-dir", help="Working directory"
     ),
@@ -695,7 +699,13 @@ def run(
         help="Timeout for the command in seconds",
     ),
 ) -> None:
-    """Execute a command in a sandbox"""
+    """Execute a command in a sandbox.
+
+    Use -- to separate sandbox run options from the command arguments when
+    the command has its own options (starting with -). Example:
+
+        prime sandbox run <id> -- bash -c "echo hello"
+    """
     try:
         base_client = APIClient()
         sandbox_client = SandboxClient(base_client)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1,5 +1,6 @@
 import json
 import random
+import shlex
 import string
 import time
 from typing import Any, Dict, List, Optional
@@ -720,8 +721,8 @@ def run(
                 key, value = env_var.split("=", 1)
                 env_vars[key] = value
 
-        # Join command list into a single string
-        command_str = " ".join(command)
+        # Join command list into a single string, preserving quoting for arguments with spaces
+        command_str = shlex.join(command)
 
         console.print(f"[bold blue]Executing command:[/bold blue] {command_str}")
         if working_dir:


### PR DESCRIPTION
Closes #90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents `--` separator for `sandbox run` and uses `shlex.join` to preserve quoting when building the command string.
> 
> - **CLI - `prime sandbox run`**:
>   - Updated `command` argument help and docstring to document using `--` to separate CLI options from command options, with example.
>   - Switched command assembly from `' '.join(...)` to `shlex.join(...)` to preserve quoting/spacing in arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdc4f2ebcd23e03ecba316f760883738bbc1a29e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->