### PR TITLE
Fix: Improve error messaging for env name dash/underscore normalization

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1478,11 +1478,14 @@ def execute_install_command(cmd: List[str], env_id: str, version: str, tool: str
             name = env_id.split("/")[-1] if "/" in env_id else env_id
             if "-" in name:
                 normalized = normalize_package_name(name)
-                error_msg += (
-                    f"\n\n[yellow]Hint: pip normalizes package names (dashes become underscores).[/yellow]"
-                    f"\n[yellow]The package '{name}' is installed as '{normalized}'.[/yellow]"
+                hint = (
+                    "\n\n[yellow]Hint: pip normalizes package names "
+                    "(dashes become underscores).[/yellow]"
+                    f"\n[yellow]The package '{name}' is installed as "
+                    f"'{normalized}'.[/yellow]"
                     f"\n[yellow]Try: uv pip install {normalized}[/yellow]"
                 )
+                error_msg += hint
 
         raise Exception(error_msg)
 


### PR DESCRIPTION
- Add hint showing normalized package name when name contains dashes (PEP 503)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts CLI output and fallback path checks for local installs; no changes to remote resolution, auth, or installation execution.
> 
> **Overview**
> Improves `prime env install` error messaging for missing *local* environments by detecting dash/underscore mismatches: when a user supplies a name with `-` and the normalized `_` directory is missing, the CLI now checks for a dashed folder and prints a hint to rename it to the expected underscore form.
> 
> Minor cleanup removes an unnecessary comment in `execute_install_command` while keeping streaming install output behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adceea21f503dfed4cb6becb9734d46cd1f6e4ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->