### PR TITLE
feat: add --context flag for temporary config profile switching

### DIFF
--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -273,13 +273,13 @@ class Config:
                         self.config["api_key"] = env_config["api_key"]
                     self.config["team_id"] = env_config.get("team_id", None)
                     self.config["user_id"] = env_config.get("user_id", None)
-                    self.config["base_url"] = env_config.get("base_url", self.DEFAULT_BASE_URL)
-                    self.config["frontend_url"] = env_config.get(
-                        "frontend_url", self.DEFAULT_FRONTEND_URL
-                    )
-                    self.config["inference_url"] = env_config.get(
-                        "inference_url", self.DEFAULT_INFERENCE_URL
-                    )
+                    # Normalize URLs the same way set_* methods do
+                    base_url = env_config.get("base_url", self.DEFAULT_BASE_URL)
+                    self.config["base_url"] = self._strip_api_v1(base_url)
+                    frontend_url = env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL)
+                    self.config["frontend_url"] = frontend_url.rstrip("/")
+                    inference_url = env_config.get("inference_url", self.DEFAULT_INFERENCE_URL)
+                    self.config["inference_url"] = inference_url.rstrip("/")
                     self.config["current_environment"] = name
                 return True
         except ValueError:

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -33,6 +33,11 @@ class Config:
         self._ensure_config_dir()
         self._load_config()
 
+        # Check for PRIME_CONTEXT env var to temporarily override config
+        context = os.getenv("PRIME_CONTEXT")
+        if context:
+            self.load_environment(context, persist=False)
+
     @staticmethod
     def _strip_api_v1(url: str) -> str:
         # make base_url consistent even if user passed a /api/v1 variant
@@ -214,15 +219,30 @@ class Config:
         }
         env_file.write_text(json.dumps(env_config, indent=2))
 
-    def load_environment(self, name: str) -> bool:
-        """Load a named environment configuration"""
+    def load_environment(self, name: str, persist: bool = True) -> bool:
+        """Load a named environment configuration.
+
+        Args:
+            name: The environment name to load
+            persist: If True, save changes to disk. If False, only update in-memory config.
+
+        Returns:
+            True if the environment was loaded successfully, False otherwise.
+        """
         if name.lower() == "production":
             # Built-in production environment
-            self.set_base_url(self.DEFAULT_BASE_URL)
-            self.set_frontend_url(self.DEFAULT_FRONTEND_URL)
-            self.set_inference_url(self.DEFAULT_INFERENCE_URL)
-            self.set_team_id(None)  # Production defaults to personal account
-            self.set_current_environment("production")
+            if persist:
+                self.set_base_url(self.DEFAULT_BASE_URL)
+                self.set_frontend_url(self.DEFAULT_FRONTEND_URL)
+                self.set_inference_url(self.DEFAULT_INFERENCE_URL)
+                self.set_team_id(None)  # Production defaults to personal account
+                self.set_current_environment("production")
+            else:
+                self.config["base_url"] = self.DEFAULT_BASE_URL
+                self.config["frontend_url"] = self.DEFAULT_FRONTEND_URL
+                self.config["inference_url"] = self.DEFAULT_INFERENCE_URL
+                self.config["team_id"] = None
+                self.config["current_environment"] = "production"
             return True
 
         try:
@@ -234,16 +254,33 @@ class Config:
                 except json.JSONDecodeError as e:
                     raise ValueError(f"Invalid JSON in environment file {sanitized_name}.json: {e}")
 
