### PR TITLE
Bump prime-cli to 0.5.26

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.25"
+__version__ = "0.5.26"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps CLI version to 0.5.26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no behavioral impact; low risk aside from downstream packaging/release expectations.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.25` to `0.5.26` in `__init__.py` (no functional code changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9601a3cd08b52c8109a7af27f497d60c7b37c1b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->