### PR TITLE
prime sandbox ssh

### DIFF
--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -1,0 +1,195 @@
+import socket
+import time
+import urllib.request
+
+from prime_sandboxes import APIClient, APIError, CreateSandboxRequest, SandboxClient
+
+
+def verify_http(url: str) -> bool:
+    """Verify HTTP endpoint is accessible and returns expected response."""
+    try:
+        # Add User-Agent header to avoid 403 from bot protection
+        req = urllib.request.Request(url, headers={"User-Agent": "curl/8.0"})
+        with urllib.request.urlopen(req, timeout=10) as response:
+            status = response.getcode()
+            body = response.read().decode("utf-8")
+            # Python's http.server returns a directory listing HTML
+            if status == 200 and "Directory listing" in body:
+                return True
+            return False
+    except Exception as e:
+        print(f"    HTTP verification error: {e}")
+        return False
+
+
+def verify_tcp(tls_socket: str, test_message: bytes = b"Hello") -> bool:
+    """Verify TCP endpoint is accessible and echoes back data."""
+    try:
+        # Parse host:port from socket address
+        host, port_str = tls_socket.rsplit(":", 1)
+        port = int(port_str)
+
+        # Connect with raw TCP
+        with socket.create_connection((host, port), timeout=10) as sock:
+            sock.sendall(test_message)
+            response = sock.recv(1024)
+            expected = b"Echo: " + test_message
+            return response == expected
+    except Exception as e:
+        print(f"    TCP verification error: {e}")
+        return False
+
+
+def main() -> None:
+    """Demonstrate HTTP and TCP port exposure"""
+    try:
+        client = APIClient()
+        sandbox_client = SandboxClient(client)
+
+        request = CreateSandboxRequest(
+            name="port-expose-demo",
+            docker_image="python:3.11-slim",
+            start_command="tail -f /dev/null",
+            cpu_cores=1,
+            memory_gb=2,
+            timeout_minutes=30,
+        )
+
+        print("Creating sandbox...")
+        sandbox = sandbox_client.create(request)
+        print(f"Created: {sandbox.name} ({sandbox.id})")
+
+        print("\nWaiting for sandbox to be running...")
+        sandbox_client.wait_for_creation(sandbox.id, max_attempts=60)
+        print("Sandbox is running!")
+
+        print("\n--- HTTP Port Exposure ---")
+        print("Starting HTTP server on port 8000...")
+        sandbox_client.execute_command(
+            sandbox.id,
+            "nohup python -m http.server 8000 > /tmp/http.log 2>&1 &",
+        )
+        time.sleep(2)  # Give server time to start
+
+        # Expose the HTTP port
+        http_exposure = sandbox_client.expose(
+            sandbox_id=sandbox.id,
+            port=8000,
+            name="web-server",
+            protocol="HTTP",
+        )
+        print("HTTP port exposed!")
+        print(f"  Exposure ID: {http_exposure.exposure_id}")
+        print(f"  URL: {http_exposure.url}")
+        print(f"  TLS Socket: {http_exposure.tls_socket}")
+        time.sleep(10)
+
+        # Verify HTTP endpoint is accessible
+        print("  Verifying HTTP endpoint...")
+        if verify_http(http_exposure.url):
+            print("  HTTP verification: SUCCESS")
+        else:
+            print("  HTTP verification: FAILED")
+
+        # Start a TCP echo server in the sandbox
+        print("\n--- TCP Port Exposure ---")
+        print("Starting TCP echo server on port 9000...")
+
+        # Create a simple TCP echo server
+        tcp_server_code = """
+import socket
+import threading
+
+def handle_client(conn, addr):
+    print(f"Connection from {addr}")
+    while True:
+        data = conn.recv(1024)
+        if not data:
+            break
+        conn.sendall(b"Echo: " + data)
+    conn.close()
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("0.0.0.0", 9000))
+server.listen(5)
+print("TCP server listening on port 9000")
+
+while True:
+    conn, addr = server.accept()
+    thread = threading.Thread(target=handle_client, args=(conn, addr))
+    thread.daemon = True
+    thread.start()
+"""
+        # Write and run the TCP server
+        sandbox_client.execute_command(
+            sandbox.id,
+            f"cat > /tmp/tcp_server.py << 'SCRIPT'\n{tcp_server_code}\nSCRIPT",
+        )
+        sandbox_client.execute_command(
+            sandbox.id,
+            "nohup python /tmp/tcp_server.py > /tmp/tcp.log 2>&1 &",
+        )
+        time.sleep(2)  # Give server time to start
+
+        # Expose the TCP port
+        tcp_exposure = sandbox_client.expose(
+            sandbox_id=sandbox.id,
+            port=9000,
+            name="echo-server",
+            protocol="TCP",
+        )
+        print("TCP port exposed!")
+        print(f"  Exposure ID: {tcp_exposure.exposure_id}")
+        print(f"  TLS Socket: {tcp_exposure.tls_socket}")
+        if tcp_exposure.external_port:
+            print(f"  External Port: {tcp_exposure.external_port}")
+        time.sleep(120)
+
+        # Verify TCP endpoint is accessible
+        print("  Verifying TCP endpoint...")
+        if verify_tcp(tcp_exposure.tls_socket):
+            print("  TCP verification: SUCCESS (echo server responded correctly)")
+        else:
+            print("  TCP verification: FAILED")
+
+        # List all exposed ports
+        print("\n--- All Exposed Ports ---")
+        ports_response = sandbox_client.list_exposed_ports(sandbox.id)
+        for port in ports_response.exposures:
+            print(f"  {port.name} (port {port.port}):")
+            print(f"    Protocol: {port.protocol}")
+            print(f"    Exposure ID: {port.exposure_id}")
+            if port.protocol == "HTTP":
+                print(f"    URL: {port.url}")
+            else:
+                print(f"    TLS Socket: {port.tls_socket}")
+
+        # Usage instructions
+        print("\n--- How to Connect ---")
+        print(f"HTTP: curl {http_exposure.url}")
+        print("TCP:  Use the TLS socket address with a TCP client")
+
+        # Clean up exposures
+        # print("\n--- Cleanup ---")
+        # print("Removing port exposures...")
+        # sandbox_client.unexpose(sandbox.id, http_exposure.exposure_id)
+        # print(f"  Removed HTTP exposure: {http_exposure.exposure_id}")
+        # sandbox_client.unexpose(sandbox.id, tcp_exposure.exposure_id)
+        # print(f"  Removed TCP exposure: {tcp_exposure.exposure_id}")
+
+        # # Delete sandbox
+        # print(f"\nDeleting sandbox {sandbox.name}...")
+        # sandbox_client.delete(sandbox.id)
+        print("Done!")
+
+    except APIError as e:
+        print(f"API Error: {e}")
+        print("Make sure you're logged in: run 'prime login' first")
+    except Exception as e:
+        print(f"Error: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -22,11 +22,11 @@ def verify_http(url: str) -> bool:
         return False
 
 
-def verify_tcp(tls_socket: str, test_message: bytes = b"Hello") -> bool:
+def verify_tcp(endpoint: str, test_message: bytes = b"Hello") -> bool:
     """Verify TCP endpoint is accessible and echoes back data."""
     try:
-        # Parse host:port from socket address
-        host, port_str = tls_socket.rsplit(":", 1)
+        # Parse host:port from endpoint address
+        host, port_str = endpoint.rsplit(":", 1)
         port = int(port_str)
 
         # Connect with raw TCP
@@ -141,14 +141,14 @@ while True:
         )
         print("TCP port exposed!")
         print(f"  Exposure ID: {tcp_exposure.exposure_id}")
