### PR TITLE
Add retry logic for transient httpx connection errors

### DIFF
--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -37,6 +37,7 @@ Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
 dev = [
     "pytest>=7.0.0",
     "pytest-xdist>=3.0.0",
+    "pytest-asyncio>=0.23.0",
     "ruff>=0.13.1",
 ]
 

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "aiofiles>=23.0.0",
+    "tenacity>=8.0.0",
 ]
 keywords = ["sandboxes", "remote-execution", "containers", "cloud", "sdk"]
 classifiers = [

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -39,7 +39,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, SandboxClient
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -15,7 +15,13 @@ from .config import Config
 
 # Retry configuration for transient connection errors
 # These errors occur when the server closes idle connections in the pool
-RETRYABLE_EXCEPTIONS = (httpx.RemoteProtocolError, httpx.ConnectError)
+# or when we fail to establish/maintain a connection
+RETRYABLE_EXCEPTIONS = (
+    httpx.RemoteProtocolError,  # Server disconnected unexpectedly
+    httpx.ConnectError,  # Connection refused/failed
+    httpx.PoolTimeout,  # No connection available in pool
+    httpx.ReadTimeout,  # Server took too long to send response
+)
 
 
 def _default_user_agent() -> str:

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -16,11 +16,11 @@ from .config import Config
 # Retry configuration for transient connection errors
 # These errors occur when the server closes idle connections in the pool
 # or when we fail to establish/maintain a connection
+# Note: ReadTimeout is NOT included because the request may have been processed
 RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
-    httpx.ReadTimeout,  # Server took too long to send response
 )
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -4,8 +4,18 @@ import sys
 from typing import Any, Dict, Optional
 
 import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from .config import Config
+
+# Retry configuration for transient connection errors
+# These errors occur when the server closes idle connections in the pool
+RETRYABLE_EXCEPTIONS = (httpx.RemoteProtocolError, httpx.ConnectError)
 
 
 def _default_user_agent() -> str:
@@ -69,6 +79,23 @@ class APIClient:
                 "No API key configured. Set PRIME_API_KEY environment variable.",
             )
 
