### PR TITLE
fix(sandboxes): add ReadError to retryable exceptions

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -21,6 +21,7 @@ RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
+    httpx.ReadError,  # Connection broken while reading response (e.g., TCP reset)
 )
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -16,7 +16,6 @@ from .config import Config
 # Retry configuration for transient connection errors
 # These errors occur when the server closes idle connections in the pool
 # or when we fail to establish/maintain a connection
-# Note: ReadTimeout is NOT included because the request may have been processed
 RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed


### PR DESCRIPTION
## Summary
- Added `httpx.ReadError` to retry list for transient TCP connection resets

Fixes rollout failures caused by connection broken during response reading (e.g., Cloud Run scaling events).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends retry logic to cover read-phase connection breaks.
> 
> - Adds `httpx.ReadError` to `RETRYABLE_EXCEPTIONS` in `client.py` (covers TCP resets/disconnects while reading)
> - Applies to both `APIClient` and `AsyncAPIClient` via shared retry policy
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f688dd369b1a8b16185b15b5fc110b24d22c07fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->