### PR TITLE
ENG-2719: Check CI status before starting run

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -327,7 +327,7 @@ class RLClient:
         """Get status for an environment including latest version and action info."""
         try:
             response = self.client.get(f"/environmentshub/{owner}/{name}/status")
-            return response.get("data", {})
+            return response.get("data") or {}
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -322,3 +322,15 @@ class RLClient:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to get RL run distributions: {e.response.text}")
             raise APIError(f"Failed to get RL run distributions: {str(e)}")
+
+    def get_environment_status(self, owner: str, name: str) -> Dict[str, Any]:
+        """Get status for an environment including latest version and action info."""
+        try:
+            response = self.client.get(f"/environmentshub/{owner}/{name}/status")
+            return response.get("data", {})
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(
+                    f"Failed to get status for {owner}/{name}: {e.response.text}"
+                )
+            raise APIError(f"Failed to get status for {owner}/{name}: {str(e)}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -541,7 +541,9 @@ def create_run(
                     elif action_status == "SUCCESS":
                         console.print(f"  [green]✓[/green] {env_config.id} [dim](success)[/dim]")
                     elif action_status in ("RUNNING", "PENDING"):
-                        console.print(f"  [yellow]○[/yellow] {env_config.id} [dim](in progress)[/dim]")
+                        console.print(
+                            f"  [yellow]○[/yellow] {env_config.id} [dim](in progress)[/dim]"
+                        )
                     else:
                         console.print(f"  [dim]-[/dim] {env_config.id} [dim](no action)[/dim]")
                 except APIError:
@@ -555,7 +557,11 @@ def create_run(
                     console.print(f"  [red]✗[/red] {env_id}")
                     console.print(f"    [link={url}]{url}[/link]\n")
 
-                console.print("[yellow]This usually means the environment doesn't compile or run, or is using an unsupported version of verifiers, so the training run will fail.[/yellow]")
+                console.print(
+                    "[yellow]This usually means the environment doesn't compile or run, "
+                    "or is using an unsupported version of verifiers, so the training run "
+                    "will fail.[/yellow]"
+                )
                 console.print("[dim]To proceed anyway, use --skip-action-check[/dim]")
                 raise typer.Exit(1)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -529,7 +529,8 @@ def create_run(
             failed_envs = []
 
             for env_config in hub_envs:
-                owner, name = env_config.id.split("/", 1)
+                env_id_base = env_config.id.split("@")[0]
+                owner, name = env_id_base.split("/", 1)
                 try:
                     status_resp = rl_client.get_environment_status(owner, name)
                     action = status_resp.get("action") or {}
@@ -552,7 +553,8 @@ def create_run(
             if failed_envs:
                 console.print("\n[red]Error: Action failed for environments:[/red]\n")
                 for env_id in failed_envs:
-                    owner, name = env_id.split("/", 1)
+                    env_id_base = env_id.split("@")[0]
+                    owner, name = env_id_base.split("/", 1)
                     url = f"{app_config.frontend_url}/dashboard/environments/{owner}/{name}/actions"
                     console.print(f"  [red]✗[/red] {env_id}")
                     console.print(f"    [link={url}]{url}[/link]\n")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -402,6 +402,11 @@ def create_run(
         help="Path to .env file containing secrets.",
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    skip_action_check: bool = typer.Option(
+        False,
+        "--skip-action-check",
+        help="Skip action status check and run even if environment action failed.",
+    ),
 ) -> None:
     """Start an RL training run from a config file.
 
@@ -456,8 +461,6 @@ def create_run(
         api_client = APIClient()
         rl_client = RLClient(api_client)
         app_config = Config()
-
-        console.print("[dim]Creating RL training run[/dim]\n")
 
         # Show configuration in organized sections
         console.print("[white]Configuration:[/white]\n")
@@ -518,6 +521,47 @@ def create_run(
             console.print(f"  Keys: {', '.join(secrets.keys())}")
 
         console.print()
+
+        # Check action status for hub environments
+        hub_envs = [e for e in cfg.env if "/" in e.id]
+        if hub_envs and not skip_action_check:
+            console.print("[dim]Checking Environment Actions...[/dim]")
+            failed_envs = []
+
+            for env_config in hub_envs:
+                owner, name = env_config.id.split("/", 1)
+                try:
+                    status_resp = rl_client.get_environment_status(owner, name)
+                    action = status_resp.get("action") or {}
+                    action_status = action.get("status")
+
+                    if action_status == "FAILED":
+                        console.print(f"  [red]✗[/red] {env_config.id} [dim](failed)[/dim]")
+                        failed_envs.append(env_config.id)
+                    elif action_status == "SUCCESS":
+                        console.print(f"  [green]✓[/green] {env_config.id} [dim](success)[/dim]")
+                    elif action_status in ("RUNNING", "PENDING"):
+                        console.print(f"  [yellow]○[/yellow] {env_config.id} [dim](in progress)[/dim]")
+                    else:
+                        console.print(f"  [dim]-[/dim] {env_config.id} [dim](no action)[/dim]")
+                except APIError:
+                    console.print(f"  [dim]-[/dim] {env_config.id} [dim](could not check)[/dim]")
+
+            if failed_envs:
+                console.print("\n[red]Error: Action failed for environments:[/red]\n")
+                for env_id in failed_envs:
+                    owner, name = env_id.split("/", 1)
+                    url = f"{app_config.frontend_url}/dashboard/environments/{owner}/{name}/actions"
+                    console.print(f"  [red]✗[/red] {env_id}")
+                    console.print(f"    [link={url}]{url}[/link]\n")
+
+                console.print("[yellow]This usually means the environment doesn't compile or run, or is using an unsupported version of verifiers, so the training run will fail.[/yellow]")
+                console.print("[dim]To proceed anyway, use --skip-action-check[/dim]")
+                raise typer.Exit(1)
+
+            console.print()
+
+        console.print("[dim]Creating RL training run...[/dim]\n")
 
         # Create the run
         run = rl_client.create_run(


### PR DESCRIPTION

<img width="986" height="508" alt="Screenshot 2026-01-26 at 4 32 43 PM" src="https://github.com/user-attachments/assets/9cadad64-d95d-41fa-aeda-cc7821ba699b" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pre-flight check to prevent starting runs when hub environments have failing actions.
> 
> - New `RLClient.get_environment_status(owner, name)` calling `/environmentshub/{owner}/{name}/status`
> - `prime rl run` now checks action status for hub environments, prints per-env status, and aborts if any are `FAILED` (with dashboard links)
> - New `--skip-action-check` flag to bypass this validation
> - Minor UX: "Creating RL training run..." message shown after checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10fcd50ae24980fea1298ae90c7b324ea6d4bd88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->