### PR TITLE
feat: Unify eval command.

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.3"
+__version__ = "0.5.5"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2235,7 +2235,6 @@ def eval_env(
             "see 'prime inference models' for available models)"
         ),
     ),
-    # --- vf-eval options ---
     num_examples: Optional[int] = typer.Option(
         5, "--num-examples", "-n", help="Number of examples"
     ),

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2022,7 +2022,7 @@ def run_eval(
     env_path: Optional[str],
 ) -> None:
     """
-    Core implementation for running verifiers' vf-eval with Prime Inference.
+    Run verifiers' vf-eval with Prime Inference
 
     This is the shared implementation used by both `prime eval` and `prime env eval`.
     """
@@ -2224,7 +2224,7 @@ def eval_env(
     ctx: typer.Context,
     environment: str = typer.Argument(
         ...,
-        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/gpqa')",
+        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/wordle')",
     ),
     model: str = typer.Option(
         "openai/gpt-4.1-mini",
@@ -2291,16 +2291,7 @@ def eval_env(
         ),
     ),
 ) -> None:
-    """
-    This command has been moved to `prime eval`. Please use `prime eval` instead.
-
-    Example:
-       prime eval meow -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
-       prime eval primeintellect/gpqa -m openai/gpt-4.1-mini -n 5
-    """
-    console.print(
-        "[yellow]'prime env eval' is deprecated. Please use 'prime eval' instead.[/yellow]\n"
-    )
+    """Use 'prime eval' instead."""
 
     run_eval(
         environment=environment,

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2023,8 +2023,6 @@ def run_eval(
 ) -> None:
     """
     Run verifiers' vf-eval with Prime Inference
-
-    This is the shared implementation used by both `prime eval` and `prime env eval`.
     """
     is_slug = (
         "/" in environment and not environment.startswith("./") and not environment.startswith("/")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2001,91 +2001,31 @@ def _install_single_environment(env_slug: str, tool: str = "uv") -> bool:
         return False
 
 
-@app.command(
-    "eval",
-    no_args_is_help=True,
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-)
-def eval_env(
-    ctx: typer.Context,
-    environment: str = typer.Argument(
-        ...,
-        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/gpqa')",
-    ),
-    model: str = typer.Option(
-        "openai/gpt-4.1-mini",
-        "--model",
-        "-m",
-        help=(
-            "Model to use (e.g. 'openai/gpt-4.1-mini', 'prime-intellect/intellect-3', "
-            "see 'prime inference models' for available models)"
-        ),
-    ),
-    # --- vf-eval options ---
-    num_examples: Optional[int] = typer.Option(
-        5, "--num-examples", "-n", help="Number of examples"
-    ),
-    rollouts_per_example: Optional[int] = typer.Option(
-        3, "--rollouts-per-example", "-r", help="Rollouts per example"
-    ),
-    max_concurrent: Optional[int] = typer.Option(
-        32, "--max-concurrent", "-c", help="Max concurrent requests"
-    ),
-    max_tokens: Optional[int] = typer.Option(
-        None, "--max-tokens", "-t", help="Max tokens to generate (unset → model default)"
-    ),
-    temperature: Optional[float] = typer.Option(None, "--temperature", "-T", help="Temperature"),
-    sampling_args: Optional[str] = typer.Option(
-        None,
-        "--sampling-args",
-        "-S",
-        help='Sampling args as JSON, e.g. \'{"enable_thinking": false, "max_tokens": 256}\'',
-    ),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
-    save_results: bool = typer.Option(True, "--save-results", "-s", help="Save results to disk"),
-    save_every: int = typer.Option(1, "--save-every", "-f", help="Save dataset every n rollouts"),
-    save_to_hf_hub: bool = typer.Option(False, "--save-to-hf-hub", "-H", help="Save to HF Hub"),
-    hf_hub_dataset_name: Optional[str] = typer.Option(
-        None, "--hf-hub-dataset-name", "-D", help="HF Hub dataset name"
-    ),
-    env_args: Optional[str] = typer.Option(
-        None, "--env-args", "-a", help='Environment args as JSON, e.g. \'{"key":"value"}\''
-    ),
-    api_key_var: Optional[str] = typer.Option(
-        None, "--api-key-var", "-k", help="override api key variable instead of using PRIME_API_KEY"
-    ),
-    api_base_url: Optional[str] = typer.Option(
-        None,
-        "--api-base-url",
-        "-b",
-        help=(
-            "override api base url variable instead of using prime inference url, "
-            "should end in '/v1'"
-        ),
-    ),
-    skip_upload: bool = typer.Option(
-        False,
-        "--skip-upload",
-        help="Skip uploading results to Prime Evals Hub (results are uploaded by default)",
-    ),
-    env_path: Optional[str] = typer.Option(
-        None,
-        "--env-path",
-        help=(
-            "Path to the environment directory "
-            "(used to locate .prime/.env-metadata.json for upstream resolution)"
-        ),
-    ),
+def run_eval(
+    environment: str,
+    model: str,
+    num_examples: Optional[int],
+    rollouts_per_example: Optional[int],
+    max_concurrent: Optional[int],
+    max_tokens: Optional[int],
+    temperature: Optional[float],
+    sampling_args: Optional[str],
+    verbose: bool,
+    save_results: bool,
+    save_every: int,
+    save_to_hf_hub: bool,
+    hf_hub_dataset_name: Optional[str],
+    env_args: Optional[str],
+    api_key_var: Optional[str],
+    api_base_url: Optional[str],
+    skip_upload: bool,
+    env_path: Optional[str],
 ) -> None:
     """
-    Run verifiers' vf-eval with Prime Inference
+    Core implementation for running verifiers' vf-eval with Prime Inference.
 
-    Example:
-       prime env eval meow -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
-       prime env eval primeintellect/gpqa -m openai/gpt-4.1-mini -n 5
-       All extra args are forwarded unchanged to vf-eval.
+    This is the shared implementation used by both `prime eval` and `prime env eval`.
     """
-
     is_slug = (
         "/" in environment and not environment.startswith("./") and not environment.startswith("/")
     )
@@ -2272,3 +2212,113 @@ def eval_env(
             )
     else:
         console.print("[dim]Skipped uploading evaluation results[/dim]")
+
+
+@app.command(
+    "eval",
+    no_args_is_help=True,
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    deprecated=True,
+)
+def eval_env(
+    ctx: typer.Context,
+    environment: str = typer.Argument(
+        ...,
+        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/gpqa')",
+    ),
+    model: str = typer.Option(
+        "openai/gpt-4.1-mini",
+        "--model",
+        "-m",
+        help=(
+            "Model to use (e.g. 'openai/gpt-4.1-mini', 'prime-intellect/intellect-3', "
+            "see 'prime inference models' for available models)"
+        ),
+    ),
+    # --- vf-eval options ---
+    num_examples: Optional[int] = typer.Option(
+        5, "--num-examples", "-n", help="Number of examples"
+    ),
+    rollouts_per_example: Optional[int] = typer.Option(
+        3, "--rollouts-per-example", "-r", help="Rollouts per example"
+    ),
+    max_concurrent: Optional[int] = typer.Option(
+        32, "--max-concurrent", "-c", help="Max concurrent requests"
+    ),
+    max_tokens: Optional[int] = typer.Option(
+        None, "--max-tokens", "-t", help="Max tokens to generate (unset → model default)"
+    ),
+    temperature: Optional[float] = typer.Option(None, "--temperature", "-T", help="Temperature"),
+    sampling_args: Optional[str] = typer.Option(
+        None,
+        "--sampling-args",
+        "-S",
+        help='Sampling args as JSON, e.g. \'{"enable_thinking": false, "max_tokens": 256}\'',
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+    save_results: bool = typer.Option(True, "--save-results", "-s", help="Save results to disk"),
+    save_every: int = typer.Option(1, "--save-every", "-f", help="Save dataset every n rollouts"),
+    save_to_hf_hub: bool = typer.Option(False, "--save-to-hf-hub", "-H", help="Save to HF Hub"),
+    hf_hub_dataset_name: Optional[str] = typer.Option(
+        None, "--hf-hub-dataset-name", "-D", help="HF Hub dataset name"
+    ),
+    env_args: Optional[str] = typer.Option(
+        None, "--env-args", "-a", help='Environment args as JSON, e.g. \'{"key":"value"}\''
+    ),
+    api_key_var: Optional[str] = typer.Option(
+        None, "--api-key-var", "-k", help="override api key variable instead of using PRIME_API_KEY"
+    ),
+    api_base_url: Optional[str] = typer.Option(
+        None,
+        "--api-base-url",
+        "-b",
+        help=(
+            "override api base url variable instead of using prime inference url, "
+            "should end in '/v1'"
+        ),
+    ),
+    skip_upload: bool = typer.Option(
+        False,
+        "--skip-upload",
+        help="Skip uploading results to Prime Evals Hub (results are uploaded by default)",
+    ),
+    env_path: Optional[str] = typer.Option(
+        None,
+        "--env-path",
+        help=(
+            "Path to the environment directory "
+            "(used to locate .prime/.env-metadata.json for upstream resolution)"
+        ),
+    ),
+) -> None:
+    """
+    This command has been moved to `prime eval`. Please use `prime eval` instead.
+
+    Example:
+       prime eval meow -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
+       prime eval primeintellect/gpqa -m openai/gpt-4.1-mini -n 5
+    """
+    console.print(
+        "[yellow]'prime env eval' is deprecated. Please use 'prime eval' instead.[/yellow]\n"
+    )
+
+    run_eval(
+        environment=environment,
+        model=model,
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
+        max_concurrent=max_concurrent,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        sampling_args=sampling_args,
+        verbose=verbose,
+        save_results=save_results,
+        save_every=save_every,
+        save_to_hf_hub=save_to_hf_hub,
+        hf_hub_dataset_name=hf_hub_dataset_name,
+        env_args=env_args,
+        api_key_var=api_key_var,
+        api_base_url=api_base_url,
+        skip_upload=skip_upload,
+        env_path=env_path,
+    )

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -500,6 +500,7 @@ app.add_typer(subcommands_app, name="")
 @app.command(
     "run",
     hidden=True,
+    no_args_is_help=True,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
 def run_eval_cmd(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -24,8 +24,17 @@ class DefaultGroup(TyperGroup):
         self.default_cmd_name = default_cmd_name
 
     def parse_args(self, ctx, args):
-        if args and args[0] not in self.commands and not args[0].startswith("-"):
-            args = [self.default_cmd_name] + list(args)
+        if not args:
+            return super().parse_args(ctx, args)
+
+        if args[0] in ("--help", "-h"):
+            return super().parse_args(ctx, args)
+
+        for arg in args:
+            if not arg.startswith("-") and arg in self.commands:
+                return super().parse_args(ctx, args)
+
+        args = [self.default_cmd_name] + list(args)
         return super().parse_args(ctx, args)
 
     def format_usage(self, ctx, formatter):
@@ -490,7 +499,10 @@ def push_eval(
 
 app = typer.Typer(
     cls=DefaultGroup,
-    help="Run evaluations or manage results (list, get, push, samples)",
+    help=(
+        "Run evaluations or manage results (list, get, push, samples).\n\n"
+        "By default, 'prime eval <environment>' runs 'prime eval run <environment>'."
+    ),
     no_args_is_help=True,
 )
 
@@ -499,7 +511,6 @@ app.add_typer(subcommands_app, name="")
 
 @app.command(
     "run",
-    hidden=True,
     no_args_is_help=True,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -19,14 +19,11 @@ console = Console()
 
 
 class DefaultGroup(TyperGroup):
-    """A TyperGroup that invokes a default command if no subcommand is matched."""
-
     def __init__(self, *args, default_cmd_name: str = "run", **kwargs):
         super().__init__(*args, **kwargs)
         self.default_cmd_name = default_cmd_name
 
     def parse_args(self, ctx, args):
-        # If first arg doesn't match a command, prepend the default command
         if args and args[0] not in self.commands and not args[0].startswith("-"):
             args = [self.default_cmd_name] + list(args)
         return super().parse_args(ctx, args)
@@ -42,8 +39,6 @@ subcommands_app = typer.Typer()
 
 
 def handle_errors(func):
-    """Decorator to handle common errors in eval commands."""
-
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -493,27 +488,25 @@ def push_eval(
         raise typer.Exit(1)
 
 
-# Main app using custom DefaultGroup for `prime eval <env>` support
 app = typer.Typer(
     cls=DefaultGroup,
     help="Run evaluations or manage results (list, get, push, samples)",
     no_args_is_help=True,
 )
 
-# Add subcommands from subcommands_app
 app.add_typer(subcommands_app, name="")
 
 
 @app.command(
     "run",
-    hidden=True,  # Hidden because it's the default - users use `prime eval <env>` directly
+    hidden=True,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
 def run_eval_cmd(
     ctx: typer.Context,
     environment: str = typer.Argument(
         ...,
-        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/gpqa')",
+        help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/wordle')",
     ),
     model: str = typer.Option(
         "openai/gpt-4.1-mini",
@@ -583,7 +576,7 @@ def run_eval_cmd(
     Run verifiers' vf-eval with Prime Inference.
 
     Examples:
-       prime eval primeintellect/gpqa -m openai/gpt-4.1-mini -n 5
+       prime eval primeintellect/wordle -m openai/gpt-4.1-mini -n 5
        prime eval wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
     """
     run_eval(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -30,9 +30,8 @@ class DefaultGroup(TyperGroup):
         if args[0] in ("--help", "-h"):
             return super().parse_args(ctx, args)
 
-        for arg in args:
-            if not arg.startswith("-") and arg in self.commands:
-                return super().parse_args(ctx, args)
+        if args[0] in self.commands:
+            return super().parse_args(ctx, args)
 
         args = [self.default_cmd_name] + list(args)
         return super().parse_args(ctx, args)

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -35,7 +35,7 @@ def push_eval_results_to_hub(
         model: Model identifier (e.g., "openai/gpt-4.1-mini")
         job_id: Unique job ID for tracking
         env_path: Optional path to the environment directory (defaults to current directory)
-        upstream_slug: Optional upstream environment slug (e.g., "primeintellect/gpqa")
+        upstream_slug: Optional upstream environment slug (e.g., "primeintellect/wordle")
                       If provided, bypasses metadata file lookup
     """
     # Step 1: Find the output directory


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies evaluation workflow by making `prime eval run` the default eval command (with shared `run_eval`), deprecating `prime env eval`, restructuring eval subcommands, and bumping version to 0.5.5.
> 
> - **CLI (evals)**:
>   - Introduce `DefaultGroup` so `prime eval <env>` defaults to `prime eval run <env>`.
>   - Add `run` subcommand that delegates to shared `run_eval`.
>   - Restructure commands into `subcommands_app` (`list`, `get`, `samples`, `push`) mounted under main `app`.
>   - Improve usage/help text and examples.
> - **CLI (env)**:
>   - Extract shared `run_eval(...)` implementation.
>   - Re-add `env eval` as a deprecated wrapper calling `run_eval`.
> - **Utils**:
>   - Update doc/help examples (e.g., upstream slug examples) in `eval_push.py`.
> - **Version**: bump `prime_cli` `__version__` to `0.5.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88e7a8777f81239ba665db9a0e76d8458d4e12cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->