+    @retry(
+        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make HTTP request with retry on transient connection errors."""
+        return self.client.request(method, url, params=params, json=json, timeout=timeout)
+
     def request(
         self,
         method: str,
@@ -88,7 +115,9 @@ class APIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            response = self.client.request(method, url, params=params, json=json, timeout=timeout)
+            response = self._request_with_retry(
+                method, url, params=params, json=json, timeout=timeout
+            )
             response.raise_for_status()
 
             result = response.json()
@@ -161,6 +190,23 @@ class AsyncAPIClient:
                 "No API key configured. Set PRIME_API_KEY environment variable.",
             )
 
+    @retry(
+        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    async def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make async HTTP request with retry on transient connection errors."""
+        return await self.client.request(method, url, params=params, json=json, timeout=timeout)
+
     async def request(
         self,
         method: str,
@@ -180,7 +226,7 @@ class AsyncAPIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            response = await self.client.request(
+            response = await self._request_with_retry(
                 method, url, params=params, json=json, timeout=timeout
             )
             response.raise_for_status()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -232,6 +232,32 @@ class SandboxClient:
             self.client,
         )
 
+    @staticmethod
+    @_gateway_retry
+    def _gateway_post(
+        url: str,
+        headers: Dict[str, str],
+        timeout: float,
+        json: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> httpx.Response:
+        """Make a POST request to the gateway with retry on transient errors."""
+        with httpx.Client(timeout=timeout) as client:
+            return client.post(url, json=json, files=files, params=params, headers=headers)
+
+    @staticmethod
+    @_gateway_retry
+    def _gateway_get(
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        timeout: float,
+    ) -> httpx.Response:
+        """Make a GET request to the gateway with retry on transient errors."""
+        with httpx.Client(timeout=timeout) as client:
+            return client.get(url, params=params, headers=headers)
+
     def _is_sandbox_reachable(self, sandbox_id: str, timeout: int = 10) -> bool:
         """Test if a sandbox is reachable by executing a simple echo command"""
         try:
@@ -339,14 +365,11 @@ class SandboxClient:
 
         try:
             client_timeout = effective_timeout + 2
-            with httpx.Client(timeout=client_timeout) as client:
-                response = client.post(
-                    url,
-                    json=payload,
-                    headers=headers,
-                )
-                response.raise_for_status()
-                return CommandResponse.model_validate(response.json())
+            response = self._gateway_post(
+                url, headers=headers, timeout=client_timeout, json=payload
+            )
+            response.raise_for_status()
+            return CommandResponse.model_validate(response.json())
         except httpx.TimeoutException as e:
             raise CommandTimeoutError(sandbox_id, command, effective_timeout) from e
         except httpx.HTTPStatusError as e:
@@ -572,29 +595,31 @@ class SandboxClient:
         effective_timeout = timeout if timeout is not None else 300
 
         with open(local_file_path, "rb") as f:
-            files = {"file": (os.path.basename(local_file_path), f)}
-            params = {"path": file_path, "sandbox_id": sandbox_id}
+            file_content = f.read()
 
-            try:
-                with httpx.Client(timeout=effective_timeout) as client:
-                    response = client.post(url, files=files, params=params, headers=headers)
-                    response.raise_for_status()
-                    return FileUploadResponse.model_validate(response.json())
-            except httpx.TimeoutException as e:
-                raise UploadTimeoutError(sandbox_id, file_path, effective_timeout) from e
-            except httpx.HTTPStatusError as e:
-                error_details = (
-                    f"HTTP {e.response.status_code} {e.request.method} "
-                    f"{e.request.url}: {e.response.text}"
-                )
-                raise APIError(f"Upload failed: {error_details}") from e
-            except httpx.RequestError as e:
-                req = getattr(e, "request", None)
-                method = getattr(req, "method", "?")
-                u = getattr(req, "url", "?")
-                raise APIError(f"Upload failed: {e.__class__.__name__} at {method} {u}: {e}") from e
-            except Exception as e:
-                raise APIError(f"Upload failed: {e.__class__.__name__}: {e}") from e
+        try:
+            files = {"file": (os.path.basename(local_file_path), file_content)}
+            params = {"path": file_path, "sandbox_id": sandbox_id}
+            response = self._gateway_post(
+                url, headers=headers, timeout=effective_timeout, files=files, params=params
+            )
+            response.raise_for_status()
+            return FileUploadResponse.model_validate(response.json())
+        except httpx.TimeoutException as e:
+            raise UploadTimeoutError(sandbox_id, file_path, effective_timeout) from e
+        except httpx.HTTPStatusError as e:
+            error_details = (
+                f"HTTP {e.response.status_code} {e.request.method} "
+                f"{e.request.url}: {e.response.text}"
+            )
+            raise APIError(f"Upload failed: {error_details}") from e
+        except httpx.RequestError as e:
+            req = getattr(e, "request", None)
+            method = getattr(req, "method", "?")
+            u = getattr(req, "url", "?")
+            raise APIError(f"Upload failed: {e.__class__.__name__} at {method} {u}: {e}") from e
+        except Exception as e:
+            raise APIError(f"Upload failed: {e.__class__.__name__}: {e}") from e
 
     def upload_bytes(
         self,
@@ -624,10 +649,11 @@ class SandboxClient:
         params = {"path": file_path, "sandbox_id": sandbox_id}
 
         try:
-            with httpx.Client(timeout=effective_timeout) as client:
-                response = client.post(url, files=files, params=params, headers=headers)
-                response.raise_for_status()
-                return FileUploadResponse.model_validate(response.json())
+            response = self._gateway_post(
+                url, headers=headers, timeout=effective_timeout, files=files, params=params
+            )
+            response.raise_for_status()
+            return FileUploadResponse.model_validate(response.json())
         except httpx.TimeoutException:
             raise UploadTimeoutError(sandbox_id, file_path, effective_timeout)
         except httpx.HTTPStatusError as e:
@@ -653,16 +679,17 @@ class SandboxClient:
         effective_timeout = timeout if timeout is not None else 300
 
         try:
-            with httpx.Client(timeout=effective_timeout) as client:
-                response = client.get(url, params=params, headers=headers)
-                response.raise_for_status()
+            response = self._gateway_get(
+                url, headers=headers, params=params, timeout=effective_timeout
+            )
+            response.raise_for_status()
 
-                dir_path = os.path.dirname(local_file_path)
-                if dir_path:
-                    os.makedirs(dir_path, exist_ok=True)
+            dir_path = os.path.dirname(local_file_path)
+            if dir_path:
+                os.makedirs(dir_path, exist_ok=True)
 
-                with open(local_file_path, "wb") as f:
-                    f.write(response.content)
+            with open(local_file_path, "wb") as f:
+                f.write(response.content)
         except httpx.TimeoutException as e:
             raise DownloadTimeoutError(sandbox_id, file_path, effective_timeout) from e
         except httpx.HTTPStatusError as e:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -44,11 +44,11 @@ from .models import (
 )
 
 # Retry configuration for transient connection errors on gateway requests
+# Note: ReadTimeout is NOT included because the request may have been processed
 GATEWAY_RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
-    httpx.ReadTimeout,  # Server took too long to send response
 )
 
 # Retry decorator for gateway requests

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -166,20 +166,20 @@ class TestSyncGatewayRetry:
         assert result == "success"
         assert call_count == 2
 
-    def test_gateway_retry_on_read_timeout(self):
-        """Test retry on ReadTimeout."""
+    def test_gateway_retry_on_connect_error(self):
+        """Test retry on ConnectError."""
         from prime_sandboxes.sandbox import _gateway_retry
 
         call_count = 0
 
         @_gateway_retry
-        def read_timeout_then_succeed():
+        def connect_error_then_succeed():
             nonlocal call_count
             call_count += 1
             if call_count < 2:
-                raise httpx.ReadTimeout("Read timed out")
+                raise httpx.ConnectError("Connection refused")
             return "success"
 
-        result = read_timeout_then_succeed()
+        result = connect_error_then_succeed()
         assert result == "success"
         assert call_count == 2

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -1,0 +1,55 @@
+"""Tests for retry logic on transient connection errors."""
+
+import httpx
+import pytest
+
+from prime_sandboxes.core.client import APIClient, APIError
+
+
+class FailThenSucceedTransport(httpx.BaseTransport):
+    """Transport that fails N times then succeeds."""
+
+    def __init__(self, fail_times: int = 2):
+        self.fail_times = fail_times
+        self.call_count = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count <= self.fail_times:
+            raise httpx.RemoteProtocolError("Server disconnected")
+        return httpx.Response(200, json={"success": True})
+
+
+class AlwaysFailTransport(httpx.BaseTransport):
+    """Transport that always fails."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        raise httpx.RemoteProtocolError("Server disconnected")
+
+
+class TestClientRetry:
+    def test_retries_and_succeeds(self):
+        """Retries on RemoteProtocolError, succeeds on 3rd attempt."""
+        transport = FailThenSucceedTransport(fail_times=2)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        result = client.request("GET", "test")
+
+        assert result == {"success": True}
+        assert transport.call_count == 3
+
+    def test_gives_up_after_max_retries(self):
+        """Raises after 3 failed attempts."""
+        transport = AlwaysFailTransport()
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match="RemoteProtocolError"):
+            client.request("GET", "test")
+
+        assert transport.call_count == 3

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from prime_sandboxes.core.client import APIClient, APIError
+from prime_sandboxes.core.client import APIClient, APIError, AsyncAPIClient
 
 
 class FailThenSucceedTransport(httpx.BaseTransport):
@@ -31,7 +31,34 @@ class AlwaysFailTransport(httpx.BaseTransport):
         raise httpx.RemoteProtocolError("Server disconnected")
 
 
-class TestClientRetry:
+class AsyncFailThenSucceedTransport(httpx.AsyncBaseTransport):
+    """Async transport that fails N times then succeeds."""
+
+    def __init__(self, fail_times: int = 2):
+        self.fail_times = fail_times
+        self.call_count = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count <= self.fail_times:
+            raise httpx.RemoteProtocolError("Server disconnected")
+        return httpx.Response(200, json={"success": True})
+
+
+class AsyncAlwaysFailTransport(httpx.AsyncBaseTransport):
+    """Async transport that always fails."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        raise httpx.RemoteProtocolError("Server disconnected")
+
+
+class TestSyncAPIClientRetry:
+    """Tests for sync APIClient retry behavior."""
+
     def test_retries_and_succeeds(self):
         """Retries on RemoteProtocolError, succeeds on 3rd attempt."""
         transport = FailThenSucceedTransport(fail_times=2)
@@ -53,3 +80,106 @@ class TestClientRetry:
             client.request("GET", "test")
 
         assert transport.call_count == 3
+
+
+class TestAsyncAPIClientRetry:
+    """Tests for async AsyncAPIClient retry behavior."""
+
+    @pytest.mark.asyncio
+    async def test_retries_and_succeeds(self):
+        """Retries on RemoteProtocolError, succeeds on 3rd attempt."""
+        transport = AsyncFailThenSucceedTransport(fail_times=2)
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        result = await client.request("GET", "test")
+
+        assert result == {"success": True}
+        assert transport.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_retries(self):
+        """Raises after 3 failed attempts."""
+        transport = AsyncAlwaysFailTransport()
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        with pytest.raises(APIError, match="RemoteProtocolError"):
+            await client.request("GET", "test")
+
+        assert transport.call_count == 3
+
+
+class TestSyncGatewayRetry:
+    """Tests for sync SandboxClient gateway retry behavior."""
+
+    def test_gateway_retry_decorator_works(self):
+        """Test the _gateway_retry decorator directly."""
+        from prime_sandboxes.sandbox import _gateway_retry
+
+        call_count = 0
+
+        @_gateway_retry
+        def flaky_function():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise httpx.RemoteProtocolError("Server disconnected")
+            return "success"
+
+        result = flaky_function()
+        assert result == "success"
+        assert call_count == 3
+
+    def test_gateway_retry_gives_up(self):
+        """Test the _gateway_retry decorator gives up after max retries."""
+        from prime_sandboxes.sandbox import _gateway_retry
+
+        call_count = 0
+
+        @_gateway_retry
+        def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise httpx.RemoteProtocolError("Server disconnected")
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            always_fail()
+
+        assert call_count == 3
+
+    def test_gateway_retry_on_pool_timeout(self):
+        """Test retry on PoolTimeout."""
+        from prime_sandboxes.sandbox import _gateway_retry
+
+        call_count = 0
+
+        @_gateway_retry
+        def pool_timeout_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise httpx.PoolTimeout("No connections available")
+            return "success"
+
+        result = pool_timeout_then_succeed()
+        assert result == "success"
+        assert call_count == 2
+
+    def test_gateway_retry_on_read_timeout(self):
+        """Test retry on ReadTimeout."""
+        from prime_sandboxes.sandbox import _gateway_retry
+
+        call_count = 0
+
+        @_gateway_retry
+        def read_timeout_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise httpx.ReadTimeout("Read timed out")
+            return "success"
+
+        result = read_timeout_then_succeed()
+        assert result == "success"
+        assert call_count == 2


### PR DESCRIPTION
Fixes intermittent `RemoteProtocolError: Server disconnected without sending a response` errors.

- Added tenacity for retry with exponential backoff
- Retries `RemoteProtocolError` and `ConnectError` up to 3 times
- Applies to both sync and async clients

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tenacity-based retries for transient httpx connection errors across sync/async API and gateway operations, with tests, refactors, and version/deps updates.
> 
> - **Core HTTP Client (`core/client.py`)**:
>   - Add tenacity-based retry (`_request_with_retry`) for sync/async requests on `httpx.RemoteProtocolError`, `httpx.ConnectError`, and `httpx.PoolTimeout` with exponential backoff.
>   - Route `request()` through the retry helpers.
> - **Sandbox Gateway (`sandbox.py`)**:
>   - Introduce `_gateway_retry` decorator and wrapper methods (`_gateway_post`, `_gateway_get`) for sync/async paths; refactor `execute_command`, `upload_file`/`upload_bytes`, and `download_file` to use them.
>   - Minor I/O adjustments (read file content then POST; ensure directory creation before writes); retain async gateway client pooling.
> - **Tests (`tests/test_client_retry.py`)**:
>   - Add unit tests covering sync/async API client retries and gateway retry decorator behavior (including failure limits and specific exceptions).
> - **Packaging/Version**:
>   - Add dependencies `tenacity` and `pytest-asyncio`; bump `__version__` to `0.2.7` in `__init__.py` and update `pyproject.toml` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943c7041ee00836c670aa5d5a7a807239fbf5d09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->