### PR TITLE
Bump vf version, add 'prime lab setup' command

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.3.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.8",
+    "verifiers>=0.1.9.post0",
     "build>=1.0.0",
     "toml>=0.10.0",
 ]

--- a/packages/prime/src/prime_cli/commands/lab.py
+++ b/packages/prime/src/prime_cli/commands/lab.py
@@ -1,0 +1,21 @@
+import typer
+
+app = typer.Typer(help="Lab commands for verifiers development")
+
+
+@app.command()
+def setup(
+    prime_rl: bool = typer.Option(
+        False, "--prime-rl", help="Install prime-rl and download prime-rl configs"
+    ),
+    vf_rl: bool = typer.Option(False, "--vf-rl", help="Download vf-rl configs"),
+    skip_agents_md: bool = typer.Option(
+        False,
+        "--skip-agents-md",
+        help="Skip downloading AGENTS.md, CLAUDE.md, and environments/AGENTS.md",
+    ),
+) -> None:
+    """Setup verifiers training workspace (passthrough to vf-setup)."""
+    from verifiers.scripts.setup import run_setup
+
+    run_setup(prime_rl=prime_rl, vf_rl=vf_rl, skip_agents_md=skip_agents_md)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -302,9 +302,7 @@ def create_run(
 
     # Resolve config env_file paths relative to config file directory
     config_dir = Path(config_path).parent
-    resolved_config_env_files = [
-        str(config_dir / env_file_path) for env_file_path in cfg.env_file
-    ]
+    resolved_config_env_files = [str(config_dir / env_file_path) for env_file_path in cfg.env_file]
 
     # Merge config and CLI env files (CLI takes precedence)
     env_files = resolved_config_env_files + (env_file or [])

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -12,12 +12,12 @@ from .commands.env import app as env_app
 from .commands.evals import app as evals_app
 from .commands.images import app as images_app
 from .commands.inference import app as inference_app
+from .commands.lab import app as lab_app
 from .commands.login import app as login_app
 from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
 from .commands.rl import app as rl_app
 from .commands.sandbox import app as sandbox_app
-from .commands.lab import app as lab_app
 from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
 from .core import Config

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -17,6 +17,7 @@ from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
 from .commands.rl import app as rl_app
 from .commands.sandbox import app as sandbox_app
+from .commands.lab import app as lab_app
 from .commands.teams import app as teams_app
 from .commands.whoami import app as whoami_app
 from .core import Config
@@ -39,6 +40,7 @@ app.add_typer(teams_app, name="teams", rich_help_panel="Account")
 app.add_typer(env_app, name="env", rich_help_panel="Lab")
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")
 app.add_typer(rl_app, name="rl", rich_help_panel="Lab")
+app.add_typer(lab_app, name="lab", rich_help_panel="Lab")
 
 # Compute commands
 app.add_typer(availability_app, name="availability", rich_help_panel="Compute")

--- a/uv.lock
+++ b/uv.lock
@@ -1691,7 +1691,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "verifiers", specifier = ">=0.1.9" },
+    { name = "verifiers", specifier = ">=0.1.9.post0" },
 ]
 provides-extras = ["dev"]
 
@@ -2744,7 +2744,7 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.9"
+version = "0.1.9.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
@@ -2764,9 +2764,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "wget" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/1d/81d9154ad37edda03de473e57e2d06b0b7e2a6f623bb30b0b43124dc85ef/verifiers-0.1.9.tar.gz", hash = "sha256:3140b16eefdc14f911acd6d3410529207a1ea6772340d620b08598830627d674", size = 186788, upload-time = "2026-01-08T21:23:50.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/ef/02094cf940da0f4c995d7e70af9db58c70ecc262d83a72113d03b9511134/verifiers-0.1.9.post0.tar.gz", hash = "sha256:dd25116aa7085a86c19f52e8b9919d4ecc95e18f5d3f9117f5fc8547b5d996b7", size = 186896, upload-time = "2026-01-08T22:02:12.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/5e/6da706f87ea03d69b277a7a75d6c5549bae7550b8a25c954b4e14f9fafce/verifiers-0.1.9-py3-none-any.whl", hash = "sha256:740c19ce74a86ff1f2f05ac0697760080f01e08d42354d597dbaf525daa80ac1", size = 163511, upload-time = "2026-01-08T21:23:48.976Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/29/1eca23230d30f5356dc1d7cee494598777dfec07b648112edfde0d1fd1fc/verifiers-0.1.9.post0-py3-none-any.whl", hash = "sha256:8a7e952ede8e1975ffad028ad7f32cfac77df4f5ec4b262244ef4da8b7b6fe5b", size = 163709, upload-time = "2026-01-08T22:02:14.134Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,15 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/5f/2cdf6f7aca3b20d3f316e9f505292e1f256a32089bd702034c29ebde6242/antlr4_python3_runtime-4.13.2.tar.gz", hash = "sha256:909b647e1d2fc2b70180ac586df3933e38919c85f98ccc656a96cd3f25ef3916", size = 117467, upload-time = "2024-08-03T19:00:12.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl", hash = "sha256:fe3835eb8d33daece0e799090eda89719dbccee7aa39ef94eed3818cafa5a7e8", size = 144462, upload-time = "2024-08-03T19:00:11.134Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1035,6 +1044,19 @@ wheels = [
 ]
 
 [[package]]
