### PR TITLE
Add support for env vars and remove @

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -98,17 +98,16 @@ class RLClient:
         wandb_entity: Optional[str] = None,
         wandb_project: Optional[str] = None,
         wandb_run_name: Optional[str] = None,
-        wandb_api_key: Optional[str] = None,
+        secrets: Optional[Dict[str, str]] = None,
         team_id: Optional[str] = None,
         eval_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
-            secrets: List[Dict[str, str]] = []
-
-            # Add W&B API key as a secret if provided
-            if wandb_api_key:
-                secrets.append({"key": "WANDB_API_KEY", "value": wandb_api_key})
+            secrets_list: List[Dict[str, str]] = []
+            if secrets:
+                for key, value in secrets.items():
+                    secrets_list.append({"key": key, "value": value})
 
             payload: Dict[str, Any] = {
                 "model": {"name": model_name},
@@ -116,7 +115,7 @@ class RLClient:
                 "rollouts_per_example": rollouts_per_example,
                 "max_steps": max_steps,
                 "batch_size": batch_size,
-                "secrets": secrets,
+                "secrets": secrets_list,
             }
 
             if trajectory_strategy:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -63,10 +63,10 @@ def clean_logs(text: str) -> str:
 
 def generate_rl_config_template(environment: str | None = None) -> str:
     """Generate a TOML config template for RL training."""
