### PR TITLE
feat: Clean up command order

### DIFF
--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -31,13 +31,6 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 
-# Account commands
-app.add_typer(login_app, name="login", rich_help_panel="Account")
-app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
-app.add_typer(config_app, name="config", rich_help_panel="Account")
-app.add_typer(teams_app, name="teams", rich_help_panel="Account")
-app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
-
 # Lab commands
 app.add_typer(env_app, name="env", rich_help_panel="Lab")
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")
@@ -52,6 +45,13 @@ app.add_typer(sandbox_app, name="sandbox", rich_help_panel="Compute")
 app.add_typer(images_app, name="images", rich_help_panel="Compute")
 app.add_typer(registry_app, name="registry", rich_help_panel="Compute")
 app.add_typer(inference_app, name="inference", rich_help_panel="Compute")
+
+# Account commands
+app.add_typer(login_app, name="login", rich_help_panel="Account")
+app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
+app.add_typer(config_app, name="config", rich_help_panel="Account")
+app.add_typer(teams_app, name="teams", rich_help_panel="Account")
+app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
Closes ENG-2696

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders command registration in `prime_cli/main.py` to adjust CLI help/order presentation.
> 
> - Moves `Account` command registrations (`login`, `whoami`, `config`, `teams`, `upgrade`) below the `Compute` group
> - No changes to command implementations or options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8253feee891b872a343f11bd547f69301e9a181e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->