### PR TITLE
Fix: Add batch upload for prime evals

### DIFF
--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
+    "tenacity>=9.1.2",
 ]
 keywords = ["evals", "evaluations"]
 classifiers = [

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -18,7 +18,6 @@ def _is_retryable(exc: BaseException) -> bool:
 
 
 def _build_user_agent() -> str:
-    """Build User-Agent string for prime-evals"""
     from prime_evals import __version__
 
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -243,11 +242,10 @@ class EvalsClient:
 
     def _upload_batch(self, evaluation_id: str, batch: List[Dict[str, Any]]) -> int:
         """Upload a single batch of samples with retry on rate limit."""
-        base_url = self.client.config.base_url
-        url = f"{base_url}/api/v1/evaluations/{evaluation_id}/samples"
+        url = f"{self.client.base_url}/api/v1/evaluations/{evaluation_id}/samples"
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.client.config.api_key}",
+            "Authorization": f"Bearer {self.client.api_key}",
             "User-Agent": _build_user_agent(),
         }
 
@@ -561,10 +559,10 @@ class AsyncEvalsClient:
         semaphore = asyncio.Semaphore(max_concurrent)
         errors: List[str] = []
 
-        base_url = self.client.config.base_url
+        base_url = self.client.base_url
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.client.config.api_key}",
+            "Authorization": f"Bearer {self.client.api_key}",
             "User-Agent": _build_user_agent(),
         }
 

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -243,11 +243,12 @@ class EvalsClient:
     def _upload_batch(self, evaluation_id: str, batch: List[Dict[str, Any]]) -> int:
         """Upload a single batch of samples with retry on rate limit."""
         url = f"{self.client.base_url}/api/v1/evaluations/{evaluation_id}/samples"
-        headers = {
+        headers: Dict[str, str] = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.client.api_key}",
             "User-Agent": _build_user_agent(),
         }
+        if self.client.api_key:
+            headers["Authorization"] = f"Bearer {self.client.api_key}"
 
         @retry(
             retry=retry_if_exception(_is_retryable),
@@ -560,11 +561,12 @@ class AsyncEvalsClient:
         errors: List[str] = []
 
         base_url = self.client.base_url
-        headers = {
+        headers: Dict[str, str] = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.client.api_key}",
             "User-Agent": _build_user_agent(),
         }
+        if self.client.api_key:
+            headers["Authorization"] = f"Bearer {self.client.api_key}"
 
         async def upload_batch(idx: int, batch: List[Dict[str, Any]]) -> int:
             url = f"{base_url}/api/v1/evaluations/{evaluation_id}/samples"

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -201,22 +201,20 @@ class EvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        batch_size: int = 512,
+        batch_size: int = 256,
     ) -> Dict[str, Any]:
         """Push evaluation samples in batches to avoid request size limits."""
         if not samples:
             return {}
 
-        response: Dict[str, Any] = {}
-
+        total_samples_pushed = 0
         for i in range(0, len(samples), batch_size):
             batch = samples[i : i + batch_size]
             payload = {"samples": batch}
-            response = self.client.request(
-                "POST", f"/evaluations/{evaluation_id}/samples", json=payload
-            )
+            self.client.request("POST", f"/evaluations/{evaluation_id}/samples", json=payload)
+            total_samples_pushed += len(batch)
 
-        return response
+        return {"samples_pushed": total_samples_pushed}
 
     def finalize_evaluation(
         self, evaluation_id: str, metrics: Optional[Dict[str, Any]] = None
@@ -473,22 +471,20 @@ class AsyncEvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        batch_size: int = 512,
+        batch_size: int = 256,
     ) -> Dict[str, Any]:
         """Push evaluation samples in batches."""
         if not samples:
             return {}
 
-        response: Dict[str, Any] = {}
-
+        total_samples_pushed = 0
         for i in range(0, len(samples), batch_size):
             batch = samples[i : i + batch_size]
             payload = {"samples": batch}
-            response = await self.client.request(
-                "POST", f"/evaluations/{evaluation_id}/samples", json=payload
-            )
+            await self.client.request("POST", f"/evaluations/{evaluation_id}/samples", json=payload)
+            total_samples_pushed += len(batch)
 
-        return response
+        return {"samples_pushed": total_samples_pushed}
 
     async def finalize_evaluation(
         self, evaluation_id: str, metrics: Optional[Dict[str, Any]] = None

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -276,8 +276,14 @@ class EvalsClient:
         current_batch: List[Dict[str, Any]] = []
         current_bytes = 20
 
-        for sample in samples:
+        for idx, sample in enumerate(samples):
             sample_size = len(json.dumps(sample)) + 1
+
+            if sample_size + 20 > max_payload_bytes:
+                raise EvalsAPIError(
+                    f"Sample {idx} exceeds maximum payload size "
+                    f"({sample_size} bytes > {max_payload_bytes - 20} bytes limit)"
+                )
 
             if current_bytes + sample_size > max_payload_bytes and current_batch:
                 batches.append(current_batch)
@@ -608,8 +614,14 @@ class AsyncEvalsClient:
         current_batch: List[Dict[str, Any]] = []
         current_bytes = 20
 
-        for sample in samples:
+        for idx, sample in enumerate(samples):
             sample_size = len(json.dumps(sample)) + 1
+
+            if sample_size + 20 > max_payload_bytes:
+                raise EvalsAPIError(
+                    f"Sample {idx} exceeds maximum payload size "
+                    f"({sample_size} bytes > {max_payload_bytes - 20} bytes limit)"
+                )
 
             if current_bytes + sample_size > max_payload_bytes and current_batch:
                 batches.append(current_batch)

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -206,6 +206,8 @@ class EvalsClient:
         """Push evaluation samples in batches to avoid request size limits."""
         if not samples:
             return {}
+        if batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
 
         total_samples_pushed = 0
         for i in range(0, len(samples), batch_size):
@@ -476,6 +478,8 @@ class AsyncEvalsClient:
         """Push evaluation samples in batches."""
         if not samples:
             return {}
+        if batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
 
         total_samples_pushed = 0
         for i in range(0, len(samples), batch_size):

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -209,6 +209,8 @@ class EvalsClient:
         """Push evaluation samples in adaptive batches with concurrent uploads."""
         if not samples:
             return {"samples_pushed": 0}
+        if max_workers < 1:
+            raise ValueError("max_workers must be at least 1")
 
         batches = self._build_batches(samples, max_payload_bytes)
         total_samples_pushed = 0
@@ -522,6 +524,8 @@ class AsyncEvalsClient:
         """Push evaluation samples in adaptive batches with concurrent uploads."""
         if not samples:
             return {"samples_pushed": 0}
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be at least 1")
 
         batches = self._build_batches(samples, max_payload_bytes)
         semaphore = asyncio.Semaphore(max_concurrent)

--- a/uv.lock
+++ b/uv.lock
@@ -1701,6 +1701,7 @@ source = { editable = "packages/prime-evals" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -1715,6 +1716,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
+    { name = "tenacity", specifier = ">=9.1.2" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Enhances sample upload performance and resilience**
> 
> - Reworks `push_samples` in `EvalsClient` and `AsyncEvalsClient` to use adaptive, size-aware batching with configurable parallelism (`max_workers`/`max_concurrent`)
> - Adds retry-on-rate-limit/network failures using `tenacity` for both sync and async HTTP uploads
> - Introduces `_build_batches` and `_upload_batch` helpers; uses explicit `httpx` requests with headers and timeouts
> - Updates `pyproject.toml` and lockfile to include `tenacity` dependency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a6053ee04113e7066809020d1d2329a2a502cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->