### PR TITLE
ENG-2515: Validate rl config on prime rl run

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -136,15 +136,15 @@ class RLClient:
             if name:
                 payload["name"] = name
 
-            # Add monitoring config if W&B is specified
-            if wandb_entity or wandb_project:
-                payload["monitoring"] = {
-                    "wandb": {
-                        "entity": wandb_entity,
-                        "project": wandb_project,
-                        "name": wandb_run_name,
-                    }
+            # Add monitoring config if W&B is fully configured
+            if wandb_entity and wandb_project:
+                wandb_config: Dict[str, Any] = {
+                    "entity": wandb_entity,
+                    "project": wandb_project,
                 }
+                if wandb_run_name:
+                    wandb_config["name"] = wandb_run_name
+                payload["monitoring"] = {"wandb": wandb_config}
 
             if team_id:
                 payload["team_id"] = team_id

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from prime_cli.core import APIClient, APIError
+from prime_cli.core import APIClient, APIError, ValidationError
 
 
 class RLModel(BaseModel):
@@ -178,6 +178,8 @@ class RLClient:
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))
+        except ValidationError:
+            raise  # Let ValidationError pass through for proper CLI handling
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to create RL run: {e.response.text}")

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -136,12 +136,13 @@ class RLClient:
             if name:
                 payload["name"] = name
 
-            # Add monitoring config if W&B is fully configured
-            if wandb_entity and wandb_project:
-                wandb_config: Dict[str, Any] = {
-                    "entity": wandb_entity,
-                    "project": wandb_project,
-                }
+            # Add monitoring config if any W&B field is set (backend validates completeness)
+            if wandb_entity or wandb_project or wandb_run_name:
+                wandb_config: Dict[str, Any] = {}
+                if wandb_entity:
+                    wandb_config["entity"] = wandb_entity
+                if wandb_project:
+                    wandb_config["project"] = wandb_project
                 if wandb_run_name:
                     wandb_config["name"] = wandb_run_name
                 payload["monitoring"] = {"wandb": wandb_config}

