### PR TITLE
fix: handle user abort (Ctrl+C) gracefully

### DIFF
--- a/packages/prime/src/prime_cli/commands/pods.py
+++ b/packages/prime/src/prime_cli/commands/pods.py
@@ -752,6 +752,9 @@ def create(
             console.print("\nPod creation cancelled")
             raise typer.Exit(0)
 
+    except typer.Abort:
+        console.print("\n[yellow]Operation cancelled[/yellow]")
+        raise typer.Exit(0)
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
@@ -1000,6 +1003,9 @@ def connect(pod_id: str) -> None:
             console.print(f"[red]SSH connection failed: {str(e)}[/red]")
             raise typer.Exit(1)
 
+    except typer.Abort:
+        console.print("\n[yellow]Operation cancelled[/yellow]")
+        raise typer.Exit(0)
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -49,4 +49,8 @@ def callback(
 
 def run() -> None:
     """Entry point for the CLI"""
-    app()
+    try:
+        app()
+    except typer.Abort:
+        typer.echo("\nOperation cancelled")
+        raise typer.Exit(0)


### PR DESCRIPTION
## Summary
- Catch `typer.Abort` exceptions to show a clean "Operation cancelled" message instead of ugly tracebacks when users press Ctrl+C during interactive prompts
- Added global handler in `main.py` for CLI-wide coverage
- Added specific handlers in `pods.py` for `create` and `connect` commands (which have their own exception handling blocks)

## Before
```
Select GPU type number [1]: ^C
Unexpected error: 
Traceback (most recent call last):
  File ".../pods.py", line 476, in create
    gpu_type_idx = typer.prompt("Select GPU type number", type=int, default=1)
  ...
click.exceptions.Abort
```

## After
```
Select GPU type number [1]: ^C
Operation cancelled
```

## Test plan
- [x] Run `prime pods create`, press Ctrl+C during prompt - should show clean message
- [x] Verify exit code is 0 (clean exit) instead of 1 (error)
- [x] Existing tests pass

Fixes #34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Catch typer.Abort to show a clean "Operation cancelled" message and exit 0 in the CLI entrypoint and pods create/connect commands.
> 
> - **CLI**:
>   - Add global `typer.Abort` handler in `prime_cli/main.py:run()` to print "Operation cancelled" and exit 0.
> - **Pods Commands** (`prime_cli/commands/pods.py`):
>   - `create`: Catch `typer.Abort`, print "Operation cancelled", exit 0.
>   - `connect` (aka `ssh`): Catch `typer.Abort`, print "Operation cancelled", exit 0.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 848e6de4018616077b146fe2a33f49e84ffe5278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->