### PR TITLE
expose additional args to vf-eval

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2062,6 +2062,8 @@ def run_eval(
     api_base_url: Optional[str],
     skip_upload: bool,
     env_path: Optional[str],
+    endpoints_path: Optional[str] = None,
+    headers: Optional[List[str]] = None,
 ) -> None:
     """
     Run verifiers' vf-eval with Prime Inference
@@ -2205,6 +2207,11 @@ def run_eval(
         cmd += ["-H"]
     if hf_hub_dataset_name:
         cmd += ["-D", hf_hub_dataset_name]
+    if endpoints_path:
+        cmd += ["-e", endpoints_path]
+    if headers:
+        for header in headers:
+            cmd += ["--header", header]
 
     # Generate job_id for end-to-end tracing of eval runs
     eval_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -2402,4 +2409,6 @@ def eval_env(
         api_base_url=api_base_url,
         skip_upload=skip_upload,
         env_path=env_path,
+        endpoints_path=None,
+        headers=None,
     )

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -2,7 +2,7 @@ import json
 import re
 from functools import wraps
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from prime_evals import EvalsAPIError, EvalsClient, InvalidEvaluationError
@@ -630,13 +630,24 @@ def run_eval_cmd(
             "(used to locate .prime/.env-metadata.json for upstream resolution)"
         ),
     ),
+    endpoints_path: Optional[str] = typer.Option(
+        None,
+        "--endpoints-path",
+        "-e",
+        help="Path to endpoints.py file with custom endpoint configurations",
+    ),
+    header: Optional[List[str]] = typer.Option(
+        None,
+        "--header",
+        help="Extra HTTP header for inference API ('Name: Value'). Repeatable.",
+    ),
 ) -> None:
     """
     Run verifiers' vf-eval with Prime Inference.
 
     Examples:
-       prime eval primeintellect/wordle -m openai/gpt-4.1-mini -n 5
-       prime eval wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
+       prime eval run primeintellect/wordle -m openai/gpt-4.1-mini -n 5
+       prime eval run wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
     """
     run_eval(
         environment=environment,
@@ -664,4 +675,6 @@ def run_eval_cmd(
         api_base_url=api_base_url,
         skip_upload=skip_upload,
         env_path=env_path,
+        endpoints_path=endpoints_path,
+        headers=header,
     )


### PR DESCRIPTION
adds missing args 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables configuring custom endpoints and HTTP headers when running evaluations.
> 
> - `evals.py`: Adds `--endpoints-path/-e` and repeatable `--header` options to `prime eval run`; updates examples; passes values to `run_eval`
> - `env.py`: Extends `run_eval` to accept `endpoints_path` and `headers`, and forwards them to `vf-eval` via `-e` and `--header`; updates deprecated `eval` passthrough with defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c42cccecbd0fab21f3da8024a601e042a99bbe19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->