### PR TITLE
change --limit -> --num (-l -> -n)

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -172,7 +172,7 @@ def compute_content_hash(env_path: Path) -> str:
 @app.command("list")
 def list_cmd(
     limit: int = typer.Option(
-        DEFAULT_LIST_LIMIT, "--limit", "-l", help="Number of environments to show"
+        DEFAULT_LIST_LIMIT, "--num", "-n", help="Number of environments to show"
     ),
     offset: int = typer.Option(0, "--offset", help="Number of environments to skip"),
     owner: Optional[str] = typer.Option(None, "--owner", help="Filter by owner name"),

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -181,7 +181,7 @@ def get_eval(
 def get_samples(
     eval_id: str = typer.Argument(..., help="The ID of the evaluation"),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
-    limit: int = typer.Option(100, "--limit", "-l", help="Samples per page"),
+    limit: int = typer.Option(100, "--num", "-n", help="Samples per page"),
     output: str = typer.Option("json", "--output", "-o", help="json|pretty"),
 ) -> None:
     _validate_output_format(output, ["json", "pretty"])


### PR DESCRIPTION
Small nit, for consistency across methods/libraries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes pagination flags across CLI.
> 
> - `prime env list`: renames `--limit`/`-l` to `--num`/`-n`
> - `prime eval samples`: renames `--limit`/`-l` to `--num`/`-n`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b22fd246719e7af930a902e655d30f4d9c06281f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->