### PR TITLE
chore: release v0.5.2

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps versions for release:
- prime: 0.5.1 → 0.5.2
- prime-evals: 0.1.5 → 0.1.6

Changes since v0.5.1:
- ENG-2194: Create `.env-metadata.json` on env pull

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps package versions: `prime` 0.5.1 → 0.5.2 and `prime-evals` 0.1.5 → 0.1.6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe46a1fd2d3bf4f85793520a2c5fe2e75a6b3f2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->