-        print(f"  TLS Socket: {tcp_exposure.tls_socket}")
+        print(f"  External Endpoint: {tcp_exposure.external_endpoint}")
         if tcp_exposure.external_port:
             print(f"  External Port: {tcp_exposure.external_port}")
         time.sleep(120)
 
         # Verify TCP endpoint is accessible
         print("  Verifying TCP endpoint...")
-        if verify_tcp(tcp_exposure.tls_socket):
+        if verify_tcp(tcp_exposure.external_endpoint):
             print("  TCP verification: SUCCESS (echo server responded correctly)")
         else:
             print("  TCP verification: FAILED")
@@ -163,12 +163,12 @@ while True:
             if port.protocol == "HTTP":
                 print(f"    URL: {port.url}")
             else:
-                print(f"    TLS Socket: {port.tls_socket}")
+                print(f"    External Endpoint: {port.external_endpoint}")
 
         # Usage instructions
         print("\n--- How to Connect ---")
         print(f"HTTP: curl {http_exposure.url}")
-        print("TCP:  Use the TLS socket address with a TCP client")
+        print(f"TCP:  Connect to {tcp_exposure.external_endpoint} with a TCP client")
 
         # Clean up exposures
         print("\n--- Cleanup ---")

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -144,7 +144,7 @@ while True:
         print(f"  External Endpoint: {tcp_exposure.external_endpoint}")
         if tcp_exposure.external_port:
             print(f"  External Port: {tcp_exposure.external_port}")
