### PR TITLE
feat: add execute_background for long-running sandbox commands

### DIFF
--- a/packages/prime-sandboxes/examples/async_background.py
+++ b/packages/prime-sandboxes/examples/async_background.py
@@ -48,7 +48,7 @@ async def create_ready_sandbox(sandbox_client: AsyncSandboxClient) -> str:
 
 
 async def execute_with_status_updates(
-    sandbox_client: AsyncSandboxClient, sandbox_id: str
+    sandbox_client: AsyncSandboxClient, sandbox_id: str, max_checks: int = 60
 ) -> BackgroundJobStatus:
     """Start a background job and poll for completion with status updates."""
     # This command counts up once per second to simulate a long-running task.
@@ -58,14 +58,14 @@ async def execute_with_status_updates(
     job = await sandbox_client.start_background_job(sandbox_id, background_command)
     print(f"✓ Job started: {job.job_id}")
 
-    checks = 0
-    while True:
+    for check in range(1, max_checks + 1):
         status = await sandbox_client.get_background_job(sandbox_id, job)
         if status.completed:
             return status
-        checks += 1
-        print(f"[status] Still running... check #{checks}")
+        print(f"[status] Still running... check #{check}")
         await asyncio.sleep(3)
+
+    raise TimeoutError(f"Job {job.job_id} did not complete within {max_checks} checks")
 
 
 async def cleanup_sandbox(sandbox_client: AsyncSandboxClient, sandbox_id: Optional[str]) -> None:

--- a/packages/prime-sandboxes/examples/async_background.py
+++ b/packages/prime-sandboxes/examples/async_background.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Async sandbox example showing execute_background usage."""
+
+import asyncio
+from typing import Optional
+
+from prime_sandboxes import (
+    APIError,
+    AsyncSandboxClient,
+    CommandResponse,
+    CreateSandboxRequest,
+)
+
+
+async def run_background_count_example() -> None:
+    """Create a sandbox, run a counting job asynchronously, and poll status."""
+    sandbox_client = AsyncSandboxClient()
+    sandbox_id: Optional[str] = None
+
+    try:
+        sandbox_id = await create_ready_sandbox(sandbox_client)
+        result = await execute_with_status_updates(sandbox_client, sandbox_id)
+        print("\nBackground job finished!")
+        print(f"exit_code: {result.exit_code}")
+        print("stdout:\n" + result.stdout.strip())
+    finally:
+        await cleanup_sandbox(sandbox_client, sandbox_id)
+
+
+async def create_ready_sandbox(sandbox_client: AsyncSandboxClient) -> str:
+    """Provision a sandbox and wait until it is running."""
+    print("Creating sandbox for async background example...")
+    sandbox = await sandbox_client.create(
+        CreateSandboxRequest(
+            name="async-background-example",
+            docker_image="python:3.11-slim",
+            cpu_cores=1,
+            memory_gb=2,
+            timeout_minutes=60,
+        )
+    )
+    print(f"✓ Created sandbox {sandbox.id}")
+
+    print("Waiting for sandbox to be ready...")
+    await sandbox_client.wait_for_creation(sandbox.id)
+    print("✓ Sandbox is running")
+    return sandbox.id
+
+
+async def execute_with_status_updates(
+    sandbox_client: AsyncSandboxClient, sandbox_id: str
+) -> CommandResponse:
+    """Kick off execute_background and report progress concurrently."""
+    # This command counts up once per second to simulate a long-running task.
+    background_command = "for i in $(seq 1 15); do echo Background counter: $i; sleep 1; done"
+
+    done = asyncio.Event()
+
+    async def show_status() -> None:
+        checks = 0
+        while not done.is_set():
+            checks += 1
+            print(f"[status] Still running... check #{checks}")
+            await asyncio.sleep(3)
+
+    async def run_job():
+        try:
+            print("\nStarting async background execution...")
+            return await sandbox_client.execute_background(
+                sandbox_id,
+                background_command,
+                poll_interval=5,
+                max_wait=120,
+            )
+        finally:
+            done.set()
+
+    result, _ = await asyncio.gather(run_job(), show_status())
+    return result
+
+
+async def cleanup_sandbox(sandbox_client: AsyncSandboxClient, sandbox_id: Optional[str]) -> None:
+    """Delete sandbox if it exists."""
+    if not sandbox_id:
+        return
+    try:
+        print("\nCleaning up sandbox...")
+        await sandbox_client.delete(sandbox_id)
+        print("✓ Sandbox deleted")
+    except APIError as exc:
+        print(f"⚠ Could not delete sandbox: {exc}")
+
+
+async def main() -> None:
+    """Entrypoint for the async example."""
+    try:
+        await run_background_count_example()
+    except APIError as exc:
+        print(f"✗ API error: {exc}")
+        print("  Make sure PRIME_API_KEY is set or run 'prime login' before executing.")
+    except Exception as exc:
+        print(f"✗ Unexpected error: {exc}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -21,6 +21,8 @@ from .exceptions import (
 )
 from .models import (
     AdvancedConfigs,
+    BackgroundJob,
+    BackgroundJobStatus,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
     CommandRequest,
@@ -62,6 +64,8 @@ __all__ = [
     "BulkDeleteSandboxRequest",
     "BulkDeleteSandboxResponse",
     "AdvancedConfigs",
+    "BackgroundJob",
+    "BackgroundJobStatus",
     # Port Forwarding
     "ExposePortRequest",
     "ExposedPort",

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -175,3 +175,21 @@ class ListExposedPortsResponse(BaseModel):
     """Response for listing exposed ports"""
 
     exposures: List[ExposedPort]
+
+
+class BackgroundJob(BaseModel):
+    """Background job handle returned when starting a background job"""
+
+    job_id: str
+    sandbox_id: str
+    log_file: str
+    exit_file: str
+
+
+class BackgroundJobStatus(BaseModel):
+    """Status of a background job"""
+
+    job_id: str
+    completed: bool
+    exit_code: Optional[int] = None
+    stdout: Optional[str] = None

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import httpx
 
+from prime_sandboxes import __version__
+
 from .core import APIClient, APIError, AsyncAPIClient
 from .exceptions import (
     CommandTimeoutError,
@@ -38,8 +40,6 @@ _ENV_VAR_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 def _build_user_agent() -> str:
     """Build User-Agent string for prime-sandboxes"""
-    from prime_sandboxes import __version__
-
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     return f"prime-sandboxes/{__version__} python/{python_version}"
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -14,8 +14,6 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import httpx
 
-from prime_sandboxes import __version__
-
 from .core import APIClient, APIError, AsyncAPIClient
 from .exceptions import (
     CommandTimeoutError,
@@ -42,6 +40,8 @@ _ENV_VAR_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 def _build_user_agent() -> str:
     """Build User-Agent string for prime-sandboxes"""
+    from prime_sandboxes import __version__
+
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     return f"prime-sandboxes/{__version__} python/{python_version}"
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -806,6 +806,69 @@ class AsyncSandboxClient:
         except Exception as e:
             raise APIError(f"Request failed: {e.__class__.__name__}: {e}") from e
 
+    async def execute_background(
+        self,
+        sandbox_id: str,
+        command: str,
+        working_dir: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        poll_interval: int = 10,
+    ) -> CommandResponse:
+        """Execute a long-running command in the background with polling (async).
+
+        Use this for commands that may exceed the 300s timeout limit.
+        The command runs detached and output is captured to temp files.
+
+        Args:
+            sandbox_id: The sandbox ID
+            command: Command to execute
+            working_dir: Working directory for command execution
+            env: Environment variables
+            poll_interval: Seconds between completion checks (default: 10)
+
+        Returns:
+            CommandResponse with stdout, stderr, and exit_code
+        """
+        import asyncio
+        import uuid
+
+        job_id = uuid.uuid4().hex[:8]
+        log_file = f"/tmp/job_{job_id}.log"
+        exit_file = f"/tmp/job_{job_id}.exit"
+
+        # Build command with working dir if specified
+        if working_dir:
+            full_cmd = f"cd {working_dir} && {command}"
+        else:
+            full_cmd = command
+
+        # Add env vars if specified
+        env_prefix = ""
+        if env:
+            for k, v in env.items():
+                escaped_v = v.replace("'", "'\\''")
+                env_prefix += f"export {k}='{escaped_v}'; "
+            full_cmd = env_prefix + full_cmd
+
+        # Start detached process
+        bg_cmd = f"nohup sh -c '{full_cmd}; echo $? > {exit_file}' > {log_file} 2>&1 &"
+        await self.execute_command(sandbox_id, bg_cmd, timeout=10)
+
+        # Poll for completion
+        while True:
+            check = await self.execute_command(
+                sandbox_id, f"cat {exit_file} 2>/dev/null", timeout=10
+            )
+            if check.stdout.strip():
+                break
+            await asyncio.sleep(poll_interval)
+
+        # Get results
+        exit_code = int(check.stdout.strip())
+        logs = await self.execute_command(sandbox_id, f"cat {log_file}", timeout=60)
+
+        return CommandResponse(stdout=logs.stdout, stderr="", exit_code=exit_code, duration_ms=0)
+
     async def wait_for_creation(
         self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 2
     ) -> None:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -376,6 +376,9 @@ class SandboxClient:
         bg_cmd = f"nohup sh -c '{full_cmd}; echo $? > {exit_file}' > {log_file} 2>&1 &"
         self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
+        # Initial delay to let the process start
+        time.sleep(5)
+
         # Poll for completion
         while True:
             check = self.execute_command(sandbox_id, f"cat {exit_file} 2>/dev/null", timeout=10)
@@ -853,6 +856,9 @@ class AsyncSandboxClient:
         # Start detached process
         bg_cmd = f"nohup sh -c '{full_cmd}; echo $? > {exit_file}' > {log_file} 2>&1 &"
         await self.execute_command(sandbox_id, bg_cmd, timeout=10)
+
+        # Initial delay to let the process start
+        await asyncio.sleep(5)
 
         # Poll for completion
         while True:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -413,13 +413,16 @@ class SandboxClient:
         Returns:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
-        check = self.execute_command(sandbox_id, f"cat {job.exit_file} 2>/dev/null", timeout=10)
+        exit_file_quoted = shlex.quote(job.exit_file)
+        log_file_quoted = shlex.quote(job.log_file)
+
+        check = self.execute_command(sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10)
 
         if not check.stdout.strip():
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
         exit_code = int(check.stdout.strip())
-        logs = self.execute_command(sandbox_id, f"cat {job.log_file}", timeout=60)
+        logs = self.execute_command(sandbox_id, f"cat {log_file_quoted}", timeout=60)
 
         return BackgroundJobStatus(
             job_id=job.job_id,
@@ -914,15 +917,18 @@ class AsyncSandboxClient:
         Returns:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
+        exit_file_quoted = shlex.quote(job.exit_file)
+        log_file_quoted = shlex.quote(job.log_file)
+
         check = await self.execute_command(
-            sandbox_id, f"cat {job.exit_file} 2>/dev/null", timeout=10
+            sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10
         )
 
         if not check.stdout.strip():
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
         exit_code = int(check.stdout.strip())
-        logs = await self.execute_command(sandbox_id, f"cat {job.log_file}", timeout=60)
+        logs = await self.execute_command(sandbox_id, f"cat {log_file_quoted}", timeout=60)
 
         return BackgroundJobStatus(
             job_id=job.job_id,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1,11 +1,13 @@
 """Sandbox client implementations."""
 
+import asyncio
 import json
 import os
 import re
 import shlex
 import sys
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -365,7 +367,6 @@ class SandboxClient:
         Returns:
             CommandResponse with stdout, stderr, and exit_code
         """
-        import uuid
 
         job_id = uuid.uuid4().hex[:8]
         log_file = f"/tmp/job_{job_id}.log"
@@ -866,8 +867,6 @@ class AsyncSandboxClient:
         Returns:
             CommandResponse with stdout, stderr, and exit_code
         """
-        import asyncio
-        import uuid
 
         job_id = uuid.uuid4().hex[:8]
         log_file = f"/tmp/job_{job_id}.log"

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -391,7 +391,9 @@ class SandboxClient:
         command_body = f"{env_prefix}{dir_prefix}{command}"
         exit_file_quoted = shlex.quote(exit_file)
         log_file_quoted = shlex.quote(log_file)
-        sh_command = f"{command_body}; echo $? > {exit_file_quoted}"
+        # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
+        # This ensures 'echo $?' always runs to capture the exit code.
+        sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
         quoted_sh_command = shlex.quote(sh_command)
 
         # Start detached process
@@ -891,7 +893,9 @@ class AsyncSandboxClient:
         command_body = f"{env_prefix}{dir_prefix}{command}"
         exit_file_quoted = shlex.quote(exit_file)
         log_file_quoted = shlex.quote(log_file)
-        sh_command = f"{command_body}; echo $? > {exit_file_quoted}"
+        # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
+        # This ensures 'echo $?' always runs to capture the exit code.
+        sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
         quoted_sh_command = shlex.quote(sh_command)
 
         # Start detached process

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -242,3 +242,17 @@ def test_execute_background_timeout(sandbox_client, shared_sandbox):
         )
 
     print("✓ Background execution timeout raised as expected")
+
+
+def test_execute_background_with_exit_command(sandbox_client, shared_sandbox):
+    """Test execute_background handles commands ending with exit"""
+    print("\nTesting execute_background with exit command...")
+    result = sandbox_client.execute_background(
+        shared_sandbox.id,
+        "echo 'before exit' && exit 5",
+        poll_interval=1,
+    )
+
+    assert result.exit_code == 5
+    assert "before exit" in result.stdout
+    print(f"✓ Exit command handled correctly, exit_code={result.exit_code}")

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -204,12 +204,12 @@ def test_execute_background(sandbox_client, shared_sandbox):
     print("\nTesting execute_background with 10s sleep...")
     result = sandbox_client.execute_background(
         shared_sandbox.id,
-        "sleep 10 && echo 'background done'",
+        'sleep 10 && echo "background\'s done"',
         poll_interval=2,
     )
 
     assert result.exit_code == 0
-    assert "background done" in result.stdout
+    assert "background's done" in result.stdout
     print(f"✓ Background execution completed: {result.stdout.strip()}")
 
 
@@ -228,3 +228,17 @@ def test_execute_background_with_working_dir(sandbox_client, shared_sandbox):
     assert result.exit_code == 0
     assert "/tmp/bgtest" in result.stdout
     print(f"✓ Background with working_dir: {result.stdout.strip()}")
+
+
+def test_execute_background_timeout(sandbox_client, shared_sandbox):
+    """Test that execute_background respects max_wait"""
+    print("\nTesting execute_background timeout handling...")
+    with pytest.raises(CommandTimeoutError):
+        sandbox_client.execute_background(
+            shared_sandbox.id,
+            "sleep 30",
+            poll_interval=1,
+            max_wait=6,
+        )
+
+    print("✓ Background execution timeout raised as expected")

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -201,10 +201,10 @@ def test_command_creates_and_reads_file(sandbox_client, shared_sandbox):
 
 def test_execute_background(sandbox_client, shared_sandbox):
     """Test execute_background for long-running commands"""
-    print("\nTesting execute_background with 5s sleep...")
+    print("\nTesting execute_background with 10s sleep...")
     result = sandbox_client.execute_background(
         shared_sandbox.id,
-        "sleep 5 && echo 'background done'",
+        "sleep 10 && echo 'background done'",
         poll_interval=2,
     )
 
@@ -220,9 +220,9 @@ def test_execute_background_with_working_dir(sandbox_client, shared_sandbox):
     print("\nTesting execute_background with working_dir...")
     result = sandbox_client.execute_background(
         shared_sandbox.id,
-        "pwd > output.txt && sleep 2 && cat output.txt",
+        "pwd > output.txt && sleep 10 && cat output.txt",
         working_dir="/tmp/bgtest",
-        poll_interval=1,
+        poll_interval=2,
     )
 
     assert result.exit_code == 0

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -197,3 +197,34 @@ def test_command_creates_and_reads_file(sandbox_client, shared_sandbox):
     assert read_result.exit_code == 0
     assert content in read_result.stdout
     print(f"✓ File operations successful: {read_result.stdout.strip()}")
+
+
+def test_execute_background(sandbox_client, shared_sandbox):
+    """Test execute_background for long-running commands"""
+    print("\nTesting execute_background with 5s sleep...")
+    result = sandbox_client.execute_background(
+        shared_sandbox.id,
+        "sleep 5 && echo 'background done'",
+        poll_interval=2,
+    )
+
+    assert result.exit_code == 0
+    assert "background done" in result.stdout
+    print(f"✓ Background execution completed: {result.stdout.strip()}")
+
+
+def test_execute_background_with_working_dir(sandbox_client, shared_sandbox):
+    """Test execute_background with working directory"""
+    sandbox_client.execute_command(shared_sandbox.id, "mkdir -p /tmp/bgtest")
+
+    print("\nTesting execute_background with working_dir...")
+    result = sandbox_client.execute_background(
+        shared_sandbox.id,
+        "pwd > output.txt && sleep 2 && cat output.txt",
+        working_dir="/tmp/bgtest",
+        poll_interval=1,
+    )
+
+    assert result.exit_code == 0
+    assert "/tmp/bgtest" in result.stdout
+    print(f"✓ Background with working_dir: {result.stdout.strip()}")


### PR DESCRIPTION
Adds `execute_background()` method to SandboxClient for commands that may exceed the 300s timeout.

Uses nohup + polling pattern - no sidecar changes needed.

```python
result = client.execute_background(sandbox_id, "make -j4", working_dir="/build", poll_interval=30)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds sync/async background job execution (`start_background_job`/`get_background_job`), associated models, docs, examples, and tests.
> 
> - **SDK (prime-sandboxes)**:
>   - **Background Jobs**: Add `SandboxClient.start_background_job/get_background_job` and async equivalents in `AsyncSandboxClient` to run long-running commands and poll results (captures stdout and exit code via `/tmp` files; supports `working_dir` and `env`).
>   - Input validation: validate env var keys; shell-quote values/paths.
> - **Models**:
>   - Add `BackgroundJob` and `BackgroundJobStatus` Pydantic models.
> - **Exports/Version**:
>   - Export new models in `__init__.py`; bump `__version__` to `0.2.5`.
> - **Docs & Examples**:
>   - README: new "Long-Running Tasks" section with sync/async usage.
>   - Add example `packages/prime-sandboxes/examples/async_background.py`.
> - **Tests**:
>   - Add background job tests covering basic run, `working_dir`, and `exit` handling in `tests/test_command_execution.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4364fa70128225aed736d89388dedad8dc6173b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->