### PR TITLE
feat: Automatic version check

### DIFF
--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 import typer
@@ -73,7 +74,7 @@ def callback(
     if ctx.invoked_subcommand is not None:
         update_available, latest = check_for_update()
         if update_available and latest:
-            console = Console(stderr=True)
+            console = Console(stderr=True, force_terminal=sys.stderr.isatty())
             console.print(
                 f"[yellow]A new version of prime is available: {latest} "
                 f"(installed: {__version__})[/yellow]"

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -1,9 +1,9 @@
-from importlib.metadata import version
 from typing import Optional
 
 import typer
 from rich.console import Console
 
+from . import __version__
 from .commands.availability import app as availability_app
 from .commands.config import app as config_app
 from .commands.disks import app as disks_app
@@ -17,8 +17,6 @@ from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
 from .core import Config
 from .utils.version_check import check_for_update
-
-__version__ = version("prime")
 
 app = typer.Typer(
     name="prime",

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -79,8 +79,9 @@ def callback(
                 f"(installed: {__version__})[/yellow]"
             )
             console.print(
-                "[dim]Run: uv pip install --upgrade prime  or  uv tool upgrade prime[/dim]\n"
+                "[dim]Run: uv pip install --upgrade prime  or  uv tool upgrade prime[/dim]"
             )
+            console.print("[dim]Set PRIME_DISABLE_VERSION_CHECK=1 to disable this check[/dim]\n")
 
 
 def run() -> None:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -2,6 +2,7 @@ from importlib.metadata import version
 from typing import Optional
 
 import typer
+from rich.console import Console
 
 from .commands.availability import app as availability_app
 from .commands.config import app as config_app
@@ -15,6 +16,7 @@ from .commands.sandbox import app as sandbox_app
 from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
 from .core import Config
+from .utils.version_check import check_for_update
 
 __version__ = version("prime")
 
@@ -68,6 +70,19 @@ def callback(
 
         # Set environment variable so Config instances in subcommands pick it up
         os.environ["PRIME_CONTEXT"] = context
+
+    # Check for updates (only when a subcommand is being executed)
+    if ctx.invoked_subcommand is not None:
+        update_available, latest = check_for_update()
+        if update_available and latest:
+            console = Console(stderr=True)
+            console.print(
+                f"[yellow]A new version of prime is available: {latest} "
+                f"(installed: {__version__})[/yellow]"
+            )
+            console.print(
+                "[dim]Run: uv pip install --upgrade prime  or  uv tool upgrade prime[/dim]\n"
+            )
 
 
 def run() -> None:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -78,9 +78,7 @@ def callback(
                 f"[yellow]A new version of prime is available: {latest} "
                 f"(installed: {__version__})[/yellow]"
             )
-            console.print(
-                "[dim]Run: uv pip install --upgrade prime  or  uv tool upgrade prime[/dim]"
-            )
+            console.print("[dim]Run: uv pip install --upgrade prime or uv tool upgrade prime[/dim]")
             console.print("[dim]Set PRIME_DISABLE_VERSION_CHECK=1 to disable this check[/dim]\n")
 
 

--- a/packages/prime/src/prime_cli/utils/version_check.py
+++ b/packages/prime/src/prime_cli/utils/version_check.py
@@ -93,7 +93,14 @@ def get_latest_pypi_version() -> str | None:
         response.raise_for_status()
         data = response.json()
         return data["info"]["version"]
-    except (httpx.RequestError, httpx.HTTPStatusError, KeyError, json.JSONDecodeError):
+    except (
+        httpx.RequestError,
+        httpx.HTTPStatusError,
+        KeyError,
+        TypeError,
+        AttributeError,
+        json.JSONDecodeError,
+    ):
         return None
 
 

--- a/packages/prime/src/prime_cli/utils/version_check.py
+++ b/packages/prime/src/prime_cli/utils/version_check.py
@@ -1,0 +1,92 @@
+import json
+import os
+import time
+from pathlib import Path
+from typing import Tuple
+
+import httpx
+from packaging import version
+
+from prime_cli import __version__
+
+PYPI_URL = "https://pypi.org/pypi/prime/json"
+CACHE_DURATION = 86400
+REQUEST_TIMEOUT = 2.0
+
+
+def _get_cache_file() -> Path:
+    """Get the path to the version check cache file."""
+    cache_dir = Path.home() / ".prime"
+    cache_dir.mkdir(exist_ok=True)
+    return cache_dir / "version_check.json"
+
+
+def _read_cache() -> dict | None:
+    """Read the cached version check data."""
+    cache_file = _get_cache_file()
+    if not cache_file.exists():
+        return None
+    try:
+        data = json.loads(cache_file.read_text())
+        return data
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_cache(latest_version: str) -> None:
+    """Write version check data to cache."""
+    cache_file = _get_cache_file()
+    try:
+        cache_data = {
+            "last_check": time.time(),
+            "latest_version": latest_version,
+        }
+        cache_file.write_text(json.dumps(cache_data))
+    except OSError:
+        pass
+
+
+def _is_cache_valid(cache_data: dict) -> bool:
+    """Check if the cache is still valid (within cache duration)."""
+    last_check = cache_data.get("last_check", 0)
+    return (time.time() - last_check) < CACHE_DURATION
+
+
+def get_latest_pypi_version() -> str | None:
+    """Fetch the latest version from PyPI."""
+    try:
+        response = httpx.get(PYPI_URL, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+        return data["info"]["version"]
+    except (httpx.RequestError, httpx.HTTPStatusError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def check_for_update() -> Tuple[bool, str | None]:
+    """Check if a newer version of prime is available on PyPI."""
+    if os.environ.get("PRIME_DISABLE_VERSION_CHECK", "").lower() in ("1", "true", "yes"):
+        return (False, None)
+
+    try:
+        cache_data = _read_cache()
+        if cache_data and _is_cache_valid(cache_data):
+            latest_version = cache_data.get("latest_version")
+        else:
+            latest_version = get_latest_pypi_version()
+            if latest_version:
+                _write_cache(latest_version)
+
+        if not latest_version:
+            return (False, None)
+
+        installed = version.parse(__version__)
+        latest = version.parse(latest_version)
+
+        if installed < latest:
+            return (True, latest_version)
+
+        return (False, latest_version)
+
+    except Exception:
+        return (False, None)


### PR DESCRIPTION
Closes ENG-2378


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a cached, throttled PyPI version check that notifies users on subcommand execution if an update is available.
> 
> - **CLI**:
>   - Integrates `check_for_update()` in `prime_cli/main.py` to run on subcommand execution and print update notices to stderr via `rich` (includes upgrade instructions and respects `PRIME_DISABLE_VERSION_CHECK`).
> - **Utilities**:
>   - Adds `prime_cli/utils/version_check.py` to fetch latest version from PyPI, cache results in `~/.prime/version_check.json` (24h TTL), throttle notifications (6h), use 2s request timeout, and compare using `packaging.version` with resilient error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5ed445931f53928bccdc238e97004a2b61ad215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->