### PR TITLE
fix --only-mine flag not filtering sandboxes in delete command

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -518,11 +518,13 @@ def delete(
 
                 if only_mine:
                     current_user_id = config.user_id
-                    sandboxes_to_delete = [
-                        s
-                        for s in all_sandboxes
-                        if (not current_user_id or not s.user_id or s.user_id == current_user_id)
-                    ]
+                    if not current_user_id:
+                        console.print(
+                            "[red]Error:[/red] Cannot filter by user - no user_id configured. "
+                            "Use --all-users to delete all sandboxes, or configure your user_id."
+                        )
+                        raise typer.Exit(1)
+                    sandboxes_to_delete = [s for s in all_sandboxes if s.user_id == current_user_id]
                 else:
                     sandboxes_to_delete = all_sandboxes
 


### PR DESCRIPTION
incorrectly includes any sandbox that has a None/empty user_id

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes the `--only-mine` behavior in `sandbox delete --all`.
> 
> - Enforces presence of `config.user_id` when `--only-mine` is used; otherwise prints an error and exits
> - Correctly filters sandboxes to delete by `s.user_id == config.user_id` (no longer deletes when `user_id` is missing or mismatched)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386fbfeaa4980dd5d0b1e250869273f3d91c757f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->