### PR TITLE
feat: Add env fork command

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1103,7 +1103,7 @@ def fork(
 
         fork_data: Dict[str, Any] = {}
         if team:
-            fork_data["team_id"] = team
+            fork_data["team_slug"] = team
 
         try:
             response = client.post(f"/environments/{env_id}/fork", json=fork_data)


### PR DESCRIPTION
## Summary
- Adds `prime env fork` command to fork environments via CLI
- Supports optional `--team` flag for team ownership

## Usage
```bash
prime env fork owner/env-name
prime env fork owner/env-name --team my-team
```

Depends on platform PR #76 for the API endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new CLI subcommand to fork environments from the hub.
> 
> - New `prime env fork` command in `env.py` calls `POST /environments/{owner/name}/fork`
> - Supports optional `--team/-t` to assign team ownership (`team_slug`)
> - Handles success/error responses and prints next-step guidance (`env pull`, modify, `env push`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5132005828f3f9b78fe776bb7339568045d8000a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->