### PR TITLE
Add --owner flag for collaborator push and show username in whoami

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -228,6 +228,12 @@ def push(
     name: Optional[str] = typer.Option(
         None, "--name", "-n", help="Override environment name (defaults to pyproject.toml name)"
     ),
+    owner: Optional[str] = typer.Option(
+        None,
+        "--owner",
+        "-o",
+        help="Owner slug (user or team) to push to (for collaborators with write access)",
+    ),
     team: Optional[str] = typer.Option(
         None,
         "--team",
@@ -379,7 +385,10 @@ def push(
 
             console.print("Resolving environment...")
             resolve_data = {"name": env_name, "visibility": visibility}
-            if team:
+            if owner:
+                # Push to a specific owner (user or team) - for collaborators with write access
+                resolve_data["owner_slug"] = owner
+            elif team:
                 resolve_data["team_slug"] = team
             elif client.config.team_id:
                 resolve_data["team_id"] = client.config.team_id

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -679,7 +679,11 @@ def logs(sandbox_id: str) -> None:
 @app.command(no_args_is_help=True)
 def run(
     sandbox_id: str,
-    command: List[str] = typer.Argument(..., help="Command to execute"),
+    command: List[str] = typer.Argument(
+        ...,
+        help="Command to execute. Use -- before commands with options "
+        "(e.g., -- bash -c 'echo hello')",
+    ),
     working_dir: Optional[str] = typer.Option(
         None, "-w", "--working-dir", help="Working directory"
     ),
@@ -695,7 +699,13 @@ def run(
         help="Timeout for the command in seconds",
     ),
 ) -> None:
-    """Execute a command in a sandbox"""
+    """Execute a command in a sandbox.
+
+    Use -- to separate sandbox run options from the command arguments when
+    the command has its own options (starting with -). Example:
+
+        prime sandbox run <id> -- bash -c "echo hello"
+    """
     try:
         base_client = APIClient()
         sandbox_client = SandboxClient(base_client)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1,5 +1,6 @@
 import json
 import random
+import shlex
 import string
 import time
 from typing import Any, Dict, List, Optional
@@ -720,8 +721,8 @@ def run(
                 key, value = env_var.split("=", 1)
                 env_vars[key] = value
 
-        # Join command list into a single string
-        command_str = " ".join(command)
+        # Join command list into a single string, preserving quoting for arguments with spaces
+        command_str = shlex.join(command)
 
         console.print(f"[bold blue]Executing command:[/bold blue] {command_str}")
         if working_dir:

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -26,6 +26,7 @@ def whoami() -> None:
         user_id = data.get("id")
         email = data.get("email")
         name = data.get("name")
+        slug = data.get("slug")
         scope = data.get("scope", {})
 
         # Update config
@@ -39,6 +40,7 @@ def whoami() -> None:
         table.add_column("Field", style="cyan")
         table.add_column("Value", style="green")
         table.add_row("User ID", user_id or "Unknown")
+        table.add_row("Username", slug or "[dim]Not set[/dim]")
         table.add_row("Name", name or "Unknown")
         table.add_row("Email", email or "Unknown")
         console.print(table)


### PR DESCRIPTION
- Add --owner/-o option to env push for collaborators
- Display username in whoami output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `--owner/-o` to `env push`, displays username in `whoami`, and improves `sandbox run` command handling with proper quoting and guidance.
> 
> - **CLI**:
>   - **Environment Push (`packages/prime/src/prime_cli/commands/env.py`)**:
>     - Add `--owner`/`-o` flag and send `owner_slug` during resolve (preferred over `--team`).
>   - **Sandbox Run (`packages/prime/src/prime_cli/commands/sandbox.py`)**:
>     - Use `shlex.join` to preserve argument quoting; enhance help/docs to use `--` before command options.
>   - **Whoami (`packages/prime/src/prime_cli/commands/whoami.py`)**:
>     - Fetch and display `slug` as "Username" in the output table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 503376090b63e1842d162a72ac83ea7029ca7fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->