### PR TITLE
Imp: Display team name in prime config view

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -59,11 +59,13 @@ def view() -> None:
 
     # Show Team
     team_id = settings["team_id"]
-    team_name = settings.get("team_name")
+    team_from_env = _env_set("PRIME_TEAM_ID")
     if team_id:
-        team_label = f"{team_name} ({team_id})" if team_name else team_id
-        if _env_set("PRIME_TEAM_ID"):
-            team_label += " (from env var)"
+        if team_from_env:
+            team_label = f"{team_id} (from env var)"
+        else:
+            team_name = settings.get("team_name")
+            team_label = f"{team_name} ({team_id})" if team_name else team_id
     else:
         team_label = "Personal Account"
     table.add_row("Team", team_label)

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
+from .teams import fetch_teams
 
 app = typer.Typer(help="Configure the CLI", no_args_is_help=True)
 console = Console()
@@ -56,12 +57,16 @@ def view() -> None:
         masked_key = "Not set"
     table.add_row("API Key", masked_key)
 
-    # Show Team ID
+    # Show Team
     team_id = settings["team_id"]
-    team_label = team_id or "Personal Account"
-    if team_id and _env_set("PRIME_TEAM_ID"):
-        team_label += " (from env var)"
-    table.add_row("Team ID", team_label)
+    team_name = settings.get("team_name")
+    if team_id:
+        team_label = f"{team_name} ({team_id})" if team_name else team_id
+        if _env_set("PRIME_TEAM_ID"):
+            team_label += " (from env var)"
+    else:
+        team_label = "Personal Account"
+    table.add_row("Team", team_label)
 
     # Show User ID
     user_id = settings.get("user_id")
