### PR TITLE
feat: Add team selection after prime login.

### DIFF
--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -233,8 +233,8 @@ def login() -> None:
                         config.update_current_environment_file()
 
                         # Attempt to fetch the current user id
+                        client = APIClient(api_key=api_key)
                         try:
-                            client = APIClient(api_key=api_key)
                             whoami_resp = client.get("/user/whoami")
                             data = (
                                 whoami_resp.get("data") if isinstance(whoami_resp, dict) else None
@@ -244,11 +244,11 @@ def login() -> None:
                                 if user_id:
                                     config.set_user_id(user_id)
                                     config.update_current_environment_file()
-                            console.print("[green]Successfully logged in![/green]")
-
-                            fetch_and_select_team(client, config)
                         except (APIError, Exception):
                             console.print("[yellow]Logged in, but failed to fetch user id[/yellow]")
+
+                        console.print("[green]Successfully logged in![/green]")
+                        fetch_and_select_team(client, config)
                     else:
                         console.print("[red]Failed to decrypt authentication token[/red]")
                     break

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -26,7 +26,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
         teams = fetch_teams(client)
 
         if not teams:
-            config.set_team_id(None)
+            config.set_team(None)
             config.update_current_environment_file()
             return
 
@@ -49,7 +49,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                 selection = typer.prompt("Select", type=int, default=1)
 
                 if selection == 1:
-                    config.set_team_id(None)
+                    config.set_team(None)
                     config.update_current_environment_file()
                     console.print("[green]Using personal account.[/green]")
                     return
@@ -61,26 +61,26 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
 
                     if not team_id:
                         console.print("[yellow]Invalid team. Using personal account.[/yellow]")
-                        config.set_team_id(None)
+                        config.set_team(None)
                         config.update_current_environment_file()
                         return
 
-                    config.set_team_id(team_id)
+                    config.set_team(team_id, team_name=team_name)
                     config.update_current_environment_file()
                     console.print(f"[green]Using team '{team_name}'.[/green]")
                     return
 
                 console.print(f"[red]Invalid selection. Enter 1-{len(teams) + 1}.[/red]")
             except Abort:
-                config.set_team_id(None)
+                config.set_team(None)
                 config.update_current_environment_file()
                 return
 
     except Abort:
-        config.set_team_id(None)
+        config.set_team(None)
         config.update_current_environment_file()
     except (APIError, Exception):
-        config.set_team_id(None)
+        config.set_team(None)
         config.update_current_environment_file()
 
 

--- a/packages/prime/src/prime_cli/commands/teams.py
+++ b/packages/prime/src/prime_cli/commands/teams.py
@@ -9,6 +9,12 @@ app = typer.Typer(help="List your teams", no_args_is_help=True)
 console = Console()
 
 
+def fetch_teams(client: APIClient) -> list[dict]:
+    """Fetch teams for the current user."""
+    response = client.get("/user/teams")
+    return response.get("data", []) if isinstance(response, dict) else []
+
+
 @app.command(name="list")
 def list_teams(
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
@@ -18,15 +24,11 @@ def list_teams(
 
     try:
         client = APIClient()
-        response = client.get("/user/teams")
-        data = response.get("data") if isinstance(response, dict) else []
+        teams = fetch_teams(client)
 
         if output == "json":
-            teams = data if isinstance(data, list) else []
             output_data_as_json({"teams": teams, "total_count": len(teams)}, console)
             return
-
-        teams = data if isinstance(data, list) else []
         table = Table(title=f"Teams (Total: {len(teams)})", show_lines=True)
         table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Name", style="blue")


### PR DESCRIPTION
Closes ENG-2239

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds interactive team selection after login and persists `team_id`/`team_name` in config and environments, with a shared `fetch_teams` helper.
> 
> - **Login flow**:
>   - Adds interactive team selection post-auth using `fetch_teams`, allowing choosing personal or a team; updates config/environment with `set_team(team_id, team_name)`.
> - **Config**:
>   - Introduces `team_name` and `set_team()` (replacing direct `set_team_id`) and `team_id_from_env`.
>   - Persists `team_name` in environments (`save_environment`, `load_environment`, `update_current_environment_file`) unless team is from env var.
>   - `config view` shows Team with name when available and env-var source when applicable.
>   - `set-team-id` resolves and stores team name; `remove-team-id`/`reset` use `set_team(None)`.
> - **Teams command**:
>   - Extracts `fetch_teams(client)` utility and reuses it in `teams list`, `config set-team-id`, and login.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9d987391e49d07ebf73a6635137824fea75c9da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->