### PR TITLE
fix for sandbox start_background_job

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -441,7 +441,7 @@ class SandboxClient:
         # Start detached process with separate stdout and stderr log files
         bg_cmd = (
             f"nohup sh -c {quoted_sh_command} "
-            f"> {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+            f"< /dev/null > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
         )
         self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
@@ -985,7 +985,7 @@ class AsyncSandboxClient:
         # Start detached process with separate stdout and stderr log files
         bg_cmd = (
             f"nohup sh -c {quoted_sh_command} "
-            f"> {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
+            f"< /dev/null > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
         )
         await self.execute_command(sandbox_id, bg_cmd, timeout=10)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -435,14 +435,14 @@ class SandboxClient:
         stderr_log_file_quoted = shlex.quote(stderr_log_file)
         # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
         # This ensures 'echo $?' always runs to capture the exit code.
-        sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
+        sh_command = (
+            f"({command_body}) > {stdout_log_file_quoted} 2> {stderr_log_file_quoted}; "
+            f"echo $? > {exit_file_quoted}"
+        )
         quoted_sh_command = shlex.quote(sh_command)
 
-        # Start detached process with separate stdout and stderr log files
-        bg_cmd = (
-            f"nohup sh -c {quoted_sh_command} "
-            f"< /dev/null > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
-        )
+        # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
+        bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
         self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(
@@ -979,14 +979,14 @@ class AsyncSandboxClient:
         stderr_log_file_quoted = shlex.quote(stderr_log_file)
         # Wrap command in subshell so 'exit' terminates the subshell, not the outer shell.
         # This ensures 'echo $?' always runs to capture the exit code.
-        sh_command = f"({command_body}); echo $? > {exit_file_quoted}"
+        sh_command = (
+            f"({command_body}) > {stdout_log_file_quoted} 2> {stderr_log_file_quoted}; "
+            f"echo $? > {exit_file_quoted}"
+        )
         quoted_sh_command = shlex.quote(sh_command)
 
-        # Start detached process with separate stdout and stderr log files
-        bg_cmd = (
-            f"nohup sh -c {quoted_sh_command} "
-            f"< /dev/null > {stdout_log_file_quoted} 2> {stderr_log_file_quoted} &"
-        )
+        # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
+        bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
         await self.execute_command(sandbox_id, bg_cmd, timeout=10)
 
         return BackgroundJob(

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -226,6 +226,28 @@ def test_start_background_job(sandbox_client, shared_sandbox):
     print(f"✓ Background execution completed: {status.stdout.strip()}")
 
 
+def test_start_background_job_returns_immediately(sandbox_client, shared_sandbox):
+    """Test that start_background_job returns immediately without waiting for the job."""
+    print("\nTesting start_background_job returns immediately...")
+
+    start_time = time.time()
+    job = sandbox_client.start_background_job(
+        shared_sandbox.id,
+        "sleep 30 && echo done",
+    )
+    elapsed = time.time() - start_time
+
+    assert job.job_id is not None
+    # Should return in under 5 seconds, not 30
+    assert elapsed < 5, f"start_background_job took {elapsed:.1f}s, expected < 5s"
+    print(f"✓ Job started in {elapsed:.2f}s (sleep 30 is running in background)")
+
+    # Verify job is still running (not completed yet)
+    status = sandbox_client.get_background_job(shared_sandbox.id, job)
+    assert not status.completed, "Job should still be running"
+    print("✓ Job correctly running in background")
+
+
 def test_start_background_job_with_working_dir(sandbox_client, shared_sandbox):
     """Test start_background_job with working directory"""
     sandbox_client.execute_command(shared_sandbox.id, "mkdir -p /tmp/bgtest")


### PR DESCRIPTION
 When execute_command runs a command in a sandbox, it sets up stdout/stderr pipes and waits for them to close before returning. When start_background_job backgrounds a process with &, the shell exits but the backgrounded process inherits copies of those pipes, keeping them open. This makes execute_command wait until the background job finishes (or times out) instead of returning immediately.

This blocks not just start_background_job itself but also subsequent commands to the same sandbox, causing timeouts like: CommandTimeoutError: Command 'cat /tmp/job_c8b5c739.exit 2>/dev/null' timed out after 30s

Fix: Redirect the outer nohup to /dev/null so the execution pipes close immediately. Output capture now happens inside sh -c, writing directly to log files.

```bash
# Takes 5 seconds (backgrounded process inherits pipes, blocks until exit)
prime sandbox run <sandbox_id> "nohup sh -c 'sleep 5 &'"
```

```bash
# Returns immediately (redirections prevent pipe inheritance)
prime sandbox run <sandbox_id> "nohup sh -c 'sleep 5 > /dev/null 2>&1 &'"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves background execution so jobs detach from the caller and still capture output and exit status.
> 
> - Update `start_background_job` (sync/async) to redirect stdout/stderr inside `sh -c` and write exit code to `exit` file; outer `nohup` now redirects to `/dev/null` to avoid inheriting pipes
> - Add test `test_start_background_job_returns_immediately` confirming immediate return and that the job continues running
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b7733709bc9efc272117e853fea6d369d3733cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->