-    env_value = environment or "primeintellect/your-environment"
+    env_value = environment or "primeintellect/reverse-text"
 
     return f'''\
-model = "meta-llama/Llama-3.1-8B-Instruct"
+model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 max_steps = 100
 
 # Training

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -294,7 +294,7 @@ def create_run(
         secrets = collect_env_vars(
             env_args=env,
             env_files=env_file,
-            overrides={"WANDB_API_KEY": wandb_api_key} if wandb_api_key else None,
+            defaults={"WANDB_API_KEY": wandb_api_key} if wandb_api_key else None,
             on_warning=warn,
         )
     except EnvParseError as e:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -89,6 +89,7 @@ id = "{env_value}"
 # [wandb]
 # project = "my-project"
 # entity = "my-team"
+# name = "my-run-name"
 
 # Optional: online evaluation
 # [eval]
@@ -241,12 +242,6 @@ def create_run(
         "--env-file",
         help="Path to .env file containing secrets.",
     ),
-    wandb_api_key: Optional[str] = typer.Option(
-        None,
-        "--wandb-api-key",
-        help="Weights & Biases API key (or set WANDB_API_KEY env var)",
-        envvar="WANDB_API_KEY",
-    ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """Start an RL training run from a config file.
@@ -294,7 +289,6 @@ def create_run(
         secrets = collect_env_vars(
             env_args=env,
             env_files=env_file,
-            defaults={"WANDB_API_KEY": wandb_api_key} if wandb_api_key else None,
             on_warning=warn,
         )
     except EnvParseError as e:
@@ -305,7 +299,7 @@ def create_run(
     if (cfg.wandb.entity or cfg.wandb.project) and "WANDB_API_KEY" not in secrets:
         console.print(
             "[yellow]Warning:[/yellow] W&B config detected but no API key provided.\n"
-            "  Set via: --wandb-api-key, -e WANDB_API_KEY, or WANDB_API_KEY env var\n"
+            "  Set via: -e WANDB_API_KEY=... or --env-file\n"
         )
 
     try:
@@ -624,4 +618,4 @@ def init_config(
     path.write_text(template)
 
     console.print(f"[green]✓[/green] Created {output_path}")
-    console.print(f"\n[dim]Run with:[/dim] prime rl {output_path}")
+    console.print(f"\n[dim]Run with:[/dim] prime rl run {output_path}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -229,7 +229,7 @@ def create_run(
     env: Optional[List[str]] = typer.Option(
         None,
         "-e",
-        "--env",
+        "--env-var",
         help=(
             "Environment variable/secret to pass to the training container. "
             "Accepts: KEY=VALUE (direct value), KEY (reads from $KEY), "

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -91,6 +91,9 @@ id = "{env_value}"
 # entity = "my-team"
 # name = "my-run-name"
 
+# Optional: environment variable files
+# env_file = ["secrets.env", "another.env"]
+
 # Optional: online evaluation
 # [eval]
 # interval = 100
@@ -140,6 +143,7 @@ class RLConfig(BaseModel):
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
     wandb: WandbConfig = Field(default_factory=WandbConfig)
+    env_file: List[str] = Field(default_factory=list)
 
 
 def load_config(path: str) -> RLConfig:
@@ -285,10 +289,13 @@ def create_run(
     def warn(msg: str) -> None:
         console.print(f"[yellow]Warning:[/yellow] {msg}")
 
+    # Merge config and CLI env files (CLI takes precedence)
+    env_files = cfg.env_file + (env_file or [])
+
     try:
         secrets = collect_env_vars(
             env_args=env,
-            env_files=env_file,
+            env_files=env_files if env_files else None,
             on_warning=warn,
         )
     except EnvParseError as e:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -74,6 +74,9 @@ batch_size = 128
 rollouts_per_example = 8
 # trajectory_strategy = "interleaved"  # or "branching"
 
+# Optional: environment variable files
+# env_file = ["secrets.env"]
+
 [sampling]
 max_tokens = 2048
 # temperature = 0.7
@@ -90,9 +93,6 @@ id = "{env_value}"
 # project = "my-project"
 # entity = "my-team"
 # name = "my-run-name"
-
-# Optional: environment variable files
-# env_file = ["secrets.env", "another.env"]
 
 # Optional: online evaluation
 # [eval]
@@ -289,8 +289,14 @@ def create_run(
     def warn(msg: str) -> None:
         console.print(f"[yellow]Warning:[/yellow] {msg}")
 
+    # Resolve config env_file paths relative to config file directory
+    config_dir = Path(config_path).parent
+    resolved_config_env_files = [
+        str(config_dir / env_file_path) for env_file_path in cfg.env_file
+    ]
+
     # Merge config and CLI env files (CLI takes precedence)
-    env_files = cfg.env_file + (env_file or [])
+    env_files = resolved_config_env_files + (env_file or [])
 
     try:
         secrets = collect_env_vars(

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -1,0 +1,169 @@
+"""Utilities for parsing environment variables and secrets."""
+
+import os
+import re
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+
+def parse_env_file(
+    file_path: Path,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> Dict[str, str]:
+    """Parse a .env file and return a dict of key-value pairs.
+
+    Supports:
+    - KEY=VALUE
+    - KEY="VALUE" (quoted values)
+    - KEY='VALUE' (single-quoted values)
+    - # comments
+    - Empty lines (ignored)
+
+    Args:
+        file_path: Path to the .env file
+        on_warning: Optional callback for warning messages
+
+    Returns:
+        Dict of environment variable key-value pairs
+    """
+    env_vars: Dict[str, str] = {}
+    with open(file_path, "r") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                if on_warning:
+                    on_warning(
+                        f"Skipping invalid line {line_num} in {file_path}: "
+                        f"missing '=' separator"
+                    )
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", key):
+                if on_warning:
+                    on_warning(
+                        f"Skipping invalid key '{key}' in {file_path}: "
+                        f"must start with letter/underscore, contain only alphanumeric/underscore"
+                    )
+                continue
+            env_vars[key] = value
+    return env_vars
+
+
+class EnvParseError(Exception):
+    """Error raised when parsing environment variables fails."""
+
+    pass
+
+
+def parse_env_arg(
+    arg: str,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> Dict[str, str]:
+    """Parse a single -e/--env argument.
+
+    Accepts:
+    - KEY=VALUE: Use the provided value
+    - KEY: Read value from environment variable $KEY
+    - path/to/file.env: If it's an existing file, parse it as an env file
+
+    Args:
+        arg: The argument string to parse
+        on_warning: Optional callback for warning messages
+
+    Returns:
+        Dict of key-value pairs (single entry for KEY=VALUE/KEY, multiple for file)
+
+    Raises:
+        EnvParseError: If the argument is invalid or env var is not set
+    """
+    path = Path(arg)
+    if path.is_file():
+        return parse_env_file(path, on_warning=on_warning)
+
+    if "=" in arg:
+        key, _, value = arg.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            value = value[1:-1]
+        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", key):
+            raise EnvParseError(
+                f"Invalid environment variable key '{key}': "
+                f"must start with letter/underscore, contain only alphanumeric/underscore"
+            )
+        return {key: value}
+
+    key = arg.strip()
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", key):
+        raise EnvParseError(
+            f"Invalid environment variable key '{key}': "
+            f"must start with letter/underscore, contain only alphanumeric/underscore"
+        )
+    value = os.environ.get(key)
+    if value is None:
+        raise EnvParseError(
+            f"Environment variable '{key}' is not set. "
+            f"Either set it or use KEY=VALUE syntax."
+        )
+    return {key: value}
+
+
+def collect_env_vars(
+    env_args: Optional[List[str]] = None,
+    env_files: Optional[List[str]] = None,
+    config_env_vars: Optional[Dict[str, str]] = None,
+    overrides: Optional[Dict[str, str]] = None,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> Dict[str, str]:
+    """Collect environment variables from various sources.
+
+    Priority (later sources override earlier):
+    1. config_env_vars (e.g., from TOML [secrets] section)
+    2. env_files (--env-file arguments)
+    3. env_args (-e/--env arguments)
+    4. overrides (explicit overrides, highest priority)
+
+    Args:
+        env_args: List of -e/--env argument values
+        env_files: List of --env-file paths
+        config_env_vars: Dict from config file
+        overrides: Dict of explicit overrides (highest priority)
+        on_warning: Optional callback for warning messages
+
+    Returns:
+        Merged dict of all environment variables
+
+    Raises:
+        EnvParseError: If a file is not found or parsing fails
+    """
+    result: Dict[str, str] = {}
+
+    if config_env_vars:
+        result.update(config_env_vars)
+
+    if env_files:
+        for file_path in env_files:
+            path = Path(file_path)
+            if not path.is_file():
+                raise EnvParseError(f"Env file not found: {file_path}")
+            result.update(parse_env_file(path, on_warning=on_warning))
+
+    if env_args:
+        for arg in env_args:
+            result.update(parse_env_arg(arg, on_warning=on_warning))
+
+    if overrides:
+        result.update(overrides)
+
+    return result
+

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -121,20 +121,20 @@ def parse_env_arg(
 def collect_env_vars(
     env_args: Optional[List[str]] = None,
     env_files: Optional[List[str]] = None,
-    overrides: Optional[Dict[str, str]] = None,
+    defaults: Optional[Dict[str, str]] = None,
     on_warning: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, str]:
     """Collect environment variables from various sources.
 
     Priority (later sources override earlier):
-    1. env_files (--env-file arguments)
-    2. env_args (-e/--env-var arguments)
-    3. overrides (explicit overrides, highest priority)
+    1. defaults (e.g., from CLI envvar, lowest priority)
+    2. env_files (--env-file arguments)
+    3. env_args (-e/--env-var arguments, highest priority)
 
     Args:
         env_args: List of -e/--env-var argument values
         env_files: List of --env-file paths
-        overrides: Dict of explicit overrides (highest priority)
+        defaults: Dict of default values (lowest priority, typically from CLI envvar)
         on_warning: Optional callback for warning messages
 
     Returns:
@@ -144,6 +144,9 @@ def collect_env_vars(
         EnvParseError: If a file is not found or parsing fails
     """
     result: Dict[str, str] = {}
+
+    if defaults:
+        result.update(defaults)
 
     if env_files:
         for file_path in env_files:
@@ -155,9 +158,6 @@ def collect_env_vars(
     if env_args:
         for arg in env_args:
             result.update(parse_env_arg(arg, on_warning=on_warning))
-
-    if overrides:
-        result.update(overrides)
 
     return result
 

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -121,20 +121,17 @@ def parse_env_arg(
 def collect_env_vars(
     env_args: Optional[List[str]] = None,
     env_files: Optional[List[str]] = None,
-    defaults: Optional[Dict[str, str]] = None,
     on_warning: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, str]:
     """Collect environment variables from various sources.
 
     Priority (later sources override earlier):
-    1. defaults (e.g., from CLI envvar, lowest priority)
-    2. env_files (--env-file arguments)
-    3. env_args (-e/--env-var arguments, highest priority)
+    1. env_files (--env-file arguments)
+    2. env_args (-e/--env-var arguments, highest priority)
 
     Args:
         env_args: List of -e/--env-var argument values
         env_files: List of --env-file paths
-        defaults: Dict of default values (lowest priority, typically from CLI envvar)
         on_warning: Optional callback for warning messages
 
     Returns:
@@ -144,9 +141,6 @@ def collect_env_vars(
         EnvParseError: If a file is not found or parsing fails
     """
     result: Dict[str, str] = {}
-
-    if defaults:
-        result.update(defaults)
 
     if env_files:
         for file_path in env_files:

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -121,22 +121,19 @@ def parse_env_arg(
 def collect_env_vars(
     env_args: Optional[List[str]] = None,
     env_files: Optional[List[str]] = None,
-    config_env_vars: Optional[Dict[str, str]] = None,
     overrides: Optional[Dict[str, str]] = None,
     on_warning: Optional[Callable[[str], None]] = None,
 ) -> Dict[str, str]:
     """Collect environment variables from various sources.
 
     Priority (later sources override earlier):
-    1. config_env_vars (e.g., from TOML [secrets] section)
-    2. env_files (--env-file arguments)
-    3. env_args (-e/--env arguments)
-    4. overrides (explicit overrides, highest priority)
+    1. env_files (--env-file arguments)
+    2. env_args (-e/--env-var arguments)
+    3. overrides (explicit overrides, highest priority)
 
     Args:
-        env_args: List of -e/--env argument values
+        env_args: List of -e/--env-var argument values
         env_files: List of --env-file paths
-        config_env_vars: Dict from config file
         overrides: Dict of explicit overrides (highest priority)
         on_warning: Optional callback for warning messages
 
@@ -147,9 +144,6 @@ def collect_env_vars(
         EnvParseError: If a file is not found or parsing fails
     """
     result: Dict[str, str] = {}
-
-    if config_env_vars:
-        result.update(config_env_vars)
 
     if env_files:
         for file_path in env_files:


### PR DESCRIPTION
- Add support for passing in env vars / secrets
- Simplify to `prime rl config.toml` (removed the non-standard `@`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds env var/secret injection to RL runs and simplifies CLI UX.
> 
> - New `utils/env_vars.py` to parse `-e/--env-var` and `--env-file` (supports KEY=VALUE, KEY from environment, and `.env` files) with validation and warnings
> - `prime rl run` now accepts `--env-var` and `--env-file`, merges with `env_file` from config (config-relative paths), shows passed secret keys, and warns if W&B configured without `WANDB_API_KEY`
> - Make `run` the default subcommand when a config path is provided; remove `@` prefix usage in help/examples and init output
> - Update template defaults (environment slug and model) and add commented `env_file` example
> - API: `RLClient.create_run` now accepts `secrets: Dict[str,str]` and sends them as `secrets` list in payload; removes `wandb_api_key` handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63bb1fca5867e9a83f7ce95a7d8f8335a57ae686. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->