### PR TITLE
fix: update sandbox examples to use prime_sandboxes imports

### DIFF
--- a/examples/sandbox_async_demo.py
+++ b/examples/sandbox_async_demo.py
@@ -5,8 +5,7 @@ Async Sandbox API Demo - shows the improved async developer experience
 
 import asyncio
 
-from prime_core import APIError
-from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
+from prime_sandboxes import APIError, AsyncSandboxClient, CreateSandboxRequest
 
 
 async def main() -> None:

--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -12,9 +12,7 @@ Works with both:
     from prime import APIClient, SandboxClient, CreateSandboxRequest
 """
 
-# Using the modern package structure (works with both prime and prime-sandboxes)
-from prime_core import APIClient, APIError
-from prime_sandboxes import CreateSandboxRequest, SandboxClient
+from prime_sandboxes import APIClient, APIError, CreateSandboxRequest, SandboxClient
 
 
 def main() -> None:

--- a/examples/sandbox_file_handling_stress_test.py
+++ b/examples/sandbox_file_handling_stress_test.py
@@ -41,12 +41,16 @@ import tempfile
 import time
 from typing import Dict, List, Tuple
 
-from prime_sandboxes import (
-    AsyncSandboxClient,
-    CreateSandboxRequest,
-)
-from prime_core import Config, APIError, UnauthorizedError, PaymentRequiredError
 import httpx
+
+from prime_sandboxes import (
+    APIError,
+    AsyncSandboxClient,
+    Config,
+    CreateSandboxRequest,
+    PaymentRequiredError,
+    UnauthorizedError,
+)
 
 
 def create_test_file(size_mb: int, file_path: str) -> str:

--- a/examples/sandbox_file_operations.py
+++ b/examples/sandbox_file_operations.py
@@ -14,9 +14,9 @@ import tempfile
 
 from prime_sandboxes import (
     AsyncSandboxClient,
+    Config,
     CreateSandboxRequest,
 )
-from prime_core import Config
 
 
 async def main() -> None:
@@ -164,8 +164,7 @@ if __name__ == "__main__":
 
 def sync_example() -> None:
     """Example using synchronous client"""
-    from prime_core import APIClient
-    from prime_sandboxes import SandboxClient
+    from prime_sandboxes import APIClient, SandboxClient
 
     print("\n🔄 Running synchronous example...")
 

--- a/examples/sandbox_tailscale.py
+++ b/examples/sandbox_tailscale.py
@@ -1,8 +1,7 @@
 import os
 import sys
 
-from prime_core import APIClient
-from prime_sandboxes import CreateSandboxRequest, SandboxClient
+from prime_sandboxes import APIClient, CreateSandboxRequest, SandboxClient
 
 
 def main() -> None:


### PR DESCRIPTION
Examples were using prime_core which does not exist. Updated to import from prime_sandboxes directly.

Files updated:
- sandbox_demo.py
- sandbox_async_demo.py  
- sandbox_file_operations.py
- sandbox_tailscale.py
- sandbox_file_handling_stress_test.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace prime_core references with prime_sandboxes across example scripts and consolidate related imports, including error types and clients.
> 
> - **Examples**:
>   - Update imports to use `prime_sandboxes` for `APIClient`, `AsyncSandboxClient`, `SandboxClient`, `CreateSandboxRequest`, and error types.
>     - `examples/sandbox_async_demo.py`: consolidate to `from prime_sandboxes import APIError, AsyncSandboxClient, CreateSandboxRequest`.
>     - `examples/sandbox_demo.py`: consolidate to `from prime_sandboxes import APIClient, APIError, CreateSandboxRequest, SandboxClient`.
>     - `examples/sandbox_file_operations.py`: move `Config` import to `prime_sandboxes`; sync example now imports `APIClient`, `SandboxClient` from `prime_sandboxes`.
>     - `examples/sandbox_file_handling_stress_test.py`: migrate `Config`, `APIError`, `UnauthorizedError`, `PaymentRequiredError` to `prime_sandboxes`; keep `httpx` import; no logic changes.
>     - `examples/sandbox_tailscale.py`: consolidate to `from prime_sandboxes import APIClient, CreateSandboxRequest, SandboxClient`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2028cc8fe212a39477ceafc6c55decc663a5ca37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->