### PR TITLE
save and return stderr in sandbox background job

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -182,7 +182,8 @@ class BackgroundJob(BaseModel):
 
     job_id: str
     sandbox_id: str
-    log_file: str
+    stdout_log_file: str
+    stderr_log_file: str
     exit_file: str
 
 
@@ -193,3 +194,4 @@ class BackgroundJobStatus(BaseModel):
     completed: bool
     exit_code: Optional[int] = None
     stdout: Optional[str] = None
+    stderr: Optional[str] = None

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -366,7 +366,8 @@ class SandboxClient:
             BackgroundJob with job_id and file paths for polling
         """
         job_id = uuid.uuid4().hex[:8]
-        log_file = f"/tmp/job_{job_id}.log"
+        stdout_log_file = f"/tmp/job_{job_id}.stdout.log"
+        stderr_log_file = f"/tmp/job_{job_id}.stderr.log"
         exit_file = f"/tmp/job_{job_id}.exit"
 
         env_prefix = ""
@@ -382,20 +383,22 @@ class SandboxClient:
         dir_prefix = f"cd {shlex.quote(working_dir)} && " if working_dir else ""
         command_body = f"{env_prefix}{dir_prefix}{command}"
         exit_file_quoted = shlex.quote(exit_file)
-        log_file_quoted = shlex.quote(log_file)
+        stdout_log_file_quoted = shlex.quote(stdout_log_file)
+        stderr_log_file_quoted = shlex.quote(stderr_log_file)
         # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
         # This ensures 'echo $?' always runs to capture the exit code.
         sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
         quoted_sh_command = shlex.quote(sh_command)
 
-        # Start detached process
-        bg_cmd = f"nohup sh -c {quoted_sh_command} > {log_file_quoted} 2>&1 &"
+        # Start detached process with separate stdout and stderr log files
+        bg_cmd = f"nohup sh -c {quoted_sh_command} > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
         self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(
             job_id=job_id,
             sandbox_id=sandbox_id,
-            log_file=log_file,
+            stdout_log_file=stdout_log_file,
+            stderr_log_file=stderr_log_file,
             exit_file=exit_file,
         )
 
@@ -414,7 +417,8 @@ class SandboxClient:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
         exit_file_quoted = shlex.quote(job.exit_file)
-        log_file_quoted = shlex.quote(job.log_file)
+        stdout_log_file_quoted = shlex.quote(job.stdout_log_file)
+        stderr_log_file_quoted = shlex.quote(job.stderr_log_file)
 
         check = self.execute_command(sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10)
 
@@ -422,13 +426,15 @@ class SandboxClient:
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
         exit_code = int(check.stdout.strip())
-        logs = self.execute_command(sandbox_id, f"cat {log_file_quoted}", timeout=60)
+        stdout_logs = self.execute_command(sandbox_id, f"cat {stdout_log_file_quoted}", timeout=60)
+        stderr_logs = self.execute_command(sandbox_id, f"cat {stderr_log_file_quoted}", timeout=60)
 
         return BackgroundJobStatus(
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=logs.stdout,
+            stdout=stdout_logs.stdout,
+            stderr=stderr_logs.stdout,
         )
 
     def wait_for_creation(
@@ -870,7 +876,8 @@ class AsyncSandboxClient:
             BackgroundJob with job_id and file paths for polling
         """
         job_id = uuid.uuid4().hex[:8]
-        log_file = f"/tmp/job_{job_id}.log"
+        stdout_log_file = f"/tmp/job_{job_id}.stdout.log"
+        stderr_log_file = f"/tmp/job_{job_id}.stderr.log"
         exit_file = f"/tmp/job_{job_id}.exit"
 
         env_prefix = ""
@@ -886,20 +893,22 @@ class AsyncSandboxClient:
         dir_prefix = f"cd {shlex.quote(working_dir)} && " if working_dir else ""
         command_body = f"{env_prefix}{dir_prefix}{command}"
         exit_file_quoted = shlex.quote(exit_file)
