### PR TITLE
Add release workflow for prime-tunnel package

### DIFF
--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -1,0 +1,85 @@
+name: Release prime-tunnel
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'packages/prime-tunnel/**'
+      - '.github/workflows/release-tunnel.yml'
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Force release even if tag exists'
+        required: false
+        default: 'false'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        working-directory: packages/prime-tunnel
+        run: |
+          VERSION=$(grep -E "^__version__\s*=\s*" src/prime_tunnel/__init__.py | sed -E 's/^__version__[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check for existing tag
+        id: check_tag
+        run: |
+          TAG="prime-tunnel-v${{ steps.version.outputs.version }}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag $TAG already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag $TAG does not exist"
+          fi
+
+      - name: Set up Python
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        working-directory: packages/prime-tunnel
+        run: |
+          uv build --out-dir dist
+
+          # Install twine for publishing
+          uv venv
+          source .venv/bin/activate
+          uv pip install twine
+
+      - name: Create tag
+        if: steps.check_tag.outputs.exists != 'true'
+        run: |
+          TAG="prime-tunnel-v${{ steps.version.outputs.version }}"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        working-directory: packages/prime-tunnel
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          source .venv/bin/activate
+          twine upload dist/*


### PR DESCRIPTION
Adds the missing release workflow for prime-tunnel package.

- Required before releasing prime v0.5.27 since it depends on prime-tunnel>=0.1.0
- Modeled after the existing release-sandboxes.yml workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds an automated publish workflow; main risk is accidental tag/PyPI publishing if mis-triggered or version parsing/tag gating is wrong.
> 
> **Overview**
> Adds a new GitHub Actions workflow `release-tunnel.yml` to automate releasing the `prime-tunnel` package.
> 
> On pushes to `main` affecting `packages/prime-tunnel/**` (or manual dispatch), it reads the package `__version__`, skips if the corresponding `prime-tunnel-vX.Y.Z` tag already exists unless `force_release` is set, builds via `uv`, creates/pushes the git tag, and publishes the dist artifacts to PyPI using `PYPI_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9905abda20b15c9530ef2501cb064c6fafadd680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->