### PR TITLE
bump: prime to 0.5.4

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI version to 0.5.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `prime_cli` package version to `0.5.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9d7a41314f1e9800cae6e9046c645a428660376. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->