### PR TITLE
Bump prime-cli to 0.5.24

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.23"
+__version__ = "0.5.24"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- Patch bump prime-cli from 0.5.23 to 0.5.24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Bumps `__version__` in `prime_cli/__init__.py` from `0.5.23` to `0.5.24`; no functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c70d0cdeb3512578e586f69fe616fa45fad3c6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->