### PR TITLE
log for prime sandbox delete --all-users

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -530,6 +530,11 @@ def delete(
 
                 if not sandbox_ids:
                     console.print("[yellow]No sandboxes to delete[/yellow]")
+                    if only_mine and all_sandboxes:
+                        console.print(
+                            "\n[dim]Note: --all only deletes your own sandboxes by default. "
+                            "Use --all-users to delete sandboxes from all team members.[/dim]"
+                        )
                     return
         else:
             parsed_ids = []


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves UX for `prime sandbox delete`.
> 
> - When using `--all` and no sandboxes are found while `--only-mine` is active (default), prints a note clarifying that `--all` deletes only your sandboxes by default and suggests `--all-users` to delete team members’ sandboxes too.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99fd9bc274fe4e5f25f2ee5bd5859b38dac20a21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->