### PR TITLE
install private env to cache

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1535,8 +1535,14 @@ def install(
                 console.print("[dim]Private environment detected, pulling and building...[/dim]")
                 try:
                     # Resolve "latest" to actual version from API response
+                    # Try multiple possible fields where version might be stored
+                    metadata = details.get("metadata") or {}
                     resolved_version = (
-                        details.get("semantic_version") or details.get("version") or target_version
+                        details.get("semantic_version")
+                        or details.get("version")
+                        or metadata.get("semantic_version")
+                        or metadata.get("version")
+                        or target_version
                     )
                     wheel_path = _pull_and_build_private_env(
                         client, owner, name, resolved_version, details

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1534,8 +1534,12 @@ def install(
             if not simple_index_url and not wheel_url and details.get("visibility") == "PRIVATE":
                 console.print("[dim]Private environment detected, pulling and building...[/dim]")
                 try:
+                    # Resolve "latest" to actual version from API response
+                    resolved_version = (
+                        details.get("semantic_version") or details.get("version") or target_version
+                    )
                     wheel_path = _pull_and_build_private_env(
-                        client, owner, name, target_version, details
+                        client, owner, name, resolved_version, details
                     )
                     if with_tool == "uv":
                         cmd_parts = ["uv", "pip", "install", str(wheel_path)]
@@ -1543,8 +1547,8 @@ def install(
                         cmd_parts = ["pip", "install", str(wheel_path)]
                     if not no_upgrade:
                         cmd_parts.insert(-1, "--upgrade")
-                    installable_envs.append((cmd_parts, env_id, target_version, name))
-                    console.print(f"[green]✓ Built {env_id}@{target_version}[/green]")
+                    installable_envs.append((cmd_parts, env_id, resolved_version, name))
+                    console.print(f"[green]✓ Built {env_id}@{resolved_version}[/green]")
                 except Exception as e:
                     failed_envs.append((f"{env_id}@{target_version}", f"Failed to build: {e}"))
                     console.print(

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1991,8 +1991,8 @@ def _safe_tar_extract(tar: tarfile.TarFile, dest_path: Path) -> None:
 
 
 def _get_env_cache_dir() -> Path:
-    """Get the cache directory for private environments."""
-    cache_dir = Path.home() / ".prime" / "envs"
+    """Get the cache directory for private environment wheels."""
+    cache_dir = Path.home() / ".prime" / "wheel_cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
 
@@ -2054,7 +2054,7 @@ def _pull_and_build_private_env(
     if not download_url:
         raise ValueError("No downloadable package found for private environment")
 
-    # Create versioned cache path: ~/.prime/envs/{owner}/{name}/{version}
+    # Create versioned cache path: ~/.prime/wheel_cache/{owner}/{name}/{version}
     cache_dir = _get_env_cache_dir()
     env_cache_path = cache_dir / owner / name / version
 

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -1,0 +1,288 @@
+"""Tests for private environment installation and caching."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Test with a known private environment
+TEST_PRIVATE_ENV = "prime-cli-test/private-reverse-text"
+TEST_PRIVATE_ENV_OWNER = "prime-cli-test"
+TEST_PRIVATE_ENV_NAME = "private-reverse-text"
+# Module name comes from the wheel (reverse_text-0.1.4), not the env name
+TEST_PRIVATE_ENV_MODULE = "reverse_text"
+
+
+@pytest.fixture
+def temp_prime_home(tmp_path: Path):
+    """Create a temporary .prime directory for cache isolation."""
+    prime_home = tmp_path / ".prime"
+    prime_home.mkdir()
+    return prime_home
+
+
+@pytest.fixture
+def clean_env_install(temp_prime_home: Path):
+    """Fixture that installs the private env and cleans up after."""
+    # Patch HOME so cache goes to temp directory
+    original_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(temp_prime_home.parent)
+
+    yield temp_prime_home
+
+    # Cleanup: uninstall after tests
+    subprocess.run(
+        ["uv", "pip", "uninstall", TEST_PRIVATE_ENV_MODULE, "-y"],
+        capture_output=True,
+    )
+
+    # Restore HOME
+    if original_home:
+        os.environ["HOME"] = original_home
+
+
+class TestPrivateEnvInstall:
+    """Tests for private environment installation."""
+
+    @pytest.mark.skipif(
+        not os.environ.get("PRIME_API_KEY"),
+        reason="PRIME_API_KEY not set - required for private env access",
+    )
+    def test_install_private_env_creates_cache(self, clean_env_install: Path):
+        """Test that installing a private env creates the correct cache structure."""
+        temp_prime_home = clean_env_install
+
+        # Install the private environment
+        result = subprocess.run(
+            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={
+                **os.environ,
+                "HOME": str(temp_prime_home.parent),
+                "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", ""),
+            },
+        )
+
+        print(f"stdout: {result.stdout}")
+        print(f"stderr: {result.stderr}")
+
+        assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
+
+        # Verify cache structure: ~/.prime/envs/{owner}/{name}/{version}/
+        envs_cache = temp_prime_home / "envs"
+        assert envs_cache.exists(), "Cache directory ~/.prime/envs/ not created"
+
+        owner_dir = envs_cache / TEST_PRIVATE_ENV_OWNER
+        assert owner_dir.exists(), f"Owner directory not created: {owner_dir}"
+
+        name_dir = owner_dir / TEST_PRIVATE_ENV_NAME
+        assert name_dir.exists(), f"Environment directory not created: {name_dir}"
+
+        # Should have at least one version directory
+        version_dirs = [d for d in name_dir.iterdir() if d.is_dir()]
+        assert len(version_dirs) > 0, "No version directories found"
+
+        version_dir = version_dirs[0]
+        # Note: version may be "latest" if API doesn't return semantic_version
+        # The important thing is the cache exists and wheel was built
+
+        # Verify wheel was built
+        dist_dir = version_dir / "dist"
+        assert dist_dir.exists(), f"dist/ directory not created: {dist_dir}"
+
+        wheels = list(dist_dir.glob("*.whl"))
+        assert len(wheels) > 0, "No wheel file found in dist/"
+
+        # Verify metadata was saved
+        metadata_path = version_dir / ".prime" / ".env-metadata.json"
+        assert metadata_path.exists(), f"Metadata file not created: {metadata_path}"
+
+    @pytest.mark.skipif(
+        not os.environ.get("PRIME_API_KEY"),
+        reason="PRIME_API_KEY not set - required for private env access",
+    )
+    def test_installed_private_env_can_be_loaded(self, clean_env_install: Path):
+        """Test that an installed private env can be loaded by verifiers."""
+        temp_prime_home = clean_env_install
+
+        # First install the environment
+        install_result = subprocess.run(
+            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={
+                **os.environ,
+                "HOME": str(temp_prime_home.parent),
+                "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", ""),
+            },
+        )
+
+        assert install_result.returncode == 0, (
+            f"Install failed: {install_result.stderr}\n{install_result.stdout}"
+        )
+
+        # Try to load the environment using verifiers, both with and without the owner/name
+        load_script = f"""
+import sys
+try:
+    from verifiers import load_environment
+    env = load_environment('{TEST_PRIVATE_ENV_MODULE}')
+    env = load_environment('{TEST_PRIVATE_ENV_OWNER}/{TEST_PRIVATE_ENV_NAME}')
+    print(f"Successfully loaded: {{type(env).__name__}}")
+    sys.exit(0)
+except ImportError as e:
+    print(f"Import error: {{e}}")
+    sys.exit(1)
+except Exception as e:
+    print(f"Load error: {{e}}")
+    sys.exit(1)
+"""
+
+        load_result = subprocess.run(
+            ["uv", "run", "python", "-c", load_script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={
+                **os.environ,
+                "HOME": str(temp_prime_home.parent),
+                "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", ""),
+            },
+        )
+
+        print(f"Load stdout: {load_result.stdout}")
+        print(f"Load stderr: {load_result.stderr}")
+
+        assert load_result.returncode == 0, (
+            f"Failed to load environment: {load_result.stderr}\n{load_result.stdout}"
+        )
+        assert "Successfully loaded" in load_result.stdout
+
+    @pytest.mark.skipif(
+        not os.environ.get("PRIME_API_KEY"),
+        reason="PRIME_API_KEY not set - required for private env access",
+    )
+    def test_cached_wheel_is_reused(self, clean_env_install: Path):
+        """Test that subsequent installs reuse the cached wheel."""
+        temp_prime_home = clean_env_install
+
+        # First install
+        result1 = subprocess.run(
+            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={
+                **os.environ,
+                "HOME": str(temp_prime_home.parent),
+                "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", ""),
+            },
+        )
+        assert result1.returncode == 0, f"First install failed: {result1.stderr}"
+
+        # Get the wheel modification time
+        envs_cache = temp_prime_home / "envs" / TEST_PRIVATE_ENV_OWNER / TEST_PRIVATE_ENV_NAME
+        version_dirs = list(envs_cache.iterdir())
+        assert len(version_dirs) > 0, f"No version dirs in {envs_cache}"
+        wheel_files = list((version_dirs[0] / "dist").glob("*.whl"))
+        assert len(wheel_files) > 0, f"No wheels in {version_dirs[0] / 'dist'}"
+        wheel_mtime_1 = wheel_files[0].stat().st_mtime
+
+        # Second install (should reuse cache)
+        result2 = subprocess.run(
+            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={
+                **os.environ,
+                "HOME": str(temp_prime_home.parent),
+                "PRIME_API_KEY": os.environ.get("PRIME_API_KEY", ""),
+            },
+        )
+        assert result2.returncode == 0, f"Second install failed: {result2.stderr}"
+
+        # Verify cache message appears
+        assert "Using cached wheel" in result2.stdout or "Using cached" in result2.stdout, (
+            f"Expected cache reuse message in output: {result2.stdout}"
+        )
+
+        # Verify wheel wasn't rebuilt (same mtime)
+        wheel_mtime_2 = wheel_files[0].stat().st_mtime
+        assert wheel_mtime_1 == wheel_mtime_2, "Wheel was rebuilt instead of reusing cache"
+
+
+class TestSafeTarExtract:
+    """Tests for tar extraction security (tar-slip prevention)."""
+
+    def test_safe_extract_blocks_absolute_path(self, tmp_path: Path):
+        """Test that absolute paths in tarball are rejected."""
+        import tarfile
+
+        from prime_cli.commands.env import _safe_tar_extract
+
+        # Create a tarball with absolute path
+        tar_path = tmp_path / "malicious.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            # Add a file with absolute path
+            info = tarfile.TarInfo(name="/etc/malicious")
+            info.size = 0
+            tar.addfile(info)
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with tarfile.open(tar_path, "r:gz") as tar:
+            with pytest.raises(ValueError, match="absolute path"):
+                _safe_tar_extract(tar, dest)
+
+    def test_safe_extract_blocks_path_traversal(self, tmp_path: Path):
+        """Test that path traversal (..) in tarball is rejected."""
+        import tarfile
+
+        from prime_cli.commands.env import _safe_tar_extract
+
+        # Create a tarball with path traversal
+        tar_path = tmp_path / "malicious.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            info = tarfile.TarInfo(name="../../../etc/malicious")
+            info.size = 0
+            tar.addfile(info)
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with tarfile.open(tar_path, "r:gz") as tar:
+            with pytest.raises(ValueError, match="'\\.\\.'"):
+                _safe_tar_extract(tar, dest)
+
+    def test_safe_extract_allows_normal_paths(self, tmp_path: Path):
+        """Test that normal paths in tarball are allowed."""
+        import tarfile
+
+        from prime_cli.commands.env import _safe_tar_extract
+
+        # Create a tarball with normal paths
+        tar_path = tmp_path / "normal.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            # Add normal files
+            info1 = tarfile.TarInfo(name="file.txt")
+            info1.size = 0
+            tar.addfile(info1)
+
+            info2 = tarfile.TarInfo(name="subdir/nested.txt")
+            info2.size = 0
+            tar.addfile(info2)
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        with tarfile.open(tar_path, "r:gz") as tar:
+            _safe_tar_extract(tar, dest)  # Should not raise
+
+        assert (dest / "file.txt").exists()
+        assert (dest / "subdir" / "nested.txt").exists()

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -7,11 +7,8 @@ from pathlib import Path
 import pytest
 
 # Test with a known private environment
-TEST_PRIVATE_ENV = "prime-cli-test/private-reverse-text"
-TEST_PRIVATE_ENV_OWNER = "prime-cli-test"
-TEST_PRIVATE_ENV_NAME = "private-reverse-text"
-# Module name comes from the wheel (reverse_text-0.1.4), not the env name
-TEST_PRIVATE_ENV_MODULE = "reverse_text"
+ENV_OWNER = "prime-cli-test"
+ENV_NAME = "private-reverse-text"
 
 
 @pytest.fixture
@@ -33,7 +30,7 @@ def clean_env_install(temp_prime_home: Path):
 
     # Cleanup: uninstall after tests
     subprocess.run(
-        ["uv", "pip", "uninstall", TEST_PRIVATE_ENV_MODULE, "-y"],
+        ["uv", "pip", "uninstall", ENV_NAME.replace("-", "_"), "-y"],
         capture_output=True,
     )
 
@@ -55,7 +52,7 @@ class TestPrivateEnvInstall:
 
         # Install the private environment
         result = subprocess.run(
-            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            ["uv", "run", "prime", "env", "install", f"{ENV_OWNER}/{ENV_NAME}"],
             capture_output=True,
             text=True,
             timeout=300,
@@ -75,10 +72,10 @@ class TestPrivateEnvInstall:
         envs_cache = temp_prime_home / "envs"
         assert envs_cache.exists(), "Cache directory ~/.prime/envs/ not created"
 
-        owner_dir = envs_cache / TEST_PRIVATE_ENV_OWNER
+        owner_dir = envs_cache / ENV_OWNER
         assert owner_dir.exists(), f"Owner directory not created: {owner_dir}"
 
-        name_dir = owner_dir / TEST_PRIVATE_ENV_NAME
+        name_dir = owner_dir / ENV_NAME
         assert name_dir.exists(), f"Environment directory not created: {name_dir}"
 
         # Should have at least one version directory
@@ -110,7 +107,7 @@ class TestPrivateEnvInstall:
 
         # First install the environment
         install_result = subprocess.run(
-            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            ["uv", "run", "prime", "env", "install", f"{ENV_OWNER}/{ENV_NAME}"],
             capture_output=True,
             text=True,
             timeout=300,
@@ -130,8 +127,8 @@ class TestPrivateEnvInstall:
 import sys
 try:
     from verifiers import load_environment
-    env = load_environment('{TEST_PRIVATE_ENV_MODULE}')
-    env = load_environment('{TEST_PRIVATE_ENV_OWNER}/{TEST_PRIVATE_ENV_NAME}')
+    env = load_environment('{ENV_NAME.replace("-", "_")}')
+    env = load_environment('{ENV_OWNER}/{ENV_NAME}')
     print(f"Successfully loaded: {{type(env).__name__}}")
     sys.exit(0)
 except ImportError as e:
@@ -172,7 +169,7 @@ except Exception as e:
 
         # First install
         result1 = subprocess.run(
-            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            ["uv", "run", "prime", "env", "install", f"{ENV_OWNER}/{ENV_NAME}"],
             capture_output=True,
             text=True,
             timeout=300,
@@ -185,7 +182,7 @@ except Exception as e:
         assert result1.returncode == 0, f"First install failed: {result1.stderr}"
 
         # Get the wheel modification time
-        envs_cache = temp_prime_home / "envs" / TEST_PRIVATE_ENV_OWNER / TEST_PRIVATE_ENV_NAME
+        envs_cache = temp_prime_home / "envs" / ENV_OWNER / ENV_NAME
         version_dirs = list(envs_cache.iterdir())
         assert len(version_dirs) > 0, f"No version dirs in {envs_cache}"
         wheel_files = list((version_dirs[0] / "dist").glob("*.whl"))
@@ -194,7 +191,7 @@ except Exception as e:
 
         # Second install (should reuse cache)
         result2 = subprocess.run(
-            ["uv", "run", "prime", "env", "install", TEST_PRIVATE_ENV],
+            ["uv", "run", "prime", "env", "install", f"{ENV_OWNER}/{ENV_NAME}"],
             capture_output=True,
             text=True,
             timeout=300,

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -25,8 +25,10 @@ def temp_home(tmp_path: Path):
         capture_output=True,
     )
 
-    # Restore HOME
-    if original_home:
+    # Restore HOME to original state
+    if original_home is None:
+        del os.environ["HOME"]
+    else:
         os.environ["HOME"] = original_home
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds secure pull/build/install flow and caching for private environments with comprehensive tests.
> 
> - `prime env install`: For PRIVATE envs lacking `simple_index_url`/`wheel_url`, auto-downloads source (`package_url`), securely extracts (`_safe_tar_extract`), determines version from `pyproject.toml`, caches under `~/.prime/wheel_cache/{owner}/{name}/{version}`, builds a wheel (prefers `uv build`), and installs from the cached wheel; honors `--no-upgrade` and logs cache reuse
> - New helpers: `_safe_tar_extract` (blocks symlinks, hardlinks, absolute paths, and traversal), `_validate_path_component`, `_get_env_cache_dir`, `_get_version_from_pyproject`, `_pull_and_build_private_env` (handles download, cache, build, metadata)
> - Tests: `tests/test_private_env_install.py` validates cache creation, environment loadability, cache reuse, path component validation, and tar extraction safety
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de6244bfacaf5cebd127dd8a9bc48385ccea543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->