### PR TITLE
retry read error

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -21,6 +21,7 @@ RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
+    httpx.ReadError,  # Connection broken while reading response
 )
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -55,6 +55,7 @@ GATEWAY_RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
+    httpx.ReadError,  # Connection broken while reading response
 )
 
 # Retry decorator for gateway requests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves network resilience by retrying on connection read failures.
> 
> - Adds `httpx.ReadError` to `RETRYABLE_EXCEPTIONS` in `core/client.py`
> - Adds `httpx.ReadError` to `GATEWAY_RETRYABLE_EXCEPTIONS` in `sandbox.py` (affecting exec/upload/download gateway calls)
> - Applies to both sync and async paths via existing tenacity retry decorators
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b893a0b6312ae8b466588cac37d433261d98395c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->