@@ -167,9 +172,24 @@ def set_team_id(
         raise typer.Exit(code=1)
 
     config = Config()
-    config.set_team_id(team_id)
+    team_name = None
     if team_id:
-        console.print(f"[green]Team ID '{team_id}' configured successfully![/green]")
+        try:
+            client = APIClient()
+            teams = fetch_teams(client)
+            for team in teams:
+                if team.get("teamId") == team_id:
+                    team_name = team.get("name")
+                    break
+        except (APIError, Exception):
+            pass
+
+    config.set_team(team_id, team_name=team_name)
+    if team_id:
+        if team_name:
+            console.print(f"[green]Team '{team_name}' ({team_id}) configured successfully![/green]")
+        else:
+            console.print(f"[green]Team ID '{team_id}' configured successfully![/green]")
     else:
         console.print("[green]Team ID cleared. Using personal account.[/green]")
 
@@ -178,7 +198,7 @@ def set_team_id(
 def remove_team_id() -> None:
     """Remove team ID to use personal account"""
     config = Config()
-    config.set_team_id(None)
+    config.set_team(None)
     console.print("[green]Team ID removed. Using personal account.[/green]")
 
 
@@ -327,7 +347,7 @@ def reset(
     if yes or typer.confirm("Are you sure you want to reset all settings?"):
         config = Config()
         config.set_api_key("")
-        config.set_team_id(None)
+        config.set_team(None)
         config.set_base_url(Config.DEFAULT_BASE_URL)
         config.set_frontend_url(Config.DEFAULT_FRONTEND_URL)
         config.set_ssh_key_path(Config.DEFAULT_SSH_KEY_PATH)

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -26,7 +26,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
         teams = fetch_teams(client)
 
         if not teams:
-            config.set_team_id(None)
+            config.set_team(None)
             config.update_current_environment_file()
             return
 
@@ -49,7 +49,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                 selection = typer.prompt("Select", type=int, default=1)
 
                 if selection == 1:
-                    config.set_team_id(None)
+                    config.set_team(None)
                     config.update_current_environment_file()
                     console.print("[green]Using personal account.[/green]")
                     return
@@ -61,26 +61,26 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
 
                     if not team_id:
                         console.print("[yellow]Invalid team. Using personal account.[/yellow]")
-                        config.set_team_id(None)
+                        config.set_team(None)
                         config.update_current_environment_file()
                         return
 
-                    config.set_team_id(team_id)
+                    config.set_team(team_id, team_name=team_name)
                     config.update_current_environment_file()
                     console.print(f"[green]Using team '{team_name}'.[/green]")
                     return
 
                 console.print(f"[red]Invalid selection. Enter 1-{len(teams) + 1}.[/red]")
             except Abort:
-                config.set_team_id(None)
+                config.set_team(None)
                 config.update_current_environment_file()
                 return
 
     except Abort:
-        config.set_team_id(None)
+        config.set_team(None)
         config.update_current_environment_file()
     except (APIError, Exception):
-        config.set_team_id(None)
+        config.set_team(None)
         config.update_current_environment_file()
 
 

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -88,14 +88,16 @@ class Config:
     @property
     def team_id(self) -> Optional[str]:
         """Get team ID with precedence: env > file > None."""
-        team_id = os.getenv("PRIME_TEAM_ID")
-        if team_id is not None:
-            return team_id
-        return self.config.get("team_id") or None
+        return os.getenv("PRIME_TEAM_ID") or self.config.get("team_id") or None
+
+    @property
+    def team_id_from_env(self) -> bool:
+        """Check if team ID is set via environment variable."""
+        return bool(os.getenv("PRIME_TEAM_ID"))
 
     @property
     def team_name(self) -> Optional[str]:
-        """Get team name from config file."""
+        """Get team name from config file (only valid if team_id not from env)."""
         return self.config.get("team_name") or None
 
     def set_team(self, value: str | None, team_name: str | None = None) -> None:
@@ -220,7 +222,7 @@ class Config:
         env_config = {
             "api_key": self.api_key,
             "team_id": self.team_id,
-            "team_name": self.team_name,
+            "team_name": None if self.team_id_from_env else self.team_name,
             "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
@@ -312,7 +314,7 @@ class Config:
                     env_config = {
                         "api_key": self.api_key,
                         "team_id": self.team_id,
-                        "team_name": self.team_name,
+                        "team_name": None if self.team_id_from_env else self.team_name,
                         "user_id": self.user_id,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict
 class ConfigModel(BaseModel):
     api_key: str = ""
     team_id: str | None = None
+    team_name: str | None = None
     user_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
@@ -92,9 +93,15 @@ class Config:
             return team_id
         return self.config.get("team_id") or None
 
-    def set_team_id(self, value: str | None) -> None:
-        """Set team ID in config file"""
-        self.config["team_id"] = value if value else None
+    @property
+    def team_name(self) -> Optional[str]:
+        """Get team name from config file."""
+        return self.config.get("team_name") or None
+
+    def set_team(self, value: str | None, team_name: str | None = None) -> None:
+        """Set team ID and name in config file."""
+        self.config["team_id"] = value or None
+        self.config["team_name"] = team_name if value else None
         self._save_config(self.config)
 
     @property
@@ -194,6 +201,7 @@ class Config:
         return {
             "api_key": self.api_key,
             "team_id": self.team_id,
+            "team_name": self.team_name,
             "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
@@ -212,6 +220,7 @@ class Config:
         env_config = {
             "api_key": self.api_key,
             "team_id": self.team_id,
+            "team_name": self.team_name,
             "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
@@ -235,13 +244,14 @@ class Config:
                 self.set_base_url(self.DEFAULT_BASE_URL)
                 self.set_frontend_url(self.DEFAULT_FRONTEND_URL)
                 self.set_inference_url(self.DEFAULT_INFERENCE_URL)
-                self.set_team_id(None)  # Production defaults to personal account
+                self.set_team(None)  # Production defaults to personal account
                 self.set_current_environment("production")
             else:
                 self.config["base_url"] = self.DEFAULT_BASE_URL
                 self.config["frontend_url"] = self.DEFAULT_FRONTEND_URL
                 self.config["inference_url"] = self.DEFAULT_INFERENCE_URL
                 self.config["team_id"] = None
+                self.config["team_name"] = None
                 self.config["current_environment"] = "production"
             return True
 
@@ -257,8 +267,11 @@ class Config:
                 if persist:
                     if "api_key" in env_config:
                         self.set_api_key(env_config["api_key"])
-                    # Set team_id from environment, defaulting to empty string
-                    self.set_team_id(env_config.get("team_id", None))
+                    # Set team_id and team_name from environment
+                    self.set_team(
+                        env_config.get("team_id", None),
+                        team_name=env_config.get("team_name", None),
+                    )
                     # Set user_id from environment
                     self.set_user_id(env_config.get("user_id", None))
                     self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
@@ -272,6 +285,7 @@ class Config:
                     if "api_key" in env_config:
                         self.config["api_key"] = env_config["api_key"]
                     self.config["team_id"] = env_config.get("team_id", None)
+                    self.config["team_name"] = env_config.get("team_name", None)
                     self.config["user_id"] = env_config.get("user_id", None)
                     # Normalize URLs the same way set_* methods do
                     base_url = env_config.get("base_url", self.DEFAULT_BASE_URL)
@@ -298,6 +312,7 @@ class Config:
                     env_config = {
                         "api_key": self.api_key,
                         "team_id": self.team_id,
+                        "team_name": self.team_name,
                         "user_id": self.user_id,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,


### PR DESCRIPTION


<img width="581" height="172" alt="CleanShot 2025-12-11 at 9  31 34" src="https://github.com/user-attachments/assets/2a090993-ee13-4b6c-9ea5-c91edf8fcbc5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display team names in `prime config view`, fetch and store team name when setting/selecting teams, and persist `team_name` across environments with env-var precedence respected.
> 
> - **Config View (`commands/config.py`)**
>   - Display team as `name (id)` when available; show `(from env var)` if `PRIME_TEAM_ID` is set.
>   - When setting team ID, fetch teams to resolve and store `team_name`; success messages reflect name.
>   - Replace `set_team_id/remove_team_id` operations with unified `set_team` usage; `reset` clears team via `set_team(None)`.
> - **Login Flow (`commands/login.py`)**
>   - Team selection now calls `set_team(team_id, team_name)`; defaults to personal with `set_team(None)` on abort/errors.
> - **Core Config (`core/config.py`)**
>   - Add `team_name` field; expose `team_id_from_env`.
>   - Introduce `set_team(team_id, team_name)`; keep `team_name` only when not using env var.
>   - `view()` includes `team_name`.
>   - Environments: save/load/update now include `team_name` (omitted when `PRIME_TEAM_ID` is set); production load clears both `team_id` and `team_name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7951fca07c0a5e23dde619ccc3b92f0e1568eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->