### PR TITLE
Add team details to whoami output

### DIFF
--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -42,7 +42,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
             )
             console.print(f"  [cyan]({idx})[/cyan] {team.get('name', 'Unknown')} {role_badge}")
 
-        console.print("\n[dim]You can always change this with 'prime config set-team-id'[/dim]")
+        console.print("\n[dim]You can always change this by running 'prime login' again.[/dim]")
 
         while True:
             try:
@@ -58,6 +58,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                     selected_team = teams[selection - 2]
                     team_id = selected_team.get("teamId")
                     team_name = selected_team.get("name", "Unknown")
+                    team_role = selected_team.get("role", "member")
 
                     if not team_id:
                         console.print("[yellow]Invalid team. Using personal account.[/yellow]")
@@ -65,7 +66,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                         config.update_current_environment_file()
                         return
 
-                    config.set_team(team_id, team_name=team_name)
+                    config.set_team(team_id, team_name=team_name, team_role=team_role)
                     config.update_current_environment_file()
                     console.print(f"[green]Using team '{team_name}'.[/green]")
                     return

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -35,14 +35,31 @@ def whoami() -> None:
             config.set_user_id(user_id)
             config.update_current_environment_file()
 
-        # Display user info table
-        table = Table(title="Current User")
+        # Display account info table
+        table = Table(title="Account")
         table.add_column("Field", style="cyan")
         table.add_column("Value", style="green")
+
+        # Account type (Team or Personal) - shown first
+        if config.team_id:
+            table.add_row("Type", "[yellow]Team[/yellow]")
+            table.add_section()
+            table.add_row("Team ID", config.team_id)
+            table.add_row("Team Name", config.team_name or "[dim]Unknown[/dim]")
+            if config.team_role:
+                table.add_row("Role", config.team_role)
+        else:
+            table.add_row("Type", "Personal")
+
+        # Add section divider between account and user details
+        table.add_section()
+
+        # User details
         table.add_row("User ID", user_id or "Unknown")
         table.add_row("Username", slug or "[dim]Not set[/dim]")
         table.add_row("Name", name or "Unknown")
         table.add_row("Email", email or "Unknown")
+
         console.print(table)
 
         # Display permissions table

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -42,7 +42,7 @@ def whoami() -> None:
 
         # Account type (Team or Personal) - shown first
         if config.team_id:
-            table.add_row("Type", "[yellow]Team[/yellow]")
+            table.add_row("Type", "Team")
             table.add_section()
             table.add_row("Team ID", config.team_id)
             table.add_row("Team Name", config.team_name or "[dim]Unknown[/dim]")

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -11,6 +11,7 @@ class ConfigModel(BaseModel):
     api_key: str = ""
     team_id: str | None = None
     team_name: str | None = None
+    team_role: str | None = None
     user_id: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
@@ -100,10 +101,18 @@ class Config:
         """Get team name from config file (only valid if team_id not from env)."""
         return self.config.get("team_name") or None
 
-    def set_team(self, value: str | None, team_name: str | None = None) -> None:
-        """Set team ID and name in config file."""
+    @property
+    def team_role(self) -> Optional[str]:
+        """Get team role from config file (only valid if team_id not from env)."""
+        return self.config.get("team_role") or None
+
+    def set_team(
+        self, value: str | None, team_name: str | None = None, team_role: str | None = None
+    ) -> None:
+        """Set team ID, name, and role in config file."""
         self.config["team_id"] = value or None
         self.config["team_name"] = team_name if value else None
+        self.config["team_role"] = team_role if value else None
         self._save_config(self.config)
 
     @property
@@ -204,6 +213,7 @@ class Config:
             "api_key": self.api_key,
             "team_id": self.team_id,
             "team_name": self.team_name,
+            "team_role": self.team_role,
             "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
@@ -223,6 +233,7 @@ class Config:
             "api_key": self.api_key,
             "team_id": self.team_id,
             "team_name": None if self.team_id_from_env else self.team_name,
+            "team_role": None if self.team_id_from_env else self.team_role,
             "user_id": self.user_id,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
@@ -254,6 +265,7 @@ class Config:
                 self.config["inference_url"] = self.DEFAULT_INFERENCE_URL
                 self.config["team_id"] = None
                 self.config["team_name"] = None
+                self.config["team_role"] = None
                 self.config["current_environment"] = "production"
             return True
 
@@ -269,10 +281,11 @@ class Config:
                 if persist:
                     if "api_key" in env_config:
                         self.set_api_key(env_config["api_key"])
-                    # Set team_id and team_name from environment
+                    # Set team_id, team_name, and team_role from environment
                     self.set_team(
                         env_config.get("team_id", None),
                         team_name=env_config.get("team_name", None),
+                        team_role=env_config.get("team_role", None),
                     )
                     # Set user_id from environment
                     self.set_user_id(env_config.get("user_id", None))
@@ -288,6 +301,7 @@ class Config:
                         self.config["api_key"] = env_config["api_key"]
                     self.config["team_id"] = env_config.get("team_id", None)
                     self.config["team_name"] = env_config.get("team_name", None)
+                    self.config["team_role"] = env_config.get("team_role", None)
                     self.config["user_id"] = env_config.get("user_id", None)
                     # Normalize URLs the same way set_* methods do
                     base_url = env_config.get("base_url", self.DEFAULT_BASE_URL)
@@ -315,6 +329,7 @@ class Config:
                         "api_key": self.api_key,
                         "team_id": self.team_id,
                         "team_name": None if self.team_id_from_env else self.team_name,
+                        "team_role": None if self.team_id_from_env else self.team_role,
                         "user_id": self.user_id,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,


### PR DESCRIPTION
#### User Account
<img width="291" height="366" alt="Screenshot 2025-12-22 at 8 26 18 PM" src="https://github.com/user-attachments/assets/4528dd89-5821-4c6d-a60a-a21de300963e" />

#### Team Account
<img width="298" height="424" alt="Screenshot 2025-12-22 at 8 27 27 PM" src="https://github.com/user-attachments/assets/6768f8e7-3e85-41a6-886d-8b36967694e1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances account context across the CLI and improves `whoami` output.
> 
> - Adds `team_role` to `ConfigModel` and `Config` with getter, `set_team(...)`, and inclusion in `view()`
> - Persists `team_role` in environment files: save, load (persist and in-memory), production reset, and `update_current_environment_file`
> - `login.py`: when selecting a team, capture `role` from API and store via `config.set_team(team_id, team_name, team_role)`; updates hint text to re-run `prime login` to change selection
> - `whoami.py`: replaces "Current User" table with "Account" view showing Personal vs Team (ID, Name, Role when applicable), followed by user details and existing token permissions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 353017f0264c51407af1efa29682b9a50e3bab30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->