### PR TITLE
Release: Bump prime cli version to 0.5.27

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -45,7 +45,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.26"
+__version__ = "0.5.27"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only bumps in package `__init__.py` files; no behavior or API surface changes beyond the reported versions.
> 
> **Overview**
> Bumps package versions for release: `prime_sandboxes` from `0.2.13` to `0.2.14` and `prime_cli` from `0.5.26` to `0.5.27` by updating `__version__` in their respective `__init__.py` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8afb6f6d5c072a44bfeaf55ea3841058d3558582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->