-        time.sleep(120)
+        time.sleep(10)
 
         # Verify TCP endpoint is accessible
         print("  Verifying TCP endpoint...")

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -42,6 +42,9 @@ def verify_tcp(endpoint: str, test_message: bytes = b"Hello") -> bool:
 
 def main() -> None:
     """Demonstrate HTTP and TCP port exposure"""
+    sandbox = None
+    sandbox_client = None
+
     try:
         client = APIClient()
         sandbox_client = SandboxClient(client)
@@ -170,18 +173,7 @@ while True:
         print(f"HTTP: curl {http_exposure.url}")
         print(f"TCP:  Connect to {tcp_exposure.external_endpoint} with a TCP client")
 
-        # Clean up exposures
-        print("\n--- Cleanup ---")
-        print("Removing port exposures...")
-        sandbox_client.unexpose(sandbox.id, http_exposure.exposure_id)
-        print(f"  Removed HTTP exposure: {http_exposure.exposure_id}")
-        sandbox_client.unexpose(sandbox.id, tcp_exposure.exposure_id)
-        print(f"  Removed TCP exposure: {tcp_exposure.exposure_id}")
-
-        # Delete sandbox
-        print(f"\nDeleting sandbox {sandbox.name}...")
-        sandbox_client.delete(sandbox.id)
-        print("Done!")
+        print("\nDemo completed successfully!")
 
     except APIError as e:
         print(f"API Error: {e}")
@@ -189,6 +181,14 @@ while True:
     except Exception as e:
         print(f"Error: {e}")
         raise
+    finally:
+        if sandbox and sandbox_client:
+            print(f"\nCleaning up sandbox {sandbox.id}...")
+            try:
+                sandbox_client.delete(sandbox.id)
+                print("Sandbox deleted.")
+            except Exception as e:
+                print(f"Warning: Failed to delete sandbox: {e}")
 
 
 if __name__ == "__main__":

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -171,16 +171,16 @@ while True:
         print("TCP:  Use the TLS socket address with a TCP client")
 
         # Clean up exposures
-        # print("\n--- Cleanup ---")
-        # print("Removing port exposures...")
-        # sandbox_client.unexpose(sandbox.id, http_exposure.exposure_id)
-        # print(f"  Removed HTTP exposure: {http_exposure.exposure_id}")
-        # sandbox_client.unexpose(sandbox.id, tcp_exposure.exposure_id)
-        # print(f"  Removed TCP exposure: {tcp_exposure.exposure_id}")
+        print("\n--- Cleanup ---")
+        print("Removing port exposures...")
+        sandbox_client.unexpose(sandbox.id, http_exposure.exposure_id)
+        print(f"  Removed HTTP exposure: {http_exposure.exposure_id}")
+        sandbox_client.unexpose(sandbox.id, tcp_exposure.exposure_id)
+        print(f"  Removed TCP exposure: {tcp_exposure.exposure_id}")
 
