### PR TITLE
feat: add prime env sync command

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1810,7 +1810,8 @@ def sync(
             raise typer.Exit(1)
 
         # Check if local content hash exists in remote versions
-        remote_hashes = {v.get("sha256", "") for v in versions_list}
+        # Note: content_hash is the directory content hash, sha256 is the wheel file hash
+        remote_hashes = {v.get("content_hash", "") for v in versions_list}
         is_in_sync = local_content_hash in remote_hashes
 
         if is_in_sync and not force:
@@ -1818,7 +1819,7 @@ def sync(
 
             # Show which version matches
             for v in versions_list:
-                if v.get("sha256") == local_content_hash:
+                if v.get("content_hash") == local_content_hash:
                     console.print(
                         f"[dim]Local content matches remote version "
                         f"{v.get('version', 'unknown')}[/dim]"
@@ -1875,7 +1876,8 @@ def sync(
 
         # Invoke the push command programmatically by calling the push logic
         # We'll use subprocess to call the push command to reuse all its logic
-        push_cmd = ["prime", "env", "push", "--path", str(env_path)]
+        # Pass --owner to ensure we push to the same namespace as the original push
+        push_cmd = ["prime", "env", "push", "--path", str(env_path), "--owner", owner]
         console.print("\n[dim]Running push...[/dim]")
 
         try:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -25,7 +25,7 @@ from prime_cli.core import Config
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
-from ..utils.env_metadata import find_environment_metadata
+from ..utils.env_metadata import find_environment_metadata, get_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
 
@@ -43,12 +43,12 @@ def display_upstream_environment_info(
     env_path: Optional[Path] = None, environment_name: Optional[str] = None
 ) -> bool:
     """Display the upstream environment name if metadata exists.
-    
+
     Checks the provided path (or current directory) for environment metadata
     and displays "Using upstream environment {owner}/{name}" if found.
-    
+
     If environment_name is provided, also checks ./environments/{module_name} as a fallback.
-    
+
     Args:
         env_path: Path to check for metadata (defaults to current directory)
         environment_name: Optional environment name to check in ./environments/{module_name}
@@ -57,14 +57,14 @@ def display_upstream_environment_info(
     module_name = None
     if environment_name:
         module_name = environment_name.replace("-", "_")
-    
+
     # Search for environment metadata in common locations
     env_metadata = find_environment_metadata(
         env_name=environment_name,
         env_path=env_path,
         module_name=module_name,
     )
-    
+
     if env_metadata and env_metadata.get("owner") and env_metadata.get("name"):
         owner = env_metadata.get("owner")
         env_name = env_metadata.get("name")
@@ -759,7 +759,7 @@ def push(
                     prime_dir = env_path / ".prime"
                     prime_dir.mkdir(exist_ok=True)
                     metadata_path = prime_dir / ".env-metadata.json"
-                    
+
                     # Backwards compatibility: Migrate .env-metadata.json from root to .prime/
                     # This handles environments that were pulled/pushed before we moved
                     # to .prime/ subfolder
@@ -787,7 +787,7 @@ def push(
                             console.print(
                                 "[yellow]Warning: Could not remove old .env-metadata.json[/yellow]"
                             )
-                    
+
                     # Read existing metadata if it exists
                     existing_metadata = {}
                     if metadata_path.exists():
@@ -810,14 +810,14 @@ def push(
                                 f"old location: {e}[/yellow]"
                             )
                             existing_metadata = {}
-                    
+
                     # Check if upstream (owner/name) changed
                     old_owner = existing_metadata.get("owner")
                     old_name = existing_metadata.get("name")
                     upstream_changed = False
                     if existing_metadata and (old_owner != owner_name or old_name != env_name):
                         upstream_changed = True
-                    
+
                     # Merge existing metadata with new push information
                     env_metadata = {
                         **existing_metadata,  # Preserve existing fields
@@ -827,10 +827,10 @@ def push(
                         "pushed_at": datetime.now().isoformat(),
                         "wheel_sha256": wheel_sha256,
                     }
-                    
+
                     with open(metadata_path, "w") as f:
                         json.dump(env_metadata, f, indent=2)
-                    
+
                     if existing_metadata:
                         message = Text("Updated environment metadata in ", style="dim")
                         message.append(str(metadata_path), style="dim")
@@ -839,7 +839,7 @@ def push(
                         message = Text("Saved environment metadata to ", style="dim")
                         message.append(str(metadata_path), style="dim")
                         console.print(message)
-                    
+
                     # Report upstream change if it occurred
                     if upstream_changed:
                         upstream_message = Text("Upstream set to ", style="dim")
@@ -1058,8 +1058,7 @@ def pull(
             # Filter out .prime directory and .env-metadata.json files
             # (created locally, not extracted)
             extracted_files = [
-                f for f in all_files
-                if f.name != ".prime" and f.name != ".env-metadata.json"
+                f for f in all_files if f.name != ".prime" and f.name != ".env-metadata.json"
             ]
             if extracted_files:
                 console.print("\nExtracted files:")
@@ -1731,6 +1730,172 @@ def uninstall(
         raise typer.Exit(1)
 
 
+@app.command()
+def sync(
+    path: str = typer.Option(".", "--path", "-p", help="Path to environment directory"),
+    auto_bump: bool = typer.Option(
+        False, "--auto-bump", help="Automatically bump patch version if local changes exist"
+    ),
+    rc: bool = typer.Option(False, "--rc", help="Bump or create a .rc pre-release (rc0 -> rc1)"),
+    post: bool = typer.Option(
+        False,
+        "--post",
+        help="Bump or create a .post release (post0 -> post1)",
+    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Push even if already in sync"),
+) -> None:
+    """Sync local environment with remote hub.
+
+    Checks if local content differs from remote and pushes changes if needed.
+    Requires the environment to have been previously pushed (has metadata).
+    """
+    try:
+        env_path = Path(path).resolve()
+
+        # Check for pyproject.toml
+        pyproject_path = env_path / "pyproject.toml"
+        if not pyproject_path.exists():
+            console.print("[red]Error: pyproject.toml not found[/red]")
+            raise typer.Exit(1)
+
+        # Read environment metadata to get owner/name
+        env_metadata = get_environment_metadata(env_path)
+        if not env_metadata:
+            console.print(
+                "[red]Error: No environment metadata found.[/red]\n"
+                "[dim]This environment hasn't been pushed yet. Use 'prime env push' first.[/dim]"
+            )
+            raise typer.Exit(1)
+
+        owner = env_metadata.get("owner")
+        env_name = env_metadata.get("name")
+
+        if not owner or not env_name:
+            console.print(
+                "[red]Error: Invalid metadata - missing owner or name.[/red]\n"
+                "[dim]Try running 'prime env push' to fix the metadata.[/dim]"
+            )
+            raise typer.Exit(1)
+
+        env_id = f"{owner}/{env_name}"
+        console.print(f"Syncing [cyan]{env_id}[/cyan]...")
+
+        # Compute local content hash
+        local_content_hash = compute_content_hash(env_path)
+        console.print(f"Local content hash: [yellow]{local_content_hash[:8]}[/yellow]")
+
+        # Fetch remote versions to check if our content hash exists
+        client = APIClient()
+
+        try:
+            response = client.get(f"/environmentshub/{owner}/{env_name}/versions")
+            if "data" in response:
+                versions_data = response["data"]
+            else:
+                versions_data = response
+
+            if isinstance(versions_data, list):
+                versions_list = versions_data
+            else:
+                versions_list = versions_data.get("versions", [])
+
+        except APIError as e:
+            if "404" in str(e):
+                console.print(
+                    "[yellow]Environment not found on remote. It may have been deleted.[/yellow]"
+                )
+                console.print("[dim]Use 'prime env push' to re-create it.[/dim]")
+                raise typer.Exit(1)
+            console.print(f"[red]Failed to fetch remote versions: {e}[/red]")
+            raise typer.Exit(1)
+
+        # Check if local content hash exists in remote versions
+        remote_hashes = {v.get("sha256", "") for v in versions_list}
+        is_in_sync = local_content_hash in remote_hashes
+
+        if is_in_sync and not force:
+            console.print("[green]✓ Already in sync with remote[/green]")
+
+            # Show which version matches
+            for v in versions_list:
+                if v.get("sha256") == local_content_hash:
+                    console.print(
+                        f"[dim]Local content matches remote version "
+                        f"{v.get('version', 'unknown')}[/dim]"
+                    )
+                    break
+            return
+
+        if is_in_sync and force:
+            console.print(
+                "[yellow]Already in sync, but --force specified. Pushing anyway...[/yellow]"
+            )
+
+        # Not in sync - need to push
+        if not is_in_sync:
+            console.print("[yellow]Local changes detected. Pushing to remote...[/yellow]")
+
+        # Read pyproject.toml for version info
+        try:
+            pyproject_data = toml.load(pyproject_path)
+            project_info = pyproject_data.get("project", {})
+            current_version = project_info.get("version")
+        except Exception as e:
+            console.print(f"[red]Failed to parse pyproject.toml: {e}[/red]")
+            raise typer.Exit(1)
+
+        # Handle version bumping if requested
+        if auto_bump or rc or post:
+            flags_set = sum(bool(x) for x in (auto_bump, rc, post))
+            if flags_set > 1:
+                console.print(
+                    "[red]Error: --auto-bump, --rc, and --post are mutually exclusive[/red]"
+                )
+                raise typer.Exit(1)
+
+            if not current_version:
+                console.print("[red]Error: No version found in pyproject.toml for auto-bump[/red]")
+                raise typer.Exit(1)
+
+            if auto_bump:
+                new_version = bump_version(current_version)
+            elif rc:
+                new_version = bump_rc_version(current_version)
+            else:
+                new_version = bump_post_version(current_version)
+
+            console.print(f"Auto-bumping version: {current_version} → {new_version}")
+
+            try:
+                update_pyproject_version(pyproject_path, new_version)
+                console.print("[green]✓ Updated version in pyproject.toml[/green]")
+            except Exception as e:
+                console.print(f"[red]Failed to update version in pyproject.toml: {e}[/red]")
+                raise typer.Exit(1)
+
+        # Invoke the push command programmatically by calling the push logic
+        # We'll use subprocess to call the push command to reuse all its logic
+        push_cmd = ["prime", "env", "push", "--path", str(env_path)]
+        console.print("\n[dim]Running push...[/dim]")
+
+        try:
+            result = subprocess.run(push_cmd, cwd=env_path)
+            if result.returncode != 0:
+                raise typer.Exit(result.returncode)
+        except FileNotFoundError:
+            console.print("[red]Failed to run push command[/red]")
+            raise typer.Exit(1)
+
+    except APIError as e:
+        console.print(f"[red]API Error: {e}[/red]")
+        raise typer.Exit(1)
+    except Exception as e:
+        if isinstance(e, typer.Exit):
+            raise
+        console.print(f"[red]Unexpected error: {e}[/red]")
+        raise typer.Exit(1)
+
+
 version_app = typer.Typer(help="Manage environment versions", no_args_is_help=True)
 app.add_typer(version_app, name="version")
 
@@ -2155,6 +2320,4 @@ def eval_env(
                 "environment if it's not the current directory.[/dim]"
             )
     else:
-        console.print(
-            "[dim]Skipped uploading evaluation results[/dim]"
-        )
+        console.print("[dim]Skipped uploading evaluation results[/dim]")


### PR DESCRIPTION
Adds `prime env sync` command that checks if local environment differs from remote and pushes changes if needed.

- Compares local content hash against remote versions
- Only pushes if there are actual changes
- Supports --auto-bump, --rc, --post flags for version bumping
- Requires environment to have been pushed before (has metadata)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `prime env sync` to compare local content hash with remote versions and push updates, supporting `--auto-bump`, `--rc`, `--post`, and `--force`.
> 
> - **CLI**:
>   - **New command**: `prime env sync`
>     - Computes local directory `content_hash` and compares against remote `/environmentshub/{owner}/{name}/versions`.
>     - Pushes only when out of sync (or with `--force`), invoking existing `env push`.
>     - Supports version bumping flags: `--auto-bump`, `--rc`, `--post` (mutually exclusive).
>     - Requires existing `.prime/.env-metadata.json`; reads owner/name via `get_environment_metadata`.
> - **Misc**:
>   - Minor formatting cleanups in console output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa1a207fbe557dcc1025b8ad8be15a99581aeed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->