### PR TITLE
Fix: Apply strict arg parsing for prime eval

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -547,10 +547,8 @@ app.add_typer(subcommands_app, name="")
     "run",
     help="Run an evaluation with API models (default provider = Prime Inference)",
     no_args_is_help=True,
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
 def run_eval_cmd(
-    ctx: typer.Context,
     environment: str = typer.Argument(
         ...,
         help="Environment name (e.g. 'wordle') or slug (e.g. 'primeintellect/wordle')",


### PR DESCRIPTION
Closes ENG-2705

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enforce strict CLI parsing for `prime eval run`.**
> 
> - Remove `context_settings={"allow_extra_args": True, "ignore_unknown_options": True}` from the `run` command
> - Drop unused `ctx: typer.Context` parameter from `run_eval_cmd`
> 
> *Impact*: Unknown/extra args now error instead of being ignored, improving validation and consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede9e0217ffc4de25449528638bea8596526619e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->