### PR TITLE
Bump prime-cli to 0.5.23

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.22"
+__version__ = "0.5.23"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
version bump for private env install feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `__version__` in `prime_cli/__init__.py` from `0.5.22` to `0.5.23`. No functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9540c8e0323ae94deb3e3bd93d77f256465755e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->