### PR TITLE
fix: allow uv install outside venv

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1465,6 +1465,16 @@ def install(
         # De-dup environment IDs just in case
         env_ids = list(dict.fromkeys(env_ids))
 
+        use_system = False
+        if with_tool == "uv" and not _has_uv_environment():
+            use_system = True
+            console.print(
+                "[yellow]No virtual environment detected. Installing into system Python with `uv pip install --system`.[/yellow]"
+            )
+            console.print(
+                "[dim]Tip: run `uv venv` (or activate your venv) to install into a virtual environment.[/dim]"
+            )
+
         # Resolving and validating environments
         installable_envs = []
         failed_envs = []
@@ -1525,7 +1535,7 @@ def install(
             console.print(f"[green]✓ Found {env_id}@{target_version}[/green]")
 
             cmd_parts = _build_install_command(
-                name, target_version, simple_index_url, wheel_url, with_tool
+                name, target_version, simple_index_url, wheel_url, with_tool, use_system=use_system
             )
             if not cmd_parts:
                 skipped_envs.append((f"{env_id}@{target_version}", "No installation method"))

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -582,6 +582,19 @@ def run_eval_cmd(
             "(used to locate .prime/.env-metadata.json for upstream resolution)"
         ),
     ),
+    install_target: str = typer.Option(
+        "prime",
+        "--install-target",
+        help=(
+            "Where to install environments with uv: prime (managed), "
+            "project (.venv), or system"
+        ),
+    ),
+    project: Optional[Path] = typer.Option(
+        None,
+        "--project",
+        help="Project directory to use with --install-target project",
+    ),
 ) -> None:
     """
     Run verifiers' vf-eval with Prime Inference.
@@ -609,4 +622,6 @@ def run_eval_cmd(
         api_base_url=api_base_url,
         skip_upload=skip_upload,
         env_path=env_path,
+        install_target=install_target,
+        project=project,
     )


### PR DESCRIPTION
## Summary
- add `--install-target {prime, project, system}` to `prime env install` and `prime eval` (default: `prime`)
- manage a Prime venv at `~/.prime/venvs/default`, or a project `.venv`, or use `uv pip install --system`
- ensure install, environment checks, and `uv run` all use the same uv context

## Rationale
`uv pip install` requires a target environment. Defaulting to a managed venv prevents accidental system installs while keeping quick‑start smooth; users can opt into project or system installs explicitly.

Fixes PrimeIntellect-ai/prime-environments#455

## Notes
- `--project` lets users point to a specific project root for the `.venv` target
