### PR TITLE
Reduce stability checks in sandbox creation logic

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -605,30 +605,18 @@ class SandboxClient:
             stderr=stderr_logs.stdout,
         )
 
-    def wait_for_creation(
-        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
-    ) -> None:
+    def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
         """Wait for sandbox to be running and stable.
 
         Args:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
-            stability_checks: Number of consecutive successful reachability checks required
         """
-        consecutive_successes = 0
         for attempt in range(max_attempts):
             sandbox = self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if self._is_sandbox_reachable(sandbox_id):
-                    consecutive_successes += 1
-                    if consecutive_successes >= stability_checks:
-                        return
-                    # Small delay between stability checks
-                    time.sleep(0.5)
-                    continue
-                else:
-                    # Reset counter if check fails
-                    consecutive_successes = 0
+                    return
             elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 ctx = {
                     "status": sandbox.status,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -605,18 +605,30 @@ class SandboxClient:
             stderr=stderr_logs.stdout,
         )
 
-    def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
+    def wait_for_creation(
+        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
+    ) -> None:
         """Wait for sandbox to be running and stable.
 
         Args:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
+            stability_checks: Number of consecutive successful reachability checks required
         """
+        consecutive_successes = 0
         for attempt in range(max_attempts):
             sandbox = self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if self._is_sandbox_reachable(sandbox_id):
-                    return
+                    consecutive_successes += 1
+                    if consecutive_successes >= stability_checks:
+                        return
+                    # Small delay between stability checks
+                    time.sleep(0.5)
+                    continue
+                else:
+                    # Reset counter if check fails
+                    consecutive_successes = 0
             elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 ctx = {
                     "status": sandbox.status,
@@ -1240,18 +1252,30 @@ class AsyncSandboxClient:
             stderr=stderr_logs.stdout,
         )
 
-    async def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
+    async def wait_for_creation(
+        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
+    ) -> None:
         """Wait for sandbox to be running and stable (async version).
 
         Args:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
+            stability_checks: Number of consecutive successful reachability checks required
         """
+        consecutive_successes = 0
         for attempt in range(max_attempts):
             sandbox = await self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if await self._is_sandbox_reachable(sandbox_id):
-                    return
+                    consecutive_successes += 1
+                    if consecutive_successes >= stability_checks:
+                        return
+                    # Small delay between stability checks
+                    await asyncio.sleep(0.5)
+                    continue
+                else:
+                    # Reset counter if check fails
+                    consecutive_successes = 0
             elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 ctx = {
                     "status": sandbox.status,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -606,7 +606,7 @@ class SandboxClient:
         )
 
     def wait_for_creation(
-        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 2
+        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
     ) -> None:
         """Wait for sandbox to be running and stable.
 
@@ -1252,31 +1252,18 @@ class AsyncSandboxClient:
             stderr=stderr_logs.stdout,
         )
 
-    async def wait_for_creation(
-        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 2
-    ) -> None:
+    async def wait_for_creation(self, sandbox_id: str, max_attempts: int = 60) -> None:
         """Wait for sandbox to be running and stable (async version).
 
         Args:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
-            stability_checks: Number of consecutive successful reachability checks required
         """
-
-        consecutive_successes = 0
         for attempt in range(max_attempts):
             sandbox = await self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if await self._is_sandbox_reachable(sandbox_id):
-                    consecutive_successes += 1
-                    if consecutive_successes >= stability_checks:
-                        return
-                    # Small delay between stability checks
-                    await asyncio.sleep(0.5)
-                    continue
-                else:
-                    # Reset counter if check fails
-                    consecutive_successes = 0
+                    return
             elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 ctx = {
                     "status": sandbox.status,

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.26"
+__version__ = "0.5.27"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.27"
+__version__ = "0.5.26"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
No need for two consecutive checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to readiness polling defaults; main risk is declaring a sandbox ready slightly earlier in rare flakey-start cases.
> 
> **Overview**
> Reduces sandbox creation “stability” validation by changing the default `stability_checks` in both sync and async `wait_for_creation` from `2` consecutive reachability checks to `1`, allowing sandboxes to be considered ready after the first successful reachability test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be8fac51eb813158b7afe5959aeeab40f324474f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->