-        log_file_quoted = shlex.quote(log_file)
+        stdout_log_file_quoted = shlex.quote(stdout_log_file)
+        stderr_log_file_quoted = shlex.quote(stderr_log_file)
         # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
         # This ensures 'echo $?' always runs to capture the exit code.
         sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
         quoted_sh_command = shlex.quote(sh_command)
 
-        # Start detached process
-        bg_cmd = f"nohup sh -c {quoted_sh_command} > {log_file_quoted} 2>&1 &"
+        # Start detached process with separate stdout and stderr log files
+        bg_cmd = f"nohup sh -c {quoted_sh_command} > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
         await self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(
             job_id=job_id,
             sandbox_id=sandbox_id,
-            log_file=log_file,
+            stdout_log_file=stdout_log_file,
+            stderr_log_file=stderr_log_file,
             exit_file=exit_file,
         )
 
@@ -918,7 +927,8 @@ class AsyncSandboxClient:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
         exit_file_quoted = shlex.quote(job.exit_file)
-        log_file_quoted = shlex.quote(job.log_file)
+        stdout_log_file_quoted = shlex.quote(job.stdout_log_file)
+        stderr_log_file_quoted = shlex.quote(job.stderr_log_file)
 
         check = await self.execute_command(
             sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10
@@ -928,13 +938,15 @@ class AsyncSandboxClient:
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
         exit_code = int(check.stdout.strip())
-        logs = await self.execute_command(sandbox_id, f"cat {log_file_quoted}", timeout=60)
+        stdout_logs = await self.execute_command(sandbox_id, f"cat {stdout_log_file_quoted}", timeout=60)
+        stderr_logs = await self.execute_command(sandbox_id, f"cat {stderr_log_file_quoted}", timeout=60)
 
         return BackgroundJobStatus(
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=logs.stdout,
+            stdout=stdout_logs.stdout,
+            stderr=stderr_logs.stdout,
         )
 
     async def wait_for_creation(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -391,7 +391,10 @@ class SandboxClient:
         quoted_sh_command = shlex.quote(sh_command)
 
         # Start detached process with separate stdout and stderr log files
-        bg_cmd = f"nohup sh -c {quoted_sh_command} > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+        bg_cmd = (
+            f"nohup sh -c {quoted_sh_command} "
+            f"> {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+        )
         self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(
@@ -901,7 +904,10 @@ class AsyncSandboxClient:
         quoted_sh_command = shlex.quote(sh_command)
 
         # Start detached process with separate stdout and stderr log files
-        bg_cmd = f"nohup sh -c {quoted_sh_command} > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+        bg_cmd = (
+            f"nohup sh -c {quoted_sh_command} "
+            f"> {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+        )
         await self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(
@@ -938,8 +944,12 @@ class AsyncSandboxClient:
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
         exit_code = int(check.stdout.strip())
-        stdout_logs = await self.execute_command(sandbox_id, f"cat {stdout_log_file_quoted}", timeout=60)
-        stderr_logs = await self.execute_command(sandbox_id, f"cat {stderr_log_file_quoted}", timeout=60)
+        stdout_logs = await self.execute_command(
+            sandbox_id, f"cat {stdout_log_file_quoted}", timeout=60
+        )
+        stderr_logs = await self.execute_command(
+            sandbox_id, f"cat {stderr_log_file_quoted}", timeout=60
+        )
 
         return BackgroundJobStatus(
             job_id=job.job_id,


### PR DESCRIPTION
pipe stdout and stderr into separate log files in background jobs to adhere to existing sandbox results schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Background jobs now write stdout and stderr to separate files and return both streams (plus exit code) in status.
> 
> - **Models**:
>   - `BackgroundJob`: replace `log_file` with `stdout_log_file` and `stderr_log_file`.
>   - `BackgroundJobStatus`: add optional `stderr` field.
> - **Sandbox client**:
>   - `start_background_job` (sync/async): redirect output to separate `stdout`/`stderr` log files; return new file paths.
>   - `get_background_job` (sync/async): read separate `stdout`/`stderr` logs and populate `stdout` and `stderr` in status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 136e61f1f93e1151aebd3ed8ec9690bb68942653. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->