### PR TITLE
Fix: Update eval sample field

### DIFF
--- a/packages/prime-evals/README.md
+++ b/packages/prime-evals/README.md
@@ -154,7 +154,7 @@ samples_batch = [
         "completion": [
             {"role": "assistant", "content": f"The answer is {i * 2}."}
         ],
-        "metadata": {"batch": 1}
+        "info": {"batch": 1}
     }
     for i in range(10)
 ]

--- a/packages/prime-evals/src/prime_evals/models.py
+++ b/packages/prime-evals/src/prime_evals/models.py
@@ -83,7 +83,7 @@ class Sample(BaseModel):
     correct: Optional[bool] = None
     format_reward: Optional[float] = Field(None, alias="formatReward")
     correctness: Optional[float] = None
-    metadata: Optional[Dict[str, Any]] = None
+    info: Optional[Dict[str, Any]] = None
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/packages/prime-evals/tests/test_evals.py
+++ b/packages/prime-evals/tests/test_evals.py
@@ -111,7 +111,7 @@ def test_sample_model_with_metadata():
         "reward": 1.0,
         "answer": "18",
         "custom_field": "custom_value",  # Extra field should be allowed
-        "metadata": {"batch": 1},
+        "info": {"batch": 1},
     }
 
     sample = Sample.model_validate(data)
@@ -119,7 +119,7 @@ def test_sample_model_with_metadata():
     assert sample.example_id == 0
     assert sample.task == "gsm8k"
     assert sample.reward == 1.0
-    assert sample.metadata == {"batch": 1}
+    assert sample.info == {"batch": 1}
 
 
 def test_evals_client_context_manager():


### PR DESCRIPTION
Closes ENG-2399

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Change overview**
> 
> - Rename `Sample` model field `metadata` to `info` in `models.py` (extra fields still allowed via `extra="allow"`).
> - Update README examples to use `info` when pushing samples.
> - Adjust tests to validate `info` instead of `metadata`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc42f60a8dcb43fb4e391456825b8ae0bfd5ec32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->