### PR TITLE
fix: handle quoted commands in sandbox run + add ls alias

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -116,7 +116,7 @@ def list_sandboxes_cmd(
     all: bool = typer.Option(False, "--all", help="Show all sandboxes including terminated ones"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """List your sandboxes (excludes terminated by default)"""
+    """List your sandboxes (shortcut: ls)"""
     validate_output_format(output, console)
 
     try:

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -722,7 +722,7 @@ def run(
                 env_vars[key] = value
 
         # Join command list into a single string, preserving quoting for arguments with spaces
-        # Handle case where user passes entire command as a single quoted string (e.g., "ls /home")
+        # Handle case where user passes entire command as a quoted string (e.g., "ls /home")
         if len(command) == 1 and " " in command[0]:
             # User passed something like "ls /home" - use it directly as a shell command
             command_str = command[0]

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -721,11 +721,13 @@ def run(
                 key, value = env_var.split("=", 1)
                 env_vars[key] = value
 
-        # Join command list into a single string, preserving quoting for arguments with spaces
         # Handle case where user passes entire command as a quoted string (e.g., "ls /home")
-        if len(command) == 1 and " " in command[0]:
-            # User passed something like "ls /home" - use it directly as a shell command
-            command_str = command[0]
+        # We need to parse it properly to handle both:
+        # - "ls /home" -> should become: ls /home
+        # - "./my script.sh" -> should become: './my script.sh' (properly quoted)
+        if len(command) == 1:
+            # Parse the single string as shell tokens, then re-join properly
+            command_str = shlex.join(shlex.split(command[0]))
         else:
             command_str = shlex.join(command)
 

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -99,6 +99,7 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
 
 
 @app.command("list")
+@app.command("ls", hidden=True)
 def list_sandboxes_cmd(
     team_id: Optional[str] = typer.Option(
         None, help="Filter by team ID (uses config team_id if not specified)"
@@ -913,35 +914,6 @@ def download_file(
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
         console.print_exception(show_locals=True)
         raise typer.Exit(1)
-
-
-@app.command("ls")
-def ls(
-    team_id: Optional[str] = typer.Option(
-        None, help="Filter by team ID (uses config team_id if not specified)"
-    ),
-    status: Optional[str] = typer.Option(None, help="Filter by status"),
-    labels: Optional[List[str]] = typer.Option(
-        None,
-        "--label",
-        "-l",
-        help="Filter by labels (can specify multiple, sandboxes must have ALL)",
-    ),
-    page: int = typer.Option(1, help="Page number"),
-    per_page: int = typer.Option(50, help="Items per page"),
-    all: bool = typer.Option(False, "--all", help="Show all sandboxes including terminated ones"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """List your sandboxes (alias for 'list')"""
-    list_sandboxes_cmd(
-        team_id=team_id,
-        status=status,
-        labels=labels,
-        page=page,
-        per_page=per_page,
-        all=all,
-        output=output,
-    )
 
 
 @app.command("reset-cache")


### PR DESCRIPTION
- Fix `sandbox run` to handle quoted commands like `"ls /home"` (was failing with "command not found")
- Add `sandbox ls` as alias for `sandbox list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Properly parse single-string quoted commands in `sandbox run` and add hidden `ls` alias for `sandbox list`.
> 
> - **CLI** (`packages/prime/src/prime_cli/commands/sandbox.py`):
>   - **`sandbox run`**: Parse single-string commands with `shlex.split` then `shlex.join` to correctly handle quoted inputs (e.g., "ls /home", "./my script.sh").
>   - **`sandbox list`**: Add hidden alias `ls`; update help text to mention shortcut.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc72bbab0acd76bab0b2642e02a865cf9f01e419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->