-        # # Delete sandbox
-        # print(f"\nDeleting sandbox {sandbox.name}...")
-        # sandbox_client.delete(sandbox.id)
+        # Delete sandbox
+        print(f"\nDeleting sandbox {sandbox.name}...")
+        sandbox_client.delete(sandbox.id)
         print("Done!")
 
     except APIError as e:

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -35,6 +35,7 @@ from .models import (
     Sandbox,
     SandboxListResponse,
     SandboxStatus,
+    SSHSession,
     UpdateSandboxRequest,
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
@@ -70,6 +71,7 @@ __all__ = [
     "ExposePortRequest",
     "ExposedPort",
     "ListExposedPortsResponse",
+    "SSHSession",
     # Exceptions
     "APIError",
     "UnauthorizedError",

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -180,7 +180,7 @@ class ExposePortRequest(BaseModel):
 
     port: int
     name: Optional[str] = None
-    protocol: str = "HTTP"  # HTTP or TCP/UDP
+    protocol: str = "HTTP"  # HTTP or TCP
 
 
 class ExposedPort(BaseModel):
@@ -193,8 +193,8 @@ class ExposedPort(BaseModel):
     url: str
     tls_socket: str
     protocol: Optional[str] = None
-    external_port: Optional[int] = None  # For TCP/UDP exposures
-    external_endpoint: Optional[str] = None  # For TCP/UDP: host:port endpoint
+    external_port: Optional[int] = None  # For TCP exposures
+    external_endpoint: Optional[str] = None  # For TCP: host:port endpoint
     created_at: Optional[str] = None
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -179,6 +179,23 @@ class ListExposedPortsResponse(BaseModel):
     exposures: List[ExposedPort]
 
 
+class SSHSession(BaseModel):
+    """SSH session details"""
+
+    session_id: str
+    exposure_id: str
+    sandbox_id: str
+    host: str
+    port: int
+    tls_socket: str
+    expires_at: datetime
+    ttl_seconds: int
+    gateway_url: str
+    user_ns: str
+    job_id: str
+    token: str
+
+
 class BackgroundJob(BaseModel):
     """Background job handle returned when starting a background job"""
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -156,6 +156,7 @@ class ExposePortRequest(BaseModel):
 
     port: int
     name: Optional[str] = None
+    protocol: str = "HTTP"  # HTTP or TCP/UDP
 
 
 class ExposedPort(BaseModel):
@@ -168,6 +169,7 @@ class ExposedPort(BaseModel):
     url: str
     tls_socket: str
     protocol: Optional[str] = None
+    external_port: Optional[int] = None  # For TCP/UDP exposures
     created_at: Optional[str] = None
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -192,6 +192,7 @@ class ExposedPort(BaseModel):
     tls_socket: str
     protocol: Optional[str] = None
     external_port: Optional[int] = None  # For TCP/UDP exposures
+    external_endpoint: Optional[str] = None  # For TCP/UDP: host:port endpoint
     created_at: Optional[str] = None
 
 
@@ -209,7 +210,7 @@ class SSHSession(BaseModel):
     sandbox_id: str
     host: str
     port: int
-    tls_socket: str
+    external_endpoint: str
     expires_at: datetime
     ttl_seconds: int
     gateway_url: str

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -550,9 +550,10 @@ class SandboxClient:
         sandbox_id: str,
         port: int,
         name: Optional[str] = None,
+        protocol: str = "HTTP",
     ) -> ExposedPort:
-        """Expose an HTTP port from a sandbox."""
-        request = ExposePortRequest(port=port, name=name)
+        """Expose a port from a sandbox."""
+        request = ExposePortRequest(port=port, name=name, protocol=protocol)
         response = self.client.request(
             "POST",
             f"/sandbox/{sandbox_id}/expose",
@@ -1006,9 +1007,10 @@ class AsyncSandboxClient:
         sandbox_id: str,
         port: int,
         name: Optional[str] = None,
+        protocol: str = "HTTP",
     ) -> ExposedPort:
-        """Expose an HTTP port from a sandbox."""
-        request = ExposePortRequest(port=port, name=name)
+        """Expose a port from a sandbox."""
+        request = ExposePortRequest(port=port, name=name, protocol=protocol)
         response = await self.client.request(
             "POST",
             f"/sandbox/{sandbox_id}/expose",

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -681,11 +681,10 @@ class SandboxClient:
     def create_ssh_session(
         self,
         sandbox_id: str,
-        public_key: str,
         ttl_seconds: Optional[int] = None,
     ) -> SSHSession:
         """Create an SSH session"""
-        payload: Dict[str, Any] = {"public_key": public_key}
+        payload: Dict[str, Any] = {}
         if ttl_seconds is not None:
             payload["ttl_seconds"] = ttl_seconds
         response = self.client.request(
@@ -1251,11 +1250,10 @@ class AsyncSandboxClient:
     async def create_ssh_session(
         self,
         sandbox_id: str,
-        public_key: str,
         ttl_seconds: Optional[int] = None,
     ) -> SSHSession:
         """Create an SSH session"""
-        payload: Dict[str, Any] = {"public_key": public_key}
+        payload: Dict[str, Any] = {}
         if ttl_seconds is not None:
             payload["ttl_seconds"] = ttl_seconds
         response = await self.client.request(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -570,6 +570,11 @@ class SandboxClient:
         response = self.client.request("GET", f"/sandbox/{sandbox_id}/expose")
         return ListExposedPortsResponse.model_validate(response)
 
+    def list_all_exposed_ports(self) -> ListExposedPortsResponse:
+        """List all exposed ports across all sandboxes for the current user"""
+        response = self.client.request("GET", "/sandbox/expose/all")
+        return ListExposedPortsResponse.model_validate(response)
+
 
 class AsyncSandboxClient:
     """Async client for sandbox API operations"""
@@ -1025,4 +1030,9 @@ class AsyncSandboxClient:
     async def list_exposed_ports(self, sandbox_id: str) -> ListExposedPortsResponse:
         """List all exposed ports for a sandbox"""
         response = await self.client.request("GET", f"/sandbox/{sandbox_id}/expose")
+        return ListExposedPortsResponse.model_validate(response)
+
+    async def list_all_exposed_ports(self) -> ListExposedPortsResponse:
+        """List all exposed ports across all sandboxes for the current user"""
+        response = await self.client.request("GET", "/sandbox/expose/all")
         return ListExposedPortsResponse.model_validate(response)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -990,9 +990,17 @@ def expose_port(
             if exposed.name:
                 console.print(f"[bold green]Name:[/bold green] {exposed.name}")
             console.print(f"[bold green]URL:[/bold green] {exposed.url}")
-            if protocol in ("TCP", "UDP") and exposed.external_port:
-                console.print(f"[bold green]External Port:[/bold green] {exposed.external_port}")
-            console.print(f"[bold green]TLS Socket:[/bold green] {exposed.tls_socket}")
+            if protocol in ("TCP", "UDP"):
+                if exposed.external_port:
+                    console.print(
+                        f"[bold green]External Port:[/bold green] {exposed.external_port}"
+                    )
+                if exposed.external_endpoint:
+                    console.print(
+                        f"[bold green]External Endpoint:[/bold green] {exposed.external_endpoint}"
+                    )
+            else:
+                console.print(f"[bold green]TLS Socket:[/bold green] {exposed.tls_socket}")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -965,7 +965,7 @@ def expose_port(
         "HTTP",
         "--protocol",
         "-p",
-        help="Protocol: HTTP or TCP/UDP",
+        help="Protocol: HTTP or TCP",
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
@@ -974,8 +974,8 @@ def expose_port(
 
     # Validate protocol
     protocol = protocol.upper()
-    if protocol not in ("HTTP", "TCP", "UDP"):
-        console.print(f"[red]Error:[/red] Invalid protocol '{protocol}'. Use HTTP, TCP, or UDP.")
+    if protocol not in ("HTTP", "TCP"):
+        console.print(f"[red]Error:[/red] Invalid protocol '{protocol}'. Use HTTP or TCP.")
         raise typer.Exit(1)
 
     try:
@@ -995,7 +995,7 @@ def expose_port(
             if exposed.name:
                 console.print(f"[bold green]Name:[/bold green] {exposed.name}")
             console.print(f"[bold green]URL:[/bold green] {exposed.url}")
-            if protocol in ("TCP", "UDP"):
+            if protocol == "TCP":
                 if exposed.external_port:
                     console.print(
                         f"[bold green]External Port:[/bold green] {exposed.external_port}"

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1126,7 +1126,6 @@ def ssh_connect(
         console.print(f"[bold blue]Exposing SSH port {port}...[/bold blue]")
         with console.status("[bold blue]Setting up SSH tunnel...", spinner="dots"):
             exposed = sandbox_client.expose(sandbox_id, port, "ssh", "TCP")
-            time.sleep(120)
 
         exposure_id = exposed.exposure_id
 
@@ -1140,6 +1139,7 @@ def ssh_connect(
 
         ssh_host = tls_parts[0]
         ssh_port = int(tls_parts[1])
+        time.sleep(120)
 
         console.print("[green]✓[/green] SSH tunnel established!")
         console.print(f"[bold green]Connecting to:[/bold green] {user}@{ssh_host}")

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -926,12 +926,7 @@ def expose_port(
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """Expose a port from a sandbox.
-
-    Protocols:
-      - HTTP: Exposed via Cloudflare Tunnel with HTTPS URL (default)
-      - TCP/UDP: Exposed via LoadBalancer with direct TCP/UDP access
-    """
+    """Expose a port from a sandbox."""
     validate_output_format(output, console)
 
     # Validate protocol

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1202,7 +1202,7 @@ def ssh_connect(
         # Create SSH session
         console.print("[bold blue]Creating SSH session...[/bold blue]")
         with console.status("[bold blue]Setting up SSH session...", spinner="dots"):
-            session = sandbox_client.create_ssh_session(sandbox_id, public_key=public_key)
+            session = sandbox_client.create_ssh_session(sandbox_id)
         session_id = session.session_id
 
         # Authorize the key

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1268,6 +1268,11 @@ def ssh_connect(
         console.print(f"[bold green]Connecting to:[/bold green] {session.session_id}@{ssh_host}")
         console.print(f"[bold green]Port:[/bold green] {ssh_port}")
         console.print()
+
+        # Wait for TCP exposure to propagate through the load balancer
+        with console.status("[bold blue]Waiting for connection to be ready...", spinner="dots"):
+            time.sleep(5)
+
         console.print("[dim]Press Ctrl+D or type 'exit' to disconnect[/dim]")
         console.print()
 
@@ -1277,6 +1282,7 @@ def ssh_connect(
         # Disable strict host key checking for dynamic hosts
         ssh_cmd.extend(["-o", "StrictHostKeyChecking=no"])
         ssh_cmd.extend(["-o", "UserKnownHostsFile=/dev/null"])
+        ssh_cmd.extend(["-o", "LogLevel=ERROR"])
 
         # Add identity file if specified
         if key_path:

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1179,9 +1179,12 @@ def ssh_connect(
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     try:
-        # Check if ssh command is available
+        # Check if ssh and ssh-keygen commands are available
         if not shutil.which("ssh"):
             console.print("[red]Error:[/red] SSH client not found. Please install OpenSSH.")
+            raise typer.Exit(1)
+        if not shutil.which("ssh-keygen"):
+            console.print("[red]Error:[/red] ssh-keygen not found. Please install OpenSSH.")
             raise typer.Exit(1)
 
         base_client = APIClient()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces SSH connectivity and TCP port exposure across SDK and CLI, plus a demo.
> 
> - **SDK (`prime_sandboxes`)**: Add `protocol` to `ExposePortRequest`; extend `ExposedPort` with `external_port`/`external_endpoint`; new `SSHSession` model and exports. `SandboxClient`/`AsyncSandboxClient`: `expose(..., protocol)`, `list_all_exposed_ports()`, `create_ssh_session()`, `close_ssh_session()`.
> - **CLI (`prime sandbox`)**: `expose` supports `--protocol HTTP|TCP` with protocol-aware output; `list-ports` can list for one sandbox or all; new `ssh` command creates ephemeral SSH sessions, authorizes key via gateway, connects, and cleans up.
> - **Examples**: New `sandbox_port_expose_demo.py` showing HTTP and TCP exposure with verification.
> 
> Backwards compatibility maintained (default protocol HTTP).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cf58328e6ae797ccdae50568ca0137c324411d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->