### PR TITLE
sandbox image sdk

### DIFF
--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "aiofiles>=23.0.0",
     "tenacity>=8.0.0",
+    "pathspec>=1.0.3",
 ]
 keywords = ["sandboxes", "remote-execution", "containers", "cloud", "sdk"]
 classifiers = [

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -23,6 +23,7 @@ from .exceptions import (
     SandboxUnresponsiveError,
     UploadTimeoutError,
 )
+from .image_client import AsyncImageClient, ImageClient
 from .models import (
     AdvancedConfigs,
     BackgroundJob,
@@ -36,6 +37,10 @@ from .models import (
     ExposedPort,
     ExposePortRequest,
     FileUploadResponse,
+    Image,
+    ImageBuildResponse,
+    ImageBuildStatus,
+    ImageListResponse,
     ListExposedPortsResponse,
     RegistryCredentialSummary,
     Sandbox,
@@ -61,6 +66,9 @@ __all__ = [
     "AsyncSandboxClient",
     "TemplateClient",
     "AsyncTemplateClient",
+    # Image Clients
+    "ImageClient",
+    "AsyncImageClient",
     # Models
     "Sandbox",
     "SandboxStatus",
@@ -77,6 +85,11 @@ __all__ = [
     "AdvancedConfigs",
     "BackgroundJob",
     "BackgroundJobStatus",
+    # Image Models
+    "Image",
+    "ImageBuildStatus",
+    "ImageBuildResponse",
+    "ImageListResponse",
     # Port Forwarding
     "ExposePortRequest",
     "ExposedPort",

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -107,6 +107,9 @@ class ImageClient:
         if team_id:
             build_request["team_id"] = team_id
 
+        if context_path and not os.path.isdir(context_path):
+            raise FileNotFoundError(f"Build context directory not found: {context_path}")
+
         # No context_path means read Dockerfile and send content directly
         if not context_path:
             if not os.path.exists(dockerfile_path):
@@ -311,6 +314,10 @@ class AsyncImageClient:
         }
         if team_id:
             build_request["team_id"] = team_id
+
+        # Validate context_path exists before making API call to avoid orphaned builds
+        if context_path and not os.path.isdir(context_path):
+            raise FileNotFoundError(f"Build context directory not found: {context_path}")
 
         # TODO: Use aiofiles or run_in_executor for file I/O to avoid blocking event loop
         # No context_path means read Dockerfile and send content directly

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -107,8 +107,12 @@ class ImageClient:
         if team_id:
             build_request["team_id"] = team_id
 
-        if context_path and not os.path.isdir(context_path):
-            raise FileNotFoundError(f"Build context directory not found: {context_path}")
+        if context_path:
+            if not os.path.isdir(context_path):
+                raise FileNotFoundError(f"Build context directory not found: {context_path}")
+            dockerfile_in_context = os.path.join(context_path, dockerfile_path)
+            if not os.path.exists(dockerfile_in_context):
+                raise FileNotFoundError(f"Dockerfile not found at {dockerfile_in_context}")
 
         # No context_path means read Dockerfile and send content directly
         if not context_path:
@@ -315,9 +319,13 @@ class AsyncImageClient:
         if team_id:
             build_request["team_id"] = team_id
 
-        # Validate context_path exists before making API call to avoid orphaned builds
-        if context_path and not os.path.isdir(context_path):
-            raise FileNotFoundError(f"Build context directory not found: {context_path}")
+        # Validate context_path and Dockerfile exist before making API call
+        if context_path:
+            if not os.path.isdir(context_path):
+                raise FileNotFoundError(f"Build context directory not found: {context_path}")
+            dockerfile_in_context = os.path.join(context_path, dockerfile_path)
+            if not os.path.exists(dockerfile_in_context):
+                raise FileNotFoundError(f"Dockerfile not found at {dockerfile_in_context}")
 
         # TODO: Use aiofiles or run_in_executor for file I/O to avoid blocking event loop
         # No context_path means read Dockerfile and send content directly

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -47,8 +47,8 @@ def _create_context_tarball(context_path: str) -> bytes:
 
         def tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
             # Get path relative to context (strip leading ./)
-            rel_path = tarinfo.name.lstrip("./")
-            if not rel_path:
+            rel_path = tarinfo.name.removeprefix("./")
+            if not rel_path or rel_path == ".":
                 return tarinfo  # Keep root directory
             if spec and spec.match_file(rel_path):
                 return None  # Exclude ignored files

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -1,0 +1,472 @@
+"""Image client implementations for building and managing container images."""
+
+import asyncio
+import hashlib
+import io
+import os
+import tarfile
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+import pathspec
+
+from .core import APIClient, APIError, AsyncAPIClient
+from .models import (
+    Image,
+    ImageBuildResponse,
+    ImageBuildStatus,
+    ImageListResponse,
+)
+
+
+def _compute_dockerfile_hash(content: str) -> str:
+    """Compute SHA256 hash of Dockerfile content for caching."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _load_dockerignore(context_path: str) -> Optional[pathspec.PathSpec]:
+    """Load .dockerignore patterns if the file exists."""
+    dockerignore_path = os.path.join(context_path, ".dockerignore")
+    if not os.path.exists(dockerignore_path):
+        return None
+
+    with open(dockerignore_path, "r") as f:
+        patterns = f.read().splitlines()
+
+    return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _create_context_tarball(context_path: str) -> bytes:
+    """Create a tar.gz archive of the build context directory."""
+    buffer = io.BytesIO()
+    context_path = os.path.abspath(context_path)
+    spec = _load_dockerignore(context_path)
+
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+
+        def tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+            # Get path relative to context (strip leading ./)
+            rel_path = tarinfo.name.lstrip("./")
+            if not rel_path:
+                return tarinfo  # Keep root directory
+            if spec and spec.match_file(rel_path):
+                return None  # Exclude ignored files
+            return tarinfo
+
+        tar.add(context_path, arcname=".", filter=tar_filter)
+
+    buffer.seek(0)
+    return buffer.read()
+
+
+class ImageClient:
+    """Client for building and managing container images."""
+
+    def __init__(self, api_client: Optional[APIClient] = None):
+        self.client = api_client or APIClient()
+
+    def build(
+        self,
+        name: str,
+        dockerfile_path: str = "Dockerfile",
+        tag: str = "latest",
+        context_path: Optional[str] = None,
+        ephemeral: bool = False,
+        team_id: Optional[str] = None,
+        wait: bool = True,
+        poll_interval: float = 2.0,
+        timeout: int = 1800,
+    ) -> Image:
+        """Build a container image from a Dockerfile.
+
+        Args:
+            name: Image name
+            dockerfile_path: Path to Dockerfile (default: "Dockerfile")
+            tag: Image tag (default: "latest")
+            context_path: Build context directory path. If not provided, only
+                the Dockerfile is sent to the server (fast path, no COPY/ADD support).
+            ephemeral: Auto-delete when linked sandbox terminates (default: False)
+            team_id: Team ID for team images (optional)
+            wait: Wait for build to complete (default: True)
+            poll_interval: Seconds between status polls (default: 2.0)
+            timeout: Maximum seconds to wait for build (default: 1800)
+
+        Returns:
+            Image object with build result
+
+        Raises:
+            FileNotFoundError: If Dockerfile not found
+            APIError: If build fails
+        """
+        # Auto-populate team_id from config if not specified
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        # Build request
+        build_request: Dict[str, Any] = {
+            "image_name": name,
+            "image_tag": tag,
+            "dockerfile_path": dockerfile_path,
+            "is_ephemeral": ephemeral,
+        }
+        if team_id:
+            build_request["team_id"] = team_id
+
+        # No context_path means read Dockerfile and send content directly
+        if not context_path:
+            if not os.path.exists(dockerfile_path):
+                raise FileNotFoundError(f"Dockerfile not found: {dockerfile_path}")
+
+            with open(dockerfile_path, "r") as f:
+                dockerfile_content = f.read()
+
+            build_request["dockerfile_content"] = dockerfile_content
+            build_request["dockerfile_hash"] = _compute_dockerfile_hash(dockerfile_content)
+
+        response = self.client.request("POST", "/images/build", json=build_request)
+        build_response = ImageBuildResponse.model_validate(response)
+
+        if build_response.cached:
+            return self._get_image_from_build_id(build_response.build_id)
+
+        # Upload build context if needed (only when context_path provided)
+        if build_response.upload_url and context_path:
+            context_bytes = _create_context_tarball(context_path)
+            self._upload_context(build_response.upload_url, context_bytes)
+
+        # Start the build (always needed, whether fast path or upload path)
+        self.client.request(
+            "POST",
+            f"/images/build/{build_response.build_id}/start",
+            json={"context_uploaded": True},
+        )
+
+        if not wait:
+            return self._get_image_from_build_id(build_response.build_id)
+
+        # Poll for completion
+        return self._wait_for_build(
+            build_response.build_id,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+
+    def _upload_context(self, upload_url: str, context_bytes: bytes) -> None:
+        """Upload build context to presigned URL."""
+        with httpx.Client(timeout=600) as http_client:
+            response = http_client.put(
+                upload_url,
+                content=context_bytes,
+                headers={"Content-Type": "application/gzip"},
+            )
+            response.raise_for_status()
+
+    def _get_image_from_build_id(self, build_id: str) -> Image:
+        """Get Image object from build status."""
+        response = self.client.request("GET", f"/images/build/{build_id}")
+        return Image(
+            id=response["id"],
+            imageRef=response.get("fullImagePath", ""),
+            imageName=response["imageName"],
+            imageTag=response["imageTag"],
+            status=ImageBuildStatus(response["status"]),
+            sizeBytes=response.get("sizeBytes"),
+            isEphemeral=response.get("isEphemeral", False),
+            dockerfileHash=response.get("dockerfileHash"),
+            createdAt=response["createdAt"],
+            errorMessage=response.get("errorMessage"),
+            teamId=response.get("teamId"),
+        )
+
+    def _wait_for_build(
+        self,
+        build_id: str,
+        poll_interval: float = 2.0,
+        timeout: int = 1800,
+    ) -> Image:
+        """Wait for build to complete and return Image."""
+        start_time = time.time()
+
+        while True:
+            if time.time() - start_time > timeout:
+                raise APIError(f"Build {build_id} timed out after {timeout} seconds")
+
+            image = self._get_image_from_build_id(build_id)
+
+            if image.status == ImageBuildStatus.COMPLETED:
+                return image
+            elif image.status == ImageBuildStatus.FAILED:
+                raise APIError(f"Build {build_id} failed: {image.error_message or 'Unknown error'}")
+            elif image.status == ImageBuildStatus.CANCELLED:
+                raise APIError(f"Build {build_id} was cancelled")
+
+            time.sleep(poll_interval)
+
+    def get_build_status(self, build_id: str) -> Image:
+        """Get the current status of an image build."""
+        return self._get_image_from_build_id(build_id)
+
+    def list(self, team_id: Optional[str] = None) -> ImageListResponse:
+        """List all images accessible to the current user."""
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        params = {}
+        if team_id:
+            params["teamId"] = team_id
+
+        response = self.client.request("GET", "/images", params=params or None)
+        images_data = response.get("data", [])
+
+        images = []
+        for img in images_data:
+            images.append(
+                Image(
+                    id=img["id"],
+                    imageRef=img.get("fullImagePath", ""),
+                    imageName=img["imageName"],
+                    imageTag=img["imageTag"],
+                    status=ImageBuildStatus(img["status"]),
+                    sizeBytes=img.get("sizeBytes"),
+                    isEphemeral=img.get("isEphemeral", False),
+                    dockerfileHash=img.get("dockerfileHash"),
+                    createdAt=img["createdAt"],
+                    errorMessage=img.get("errorMessage"),
+                    teamId=img.get("teamId"),
+                    displayRef=img.get("displayRef"),
+                )
+            )
+
+        return ImageListResponse(images=images, total=len(images))
+
+    def delete(
+        self,
+        name: str,
+        tag: str = "latest",
+        team_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Delete an image."""
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        params = {}
+        if team_id:
+            params["teamId"] = team_id
+
+        return self.client.request(
+            "DELETE",
+            f"/images/{name}/{tag}",
+            params=params or None,
+        )
+
+
+class AsyncImageClient:
+    """Async client for building and managing container images."""
+
+    def __init__(self, api_client: Optional[AsyncAPIClient] = None):
+        self.client = api_client or AsyncAPIClient()
+
+    async def build(
+        self,
+        name: str,
+        dockerfile_path: str = "Dockerfile",
+        tag: str = "latest",
+        context_path: Optional[str] = None,
+        ephemeral: bool = False,
+        team_id: Optional[str] = None,
+        wait: bool = True,
+        poll_interval: float = 2.0,
+        timeout: int = 1800,
+    ) -> Image:
+        """Build a container image from a Dockerfile.
+
+        Args:
+            name: Image name
+            dockerfile_path: Path to Dockerfile (default: "Dockerfile")
+            tag: Image tag (default: "latest")
+            context_path: Build context directory path. If not provided, only
+                the Dockerfile is sent to the server (fast path, no COPY/ADD support).
+            ephemeral: Auto-delete when linked sandbox terminates (default: False)
+            team_id: Team ID for team images (optional)
+            wait: Wait for build to complete (default: True)
+            poll_interval: Seconds between status polls (default: 2.0)
+            timeout: Maximum seconds to wait for build (default: 1800)
+
+        Returns:
+            Image object with build result
+
+        Raises:
+            FileNotFoundError: If Dockerfile not found
+            APIError: If build fails
+        """
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        build_request: Dict[str, Any] = {
+            "image_name": name,
+            "image_tag": tag,
+            "dockerfile_path": dockerfile_path,
+            "is_ephemeral": ephemeral,
+        }
+        if team_id:
+            build_request["team_id"] = team_id
+
+        # No context_path means read Dockerfile and send content directly
+        if not context_path:
+            if not os.path.exists(dockerfile_path):
+                raise FileNotFoundError(f"Dockerfile not found: {dockerfile_path}")
+
+            with open(dockerfile_path, "r") as f:
+                dockerfile_content = f.read()
+
+            build_request["dockerfile_content"] = dockerfile_content
+            build_request["dockerfile_hash"] = _compute_dockerfile_hash(dockerfile_content)
+
+        response = await self.client.request("POST", "/images/build", json=build_request)
+        build_response = ImageBuildResponse.model_validate(response)
+
+        if build_response.cached:
+            return await self._get_image_from_build_id(build_response.build_id)
+
+        # Upload build context if needed (only when context_path provided)
+        if build_response.upload_url and context_path:
+            context_bytes = _create_context_tarball(context_path)
+            await self._upload_context(build_response.upload_url, context_bytes)
+
+        # Start the build (always needed, whether fast path or upload path)
+        await self.client.request(
+            "POST",
+            f"/images/build/{build_response.build_id}/start",
+            json={"context_uploaded": True},
+        )
+
+        if not wait:
+            return await self._get_image_from_build_id(build_response.build_id)
+
+        # Poll for completion
+        return await self._wait_for_build(
+            build_response.build_id,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+
+    async def _upload_context(self, upload_url: str, context_bytes: bytes) -> None:
+        """Upload build context to presigned URL."""
+        async with httpx.AsyncClient(timeout=600) as http_client:
+            response = await http_client.put(
+                upload_url,
+                content=context_bytes,
+                headers={"Content-Type": "application/gzip"},
+            )
+            response.raise_for_status()
+
+    async def _get_image_from_build_id(self, build_id: str) -> Image:
+        """Get Image object from build status."""
+        response = await self.client.request("GET", f"/images/build/{build_id}")
+        return Image(
+            id=response["id"],
+            imageRef=response.get("fullImagePath", ""),
+            imageName=response["imageName"],
+            imageTag=response["imageTag"],
+            status=ImageBuildStatus(response["status"]),
+            sizeBytes=response.get("sizeBytes"),
+            isEphemeral=response.get("isEphemeral", False),
+            dockerfileHash=response.get("dockerfileHash"),
+            createdAt=response["createdAt"],
+            errorMessage=response.get("errorMessage"),
+            teamId=response.get("teamId"),
+        )
+
+    async def _wait_for_build(
+        self,
+        build_id: str,
+        poll_interval: float = 2.0,
+        timeout: int = 1800,
+    ) -> Image:
+        """Wait for build to complete and return Image."""
+        start_time = time.time()
+
+        while True:
+            if time.time() - start_time > timeout:
+                raise APIError(f"Build {build_id} timed out after {timeout} seconds")
+
+            image = await self._get_image_from_build_id(build_id)
+
+            if image.status == ImageBuildStatus.COMPLETED:
+                return image
+            elif image.status == ImageBuildStatus.FAILED:
+                raise APIError(f"Build {build_id} failed: {image.error_message or 'Unknown error'}")
+            elif image.status == ImageBuildStatus.CANCELLED:
+                raise APIError(f"Build {build_id} was cancelled")
+
+            await asyncio.sleep(poll_interval)
+
+    async def get_build_status(self, build_id: str) -> Image:
+        """Get the current status of an image build."""
+        return await self._get_image_from_build_id(build_id)
+
+    async def list(self, team_id: Optional[str] = None) -> ImageListResponse:
+        """List all images accessible to the current user."""
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        params = {}
+        if team_id:
+            params["teamId"] = team_id
+
+        response = await self.client.request("GET", "/images", params=params or None)
+        images_data = response.get("data", [])
+
+        images = []
+        for img in images_data:
+            images.append(
+                Image(
+                    id=img["id"],
+                    imageRef=img.get("fullImagePath", ""),
+                    imageName=img["imageName"],
+                    imageTag=img["imageTag"],
+                    status=ImageBuildStatus(img["status"]),
+                    sizeBytes=img.get("sizeBytes"),
+                    isEphemeral=img.get("isEphemeral", False),
+                    dockerfileHash=img.get("dockerfileHash"),
+                    createdAt=img["createdAt"],
+                    errorMessage=img.get("errorMessage"),
+                    teamId=img.get("teamId"),
+                    displayRef=img.get("displayRef"),
+                )
+            )
+
+        return ImageListResponse(images=images, total=len(images))
+
+    async def delete(
+        self,
+        name: str,
+        tag: str = "latest",
+        team_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Delete an image."""
+        if team_id is None:
+            team_id = self.client.config.team_id
+
+        params = {}
+        if team_id:
+            params["teamId"] = team_id
+
+        return await self.client.request(
+            "DELETE",
+            f"/images/{name}/{tag}",
+            params=params or None,
+        )
+
+    async def aclose(self) -> None:
+        """Close the async client."""
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "AsyncImageClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Async context manager exit."""
+        await self.aclose()

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -86,7 +86,7 @@ class ImageClient:
             tag: Image tag (default: "latest")
             context_path: Build context directory path. If not provided, only
                 the Dockerfile is sent to the server (fast path, no COPY/ADD support).
-            ephemeral: Auto-delete when linked sandbox terminates (default: False)
+            ephemeral: Auto-delete after 24 hours (default: False)
             team_id: Team ID for team images (optional)
             wait: Wait for build to complete (default: True)
             poll_interval: Seconds between status polls (default: 2.0)
@@ -294,7 +294,7 @@ class AsyncImageClient:
             tag: Image tag (default: "latest")
             context_path: Build context directory path. If not provided, only
                 the Dockerfile is sent to the server (fast path, no COPY/ADD support).
-            ephemeral: Auto-delete when linked sandbox terminates (default: False)
+            ephemeral: Auto-delete after 24 hours (default: False)
             team_id: Team ID for team images (optional)
             wait: Wait for build to complete (default: True)
             poll_interval: Seconds between status polls (default: 2.0)

--- a/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/image_client.py
@@ -1,7 +1,6 @@
 """Image client implementations for building and managing container images."""
 
 import asyncio
-import hashlib
 import io
 import os
 import tarfile
@@ -18,11 +17,6 @@ from .models import (
     ImageBuildStatus,
     ImageListResponse,
 )
-
-
-def _compute_dockerfile_hash(content: str) -> str:
-    """Compute SHA256 hash of Dockerfile content for caching."""
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
 def _load_dockerignore(context_path: str) -> Optional[pathspec.PathSpec]:
@@ -122,7 +116,6 @@ class ImageClient:
                 dockerfile_content = f.read()
 
             build_request["dockerfile_content"] = dockerfile_content
-            build_request["dockerfile_hash"] = _compute_dockerfile_hash(dockerfile_content)
 
         response = self.client.request("POST", "/images/build", json=build_request)
         build_response = ImageBuildResponse.model_validate(response)
@@ -329,7 +322,6 @@ class AsyncImageClient:
                 dockerfile_content = f.read()
 
             build_request["dockerfile_content"] = dockerfile_content
-            build_request["dockerfile_hash"] = _compute_dockerfile_hash(dockerfile_content)
 
         response = await self.client.request("POST", "/images/build", json=build_request)
         build_response = ImageBuildResponse.model_validate(response)

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -87,6 +87,8 @@ class Sandbox(BaseModel):
     team_id: Optional[str] = Field(None, alias="teamId")
     kubernetes_job_id: Optional[str] = Field(None, alias="kubernetesJobId")
     registry_credentials_id: Optional[str] = Field(default=None, alias="registryCredentialsId")
+    image_build_id: Optional[str] = Field(default=None, alias="imageBuildId")
+    image_build_status: Optional[str] = Field(default=None, alias="imageBuildStatus")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -111,11 +113,6 @@ class CreateSandboxRequest(BaseModel):
     dockerfile: Optional[str] = Field(
         default=None,
         description="Path to Dockerfile for building image (e.g., './Dockerfile')",
-    )
-    build_context: Optional[str] = Field(
-        default=None,
-        description="Build context directory path. If not provided, only the "
-        "Dockerfile is used (no COPY/ADD support).",
     )
     start_command: Optional[str] = "tail -f /dev/null"
     cpu_cores: int = 1

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -292,7 +292,9 @@ class ImageBuildResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    build_id: str = Field(..., alias="buildId", description="Build ID for tracking")
+    build_id: Optional[str] = Field(
+        default=None, alias="buildId", description="Build ID for tracking (None when cached)"
+    )
     upload_url: Optional[str] = Field(
         default=None, alias="uploadUrl", description="Presigned URL for context upload"
     )
@@ -301,3 +303,9 @@ class ImageBuildResponse(BaseModel):
     )
     image_ref: str = Field(..., alias="fullImagePath", description="Full image reference")
     cached: bool = Field(default=False, description="Whether a cached image was found")
+    image_id: Optional[str] = Field(default=None, alias="imageId", description="Image ID")
+    image_name: Optional[str] = Field(default=None, alias="imageName", description="Image name")
+    image_tag: Optional[str] = Field(default=None, alias="imageTag", description="Image tag")
+    created_at: Optional[datetime] = Field(
+        default=None, alias="createdAt", description="Creation timestamp"
+    )

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "verifiers>=0.1.9.post1",
     "build>=1.0.0",
     "toml>=0.10.0",
+    "pathspec>=1.0.3",
 ]
 keywords = ["cli", "gpu", "cloud", "compute"]
 classifiers = [

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -82,8 +82,8 @@ def push_image(
             spec = _load_dockerignore(context)
 
             def tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
-                rel_path = tarinfo.name.lstrip("./")
-                if not rel_path:
+                rel_path = tarinfo.name.removeprefix("./")
+                if not rel_path or rel_path == ".":
                     return tarinfo  # Keep root directory
                 if spec and spec.match_file(rel_path):
                     return None  # Exclude ignored files

--- a/uv.lock
+++ b/uv.lock
@@ -1610,6 +1610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
+]
+
+[[package]]
 name = "pathvalidate"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1659,6 +1668,7 @@ dependencies = [
     { name = "build" },
     { name = "cryptography" },
     { name = "httpx" },
+    { name = "pathspec" },
     { name = "prime-evals" },
     { name = "prime-sandboxes" },
     { name = "pydantic" },
@@ -1681,6 +1691,7 @@ requires-dist = [
     { name = "build", specifier = ">=1.0.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "pathspec", specifier = ">=1.0.3" },
     { name = "prime-evals", editable = "packages/prime-evals" },
     { name = "prime-sandboxes", editable = "packages/prime-sandboxes" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -1753,6 +1764,7 @@ source = { editable = "packages/prime-sandboxes" }
 dependencies = [
     { name = "aiofiles" },
     { name = "httpx" },
+    { name = "pathspec" },
     { name = "pydantic" },
     { name = "tenacity" },
 ]
@@ -1769,6 +1781,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "pathspec", specifier = ">=1.0.3" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new build/upload logic and changes request/response models and CLI parameters around image building; incorrect mapping or tarball filtering could break image builds or sandbox creation payloads.
> 
> **Overview**
> Adds a new `ImageClient`/`AsyncImageClient` to the `prime-sandboxes` SDK for building, polling, listing, and deleting registry images via the `/images` API, including optional build-context upload as a `.tar.gz` that honors `.dockerignore`.
> 
> Extends SDK models with `Image*` types plus sandbox fields (`imageBuildId`/`imageBuildStatus`) and relaxes `CreateSandboxRequest` to allow either a prebuilt `docker_image` or a `dockerfile`-based build. The `prime images push` command now filters the context using `.dockerignore` and drops the previously-sent `platform` parameter, and both the SDK and CLI add `pathspec` as a dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 194cc04717cae0b43626e75df9b3205fe8ed8ad6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->