### PR TITLE
feat: Add --save-steps CLI option for checkpoint interval

### DIFF
--- a/configs/rl.toml
+++ b/configs/rl.toml
@@ -1,0 +1,14 @@
+model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+environments = ["will/wordle"]
+
+rollouts = 8      # number of attempts per prompt/example
+max_steps = 10    # total training iterations
+seq_len = 4096    # max tokens per response
+save_steps = 5    # checkpoint save interval
+
+# name = "my-experiment"
+
+# [wandb]
+# entity = "my-team"
+# project = "my-project"
+# name = "experiment-1"

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -30,6 +30,7 @@ class RLRun(BaseModel):
     rollouts_per_example: int = Field(..., alias="rolloutsPerExample")
     seq_len: int = Field(..., alias="seqLen")
     max_steps: int = Field(..., alias="maxSteps")
+    save_steps: Optional[int] = Field(None, alias="saveSteps")
     base_model: str = Field(..., alias="baseModel")
     environments: List[Dict[str, Any]] = Field(default_factory=list)
     run_config: Optional[Dict[str, Any]] = Field(None, alias="runConfig")
@@ -88,6 +89,7 @@ class RLClient:
         rollouts_per_example: int = 8,
         seq_len: int = 4096,
         max_steps: int = 100,
+        save_steps: Optional[int] = None,
         name: Optional[str] = None,
         wandb_entity: Optional[str] = None,
         wandb_project: Optional[str] = None,
@@ -113,6 +115,9 @@ class RLClient:
                 "max_steps": max_steps,
                 "secrets": secrets,
             }
+
+            if save_steps is not None:
+                payload["save_steps"] = save_steps
 
             if name:
                 payload["name"] = name

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -81,6 +81,7 @@ environments = ["{env_value}"]
 rollouts = 8      # number of attempts per prompt/example
 max_steps = 100   # total training iterations
 seq_len = 4096    # max tokens per response
+save_steps = 50   # checkpoint save interval
 
 # name = "my-experiment"
 
@@ -119,6 +120,7 @@ class RLRunConfig(BaseConfig):
     rollouts: int = 8
     seq_len: int = 4096
     max_steps: int = 100
+    save_steps: int | None = None
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     run_config: Optional[Dict[str, Any]] = Field(default=None)
     eval: EvalConfig = Field(default_factory=EvalConfig)
@@ -476,6 +478,9 @@ def create_run(
     max_steps: Optional[int] = typer.Option(
         None, "--max-steps", help="Maximum training steps [default: 100]"
     ),
+    save_steps: Optional[int] = typer.Option(
+        None, "--save-steps", help="Checkpoint save interval [default: 50]"
+    ),
     wandb_entity: Optional[str] = typer.Option(
         None, "--wandb-entity", help="Weights & Biases entity (username or team name)"
     ),
@@ -583,6 +588,7 @@ def create_run(
         rollouts=rollouts,
         seq_len=seq_len,
         max_steps=max_steps,
+        save_steps=save_steps,
         wandb_entity=wandb_entity,
         wandb_project=wandb_project,
         wandb_name=wandb_name,
@@ -675,6 +681,8 @@ def create_run(
         console.print(f"  Model: {cfg.model}")
         console.print(f"  Environments: {', '.join(cfg.environments)}")
         console.print(f"  Max Steps: {cfg.max_steps}")
+        if cfg.save_steps:
+            console.print(f"  Save Steps: {cfg.save_steps}")
         console.print(f"  Rollouts per Example: {cfg.rollouts}")
         console.print(f"  Sequence Length: {cfg.seq_len}")
         if cfg.wandb.project:
@@ -695,6 +703,7 @@ def create_run(
             rollouts_per_example=cfg.rollouts,
             seq_len=cfg.seq_len,
             max_steps=cfg.max_steps,
+            save_steps=cfg.save_steps,
             name=cfg.name,
             wandb_entity=cfg.wandb.entity,
             wandb_project=cfg.wandb.project,


### PR DESCRIPTION
## Summary
Add `--save-steps` option to `prime rl run` command for configuring checkpoint save interval.

## Changes
- Add `save_steps` field to `RLRunConfig`
- Add `--save-steps` CLI option  
- Include `save_steps` in API payload when set
- Display `save_steps` in run configuration summary
- Add `save_steps` to template and default config

## Why
Short training runs (`max_steps < 50`) don't produce adapters because the default `save_steps=50` means no checkpoint is saved. This option allows users to set a smaller interval.

## Usage
```bash
# Set checkpoint interval to 5 steps
prime rl run owner/env --max-steps 10 --save-steps 5

# Or in config file
save_steps = 5
```

## Related
- Platform PR: https://github.com/PrimeIntellect-ai/platform/pull/72