### PR TITLE
Bump prime-sandboxes to 0.2.11

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -45,7 +45,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
- version bump for prime-sandboxes package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates package version identifier.
> 
> - Set `__version__` to `0.2.11` in `prime_sandboxes/__init__.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d257a5695b7baf1ad5f8358b6cd2745453d441ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->