-                if "api_key" in env_config:
-                    self.set_api_key(env_config["api_key"])
-                # Set team_id from environment, defaulting to empty string
-                self.set_team_id(env_config.get("team_id", None))
-                # Set user_id from environment
-                self.set_user_id(env_config.get("user_id", None))
-                self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
-                self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
-                self.set_inference_url(env_config.get("inference_url", self.DEFAULT_INFERENCE_URL))
-                self.set_current_environment(name)
+                if persist:
+                    if "api_key" in env_config:
+                        self.set_api_key(env_config["api_key"])
+                    # Set team_id from environment, defaulting to empty string
+                    self.set_team_id(env_config.get("team_id", None))
+                    # Set user_id from environment
+                    self.set_user_id(env_config.get("user_id", None))
+                    self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
+                    self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
+                    self.set_inference_url(
+                        env_config.get("inference_url", self.DEFAULT_INFERENCE_URL)
+                    )
+                    self.set_current_environment(name)
+                else:
+                    # In-memory only - don't persist to disk
+                    if "api_key" in env_config:
+                        self.config["api_key"] = env_config["api_key"]
+                    self.config["team_id"] = env_config.get("team_id", None)
+                    self.config["user_id"] = env_config.get("user_id", None)
+                    self.config["base_url"] = env_config.get("base_url", self.DEFAULT_BASE_URL)
+                    self.config["frontend_url"] = env_config.get(
+                        "frontend_url", self.DEFAULT_FRONTEND_URL
+                    )
+                    self.config["inference_url"] = env_config.get(
+                        "inference_url", self.DEFAULT_INFERENCE_URL
+                    )
+                    self.config["current_environment"] = name
                 return True
         except ValueError:
             # Re-raise sanitization errors

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -1,4 +1,5 @@
 from importlib.metadata import version
+from typing import Optional
 
 import typer
 
@@ -13,6 +14,7 @@ from .commands.pods import app as pods_app
 from .commands.sandbox import app as sandbox_app
 from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
+from .core import Config
 
 __version__ = version("prime")
 
@@ -40,11 +42,32 @@ app.add_typer(evals_app, name="eval")
 def callback(
     ctx: typer.Context,
     version_flag: bool = typer.Option(False, "--version", "-v", help="Show version and exit"),
+    context: Optional[str] = typer.Option(
+        None,
+        "--context",
+        "-c",
+        help="Use a specific config context/environment for this command",
+    ),
 ) -> None:
     """Prime Intellect CLI"""
     if version_flag:
         typer.echo(f"Prime CLI version: {__version__}")
         raise typer.Exit()
+
+    if context:
+        import os
+
+        config = Config()
+        # Check if the context exists
+        if context.lower() != "production" and context not in config.list_environments():
+            typer.echo(f"Error: Unknown context '{context}'", err=True)
+            typer.echo("Available contexts:", err=True)
+            for env_name in config.list_environments():
+                typer.echo(f"  - {env_name}", err=True)
+            raise typer.Exit(1)
+
+        # Set environment variable so Config instances in subcommands pick it up
+        os.environ["PRIME_CONTEXT"] = context
 
 
 def run() -> None:


### PR DESCRIPTION
## Summary
- Adds `--context`/`-c` global flag to temporarily use a different config profile for a single command
- Similar to `kubectl --context` - allows switching between users/environments without running `prime config use`

## Usage
```bash
# Instead of:
prime config use user1
prime sandbox create ...
prime config use user2
prime sandbox create ...

# You can now do:
prime --context user1 sandbox create ...
prime --context user2 sandbox create ...

# Or with short flag:
prime -c production pods list
```

## Implementation
- Added `--context` option to main app callback
- Sets `PRIME_CONTEXT` env var which `Config` checks on init
- Added `persist=False` option to `load_environment()` for in-memory-only loading

## Test plan
- [x] `prime --context production config view` shows production config
- [x] `prime config view` after still shows original config (not persisted)
- [x] `prime --context nonexistent ...` shows helpful error with available contexts
- [x] All existing tests pass

Closes #91

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a global `--context/-c` flag that temporarily switches the config environment for a single command via `PRIME_CONTEXT`, backed by `Config.load_environment(..., persist=False)`.
> 
> - **CLI**:
>   - Add global `--context`/`-c` option in `prime_cli/main.py` to use a specific config environment per command.
>   - Validates context (except `production`) against `Config.list_environments()` and prints available contexts on error.
>   - Sets `PRIME_CONTEXT` so subcommands inherit the selected environment.
> - **Config**:
>   - Check `PRIME_CONTEXT` on init in `core/config.py` and `load_environment(context, persist=False)` for in-memory override.
>   - Extend `load_environment(name, persist=True|False)` to support non-persistent loading for `production` and saved environments, including URL normalization and selective field updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 580d47c09a2fcaa6f742b19b56b91b1b298c06dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->