+name = "latex2sympy2-extended"
+version = "1.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "sympy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/472f9115c14c6f6d8a5889cabe3418283d708bde62ce00402c29441deed4/latex2sympy2_extended-1.10.2.tar.gz", hash = "sha256:41a517ffcc5a140e910a7d1646ce6ff440817e5f9d48fc8279d88bd0925bc389", size = 206188, upload-time = "2025-07-02T15:26:06.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/60/dfbbf40e3a371388c0e03ff65b01319b7d4023e883df6d7261125772ffdc/latex2sympy2_extended-1.10.2-py3-none-any.whl", hash = "sha256:f910442c5b02a466c1046f47d05cc5285181068b882399281f30102715337fb7", size = 207855, upload-time = "2025-07-02T15:26:04.88Z" },
+]
+
+[[package]]
 name = "linkify-it-py"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1130,6 +1152,18 @@ wheels = [
 ]
 
 [[package]]
+name = "math-verify"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latex2sympy2-extended" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/b5/b1db6fa6b6c28ebbe1889ee11a4703a72a2ca7750ec415f4559c758cf01a/math_verify-0.8.0.tar.gz", hash = "sha256:3295e0adb94bfe553ff6e3189c44f1916a85aa24ab5d1900f2086a706e28f7c4", size = 60191, upload-time = "2025-07-02T15:52:07.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/9f/59979f699b5c97334298f1295bc9fcdc9904d98d2276479bffff863d23b1/math_verify-0.8.0-py3-none-any.whl", hash = "sha256:31ca651296d817a9bb3fd58ca1fd0d192dcea709b1e5ecf2d0a4514c16f89087", size = 29994, upload-time = "2025-07-02T15:52:05.023Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1216,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1648,7 +1691,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "verifiers", specifier = ">=0.1.8" },
+    { name = "verifiers", specifier = ">=0.1.9" },
 ]
 provides-extras = ["dev"]
 
@@ -2486,6 +2529,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2689,11 +2744,13 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.8.post1"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
     { name = "jinja2" },
+    { name = "math-verify" },
+    { name = "mcp" },
     { name = "nest-asyncio" },
     { name = "openai" },
     { name = "openai-agents" },
@@ -2701,14 +2758,15 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
     { name = "rich" },
+    { name = "tenacity" },
     { name = "textual" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "wget" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8f/8ab2a095cdc7db4cbbb8b21c8bb208aa7043cc6dfc99b65f24fd235f8bfd/verifiers-0.1.8.post1.tar.gz", hash = "sha256:8be547ecfdac8464128798b083601ca576061a3bdf522920c57dc0dc71ae649f", size = 117959, upload-time = "2025-11-26T07:50:29.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/1d/81d9154ad37edda03de473e57e2d06b0b7e2a6f623bb30b0b43124dc85ef/verifiers-0.1.9.tar.gz", hash = "sha256:3140b16eefdc14f911acd6d3410529207a1ea6772340d620b08598830627d674", size = 186788, upload-time = "2026-01-08T21:23:50.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/0a/38a238f53de3aedd46a4cf36f06e8bce9a68e314d4b61ab6c7b8acd03dca/verifiers-0.1.8.post1-py3-none-any.whl", hash = "sha256:8ea9e536f3c1a40f28f000bc7196a84afd5d51bb497aae1262ab7852ccc19f9d", size = 106975, upload-time = "2025-11-26T07:50:28.157Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/6da706f87ea03d69b277a7a75d6c5549bae7550b8a25c954b4e14f9fafce/verifiers-0.1.9-py3-none-any.whl", hash = "sha256:740c19ce74a86ff1f2f05ac0697760080f01e08d42354d597dbaf525daa80ac1", size = 163511, upload-time = "2026-01-08T21:23:48.976Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Updates verifiers version to v0.1.9.post0
- Adds pass-through to verifiers' `vf-setup` for setting up workspace (downloading configs, agents.md, folder structure)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds new Lab setup command and updates verifiers**
> 
> - New `lab` command group with `prime lab setup` that proxies to `verifiers.scripts.setup.run_setup` to bootstrap verifiers training workspaces; supports `--prime-rl`, `--vf-rl`, and `--skip-agents-md` options
> - Wired `lab` into the CLI in `main.py` under the Lab section
> - Bumps `verifiers` dependency to `>=0.1.9.post0`; lockfile updated (notably adds `math-verify`, `mcp`, `tenacity`, `sympy` stack) 
> - Minor non-functional cleanup in `rl.py` (env file resolution list comprehension)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 585588b4b0f86c392adaa0a85388c90f43f8ae48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->