### PR TITLE
sandbox float resources

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -34,9 +34,9 @@ class Sandbox(BaseModel):
     name: str
     docker_image: str = Field(..., alias="dockerImage")
     start_command: Optional[str] = Field(None, alias="startCommand")
-    cpu_cores: int = Field(..., alias="cpuCores")
-    memory_gb: int = Field(..., alias="memoryGB")
-    disk_size_gb: int = Field(..., alias="diskSizeGB")
+    cpu_cores: float = Field(..., alias="cpuCores")
+    memory_gb: float = Field(..., alias="memoryGB")
+    disk_size_gb: float = Field(..., alias="diskSizeGB")
     disk_mount_path: str = Field(..., alias="diskMountPath")
     gpu_count: int = Field(..., alias="gpuCount")
     network_access: bool = Field(True, alias="networkAccess")
@@ -77,9 +77,9 @@ class CreateSandboxRequest(BaseModel):
     name: str
     docker_image: str
     start_command: Optional[str] = "tail -f /dev/null"
-    cpu_cores: int = 1
-    memory_gb: int = 2
-    disk_size_gb: int = 5
+    cpu_cores: float = 1.0
+    memory_gb: float = 2.0
+    disk_size_gb: float = 5.0
     gpu_count: int = 0
     network_access: bool = True
     timeout_minutes: int = 60
@@ -97,9 +97,9 @@ class UpdateSandboxRequest(BaseModel):
     name: Optional[str] = None
     docker_image: Optional[str] = None
     start_command: Optional[str] = None
-    cpu_cores: Optional[int] = None
-    memory_gb: Optional[int] = None
-    disk_size_gb: Optional[int] = None
+    cpu_cores: Optional[float] = None
+    memory_gb: Optional[float] = None
+    disk_size_gb: Optional[float] = None
     gpu_count: Optional[int] = None
     timeout_minutes: Optional[int] = None
     environment_vars: Optional[Dict[str, str]] = None

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -325,9 +325,9 @@ def create(
     start_command: Optional[str] = typer.Option(
         "tail -f /dev/null", help="Command to run in the container"
     ),
-    cpu_cores: int = typer.Option(1, help="Number of CPU cores"),
-    memory_gb: int = typer.Option(2, help="Memory in GB"),
-    disk_size_gb: int = typer.Option(10, help="Disk size in GB"),
+    cpu_cores: float = typer.Option(1.0, help="Number of CPU cores"),
+    memory_gb: float = typer.Option(2.0, help="Memory in GB"),
+    disk_size_gb: float = typer.Option(10.0, help="Disk size in GB"),
     gpu_count: int = typer.Option(0, help="Number of GPUs"),
     network_access: bool = typer.Option(
         True,

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -39,9 +39,9 @@ def format_price(value: float) -> str:
     return f"${value:.2f}"
 
 
-def format_resources(cpu_cores: int, memory_gb: int, gpu_count: int = 0) -> str:
+def format_resources(cpu_cores: float, memory_gb: float, gpu_count: int = 0) -> str:
     """Format resource specifications as compact string."""
-    resources = f"{cpu_cores}CPU/{memory_gb}GB"
+    resources = f"{cpu_cores:g}CPU/{memory_gb:g}GB"
     if gpu_count > 0:
         resources += f"/{gpu_count}GPU"
     return resources


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables fractional resource specifications for sandboxes across SDK models and CLI.
> 
> - Change `cpu_cores`, `memory_gb`, `disk_size_gb` from `int` to `float` in `models.py` (`Sandbox`, `CreateSandboxRequest`, `UpdateSandboxRequest`) and update defaults
> - Update CLI `sandbox create` options to accept floats for CPU/memory/disk
> - Adjust `format_resources` to accept floats and display using `:g` for compact formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9c815807235a00b684a1c801b13c49340f6960c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->