### PR TITLE
ENG-2726: Add ability to search envs + fetch actions status/logs

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -327,7 +327,7 @@ class RLClient:
         """Get status for an environment including latest version and action info."""
         try:
             response = self.client.get(f"/environmentshub/{owner}/{name}/status")
-            return response.get("data", {})
+            return response.get("data") or {}
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -327,7 +327,7 @@ class RLClient:
         """Get status for an environment including latest version and action info."""
         try:
             response = self.client.get(f"/environmentshub/{owner}/{name}/status")
-            return response.get("data") or {}
+            return response.get("data", {})
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -184,7 +184,7 @@ def _format_ci_status(status: Optional[str]) -> Text:
     return Text(status, style=color)
 
 
-@app.command("list")
+@app.command("list", rich_help_panel="Explore")
 def list_cmd(
     limit: int = typer.Option(
         DEFAULT_LIST_LIMIT, "--limit", "-l", help="Number of environments to show"
@@ -378,13 +378,13 @@ def _format_duration(start: Optional[datetime], end: Optional[datetime]) -> str:
     return f"{int(hours)}h {int(minutes % 60)}m"
 
 
-@app.command("status")
+@app.command("status", rich_help_panel="Explore")
 def status_cmd(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name)"),
     output: str = typer.Option("table", "--output", help="Output format: table or json"),
     job_limit: int = typer.Option(5, "--jobs", "-j", help="Number of recent jobs to show"),
 ) -> None:
-    """Show CI/test status for an environment
+    """Show CI/action status for an environment
 
     Examples:
         prime env status owner/my-env
@@ -478,7 +478,7 @@ def status_cmd(
         raise typer.Exit(1)
 
 
-@app.command()
+@app.command(rich_help_panel="Manage")
 def push(
     path: str = typer.Option(".", "--path", "-p", help="Path to environment directory"),
     name: Optional[str] = typer.Option(
@@ -1106,7 +1106,7 @@ def push(
         raise typer.Exit(1)
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Manage")
 def init(
     name: str = typer.Argument(..., help="Name of the new environment"),
     path: str = typer.Option(
@@ -1141,7 +1141,7 @@ def init(
         raise typer.Exit(1)
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Manage")
 def pull(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name or owner/name@version)"),
     target: Optional[str] = typer.Option(None, "--target", "-t", help="Target directory"),
@@ -1496,7 +1496,7 @@ def get_install_command(
         raise ValueError(f"Unsupported package manager: {tool}. Use 'uv' or 'pip'.")
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Explore")
 def info(
     env_id: str = typer.Argument(..., help="Environment ID (owner/name)"),
     version: str = typer.Option("latest", "--version", "-v", help="Version to show"),
@@ -1689,7 +1689,7 @@ def execute_install_command(cmd: List[str], env_id: str, version: str, tool: str
     console.print(f"\n[green]✓ Successfully installed {env_id}@{version}[/green]")
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Manage")
 def install(
     env_ids: List[str] = typer.Argument(
         ..., help="Environment ID(s) to install (owner/name or local name)"
@@ -1959,7 +1959,7 @@ def execute_uninstall_command(cmd: List[str], env_name: str, tool: str) -> None:
         raise typer.Exit(1)
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Manage")
 def uninstall(
     env_name: str = typer.Argument(..., help="Environment name to uninstall"),
     with_tool: str = typer.Option(
@@ -2020,7 +2020,7 @@ def uninstall(
 
 
 version_app = typer.Typer(help="Manage environment versions", no_args_is_help=True)
-app.add_typer(version_app, name="version")
+app.add_typer(version_app, name="version", rich_help_panel="Manage")
 
 
 @version_app.command("list", no_args_is_help=True)
@@ -2176,7 +2176,7 @@ def delete_version(
         raise typer.Exit(1)
 
 
-@app.command(no_args_is_help=True)
+@app.command(no_args_is_help=True, rich_help_panel="Manage")
 def delete(
     env_id: str = typer.Argument(..., help="Environment ID to delete"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
@@ -2823,6 +2823,7 @@ def run_eval(
     no_args_is_help=True,
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
     deprecated=True,
+    rich_help_panel="Deprecated",
 )
 def eval_env(
     ctx: typer.Context,

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -44,9 +44,9 @@ DEFAULT_HASH_LENGTH = 8
 DEFAULT_LIST_LIMIT = 20
 MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 
-# Actions subcommand app
-actions_app = typer.Typer(help="Manage environment actions (CI jobs)", no_args_is_help=True)
-app.add_typer(actions_app, name="actions")
+# Action subcommand app
+action_app = typer.Typer(help="Manage environment actions (CI jobs)", no_args_is_help=True)
+app.add_typer(action_app, name="action", rich_help_panel="Manage")
 
 # Log cleaning pattern
 ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -83,7 +83,7 @@ def _parse_environment_slug(environment: str) -> Tuple[str, str]:
     return parts[0], parts[1]
 
 
-@actions_app.command("list")
+@action_app.command("list")
 def actions_list(
     environment: str = typer.Argument(
         ...,
@@ -180,7 +180,7 @@ def actions_list(
         raise typer.Exit(1)
 
 
-@actions_app.command("logs")
+@action_app.command("logs")
 def actions_logs(
     environment: str = typer.Argument(
         ...,
@@ -263,7 +263,7 @@ def actions_logs(
         raise typer.Exit(1)
 
 
-@actions_app.command("retry")
+@action_app.command("retry")
 def actions_retry(
     environment: str = typer.Argument(
         ...,
@@ -310,7 +310,7 @@ def actions_retry(
             console.print(f"[dim]Version: {data.get('version_id')}[/dim]")
             job_id = data.get('job_id')
             console.print(
-                f"\n[dim]Use 'prime env actions logs {environment} {job_id}' to view logs[/dim]"
+                f"\n[dim]Use 'prime env action logs {environment} {job_id}' to view logs[/dim]"
             )
         else:
             console.print(f"[red]Retry failed:[/red] {data.get('message', 'Unknown error')}")

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -429,6 +429,7 @@ def push_eval(
 
     The directory must contain metadata.json and results.jsonl files.
 
+    \b
     Examples:
         prime eval push                                    # Push current dir or auto-discover
         prime eval push outputs/evals/gsm8k--gpt-4/abc123  # Push specific directory
@@ -660,9 +661,10 @@ def run_eval_cmd(
     """
     Run verifiers' vf-eval with Prime Inference.
 
+    \b
     Examples:
-       prime eval run primeintellect/wordle -m openai/gpt-4.1-mini -n 5
-       prime eval run wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
+        prime eval run primeintellect/wordle -m openai/gpt-4.1-mini -n 5
+        prime eval run wordle -m openai/gpt-4.1-mini -n 2 -r 3 -t 1024 -T 0.7
     """
     run_eval(
         environment=environment,

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -40,6 +40,7 @@ def push_image(
     """
     Build and push a Docker image to Prime Intellect registry.
 
+    \b
     Examples:
         prime images push myapp:v1.0.0
         prime images push myapp:latest --dockerfile custom.Dockerfile
@@ -186,6 +187,7 @@ def list_images(
     """
     List all images you've pushed to Prime Intellect registry.
 
+    \b
     Examples:
         prime images list
         prime images list --output json
@@ -279,6 +281,7 @@ def delete_image(
     Note: This removes the database record but does not delete the actual
     image from Google Artifact Registry.
 
+    \b
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -557,7 +557,7 @@ def create_run(
                     owner, name = env_id_base.split("/", 1)
                     url = f"{app_config.frontend_url}/dashboard/environments/{owner}/{name}/actions"
                     console.print(f"  [red]✗[/red] {env_id}")
-                    console.print(f"    [dim]Details: prime env action logs {env_id_base}[/dim]")
+                    console.print(f"    [dim]Details: prime env action list {env_id_base}[/dim]")
                     console.print(f"    [dim]View at: [link={url}]{url}[/link][/dim]\n")
 
                 console.print(

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -557,7 +557,8 @@ def create_run(
                     owner, name = env_id_base.split("/", 1)
                     url = f"{app_config.frontend_url}/dashboard/environments/{owner}/{name}/actions"
                     console.print(f"  [red]✗[/red] {env_id}")
-                    console.print(f"    [link={url}]{url}[/link]\n")
+                    console.print(f"    [dim]Details: prime env action logs {env_id_base}[/dim]")
+                    console.print(f"    [dim]View at: [link={url}]{url}[/link][/dim]\n")
 
                 console.print(
                     "[yellow]This usually means the environment doesn't compile or run, "

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1160,9 +1160,10 @@ def ssh_connect(
 
     This command creates a SSH session with an ephemeral key and cleans up on disconnect.
 
-    Examples:\n
-        prime sandbox ssh sb_abc123\n
-        prime sandbox ssh sb_abc123 -- -L 3000:localhost:3000\n
+    \b
+    Examples:
+        prime sandbox ssh sb_abc123
+        prime sandbox ssh sb_abc123 -- -L 3000:localhost:3000
     """
     session_id: Optional[str] = None
     sandbox_client: Optional[SandboxClient] = None

--- a/packages/prime/src/prime_cli/utils/time_utils.py
+++ b/packages/prime/src/prime_cli/utils/time_utils.py
@@ -34,6 +34,42 @@ def human_age(created: datetime) -> str:
         return f"{days}d"
 
 
+def format_time_ago(dt: Union[datetime, str, None]) -> str:
+    """Format a datetime as a human-readable 'time ago' string.
+
+    Args:
+        dt: A datetime object, ISO format string, or None
+
+    Returns:
+        A human-readable string like "just now", "5m ago", "2h ago", "3d ago",
+        or the date in YYYY-MM-DD format for dates older than 30 days.
+        Returns "-" if dt is None.
+    """
+    if not dt:
+        return "-"
+
+    if isinstance(dt, str):
+        # Parse ISO format string, handling various formats
+        dt = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+
+    diff = now_utc() - to_utc(dt)
+    total_seconds = int(diff.total_seconds())
+
+    if total_seconds < 60:
+        return "just now"
+    elif total_seconds < 3600:
+        minutes = total_seconds // 60
+        return f"{minutes}m ago"
+    elif total_seconds < 86400:
+        hours = total_seconds // 3600
+        return f"{hours}h ago"
+    elif total_seconds < 2592000:  # 30 days
+        days = total_seconds // 86400
+        return f"{days}d ago"
+    else:
+        return to_utc(dt).strftime("%Y-%m-%d")
+
+
 def iso_timestamp(dt: Union[datetime, str]) -> str:
     """Convert datetime or ISO string to standardized timestamp format."""
     if isinstance(dt, str):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that call new hub endpoints and introduces a log-following loop with rate-limit handling; risk is mostly around API compatibility and potential noisy polling/edge cases, not data/security.
> 
> **Overview**
> Enhances `prime env` with *hub discovery improvements* and *action (CI job) inspection tooling*.
> 
> `prime env list` now supports search, tag filtering, sorting, starred/mine filters (auth-gated), and optional inclusion of latest CI status; table/JSON output now includes version/stars/updated date and can show a colored action-status column. Adds `prime env status` for per-environment latest version + action status, and introduces `prime env action` subcommands to list actions, fetch/follow logs (with ANSI stripping and basic rate-limit backoff), and retry an action.
> 
> Also adds `format_time_ago` to `time_utils` and uses it for action timestamps, updates RL failure messaging to point to the new action list command, and makes minor CLI help formatting/panel organization tweaks (including `\b` examples blocks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c32730c2b3c3fef370a1dba0b98d7e75f856a2f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->