### PR TITLE
Add CI check to block version bumps in non-release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Fetch base branch
+      run: git fetch origin ${{ github.base_ref }}
+
     - name: Check for version bumps in non-release PRs
       env:
         BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches: [ "main", "develop" ]
   pull_request:
     branches: [ "main", "develop" ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:
   check-version-bump:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,12 @@ name: CI
 
 permissions:
   contents: read
-  pull-requests: read
 
 on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
     branches: [ "main", "develop" ]
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:
   check-version-bump:
@@ -22,23 +20,11 @@ jobs:
 
     - name: Check for version bumps in non-release PRs
       env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
         BRANCH_NAME: ${{ github.head_ref }}
       run: |
-        # Check if this is a release PR (by label or branch name)
-        LABELS=$(gh pr view $PR_NUMBER --json labels -q '.labels[].name' 2>/dev/null || echo "")
-
-        IS_RELEASE=false
-        if echo "$LABELS" | grep -qiE "^release$"; then
-          IS_RELEASE=true
-          echo "✅ PR has 'release' label - version bumps allowed"
-        elif echo "$BRANCH_NAME" | grep -qE "^release/"; then
-          IS_RELEASE=true
+        # Check if this is a release PR (by branch name)
+        if echo "$BRANCH_NAME" | grep -qE "^release/"; then
           echo "✅ Branch matches 'release/*' pattern - version bumps allowed"
-        fi
-
-        if [ "$IS_RELEASE" = "true" ]; then
           exit 0
         fi
 
@@ -70,9 +56,7 @@ jobs:
           echo -e "$BUMPED_FILES"
           echo ""
           echo "Version bumps should only be done in release PRs."
-          echo "To mark this as a release PR, either:"
-          echo "  1. Add the 'release' label to this PR"
-          echo "  2. Use a branch name starting with 'release/'"
+          echo "Use a branch name starting with 'release/' for release PRs."
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   push:
@@ -10,6 +11,73 @@ on:
     branches: [ "main", "develop" ]
 
 jobs:
+  check-version-bump:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Check for version bumps in non-release PRs
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        BRANCH_NAME: ${{ github.head_ref }}
+      run: |
+        # Check if this is a release PR (by label or branch name)
+        LABELS=$(gh pr view $PR_NUMBER --json labels -q '.labels[].name' 2>/dev/null || echo "")
+
+        IS_RELEASE=false
+        if echo "$LABELS" | grep -qiE "^release$"; then
+          IS_RELEASE=true
+          echo "✅ PR has 'release' label - version bumps allowed"
+        elif echo "$BRANCH_NAME" | grep -qE "^release/"; then
+          IS_RELEASE=true
+          echo "✅ Branch matches 'release/*' pattern - version bumps allowed"
+        fi
+
+        if [ "$IS_RELEASE" = "true" ]; then
+          exit 0
+        fi
+
+        # Get the list of changed files
+        CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+        # Version files to check
+        VERSION_FILES=(
+          "packages/prime/src/prime_cli/__init__.py"
+          "packages/prime-sandboxes/src/prime_sandboxes/__init__.py"
+          "packages/prime-evals/src/prime_evals/__init__.py"
+          "packages/prime-mcp-server/src/prime_mcp/__init__.py"
+        )
+
+        BUMPED_FILES=""
+        for FILE in "${VERSION_FILES[@]}"; do
+          if echo "$CHANGED_FILES" | grep -q "^$FILE$"; then
+            # Check if __version__ was actually changed
+            if git diff origin/${{ github.base_ref }}...HEAD -- "$FILE" | grep -qE "^\+__version__"; then
+              BUMPED_FILES="$BUMPED_FILES\n  - $FILE"
+            fi
+          fi
+        done
+
+        if [ -n "$BUMPED_FILES" ]; then
+          echo "❌ Version bump detected in non-release PR!"
+          echo ""
+          echo "The following version files were modified:"
+          echo -e "$BUMPED_FILES"
+          echo ""
+          echo "Version bumps should only be done in release PRs."
+          echo "To mark this as a release PR, either:"
+          echo "  1. Add the 'release' label to this PR"
+          echo "  2. Use a branch name starting with 'release/'"
+          exit 1
+        fi
+
+        echo "✅ No version bumps detected - OK"
+
+
   lint-format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a lint check that prevents version bumps in regular PRs.

- Blocks changes to `__version__` in package `__init__.py` files
- Allows version bumps only for PRs with `release` label or `release/*` branch names
- Covers all 4 packages (prime, prime-sandboxes, prime-evals, prime-mcp-server)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds an extra guardrail; main risk is false positives/negatives from the shell-based diff detection causing unexpected PR failures.
> 
> **Overview**
> Adds a new GitHub Actions job `check-version-bump` that runs on pull requests and blocks changes to `__version__` in the four package `__init__.py` files.
> 
> The check allows version bumps only when the PR branch name matches `release/*`, otherwise it fails the workflow and lists the offending files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cdaff6f3b79cbd2414b92458e134b8aba4e4d3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->