### PR TITLE
Support URL dependencies in env install

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -10,6 +10,8 @@ import tempfile
 import uuid
 import zipfile
 from datetime import datetime
+
+# Wheel METADATA files use RFC 822 format (PEP 566), same as email headers
 from email.parser import Parser as EmailParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2088,6 +2088,7 @@ def _install_single_environment(env_slug: str, tool: str = "uv") -> bool:
 
     simple_index_url = details.get("simple_index_url")
     wheel_url = process_wheel_url(details.get("wheel_url"))
+    url_dependencies = details.get("url_dependencies", [])
 
     if not simple_index_url and not wheel_url:
         if details.get("visibility") == "PRIVATE":
@@ -2099,7 +2100,9 @@ def _install_single_environment(env_slug: str, tool: str = "uv") -> bool:
             console.print(f"[red]No installation method available for {env_slug}[/red]")
         return False
 
-    cmd_parts = _build_install_command(name, version, simple_index_url, wheel_url, tool)
+    cmd_parts = _build_install_command(
+        name, version, simple_index_url, wheel_url, tool, url_dependencies=url_dependencies
+    )
     if not cmd_parts:
         console.print(f"[red]Failed to build install command for {env_slug}[/red]")
         return False

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2058,7 +2058,11 @@ def _build_install_command(
             return cmd
     elif wheel_url:
         try:
-            return get_install_command(tool, wheel_url, no_upgrade)
+            cmd = get_install_command(tool, wheel_url, no_upgrade)
+            # Add URL dependencies for wheel-only installs too
+            if url_dependencies:
+                cmd.extend(url_dependencies)
+            return cmd
         except ValueError:
             return None
 


### PR DESCRIPTION
Pass URL dependencies as direct requirements to uv install, working around the transitive URL dependency restriction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances environment installs and metadata to handle URL-based dependencies.
> 
> - Extracts `Requires-Dist` from wheel `METADATA` via new `extract_requires_dist_from_wheel` and uploads it in `metadata.requires_dist`
> - Reads `url_dependencies` from API responses and passes them as direct requirements in install commands for both `uv` and `pip` (simple index and wheel-only paths)
> - Updates `_install_single_environment` and bulk `install` flow to propagate `url_dependencies`; adds necessary imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c0b67d030f37b9ff9fd0c9c88d8a1c4cf11bf07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->