### PR TITLE
fix for saving results, version bump

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.14"
+__version__ = "0.5.15"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2195,7 +2195,7 @@ def run_eval(
         cmd += ["-N"]
     if state_columns:
         cmd += ["-C", state_columns]
-    if save_results:
+    if save_results or not skip_upload:
         cmd += ["-s"]
     if save_every is not None:
         cmd += ["-f", str(save_every)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures eval runs save results when uploads are enabled and bumps package version.
> 
> - In `commands/env.py`, pass `-s` to `vf-eval` when `save_results` is set or when `--skip-upload` is not used, ensuring results are saved for upload by default
> - Bump `prime_cli` version to `0.5.15` in `__init__.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5c78c80729b32bc66a528f4ab1dc420a66ba05c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->