### PR TITLE
feat: Add global team notice

### DIFF
--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -208,6 +208,15 @@ prime config set-ssh-key-path ~/.ssh/id_rsa.pub
 prime config view
 ```
 
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PRIME_API_KEY` | API key for authentication |
+| `PRIME_TEAM_ID` | Team ID to use for all operations |
+| `PRIME_DISABLE_VERSION_CHECK` | Set to `1` to disable update notifications |
+| `PRIME_DISABLE_TEAM_NOTICE` | Set to `1` to disable the team account notice |
+
 ## Python SDK
 
 Prime also provides a Python SDK for programmatic access:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2163,12 +2163,6 @@ def run_eval(
     # If a team is configured, pass it to vf-eval via header
     if config.team_id:
         cmd += ["--header", f"X-Prime-Team-ID: {config.team_id}"]
-        if config.team_id_from_env:
-            console.print(f"[cyan]ℹ Using team account: {config.team_id} (from env var)[/cyan]")
-        elif config.team_name:
-            console.print(f"[cyan]ℹ Using team account: {config.team_name}[/cyan]")
-        else:
-            console.print(f"[cyan]ℹ Using team account: {config.team_id}[/cyan]")
 
     console.print(f"[dim]Eval job_id: {job_id}[/dim]")
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2163,6 +2163,12 @@ def run_eval(
     # If a team is configured, pass it to vf-eval via header
     if config.team_id:
         cmd += ["--header", f"X-Prime-Team-ID: {config.team_id}"]
+        if config.team_id_from_env:
+            console.print(f"[cyan]ℹ Using team account: {config.team_id} (from env var)[/cyan]")
+        elif config.team_name:
+            console.print(f"[cyan]ℹ Using team account: {config.team_name}[/cyan]")
+        else:
+            console.print(f"[cyan]ℹ Using team account: {config.team_id}[/cyan]")
 
     console.print(f"[dim]Eval job_id: {job_id}[/dim]")
 

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -72,15 +72,27 @@ def callback(
 
     # Check for updates (only when a subcommand is being executed)
     if ctx.invoked_subcommand is not None:
+        console = Console(stderr=True, force_terminal=sys.stderr.isatty())
+
         update_available, latest = check_for_update()
         if update_available and latest:
-            console = Console(stderr=True, force_terminal=sys.stderr.isatty())
             console.print(
                 f"[yellow]A new version of prime is available: {latest} "
                 f"(installed: {__version__})[/yellow]"
             )
             console.print("[dim]Run: uv pip install --upgrade prime or uv tool upgrade prime[/dim]")
             console.print("[dim]Set PRIME_DISABLE_VERSION_CHECK=1 to disable this check[/dim]\n")
+
+        config = Config()
+        if config.team_id:
+            if config.team_id_from_env:
+                console.print(
+                    f"[cyan]ℹ Using team account: {config.team_id} (from env var)[/cyan]\n"
+                )
+            elif config.team_name:
+                console.print(f"[cyan]ℹ Using team account: {config.team_name}[/cyan]\n")
+            else:
+                console.print(f"[cyan]ℹ Using team account: {config.team_id}[/cyan]\n")
 
 
 def run() -> None:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Optional
 
@@ -56,8 +57,6 @@ def callback(
         raise typer.Exit()
 
     if context:
-        import os
-
         config = Config()
         # Check if the context exists
         if context.lower() != "production" and context not in config.list_environments():
@@ -84,15 +83,10 @@ def callback(
             console.print("[dim]Set PRIME_DISABLE_VERSION_CHECK=1 to disable this check[/dim]\n")
 
         config = Config()
-        if config.team_id:
-            if config.team_id_from_env:
-                console.print(
-                    f"[cyan]ℹ Using team account: {config.team_id} (from env var)[/cyan]\n"
-                )
-            elif config.team_name:
-                console.print(f"[cyan]ℹ Using team account: {config.team_name}[/cyan]\n")
-            else:
-                console.print(f"[cyan]ℹ Using team account: {config.team_id}[/cyan]\n")
+        if config.team_id and not os.getenv("PRIME_DISABLE_TEAM_NOTICE"):
+            team_display = config.team_name or config.team_id
+            suffix = " (from env var)" if config.team_id_from_env else ""
+            console.print(f"[dim]Using team account: {team_display}{suffix}[/dim]\n")
 
 
 def run() -> None:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -83,8 +83,14 @@ def callback(
             console.print("[dim]Set PRIME_DISABLE_VERSION_CHECK=1 to disable this check[/dim]\n")
 
         config = Config()
-        if config.team_id and not os.getenv("PRIME_DISABLE_TEAM_NOTICE"):
-            team_display = config.team_name or config.team_id
+        if config.team_id and os.environ.get("PRIME_DISABLE_TEAM_NOTICE", "").lower() not in (
+            "1",
+            "true",
+            "yes",
+        ):
+            team_display = (
+                config.team_id if config.team_id_from_env else (config.team_name or config.team_id)
+            )
             suffix = " (from env var)" if config.team_id_from_env else ""
             console.print(f"[dim]Using team account: {team_display}{suffix}[/dim]\n")
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CLI**
> 
> - Prints a dim "Using team account" notice on subcommand execution, showing `team_name`/`team_id` and marking when sourced from env; respects `PRIME_DISABLE_TEAM_NOTICE` (`1/true/yes`) to suppress
> - Creates `Console` before update check (no behavior change) and removes inline `os` import
> 
> **Docs**
> 
> - Adds an Environment Variables table listing `PRIME_API_KEY`, `PRIME_TEAM_ID`, `PRIME_DISABLE_VERSION_CHECK`, and `PRIME_DISABLE_TEAM_NOTICE`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb5a111d3b16f7ecc74c2da825d20ca86b3ac4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->