### PR TITLE
Add ability to fetch metrics/rollouts/distributions on CLI

### DIFF
--- a/packages/prime/src/prime_cli/commands/lab.py
+++ b/packages/prime/src/prime_cli/commands/lab.py
@@ -1,6 +1,6 @@
 import typer
 
-app = typer.Typer(help="Lab commands for verifiers development")
+app = typer.Typer(help="Lab commands for verifiers development", no_args_is_help=True)
 
 
 @app.command()

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -927,7 +927,9 @@ def get_distributions(
     distribution_type: Optional[str] = typer.Option(
         None, "--type", "-t", help="Distribution type (defaults to all)"
     ),
-    step: Optional[int] = typer.Option(None, "--step", "-s", help="Step number (defaults to latest)"),
+    step: Optional[int] = typer.Option(
+        None, "--step", "-s", help="Step number (defaults to latest)"
+    ),
 ) -> None:
     """Get reward/advantage distribution histogram for a run.
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -614,7 +614,7 @@ def list_runs(
     num: int = typer.Option(20, "--num", "-n", help="Number of most recent runs to show"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """List your RL training runs (alias: ls)."""
+    """List your runs (alias: ls)."""
     _list_runs_impl(team, num, output)
 
 
@@ -623,7 +623,7 @@ def get_run(
     run_id: str = typer.Argument(..., help="Run ID to get details for"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """Get details of a specific RL training run.
+    """Get details of a specific run.
 
     Example:
 
@@ -678,7 +678,7 @@ def stop_run(
     run_id: str = typer.Argument(..., help="Run ID to stop"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ) -> None:
-    """Stop an RL training run."""
+    """Stop a run."""
     try:
         if not force:
             confirm = typer.confirm(f"Are you sure you want to stop run {run_id}?")
@@ -704,7 +704,7 @@ def delete_run(
     run_id: str = typer.Argument(..., help="Run ID to delete"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ) -> None:
-    """Delete an RL training run."""
+    """Delete a run."""
     try:
         if not force:
             confirm = typer.confirm(f"Are you sure you want to permanently delete run {run_id}?")
@@ -729,7 +729,7 @@ def get_logs(
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
 ) -> None:
-    """Get logs for an RL training run."""
+    """Get logs for a run."""
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
@@ -795,7 +795,7 @@ def init_config(
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing file"),
 ) -> None:
-    """Generate a template config file for RL training.
+    """Generate a template config file for a training run.
 
     Example:
 
@@ -835,7 +835,7 @@ def get_metrics(
     max_step: Optional[int] = typer.Option(None, "--max-step", help="Maximum step (inclusive)"),
     limit: Optional[int] = typer.Option(None, "--limit", "-n", help="Maximum number of records"),
 ) -> None:
-    """Get training metrics for an RL run (JSON output).
+    """Get training metrics for a run.
 
     Example:
 
@@ -870,7 +870,7 @@ def get_rollouts(
     page: int = typer.Option(1, "--page", "-p", help="Page number (1-indexed)"),
     limit: int = typer.Option(100, "--limit", "-n", help="Number of samples per page"),
 ) -> None:
-    """Get rollout samples for an RL run (JSON output).
+    """Get rollout samples for a run.
 
     Example:
 
@@ -900,7 +900,7 @@ def get_rollouts(
 def get_progress(
     run_id: str = typer.Argument(..., help="Run ID to get progress for"),
 ) -> None:
-    """Get progress information for an RL run (JSON output).
+    """Get progress information, including which steps have samples and distributions.
 
     Example:
 
@@ -929,7 +929,7 @@ def get_distributions(
     ),
     step: Optional[int] = typer.Option(None, "--step", "-s", help="Step number (defaults to latest)"),
 ) -> None:
-    """Get reward/advantage distribution histogram for an RL run (JSON output).
+    """Get reward/advantage distribution histogram for a run.
 
     Example:
 

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -41,8 +41,8 @@ app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 # Lab commands
 app.add_typer(env_app, name="env", rich_help_panel="Lab")
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")
-app.add_typer(lab_app, name="lab", rich_help_panel="Lab")
 app.add_typer(rl_app, name="rl", rich_help_panel="Lab")
+app.add_typer(lab_app, name="lab", rich_help_panel="Lab")
 
 # Compute commands
 app.add_typer(availability_app, name="availability", rich_help_panel="Compute")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Adds RL monitoring and introspection**
> 
> - New CLI subcommands under `prime rl`: `get`, `metrics`, `rollouts`, `progress`, `distributions`; outputs JSON for easy piping
> - API client (`api/rl.py`) adds: `get_run`, `get_metrics`, `get_rollouts`, `get_progress`, `get_distributions`
> 
> **CLI UX improvements**
> 
> - `list` command extracted to `_list_runs_impl`; adds alias `ls` and JSON support retained
> - Adds `rich_help_panel` grouping for `run`, `models`, `list/ls`, `get`, `stop`, `delete`, `logs`, `init`, `metrics`, `rollouts`, `progress`, `distributions`
> - `lab` Typer now `no_args_is_help=True`; main CLI registers `rl` and `lab` under Lab
> 
> **Other**
> 
> - Minor output/wording tweaks in run details and init help; logs command categorized under "Monitoring"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9265814c301d1878638ae53524186a67e8d65706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->