--- a/packages/prime/src/prime_cli/client.py
+++ b/packages/prime/src/prime_cli/client.py
@@ -7,6 +7,7 @@ from prime_cli.core import (
     AsyncAPIClient,
     PaymentRequiredError,
     UnauthorizedError,
+    ValidationError,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "APITimeoutError",
     "PaymentRequiredError",
     "UnauthorizedError",
+    "ValidationError",
 ]

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -423,7 +423,7 @@ def create_run(
 
     # Resolve config env file paths relative to config file directory
     config_dir = Path(config_path).parent
-    config_env_files = cfg.env_files + cfg.env_file  # support both, prefer env_files
+    config_env_files = cfg.env_file + cfg.env_files  # support both, env_files takes precedence
     resolved_config_env_files = [str(config_dir / p) for p in config_env_files]
 
     # Merge config and CLI env files (CLI takes precedence)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -70,7 +70,7 @@ def generate_rl_config_template(environment: str | None = None) -> str:
 model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
 max_steps = 100
 
-# env_file = ["secrets.env"] # optional file(s) for keys/secrets
+# env_files = ["secrets.env"] # optional file(s) for secrets
 
 # Training
 batch_size = 128
@@ -281,7 +281,8 @@ class RLConfig(BaseModel):
     val: ValConfig = Field(default_factory=ValConfig)
     buffer: BufferConfig = Field(default_factory=BufferConfig)
     wandb: WandbConfig = Field(default_factory=WandbConfig)
-    env_file: List[str] = Field(default_factory=list)
+    env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
+    env_files: List[str] = Field(default_factory=list)
 
 
 def _format_validation_errors(errors: list[dict]) -> list[str]:
@@ -419,9 +420,10 @@ def create_run(
     def warn(msg: str) -> None:
         console.print(f"[yellow]Warning:[/yellow] {msg}")
 
-    # Resolve config env_file paths relative to config file directory
+    # Resolve config env file paths relative to config file directory
     config_dir = Path(config_path).parent
-    resolved_config_env_files = [str(config_dir / p) for p in cfg.env_file]
+    config_env_files = cfg.env_files + cfg.env_file  # support both, prefer env_files
+    resolved_config_env_files = [str(config_dir / p) for p in config_env_files]
 
     # Merge config and CLI env files (CLI takes precedence)
     all_env_files = resolved_config_env_files + (env_file or [])

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -132,11 +132,9 @@ id = "{env_value}"
 
 
 class EnvConfig(BaseModel):
-    """Training environment configuration."""
-
     model_config = ConfigDict(extra="forbid")
 
-    id: Annotated[str, Field(description="Environment ID in owner/name format")]
+    id: str
     name: str | None = None
     args: Dict[str, Any] = Field(default_factory=dict)
 
@@ -148,7 +146,6 @@ class EnvConfig(BaseModel):
         return v
 
     def to_api_dict(self) -> Dict[str, Any]:
-        """Convert to API payload format, excluding None values."""
         result: Dict[str, Any] = {"id": self.id}
         if self.name is not None:
             result["name"] = self.name
@@ -158,19 +155,13 @@ class EnvConfig(BaseModel):
 
 
 class EvalEnvConfig(BaseModel):
-    """Evaluation environment configuration."""
-
     model_config = ConfigDict(extra="forbid")
 
-    id: Annotated[str, Field(description="Environment ID in owner/name format")]
+    id: str
     name: str | None = None
     args: Dict[str, Any] = Field(default_factory=dict)
-    num_examples: Annotated[
-        int | None, Field(description="Number of examples to evaluate (-1 for all)")
-    ] = None
-    rollouts_per_example: Annotated[
-        int | None, Field(ge=1, description="Rollouts per example")
-    ] = None
+    num_examples: int | None = None
+    rollouts_per_example: Annotated[int | None, Field(ge=1)] = None
 
     @field_validator("id")
     @classmethod
@@ -180,7 +171,6 @@ class EvalEnvConfig(BaseModel):
         return v
 
     def to_api_dict(self) -> Dict[str, Any]:
-        """Convert to API payload format, excluding None values."""
         result: Dict[str, Any] = {"id": self.id}
         if self.name is not None:
             result["name"] = self.name
@@ -194,35 +184,22 @@ class EvalEnvConfig(BaseModel):
 
 
 class SamplingConfig(BaseModel):
-    """Sampling configuration for token generation."""
-
     model_config = ConfigDict(extra="forbid")
 
-    max_tokens: Annotated[
-        int | None, Field(ge=1, description="Maximum output tokens per turn")
-    ] = None
-    temperature: Annotated[float | None, Field(ge=0, description="Sampling temperature")] = None
+    max_tokens: Annotated[int | None, Field(ge=1)] = None
+    temperature: Annotated[float | None, Field(ge=0)] = None
 
 
 class EvalConfig(BaseModel):
-    """Online evaluation configuration."""
-
     model_config = ConfigDict(extra="forbid")
 
-    interval: Annotated[
-        int | None, Field(ge=1, description="Evaluation interval in steps")
-    ] = None
-    num_examples: Annotated[
-        int | None, Field(ge=-1, description="Number of examples to evaluate")
-    ] = None
-    rollouts_per_example: Annotated[
-        int | None, Field(ge=1, description="Rollouts per example")
-    ] = None
+    interval: Annotated[int | None, Field(ge=1)] = None
+    num_examples: Annotated[int | None, Field(ge=-1)] = None
+    rollouts_per_example: Annotated[int | None, Field(ge=1)] = None
     eval_base_model: bool | None = None
     env: List[EvalEnvConfig] = Field(default_factory=list)
 
     def to_api_dict(self) -> Dict[str, Any] | None:
-        """Convert to API payload format. Returns None if no eval envs configured."""
         if not self.env:
             return None
         result: Dict[str, Any] = {"environments": [e.to_api_dict() for e in self.env]}
@@ -238,22 +215,13 @@ class EvalConfig(BaseModel):
 
 
 class ValConfig(BaseModel):
-    """Validation configuration during training."""
-
     model_config = ConfigDict(extra="forbid")
 
-    num_examples: Annotated[
-        int | None, Field(ge=1, description="Number of validation examples")
-    ] = None
-    rollouts_per_example: Annotated[
-        int | None, Field(ge=1, description="Rollouts per example")
-    ] = None
-    interval: Annotated[
-        int | None, Field(ge=1, description="Validation interval in steps")
-    ] = None
+    num_examples: Annotated[int | None, Field(ge=1)] = None
+    rollouts_per_example: Annotated[int | None, Field(ge=1)] = None
+    interval: Annotated[int | None, Field(ge=1)] = None
 
     def to_api_dict(self) -> Dict[str, Any] | None:
-        """Convert to API payload format. Returns None if no val config set."""
         result: Dict[str, Any] = {}
         if self.num_examples is not None:
             result["num_examples"] = self.num_examples
@@ -265,24 +233,12 @@ class ValConfig(BaseModel):
 
 
 class BufferConfig(BaseModel):
-    """Buffer configuration for difficulty filtering."""
-
     model_config = ConfigDict(extra="forbid")
 
-    easy_threshold: Annotated[
-        float | None, Field(ge=0, le=1, description="Threshold for easy classification")
-    ] = None
-    hard_threshold: Annotated[
-        float | None, Field(ge=0, le=1, description="Threshold for hard classification")
-    ] = None
-    easy_fraction: Annotated[
-        float | None,
-        Field(ge=0, le=1, description="Fraction of easy problems to convert to normal"),
-    ] = None
-    hard_fraction: Annotated[
-        float | None,
-        Field(ge=0, le=1, description="Fraction of hard problems to convert to normal"),
-    ] = None
+    easy_threshold: Annotated[float | None, Field(ge=0, le=1)] = None
+    hard_threshold: Annotated[float | None, Field(ge=0, le=1)] = None
+    easy_fraction: Annotated[float | None, Field(ge=0, le=1)] = None
+    hard_fraction: Annotated[float | None, Field(ge=0, le=1)] = None
     online_difficulty_filtering: bool | None = None
     env_ratios: List[float] | None = None
     skip_verification: bool | None = None
@@ -303,7 +259,6 @@ class BufferConfig(BaseModel):
         return self
 
     def to_api_dict(self) -> Dict[str, Any] | None:
-        """Convert to API payload format. Returns None if no buffer config set."""
         result: Dict[str, Any] = {}
         if self.easy_threshold is not None:
             result["easy_threshold"] = self.easy_threshold
@@ -325,8 +280,6 @@ class BufferConfig(BaseModel):
 
 
 class WandbConfig(BaseModel):
-    """Weights & Biases logging configuration."""
-
     model_config = ConfigDict(extra="forbid")
 
     entity: str | None = None
@@ -335,7 +288,6 @@ class WandbConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_required_fields(self):
-        """Require entity and project together (name is optional, auto-generated by W&B)."""
         required = {"entity": self.entity, "project": self.project}
         set_fields = {k for k, v in required.items() if v is not None}
         missing_fields = {k for k, v in required.items() if v is None}
@@ -348,27 +300,22 @@ class WandbConfig(BaseModel):
         return self
 
     def is_enabled(self) -> bool:
-        """Check if wandb logging is configured."""
         return self.entity is not None and self.project is not None
 
 
 class RLConfig(BaseModel):
-    """RL training run configuration."""
-
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
-    model: Annotated[str | None, Field(description="HuggingFace model name")] = None
-    max_steps: Annotated[int, Field(ge=1, description="Maximum training steps")] = 100
-    batch_size: Annotated[int, Field(ge=1, description="Training batch size")] = 128
-    rollouts_per_example: Annotated[int, Field(ge=1, description="Rollouts per example")] = 8
+    model: str | None = None
+    max_steps: Annotated[int, Field(ge=1)] = 100
+    batch_size: Annotated[int, Field(ge=1)] = 128
+    rollouts_per_example: Annotated[int, Field(ge=1)] = 8
     trajectory_strategy: Literal["interleaved", "branching"] | None = None
-    learning_rate: Annotated[float | None, Field(gt=0, description="Learning rate")] = None
-    lora_alpha: Annotated[int | None, Field(ge=1, description="LoRA alpha value")] = None
-    oversampling_factor: Annotated[
-        float | None, Field(ge=1, description="Oversampling factor")
-    ] = None
-    max_async_level: Annotated[int | None, Field(ge=1, description="Maximum async level")] = None
+    learning_rate: Annotated[float | None, Field(gt=0)] = None
+    lora_alpha: Annotated[int | None, Field(ge=1)] = None
+    oversampling_factor: Annotated[float | None, Field(ge=1)] = None
+    max_async_level: Annotated[int | None, Field(ge=1)] = None
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -259,9 +259,6 @@ class WandbConfig(BaseModel):
     project: str | None = None
     name: str | None = None
 
-    def is_enabled(self) -> bool:
-        return self.entity is not None and self.project is not None
-
 
 class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -479,9 +476,9 @@ def create_run(
                 console.print(f"  Temperature: {cfg.sampling.temperature}")
 
         # W&B
-        if cfg.wandb.is_enabled():
+        if cfg.wandb.entity or cfg.wandb.project:
             console.print("\n[cyan]Weights & Biases[/cyan]")
-            console.print(f"  Project: {cfg.wandb.entity}/{cfg.wandb.project}")
+            console.print(f"  Project: {cfg.wandb.entity or '?'}/{cfg.wandb.project or '?'}")
             if cfg.wandb.name:
                 console.print(f"  Run Name: {cfg.wandb.name}")
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -140,11 +140,12 @@ class EnvConfig(BaseModel):
     args: Dict[str, Any] = Field(default_factory=dict)
 
     def to_api_dict(self) -> Dict[str, Any]:
-        return {
-            "id": self.id,
-            "name": self.name,
-            "args": self.args,
-        }
+        result: Dict[str, Any] = {"id": self.id}
+        if self.name is not None:
+            result["name"] = self.name
+        if self.args:
+            result["args"] = self.args
+        return result
 
 
 class EvalEnvConfig(BaseModel):
@@ -157,11 +158,11 @@ class EvalEnvConfig(BaseModel):
     rollouts_per_example: int | None = None
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
-            "id": self.id,
-            "name": self.name,
-            "args": self.args,
-        }
+        result: Dict[str, Any] = {"id": self.id}
+        if self.name is not None:
+            result["name"] = self.name
+        if self.args:
+            result["args"] = self.args
         if self.num_examples is not None:
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -146,12 +146,11 @@ class EnvConfig(BaseModel):
         return v
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {"id": self.id}
-        if self.name is not None:
-            result["name"] = self.name
-        if self.args:
-            result["args"] = self.args
-        return result
+        return {
+            "id": self.id,
+            "name": self.name,
+            "args": self.args,
+        }
 
 
 class EvalEnvConfig(BaseModel):
@@ -160,7 +159,7 @@ class EvalEnvConfig(BaseModel):
     id: str
     name: str | None = None
     args: Dict[str, Any] = Field(default_factory=dict)
-    num_examples: int | None = None
+    num_examples: Annotated[int | None, Field(ge=-1)] = None
     rollouts_per_example: Annotated[int | None, Field(ge=1)] = None
 
     @field_validator("id")
@@ -171,11 +170,11 @@ class EvalEnvConfig(BaseModel):
         return v
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {"id": self.id}
-        if self.name is not None:
-            result["name"] = self.name
-        if self.args:
-            result["args"] = self.args
+        result: Dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "args": self.args,
+        }
         if self.num_examples is not None:
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:
@@ -485,11 +484,17 @@ def create_run(
 
     # Validate required fields for running (optional in schema, required for execution)
     if not cfg.env:
-        console.print("[red]Error:[/red] No environments specified. Add \\[\\[env]] sections to the config file.")
+        console.print(
+            "[red]Error:[/red] No environments specified. "
+            "Add \\[\\[env]] sections to the config file."
+        )
         raise typer.Exit(1)
 
     if not cfg.model:
-        console.print("[red]Error:[/red] No model specified. Add 'model = \"...\"' to the config file.")
+        console.print(
+            "[red]Error:[/red] No model specified. "
+            "Add 'model = \"...\"' to the config file."
+        )
         raise typer.Exit(1)
 
     # Collect secrets from all sources

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -266,7 +266,7 @@ class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
-    model: str | None = None
+    model: str
     max_steps: int = 100
     batch_size: int = 128
     rollouts_per_example: int = 8

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -447,7 +447,9 @@ def create_run(
         console.print("  - env_files in your config: env_files = [\"secrets.env\"]")
         console.print("  - CLI flag: --env-file secrets.env")
         console.print("  - CLI flag: -e WANDB_API_KEY=your-key")
-        console.print("  - Environment variable: export WANDB_API_KEY=your-key && prime rl run ... -e WANDB_API_KEY")
+        console.print(
+            "  - Environment variable: export WANDB_API_KEY=... && prime rl ... -e WANDB_API_KEY"
+        )
         raise typer.Exit(1)
 
     try:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -561,7 +561,7 @@ def create_run(
         console.print("[red]Configuration Error:[/red]")
         for err in e.errors:
             loc = err.get("loc", [])
-            path = ".".join(str(x) for x in loc if x and x != "body")
+            path = ".".join(str(x) for x in loc if x != "body")
             msg = err.get("msg", "")
             if msg.startswith("Value error, "):
                 msg = msg[len("Value error, ") :]

--- a/packages/prime/src/prime_cli/core/__init__.py
+++ b/packages/prime/src/prime_cli/core/__init__.py
@@ -7,6 +7,7 @@ from .client import (
     AsyncAPIClient,
     PaymentRequiredError,
     UnauthorizedError,
+    ValidationError,
 )
 from .config import Config
 
@@ -18,4 +19,5 @@ __all__ = [
     "Config",
     "PaymentRequiredError",
     "UnauthorizedError",
+    "ValidationError",
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **RL CLI validation and UX improvements**
> 
> - Introduces `ValidationError` in `core` (sync/async) to map HTTP 422 responses; re-exported via `prime_cli.client` and handled in RL API/commands to show field-level errors
> - Tightens schema: Pydantic `extra="forbid"` across RL config models; `model` is now required; improved TOML load with per-field error formatting
> - Config/env handling: support new `env_files` (keep `env_file` deprecated), resolve paths relative to config, merge with `--env-file`; validate `WANDB_API_KEY` when W&B is configured; send partial W&B config and let backend validate
> - Refactors payload building via `to_api_dict()` helpers for env/eval/val/buffer; minor output polish for configuration sections
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c1923bef40f2d81f174b0dac8a47600fd6433c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->