### PR TITLE
ENG-2755: Show capacity for prime rl models

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -12,8 +12,6 @@ class RLModel(BaseModel):
     """Model available for RL training."""
 
     name: str = Field(..., description="Model name")
-    total_capacity: int = Field(0, alias="totalCapacity")
-    running_count: int = Field(0, alias="runningCount")
     at_capacity: bool = Field(False, alias="atCapacity")
 
     model_config = ConfigDict(populate_by_name=True)

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -12,6 +12,9 @@ class RLModel(BaseModel):
     """Model available for RL training."""
 
     name: str = Field(..., description="Model name")
+    total_capacity: int = Field(0, alias="totalCapacity")
+    running_count: int = Field(0, alias="runningCount")
+    at_capacity: bool = Field(False, alias="atCapacity")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -650,10 +650,15 @@ def list_models(
             return
 
         table = Table(title="Prime RL — Models")
-        table.add_column("id", style="cyan")
+        table.add_column("Model", style="cyan")
+        table.add_column("Status")
 
         for model in models:
-            table.add_row(model.name)
+            if model.at_capacity:
+                status = "[red]At Capacity[/red]"
+            else:
+                status = "[green]Available[/green]"
+            table.add_row(model.name, status)
 
         console.print(table)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, read-only CLI/API model change; primary risk is compatibility if the backend omits or renames the `atCapacity` field.
> 
> **Overview**
> The RL models API/CLI output now exposes per-model capacity via a new `RLModel.at_capacity` field (mapped from `atCapacity`).
> 
> `prime rl models` table output is updated to include a **Status** column that renders models as *Available* vs *At Capacity* based on that flag (JSON output includes the new field via `model_dump`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e210cd6e4ecff4b8afda345c58eb01654d01159d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->