### PR TITLE
Bump prime-cli version to 0.5.22

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -46,7 +46,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.21"
+__version__ = "0.5.22"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime-cli version from 0.5.21 to 0.5.22.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Version bumps only.
> 
> - Update `prime_cli.__version__` from `0.5.21` to `0.5.22`
> - Update `prime_sandboxes.__version__` from `0.2.11` to `0.2.12`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc64a79427644c58daf5b5c8f786344597b5bf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->