### PR TITLE
feat: Add hosted evals commands

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2891,20 +2891,21 @@ def run_eval(
                 env_path=Path(env_path) if env_path else None,
             )
 
-            console.print(
-                "[red]Error: Hosted evaluations require environment slug (owner/name).[/red]"
-            )
-
             if metadata and metadata.get("owner") and metadata.get("name"):
-                suggested_slug = f"{metadata['owner']}/{metadata['name']}"
-                console.print("[yellow]Tip:[/yellow] Found local environment metadata.")
-                console.print(f"[dim]Try:[/dim] prime eval {suggested_slug} --hosted")
+                upstream_owner = metadata["owner"]
+                upstream_name = metadata["name"]
+                is_slug = True
+                console.print(
+                    f"[dim]Resolved upstream environment: {upstream_owner}/{upstream_name}[/dim]"
+                )
             else:
+                console.print(
+                    "[red]Error: Hosted evaluations require environment slug (owner/name).[/red]"
+                )
                 console.print(
                     f"[dim]Example: prime eval primeintellect/{environment} --hosted[/dim]"
                 )
-
-            raise typer.Exit(1)
+                raise typer.Exit(1)
 
         client = APIClient(require_auth=False)
         try:
@@ -3023,10 +3024,11 @@ def run_eval(
                 if result.status != EvalStatus.COMPLETED:
                     raise typer.Exit(1)
             else:
+                eval_id = result.evaluation_id
                 console.print("[green]✓ Hosted evaluation started[/green]")
-                console.print(f"\n[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
-                console.print("\n[dim]View logs with:[/dim]")
-                console.print(f"  prime eval logs {result.evaluation_id} -f")
+                console.print(f"\n[cyan]Evaluation ID:[/cyan] {eval_id}")
+                console.print(f"\n[dim]View logs with:[/dim]   prime eval logs {eval_id} -f")
+                console.print(f"[dim]Stop eval with:[/dim]     prime eval stop {eval_id}")
 
         except APIError as e:
             console.print(f"[red]Hosted evaluation failed: {e}[/red]")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -35,7 +35,7 @@ from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
 from ..utils.hosted_eval import print_hosted_result, run_hosted_evaluation
-from ..utils.schemas import HostedEvalConfig
+from ..utils.schemas import EvalStatus, HostedEvalConfig
 from ..utils.time_utils import format_time_ago, iso_timestamp
 
 app = typer.Typer(help="Manage verifiers environments", no_args_is_help=True)
@@ -311,7 +311,7 @@ def actions_retry(
             console.print("[green]Successfully triggered retry[/green]")
             console.print(f"[dim]Job ID: {data.get('job_id')}[/dim]")
             console.print(f"[dim]Version: {data.get('version_id')}[/dim]")
-            job_id = data.get('job_id')
+            job_id = data.get("job_id")
             console.print(
                 f"\n[dim]Use 'prime env action logs {environment} {job_id}' to view logs[/dim]"
             )
@@ -479,9 +479,7 @@ def list_cmd(
     search: Optional[str] = typer.Option(
         None, "--search", "-s", help="Search by name or description"
     ),
-    tag: Optional[List[str]] = typer.Option(
-        None, "--tag", "-t", help="Filter by tag (repeatable)"
-    ),
+    tag: Optional[List[str]] = typer.Option(None, "--tag", "-t", help="Filter by tag (repeatable)"),
     action_status: Optional[str] = typer.Option(
         None, "--action-status", help="Filter by action status (SUCCESS/FAILED/RUNNING/PENDING)"
     ),
@@ -3038,10 +3036,6 @@ def run_eval(
 
     if is_slug:
         console.print(f"[dim]Using upstream environment {upstream_owner}/{upstream_name}[/dim]\n")
-
-        requested_version = "latest"
-        if "@" in environment:
-            _, requested_version = environment.rsplit("@", 1)
 
         if not _is_environment_installed(env_name_for_vf_eval, requested_version):
             console.print(f"[cyan]Installing {environment}...[/cyan]")

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -657,14 +657,56 @@ def run_eval_cmd(
         "--header",
         help="Extra HTTP header for inference API ('Name: Value'). Repeatable.",
     ),
+    hosted: bool = typer.Option(
+        False,
+        "--hosted",
+        help="Run evaluation on the platform instead of locally",
+    ),
+    poll_interval: float = typer.Option(
+        10.0,
+        "--poll-interval",
+        help="Polling interval in seconds for hosted evaluation status",
+    ),
+    no_stream_logs: bool = typer.Option(
+        False,
+        "--no-stream-logs",
+        help="Disable log streaming for hosted evaluations",
+    ),
+    timeout_minutes: Optional[int] = typer.Option(
+        None,
+        "--timeout-minutes",
+        help="Timeout in minutes for hosted evaluation (default: 120, max: 1440)",
+    ),
+    allow_sandbox_access: bool = typer.Option(
+        False,
+        "--allow-sandbox-access",
+        help="Allow sandbox read/write access for hosted evaluations",
+    ),
+    allow_instances_access: bool = typer.Option(
+        False,
+        "--allow-instances-access",
+        help="Allow pod/instance creation and management for hosted evaluations",
+    ),
+    custom_secrets: Optional[str] = typer.Option(
+        None,
+        "--custom-secrets",
+        help='Custom secrets for hosted eval as JSON (e.g., \'{"API_KEY": "xxx"}\')',
+    ),
+    eval_name: Optional[str] = typer.Option(
+        None,
+        "--eval-name",
+        help="Custom name for the hosted evaluation",
+    ),
 ) -> None:
     """
-    Run verifiers' vf-eval with Prime Inference.
+    Run verifiers' vf-eval with Prime Inference (local) or on the platform (--hosted).
 
     \b
     Examples:
         prime eval run primeintellect/wordle -m openai/gpt-4.1-mini -n 5
         prime eval run wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
+        prime eval run primeintellect/gsm8k --hosted -m openai/gpt-4.1-mini -n 10
+        prime eval run primeintellect/gsm8k --hosted -f  # Follow logs until completion
     """
     run_eval(
         environment=environment,
@@ -694,4 +736,12 @@ def run_eval_cmd(
         env_path=env_path,
         endpoints_path=endpoints_path,
         headers=header,
+        hosted=hosted,
+        poll_interval=poll_interval,
+        no_stream_logs=no_stream_logs,
+        timeout_minutes=timeout_minutes,
+        allow_sandbox_access=allow_sandbox_access,
+        allow_instances_access=allow_instances_access,
+        custom_secrets=custom_secrets,
+        eval_name=eval_name,
     )

--- a/packages/prime/src/prime_cli/utils/display.py
+++ b/packages/prime/src/prime_cli/utils/display.py
@@ -1,11 +1,13 @@
 """Display utilities for table and JSON output."""
 
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import typer
 from rich.console import Console
 from rich.table import Table
+
+from ..core.config import Config
 
 
 def validate_output_format(output: str, console: Console) -> None:
@@ -74,3 +76,10 @@ DISK_STATUS_COLORS = {
     "ERROR": "red",
     "TERMINATED": "white",
 }
+
+
+def get_eval_viewer_url(eval_id: str, viewer_url: Optional[str] = None) -> str:
+    if viewer_url:
+        return viewer_url
+    config = Config()
+    return f"{config.frontend_url}/dashboard/evaluations/{eval_id}"

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -210,11 +210,11 @@ def push_eval_results_to_hub(
     if converted_results:
         evals_client.push_samples(eval_id, converted_results)
 
-    evals_client.finalize_evaluation(eval_id, metrics=metrics)
+    finalize_response = evals_client.finalize_evaluation(eval_id, metrics=metrics)
 
     console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
-    frontend_url = api_client.config.frontend_url
-    eval_url = f"{frontend_url}/dashboard/evaluations/{eval_id}"
-    console.print("\n[green]View results at:[/green]")
-    console.print(f"  [link={eval_url}]{eval_url}[/link]")
+    viewer_url = finalize_response.get("viewer_url")
+    if viewer_url:
+        console.print("\n[green]View results at:[/green]")
+        console.print(f"  [link={viewer_url}]{viewer_url}[/link]")

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -7,7 +7,7 @@ from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
 from prime_cli.core import APIClient
-from prime_cli.core.config import Config
+from prime_cli.utils.display import get_eval_viewer_url
 
 from .env_metadata import find_environment_metadata
 
@@ -215,10 +215,6 @@ def push_eval_results_to_hub(
 
     console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
-    viewer_url = finalize_response.get("viewer_url")
-    if not viewer_url:
-        # Fallback: construct URL from frontend_url and eval_id
-        config = Config()
-        viewer_url = f"{config.frontend_url}/dashboard/rft/evals/{eval_id}"
+    viewer_url = get_eval_viewer_url(eval_id, finalize_response.get("viewer_url"))
     console.print("\n[green]View results at:[/green]")
     console.print(f"  [link={viewer_url}]{viewer_url}[/link]")

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -7,6 +7,7 @@ from prime_evals import EvalsAPIError, EvalsClient
 from rich.console import Console
 
 from prime_cli.core import APIClient
+from prime_cli.core.config import Config
 
 from .env_metadata import find_environment_metadata
 
@@ -215,6 +216,9 @@ def push_eval_results_to_hub(
     console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
     viewer_url = finalize_response.get("viewer_url")
-    if viewer_url:
-        console.print("\n[green]View results at:[/green]")
-        console.print(f"  [link={viewer_url}]{viewer_url}[/link]")
+    if not viewer_url:
+        # Fallback: construct URL from frontend_url and eval_id
+        config = Config()
+        viewer_url = f"{config.frontend_url}/dashboard/rft/evals/{eval_id}"
+    console.print("\n[green]View results at:[/green]")
+    console.print(f"  [link={viewer_url}]{viewer_url}[/link]")

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,0 +1,216 @@
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.spinner import Spinner
+from rich.text import Text
+
+from prime_cli.core import APIError, AsyncAPIClient
+
+console = Console()
+
+
+@dataclass
+class HostedEvalConfig:
+    environment_id: str
+    inference_model: str
+    num_examples: int
+    rollouts_per_example: int
+    env_args: Optional[dict[str, str]] = None
+    name: Optional[str] = None
+    timeout_minutes: Optional[int] = None
+    allow_sandbox_access: bool = False
+    allow_instances_access: bool = False
+    custom_secrets: Optional[dict[str, str]] = None
+
+
+@dataclass
+class HostedEvalResult:
+    evaluation_id: str
+    status: str
+    viewer_url: Optional[str]
+    total_samples: int
+    avg_score: Optional[float]
+    min_score: Optional[float]
+    max_score: Optional[float]
+    error_message: Optional[str] = None
+    logs: Optional[str] = None
+
+
+async def create_hosted_evaluation(
+    client: AsyncAPIClient,
+    config: HostedEvalConfig,
+) -> dict[str, Any]:
+    eval_config: dict[str, Any] = {
+        "num_examples": config.num_examples,
+        "rollouts_per_example": config.rollouts_per_example,
+        "allow_sandbox_access": config.allow_sandbox_access,
+        "allow_instances_access": config.allow_instances_access,
+    }
+
+    if config.env_args:
+        eval_config["env_args"] = config.env_args
+
+    if config.timeout_minutes:
+        eval_config["timeout_minutes"] = config.timeout_minutes
+
+    if config.custom_secrets:
+        eval_config["custom_secrets"] = config.custom_secrets
+
+    payload: dict[str, Any] = {
+        "environment_ids": [config.environment_id],
+        "inference_model": config.inference_model,
+        "eval_config": eval_config,
+    }
+
+    if config.name:
+        payload["name"] = config.name
+
+    return await client.post("/hosted-evals/evaluations", json=payload)
+
+
+async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str, Any]:
+    return await client.get(f"/evaluations/{evaluation_id}")
+
+
+async def get_evaluation_logs(client: AsyncAPIClient, evaluation_id: str) -> str:
+    try:
+        response = await client.get(f"/hosted-evals/evaluations/{evaluation_id}/logs")
+        return response.get("logs", "")
+    except APIError:
+        return ""
+
+
+async def run_hosted_evaluation(
+    config: HostedEvalConfig,
+    poll_interval: float = 10.0,
+    stream_logs: bool = True,
+) -> HostedEvalResult:
+    async with AsyncAPIClient() as client:
+        console.print(
+            f"[cyan]Creating hosted evaluation for environment {config.environment_id}[/cyan]"
+        )
+        console.print(f"[dim]Model: {config.inference_model}[/dim]")
+        console.print(
+            f"[dim]Configuration: num_examples={config.num_examples}, "
+            f"rollouts_per_example={config.rollouts_per_example}[/dim]"
+        )
+        console.print()
+
+        result = await create_hosted_evaluation(client, config)
+        evaluation_id = result.get("evaluation_id")
+
+        if not evaluation_id:
+            raise APIError("Failed to get evaluation ID from response")
+
+        console.print(f"[green]✓ Created hosted evaluation:[/green] {evaluation_id}")
+        console.print()
+
+        last_log_length = 0
+        terminal_statuses = {"COMPLETED", "FAILED", "TIMEOUT", "CANCELLED"}
+
+        with Live(
+            Panel(
+                Text.assemble(
+                    (Spinner("dots").render(time.time()), "cyan"),
+                    " Waiting for evaluation to start...",
+                ),
+                title="[bold]Hosted Evaluation[/bold]",
+                border_style="blue",
+            ),
+            refresh_per_second=4,
+            console=console,
+        ) as live:
+            while True:
+                await asyncio.sleep(poll_interval)
+
+                eval_data = await get_evaluation(client, evaluation_id)
+                status = eval_data.get("status", "UNKNOWN")
+
+                status_color = {
+                    "PENDING": "yellow",
+                    "RUNNING": "cyan",
+                    "COMPLETED": "green",
+                    "FAILED": "red",
+                    "TIMEOUT": "red",
+                    "CANCELLED": "yellow",
+                }.get(status, "white")
+
+                total_samples = eval_data.get("total_samples", 0)
+                status_text = Text.assemble(
+                    "Status: ",
+                    (status, status_color),
+                    f" | Samples: {total_samples}",
+                )
+                live.update(
+                    Panel(
+                        status_text,
+                        title="[bold]Hosted Evaluation[/bold]",
+                        border_style="blue",
+                    )
+                )
+
+                if stream_logs and status in ("RUNNING", "COMPLETED", "FAILED"):
+                    logs = await get_evaluation_logs(client, evaluation_id)
+                    if logs and len(logs) > last_log_length:
+                        live.stop()
+                        new_logs = logs[last_log_length:]
+                        console.print(new_logs, end="")
+                        last_log_length = len(logs)
+                        live.start()
+
+                if status in terminal_statuses:
+                    live.stop()
+                    break
+
+        eval_data = await get_evaluation(client, evaluation_id)
+        final_logs = await get_evaluation_logs(client, evaluation_id)
+
+        return HostedEvalResult(
+            evaluation_id=evaluation_id,
+            status=eval_data.get("status", "UNKNOWN"),
+            viewer_url=eval_data.get("viewer_url"),
+            total_samples=eval_data.get("total_samples", 0),
+            avg_score=eval_data.get("avg_score"),
+            min_score=eval_data.get("min_score"),
+            max_score=eval_data.get("max_score"),
+            error_message=eval_data.get("error_message"),
+            logs=final_logs,
+        )
+
+
+def print_hosted_result(result: HostedEvalResult) -> None:
+    console.print()
+    console.rule("[bold]Hosted Evaluation Results[/bold]")
+    console.print()
+    console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
+
+    status_color = {
+        "COMPLETED": "green",
+        "FAILED": "red",
+        "TIMEOUT": "red",
+        "CANCELLED": "yellow",
+    }.get(result.status, "white")
+    console.print(f"[cyan]Status:[/cyan] [{status_color}]{result.status}[/{status_color}]")
+    console.print(f"[cyan]Total samples:[/cyan] {result.total_samples}")
+
+    if result.avg_score is not None:
+        console.print(f"[cyan]Average score:[/cyan] {result.avg_score:.4f}")
+    if result.min_score is not None:
+        console.print(f"[cyan]Min score:[/cyan] {result.min_score:.4f}")
+    if result.max_score is not None:
+        console.print(f"[cyan]Max score:[/cyan] {result.max_score:.4f}")
+
+    console.print()
+
+    if result.viewer_url:
+        console.print(f"[bold green]View results:[/bold green] {result.viewer_url}")
+
+    if result.error_message:
+        console.print(f"\n[red]Error:[/red] {result.error_message}")
+
+    console.print()

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,12 +1,10 @@
 import asyncio
-import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
-from rich.spinner import Spinner
 from rich.text import Text
 
 from prime_cli.core import APIError, AsyncAPIClient
@@ -70,7 +68,7 @@ async def create_hosted_evaluation(
     if config.name:
         payload["name"] = config.name
 
-    return await client.post("/hosted-evals/evaluations", json=payload)
+    return await client.post("/hosted-evaluations", json=payload)
 
 
 async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str, Any]:
@@ -79,7 +77,7 @@ async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str
 
 async def get_evaluation_logs(client: AsyncAPIClient, evaluation_id: str) -> str:
     try:
-        response = await client.get(f"/hosted-evals/evaluations/{evaluation_id}/logs")
+        response = await client.get(f"/hosted-evaluations/{evaluation_id}/logs")
         return response.get("logs", "")
     except APIError:
         return ""
@@ -116,7 +114,7 @@ async def run_hosted_evaluation(
         with Live(
             Panel(
                 Text.assemble(
-                    (Spinner("dots").render(time.time()), "cyan"),
+                    "[cyan]⠋[/cyan]",
                     " Waiting for evaluation to start...",
                 ),
                 title="[bold]Hosted Evaluation[/bold]",

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -8,6 +8,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from prime_cli.core import APIError, AsyncAPIClient
+from prime_cli.core.config import Config
 from prime_cli.utils.schemas import (
     EvalStatus,
     HostedEvalConfig,
@@ -279,6 +280,16 @@ def print_hosted_result(result: HostedEvalResult) -> None:
     console.print()
     console.rule("[bold]Hosted Evaluation Results[/bold]")
     console.print()
+
+    # Show clear success/failure indicator
+    if result.status == EvalStatus.COMPLETED:
+        console.print("[bold green]✓ Evaluation completed successfully![/bold green]")
+    elif result.status == EvalStatus.FAILED:
+        console.print("[bold red]✗ Evaluation failed[/bold red]")
+    elif result.status == EvalStatus.CANCELLED:
+        console.print("[bold yellow]○ Evaluation was cancelled[/bold yellow]")
+
+    console.print()
     console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
 
     status_color = result.status.color
@@ -294,12 +305,21 @@ def print_hosted_result(result: HostedEvalResult) -> None:
 
     console.print()
 
-    if result.viewer_url:
-        console.print(f"[bold green]View results:[/bold green] {result.viewer_url}")
+    viewer_url = result.viewer_url
+    if not viewer_url:
+        # Fallback: construct URL from frontend_url and eval_id
+        config = Config()
+        viewer_url = f"{config.frontend_url}/dashboard/rft/evals/{result.evaluation_id}"
+    console.print(f"[bold green]View results:[/bold green] {viewer_url}")
 
     if result.error_message:
         console.print(f"\n[red]Error:[/red] {result.error_message}")
 
+    console.print()
+    console.print("[dim]CLI commands:[/dim]")
+    console.print(f"  prime eval get {result.evaluation_id}")
+    console.print(f"  prime eval samples {result.evaluation_id}")
+    console.print(f"  prime eval logs {result.evaluation_id}")
     console.print()
 
 
@@ -310,8 +330,39 @@ def stop_hosted_evaluation(eval_id: str) -> None:
             async with AsyncAPIClient() as client:
                 return await client.post(f"/hosted-evaluations/{eval_id}/cancel")
 
-        asyncio.run(do_stop())
-        console.print(f"[green]✓ Stopped evaluation {eval_id}[/green]")
+        result = asyncio.run(do_stop())
+        status = result.get("status", "CANCELLED")
+        message = result.get("message", "Evaluation cancelled successfully")
+        console.print(f"[green]✓ {message}[/green]")
+        console.print(f"[dim]Status: {status}[/dim]")
+        console.print()
+        console.print(
+            "[dim]The sandbox has been terminated. "
+            "Any partial results may still be available.[/dim]"
+        )
+        console.print(f"[dim]View results: prime eval get {eval_id}[/dim]")
     except APIError as e:
         console.print(f"[red]Error stopping evaluation:[/red] {e}")
+        raise SystemExit(1)
+
+
+def extend_hosted_evaluation_timeout(eval_id: str, additional_minutes: int) -> None:
+    """Extend the timeout of a running hosted evaluation."""
+    try:
+
+        async def do_extend():
+            async with AsyncAPIClient() as client:
+                return await client.patch(
+                    f"/hosted-evaluations/{eval_id}/timeout",
+                    json={"additional_minutes": additional_minutes},
+                )
+
+        result = asyncio.run(do_extend())
+        new_timeout = result.get("new_timeout_minutes", "unknown")
+        console.print(
+            f"[green]✓ Extended timeout for evaluation {eval_id}[/green]\n"
+            f"[dim]New total timeout: {new_timeout} minutes[/dim]"
+        )
+    except APIError as e:
+        console.print(f"[red]Error extending timeout:[/red] {e}")
         raise SystemExit(1)

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -184,7 +184,7 @@ async def follow_hosted_evaluation(
 
                 try:
                     eval_data = await get_evaluation(client, evaluation_id)
-                    status_str = eval_data.get("status", "UNKNOWN")
+                    status_str = str(eval_data.get("status", ""))
                     status = parse_eval_status(status_str)
                     consecutive_errors = 0
 

--- a/packages/prime/src/prime_cli/utils/schemas.py
+++ b/packages/prime/src/prime_cli/utils/schemas.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class EvalStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    TIMEOUT = "TIMEOUT"
+    CANCELLED = "CANCELLED"
+
+    @classmethod
+    def terminal_statuses(cls) -> set["EvalStatus"]:
+        return {cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
+
+    @classmethod
+    def has_logs_statuses(cls) -> set["EvalStatus"]:
+        return {cls.RUNNING, cls.COMPLETED, cls.FAILED}
+
+    @property
+    def color(self) -> str:
+        return {
+            EvalStatus.PENDING: "yellow",
+            EvalStatus.RUNNING: "cyan",
+            EvalStatus.COMPLETED: "green",
+            EvalStatus.FAILED: "red",
+            EvalStatus.TIMEOUT: "red",
+            EvalStatus.CANCELLED: "yellow",
+        }.get(self, "white")
+
+
+@dataclass
+class HostedEvalConfig:
+    environment_id: str
+    inference_model: str
+    num_examples: int
+    rollouts_per_example: int
+    env_args: Optional[dict[str, str]] = None
+    name: Optional[str] = None
+    timeout_minutes: Optional[int] = None
+    allow_sandbox_access: bool = False
+    allow_instances_access: bool = False
+    custom_secrets: Optional[dict[str, str]] = None
+
+
+@dataclass
+class HostedEvalResult:
+    evaluation_id: str
+    status: EvalStatus
+    viewer_url: Optional[str]
+    total_samples: int
+    avg_score: Optional[float]
+    min_score: Optional[float]
+    max_score: Optional[float]
+    error_message: Optional[str] = None
+    logs: Optional[str] = None
+
+
+@dataclass
+class HostedEvalCreationResult:
+    evaluation_id: str
+    viewer_url: Optional[str] = None

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from prime_cli.commands.evals import (
     _has_eval_files,
-    _load_eval_directory,
+    _load_verifiers_format,
     _validate_eval_path,
 )
 
@@ -121,7 +121,7 @@ class TestValidateEvalPath:
 
 
 class TestLoadEvalDirectory:
-    """Tests for _load_eval_directory function"""
+    """Tests for _load_verifiers_format function"""
 
     def test_loads_valid_eval_data(self, tmp_path):
         """Loads and parses valid eval directory"""
@@ -140,7 +140,7 @@ class TestLoadEvalDirectory:
         ]
         (tmp_path / "results.jsonl").write_text("\n".join(json.dumps(r) for r in results))
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         assert data["eval_name"] == "gsm8k-gpt-4"
         assert data["model_name"] == "gpt-4"
@@ -157,7 +157,7 @@ class TestLoadEvalDirectory:
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         assert data["eval_name"] == "math-problems-claude-3"
         assert data["env"] == "math-problems"
@@ -169,7 +169,7 @@ class TestLoadEvalDirectory:
         (tmp_path / "results.jsonl").write_text("")
 
         with pytest.raises(ValueError) as exc_info:
-            _load_eval_directory(tmp_path)
+            _load_verifiers_format(tmp_path)
 
         assert "env_id" in str(exc_info.value)
 
@@ -180,7 +180,7 @@ class TestLoadEvalDirectory:
         (tmp_path / "results.jsonl").write_text("")
 
         with pytest.raises(ValueError) as exc_info:
-            _load_eval_directory(tmp_path)
+            _load_verifiers_format(tmp_path)
 
         assert "model" in str(exc_info.value)
 
@@ -192,7 +192,7 @@ class TestLoadEvalDirectory:
         results_content = '{"id": 0, "reward": 1.0}\ninvalid json line\n{"id": 1, "reward": 0.5}'
         (tmp_path / "results.jsonl").write_text(results_content)
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         # Should only have 2 valid results, skipping the invalid line
         assert len(data["results"]) == 2
@@ -213,7 +213,7 @@ class TestLoadEvalDirectory:
         )
         (tmp_path / "results.jsonl").write_text(results_content)
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         # Should only have 2 valid dict results
         assert len(data["results"]) == 2
@@ -234,7 +234,7 @@ class TestLoadEvalDirectory:
         results = [{"id": 42, "reward": 1.0}]
         (tmp_path / "results.jsonl").write_text(json.dumps(results[0]))
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         assert data["results"][0]["example_id"] == 42
         assert data["results"][0]["id"] == 42  # Original field preserved
@@ -252,7 +252,7 @@ class TestLoadEvalDirectory:
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
-        data = _load_eval_directory(tmp_path)
+        data = _load_verifiers_format(tmp_path)
 
         assert data["metrics"] == {
             "reward": 0.75,
@@ -268,7 +268,7 @@ class TestLoadEvalDirectory:
         (tmp_path / "results.jsonl").write_text("")
 
         with pytest.raises(json.JSONDecodeError):
-            _load_eval_directory(tmp_path)
+            _load_verifiers_format(tmp_path)
 
 
 if __name__ == "__main__":

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,0 +1,208 @@
+from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
+
+
+class TestLogCleaning:
+    """Test log cleaning utilities"""
+
+    def test_strip_ansi_basic(self):
+        """Test stripping basic ANSI escape codes"""
+        text = "\x1b[31mRed text\x1b[0m"
+        assert strip_ansi(text) == "Red text"
+
+    def test_strip_ansi_multiple_codes(self):
+        """Test stripping multiple ANSI codes"""
+        text = "\x1b[1m\x1b[32mBold green\x1b[0m\x1b[0m text"
+        assert strip_ansi(text) == "Bold green text"
+
+    def test_strip_ansi_no_codes(self):
+        """Test text without ANSI codes remains unchanged"""
+        text = "Plain text"
+        assert strip_ansi(text) == "Plain text"
+
+    def test_strip_ansi_empty(self):
+        """Test empty string"""
+        assert strip_ansi("") == ""
+
+    def test_filter_progress_bars_100_percent(self):
+        """Test that 100% progress bars are kept"""
+        text = "Progress: 100%|██████████| 10/10 [00:01<00:00]"
+        result = filter_progress_bars(text)
+        assert "100%" in result
+
+    def test_filter_progress_bars_partial(self):
+        """Test that partial progress bars are filtered out"""
+        text = "Progress: 50%|█████     | 5/10 [00:01<00:01]"
+        result = filter_progress_bars(text)
+        assert result == ""
+
+    def test_filter_progress_bars_mixed(self):
+        """Test mixed content with progress bars"""
+        text = """Starting evaluation
+Progress: 50%|█████     | 5/10 [00:01<00:01]
+Progress: 100%|██████████| 10/10 [00:02<00:00]
+Evaluation complete"""
+        result = filter_progress_bars(text)
+        assert "Starting evaluation" in result
+        assert "Evaluation complete" in result
+        assert "100%" in result
+        assert "50%" not in result
+
+    def test_filter_progress_bars_preserves_regular_lines(self):
+        """Test that regular log lines are preserved"""
+        text = """Model loaded successfully
+Processing batch 1
+Result: accuracy=0.95"""
+        result = filter_progress_bars(text)
+        lines = result.splitlines()
+        assert len(lines) == 3
+        assert "Model loaded successfully" in result
+        assert "Processing batch 1" in result
+        assert "Result: accuracy=0.95" in result
+
+    def test_clean_logs_combined(self):
+        """Test combined cleaning of ANSI codes and progress bars"""
+        text = """\x1b[32mStarting evaluation\x1b[0m
+Progress: 50%|█████     | 5/10 [00:01<00:01]
+\x1b[1mProgress: 100%|██████████| 10/10 [00:02<00:00]\x1b[0m
+\x1b[32m✓ Evaluation complete\x1b[0m"""
+        result = clean_logs(text)
+        assert "Starting evaluation" in result
+        assert "✓ Evaluation complete" in result
+        assert "100%" in result
+        assert "50%" not in result
+        assert "\x1b" not in result
+
+    def test_clean_logs_empty(self):
+        """Test clean_logs with empty string"""
+        assert clean_logs("") == ""
+
+    def test_clean_logs_multiline_with_empty_lines(self):
+        """Test that empty lines are filtered out"""
+        text = """Line 1
+
+Line 3
+
+Line 5"""
+        result = clean_logs(text)
+        lines = result.splitlines()
+        assert len(lines) == 3
+        assert lines[0] == "Line 1"
+        assert lines[1] == "Line 3"
+        assert lines[2] == "Line 5"
+
+
+class TestLogStreaming:
+    """Test log streaming logic"""
+
+    def test_line_comparison_first_logs(self):
+        """Test printing all lines when no previous logs exist"""
+        last_logs = ""
+        new_logs = """Line 1
+Line 2
+Line 3"""
+
+        new_lines = new_logs.splitlines()
+
+        if not last_logs:
+            # Should print all lines
+            assert len(new_lines) == 3
+            assert new_lines == ["Line 1", "Line 2", "Line 3"]
+
+    def test_line_comparison_new_lines(self):
+        """Test printing only new lines when logs grow"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 1
+Line 2
+Line 3
+Line 4
+Line 5"""
+
+        old_lines = last_logs.splitlines()
+        new_lines = new_logs.splitlines()
+
+        # Find overlap
+        overlap = 0
+        max_overlap = min(len(old_lines), len(new_lines))
+        for i in range(1, max_overlap + 1):
+            if old_lines[-i:] == new_lines[:i]:
+                overlap = i
+
+        # Should only print new lines
+        new_content = new_lines[overlap:]
+        assert new_content == ["Line 4", "Line 5"]
+
+    def test_line_comparison_no_new_lines(self):
+        """Test no output when logs haven't changed"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 1
+Line 2
+Line 3"""
+
+        # Logs are identical, no new lines to print
+        assert last_logs == new_logs
+
+    def test_line_comparison_with_overlap(self):
+        """Test finding overlap between old and new logs"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 2
+Line 3
+Line 4
+Line 5"""
+
+        old_lines = last_logs.splitlines()
+        new_lines = new_logs.splitlines()
+
+        # Find overlap
+        overlap = 0
+        max_overlap = min(len(old_lines), len(new_lines))
+        for i in range(1, max_overlap + 1):
+            if old_lines[-i:] == new_lines[:i]:
+                overlap = i
+
+        # Last 2 lines of old match first 2 lines of new
+        # So we should print lines after the overlap
+        new_content = new_lines[overlap:]
+        assert overlap == 2
+        assert new_content == ["Line 4", "Line 5"]
+
+
+class TestProgressBarPatterns:
+    """Test various progress bar patterns from different tools"""
+
+    def test_tqdm_progress_bar(self):
+        """Test tqdm-style progress bar detection"""
+        text = "100%|██████████| 100/100 [00:10<00:00, 10.00it/s]"
+        result = filter_progress_bars(text)
+        assert "100%" in result
+
+    def test_rich_progress_bar(self):
+        """Test rich-style progress indicators"""
+        text = "Processing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%"
+        # Should be filtered if it contains percentage and bar characters
+        # but our current implementation focuses on tqdm-style bars
+        # This test documents current behavior
+        result = filter_progress_bars(text)
+        # Rich bars with unicode chars should pass through if not matching tqdm pattern
+        assert len(result) > 0
+
+    def test_multiple_progress_updates(self):
+        """Test multiple progress updates where only 100% is kept"""
+        text = """Task started
+25%|██▌       | 25/100 [00:02<00:06, 10.00it/s]
+50%|█████     | 50/100 [00:05<00:05, 10.00it/s]
+75%|███████▌  | 75/100 [00:07<00:02, 10.00it/s]
+100%|██████████| 100/100 [00:10<00:00, 10.00it/s]
+Task completed"""
+        result = filter_progress_bars(text)
+        assert "Task started" in result
+        assert "Task completed" in result
+        assert "100%" in result
+        assert "25%" not in result
+        assert "50%" not in result
+        assert "75%" not in result


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI flows that create/cancel remote evaluations and handle polling/log streaming; risk is mainly around API contract correctness, error handling, and user-facing prompts, but changes are isolated to eval-related commands.
> 
> **Overview**
> Adds **hosted evaluation** support to `prime eval` / `prime env eval`: a new `--hosted` mode starts evaluations on the platform (resolving `owner/name` from slug or local metadata, optionally prompting to `prime env push` if missing), and supports streaming status/logs with polling plus hosted-only options (timeouts, sandbox/instances access, custom secrets, naming).
> 
> Introduces new `prime eval` management commands for hosted runs: `logs` (tail/follow with status-aware termination + rate-limit handling), `stop` (cancel), and `pull` (export completed results into verifiers `metadata.json` + `results.jsonl` on disk). Output UX is improved by standardizing viewer URLs via `get_eval_viewer_url`, and tests add coverage for hosted log cleaning/streaming helpers and rename `_load_eval_directory` to `_load_verifiers_format`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34cda1be55ad5877184389c21cf6756009a45a7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->