### PR TITLE
Bump prime version to 0.5.11

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -41,7 +41,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Version bump for PyPI release - includes env var support from #282

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares packages for release by updating version constants.
> 
> - Bumps `prime_cli` `__version__` to `0.5.11`
> - Bumps `prime_sandboxes` `__version__` to `0.2.9`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 007429d0f37daf9da5b7ccab60927da1e910d769. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->