### PR TITLE
feat: Add automatic update notification

### DIFF
--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -2,6 +2,7 @@ from importlib.metadata import version
 from typing import Optional
 
 import typer
+from rich.console import Console
 
 from .commands.availability import app as availability_app
 from .commands.config import app as config_app
@@ -15,6 +16,7 @@ from .commands.sandbox import app as sandbox_app
 from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
 from .core import Config
+from .utils.version_check import check_for_update
 
 __version__ = version("prime")
 
@@ -72,6 +74,13 @@ def callback(
 
 def run() -> None:
     """Entry point for the CLI"""
+    # Check for updates or skip if cached
+    if latest_version := check_for_update(__version__):
+        Console(stderr=True).print(
+            f"[bold yellow]Update available:[/bold yellow] {__version__} → {latest_version}\n"
+            f"Run: [bold cyan]uv tool upgrade prime[/bold cyan]\n"
+        )
+
     try:
         app()
     except typer.Abort:

--- a/packages/prime/src/prime_cli/utils/version_check.py
+++ b/packages/prime/src/prime_cli/utils/version_check.py
@@ -1,0 +1,72 @@
+"""Version check utilities for update notifications."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+import httpx
+
+CACHE_PATH = Path.home() / ".prime" / "version_cache.json"
+CACHE_TTL = 3600  # 1 hour
+PYPI_URL = "https://pypi.org/pypi/prime/json"
+
+
+def _is_prerelease(v: str) -> bool:
+    return any(tag in v.lower() for tag in ("a", "b", "rc", "dev", "alpha", "beta"))
+
+
+def _parse_version(v: str) -> Tuple[int, ...]:
+    base = v.split("a")[0].split("b")[0].split("rc")[0].split(".dev")[0]
+    parts = tuple(int(p) for p in base.split(".") if p.isdigit()) or (0,)
+    # Append 0 for prerelease, 1 for stable so 0.6.0 > 0.6.0a1
+    return parts + (0 if _is_prerelease(v) else 1,)
+
+
+def _get_latest_stable(releases: dict) -> Optional[str]:
+    stable = [v for v in releases.keys() if not _is_prerelease(v)]
+    if not stable:
+        return None
+    return max(stable, key=_parse_version)
+
+
+def check_for_update(current_version: str) -> Optional[str]:
+    if os.environ.get("PRIME_NO_UPDATE_NOTIFIER") or not sys.stderr.isatty():
+        return None
+
+    # Check cache
+    latest = None
+    should_fetch = True
+    if CACHE_PATH.exists():
+        try:
+            cache = json.loads(CACHE_PATH.read_text())
+            if time.time() - cache.get("checked_at", 0) < CACHE_TTL:
+                latest = cache.get("latest_version")
+                should_fetch = False
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Fetch from PyPI if needed
+    if should_fetch:
+        try:
+            resp = httpx.get(PYPI_URL, timeout=3.0, follow_redirects=True)
+            resp.raise_for_status()
+            latest = _get_latest_stable(resp.json().get("releases", {}))
+        except (httpx.HTTPError, json.JSONDecodeError, KeyError):
+            return None
+        if latest:
+            try:
+                CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+                CACHE_PATH.write_text(json.dumps({
+                    "checked_at": time.time(),
+                    "latest_version": latest,
+                }))
+            except OSError:
+                pass
+
+    # Compare versions
+    if latest and _parse_version(latest) > _parse_version(current_version):
+        return latest
+    return None

--- a/packages/prime/tests/test_version_check.py
+++ b/packages/prime/tests/test_version_check.py
@@ -1,0 +1,53 @@
+"""Tests for version check functionality."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from prime_cli.utils.version_check import _get_latest_stable, check_for_update
+
+MOCK_TTY = patch("sys.stderr.isatty", return_value=True)
+
+
+class TestGetLatestStable:
+    def test_finds_latest_stable_ignoring_prereleases(self) -> None:
+        releases = {"0.5.0": [], "0.5.5": [], "0.6.0a1": [], "0.5.6": []}
+        assert _get_latest_stable(releases) == "0.5.6"
+
+
+class TestCheckForUpdate:
+    def test_returns_none_when_disabled(self) -> None:
+        with patch.dict("os.environ", {"PRIME_NO_UPDATE_NOTIFIER": "1"}):
+            assert check_for_update("0.5.5") is None
+
+    def test_uses_cache_when_fresh(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / "version_cache.json"
+        cache_file.write_text(json.dumps({
+            "checked_at": time.time(),
+            "latest_version": "0.6.0",
+        }))
+        with (
+            MOCK_TTY,
+            patch("prime_cli.utils.version_check.CACHE_PATH", cache_file),
+            patch("httpx.get") as mock_get,
+        ):
+            assert check_for_update("0.5.5") == "0.6.0"
+            mock_get.assert_not_called()
+
+    def test_fetches_when_cache_expired(self, tmp_path: Path) -> None:
+        cache_file = tmp_path / "version_cache.json"
+        cache_file.write_text(json.dumps({
+            "checked_at": time.time() - 7200,
+            "latest_version": "0.6.0",
+        }))
+        mock_resp = type("Response", (), {
+            "raise_for_status": lambda self: None,
+            "json": lambda self: {"releases": {"0.5.5": [], "0.7.0": []}}
+        })()
+        with (
+            MOCK_TTY,
+            patch("prime_cli.utils.version_check.CACHE_PATH", cache_file),
+            patch("httpx.get", return_value=mock_resp),
+        ):
+            assert check_for_update("0.5.5") == "0.7.0"


### PR DESCRIPTION
## Summary
- Warns users when a newer stable version is available on PyPI
- Caches result for 1 hour to avoid repeated network calls
- Skips check if `PRIME_NO_UPDATE_NOTIFIER` is set or not running in TTY

## Test plan
- [x] Unit tests for version parsing, cache usage, and expiry
- [x] Manual testing of cache creation and reuse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CLI update notification that checks PyPI for newer stable versions with a 1-hour cache and opt-out when not TTY or env-var is set.
> 
> - **CLI**:
>   - On startup, `run()` calls `check_for_update(__version__)` and prints a styled message via `rich.Console` when a newer version is available, including an `uv tool upgrade prime` hint.
>   - Skips notification when not attached to a TTY or when `PRIME_NO_UPDATE_NOTIFIER` is set.
> - **Utilities** (`packages/prime/src/prime_cli/utils/version_check.py`):
>   - New `check_for_update` with 1-hour JSON cache at `~/.prime/version_cache.json`; fetches `https://pypi.org/pypi/prime/json` via `httpx`.
>   - Ignores prereleases and compares versions using `_parse_version`; returns latest stable when newer than current.
> - **Tests** (`packages/prime/tests/test_version_check.py`):
>   - Unit tests for latest stable selection, cache hit (no network), and expired cache refetching; includes opt-out test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee39498110730030abe9b1b8b04a0bba1e2b0c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->