### PR TITLE
bump background job check timeout

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -471,7 +471,7 @@ class SandboxClient:
         stdout_log_file_quoted = shlex.quote(job.stdout_log_file)
         stderr_log_file_quoted = shlex.quote(job.stderr_log_file)
 
-        check = self.execute_command(sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10)
+        check = self.execute_command(sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=30)
 
         if not check.stdout.strip():
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
@@ -1016,7 +1016,7 @@ class AsyncSandboxClient:
         stderr_log_file_quoted = shlex.quote(job.stderr_log_file)
 
         check = await self.execute_command(
-            sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=10
+            sandbox_id, f"cat {exit_file_quoted} 2>/dev/null", timeout=30
         )
 
         if not check.stdout.strip():


### PR DESCRIPTION
10s weren't enough when running online-eval in our prod training setting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends background job status polling to avoid premature timeouts.
> 
> - In `sandbox.py`, increases the `timeout` for `cat {exit_file}` from 10s to 30s in both `get_background_job` and `async get_background_job` when checking the job exit file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e077bbefb5e83a2f9727ac242447dd7ec0d5c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->