### PR TITLE
fix: add --upgrade flag to env install

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1921,6 +1921,7 @@ def _build_install_command(
                     "uv",
                     "pip",
                     "install",
+                    "--upgrade",
                     f"{normalized_name}=={version}",
                     "--extra-index-url",
                     simple_index_url,
@@ -1929,6 +1930,7 @@ def _build_install_command(
                 "uv",
                 "pip",
                 "install",
+                "--upgrade",
                 normalized_name,
                 "--extra-index-url",
                 simple_index_url,
@@ -1938,6 +1940,7 @@ def _build_install_command(
                 return [
                     "pip",
                     "install",
+                    "--upgrade",
                     f"{normalized_name}=={version}",
                     "--extra-index-url",
                     simple_index_url,
@@ -1945,6 +1948,7 @@ def _build_install_command(
             return [
                 "pip",
                 "install",
+                "--upgrade",
                 normalized_name,
                 "--extra-index-url",
                 simple_index_url,

--- a/uv.lock
+++ b/uv.lock
@@ -1709,11 +1709,13 @@ dependencies = [
     { name = "aiofiles" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -1724,8 +1726,10 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
+    { name = "tenacity", specifier = ">=8.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -2479,6 +2483,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds missing --upgrade flag to simple index URL install commands, making behavior consistent with wheel URL path. Without this, prime env install owner/env wouldn't upgrade if an older version was already installed.

|         | Before (main)                         | After (fix)                       |
|---------|---------------------------------------|-----------------------------------|
| Command | uv pip install meow ...               | uv pip install --upgrade meow ... |
| Result  | "Audited 1 package" - stays on 0.1.32 | "- meow==0.1.32 + meow==0.1.143"  |