### PR TITLE
test: add tests for float disk_size_gb

### DIFF
--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -55,4 +55,48 @@ def test_sandbox_model_with_alias():
     assert sandbox.name == "test-sandbox"
     assert sandbox.cpu_cores == 2
     assert sandbox.memory_gb == 4
+    assert sandbox.disk_size_gb == 10
     assert sandbox.status == "RUNNING"
+
+
+def test_create_sandbox_request_float_disk_size():
+    """Test that disk_size_gb accepts float values"""
+    request = CreateSandboxRequest(
+        name="test-sandbox",
+        docker_image="python:3.11-slim",
+        disk_size_gb=0.5,
+    )
+    assert request.disk_size_gb == 0.5
+
+
+def test_create_sandbox_request_fractional_disk_sizes():
+    """Test various fractional disk size values"""
+    for size in [0.5, 1.5, 2.25, 10.5]:
+        request = CreateSandboxRequest(
+            name="test-sandbox",
+            docker_image="python:3.11-slim",
+            disk_size_gb=size,
+        )
+        assert request.disk_size_gb == size
+
+
+def test_sandbox_model_float_disk_size():
+    """Test Sandbox model handles float diskSizeGB from API"""
+    data = {
+        "id": "test-123",
+        "name": "test-sandbox",
+        "dockerImage": "python:3.11-slim",
+        "cpuCores": 2,
+        "memoryGB": 4,
+        "diskSizeGB": 0.5,
+        "diskMountPath": "/workspace",
+        "gpuCount": 0,
+        "status": "RUNNING",
+        "timeoutMinutes": 120,
+        "labels": ["test"],
+        "createdAt": "2024-01-01T00:00:00Z",
+        "updatedAt": "2024-01-01T00:00:00Z",
+    }
+
+    sandbox = Sandbox.model_validate(data)
+    assert sandbox.disk_size_gb == 0.5


### PR DESCRIPTION
adds unit tests for float disk_size_gb support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add tests to verify fractional disk_size_gb handling in CreateSandboxRequest and Sandbox models, and extend alias test to assert disk_size parsing.
> 
> - **Tests**:
>   - Add unit tests in `packages/prime-sandboxes/tests/test_models.py` to validate fractional `disk_size_gb` in `CreateSandboxRequest` and `Sandbox` (via `diskSizeGB` alias), including multiple fractional values.
>   - Update existing alias-handling test to assert `disk_size_gb` is correctly parsed from `diskSizeGB`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e955db26f17604066a1c4fde18cd750ed21830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->