### PR TITLE
Feat: Add secrets subcommands

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -36,7 +36,7 @@ from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
     any_provided,
     prompt_for_value,
-    select_item_interactive,
+    require_selection,
     validate_env_var_name,
 )
 from ..utils.time_utils import format_time_ago, iso_timestamp
@@ -3484,15 +3484,9 @@ def env_secret_update(
 
         if not secret_id:
             secrets = _fetch_env_secrets(client, env_id)
-            if not secrets:
-                console.print(f"[yellow]No secrets to update for {owner}/{env_name}.[/yellow]")
-                raise typer.Exit()
-
-            selected = select_item_interactive(secrets, "update", item_type="secret")
-            if not selected:
-                console.print("\n[dim]Cancelled.[/dim]")
-                raise typer.Exit()
-
+            selected = require_selection(
+                secrets, "update", f"No secrets to update for {owner}/{env_name}."
+            )
             secret_id = selected.get("id")
 
         if not any_provided(name, value, description):
@@ -3562,15 +3556,9 @@ def env_secret_delete(
 
         if not secret_id:
             secrets = _fetch_env_secrets(client, env_id)
-            if not secrets:
-                console.print(f"[yellow]No secrets to delete for {owner}/{env_name}.[/yellow]")
-                raise typer.Exit()
-
-            selected = select_item_interactive(secrets, "delete", item_type="secret")
-            if not selected:
-                console.print("\n[dim]Cancelled.[/dim]")
-                raise typer.Exit()
-
+            selected = require_selection(
+                secrets, "delete", f"No secrets to delete for {owner}/{env_name}."
+            )
             secret_id = selected.get("id")
             secret_name = selected.get("name")
         else:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -33,7 +33,7 @@ from ..utils import output_data_as_json, validate_output_format
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
-from ..utils.prompt import prompt_for_value, select_item_interactive
+from ..utils.prompt import any_provided, prompt_for_value, select_item_interactive
 from ..utils.time_utils import format_time_ago, iso_timestamp
 
 app = typer.Typer(help="Manage verifiers environments", no_args_is_help=True)
@@ -3409,7 +3409,7 @@ def env_secret_update(
 
             secret_id = selected.get("id")
 
-        if not any([name, value, description]):
+        if not any_provided(name, value, description):
             console.print("\n[bold]What would you like to update?[/bold]")
             new_value = prompt_for_value("New value", required=False, hide_input=True)
             if new_value:
@@ -3420,9 +3420,9 @@ def env_secret_update(
                 raise typer.Exit()
 
         payload: Dict[str, Any] = {}
-        if name:
+        if name is not None:
             payload["name"] = name
-        if value:
+        if value is not None:
             payload["value"] = value
         if description is not None:
             payload["description"] = description
@@ -3806,7 +3806,7 @@ def var_update(
     """Update an environment variable."""
     validate_output_format(output, console)
 
-    if not any([name, value, description]):
+    if not any_provided(name, value, description):
         console.print(
             "[red]Error: At least one of --name, --value, or --description is required[/red]"
         )
@@ -3819,9 +3819,9 @@ def var_update(
         env_id = _get_environment_id(client, owner, env_name)
 
         payload: Dict[str, Any] = {}
-        if name:
+        if name is not None:
             payload["name"] = name
-        if value:
+        if value is not None:
             payload["value"] = value
         if description is not None:
             payload["description"] = description

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -33,6 +33,7 @@ from ..utils import output_data_as_json, validate_output_format
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import push_eval_results_to_hub
 from ..utils.formatters import format_file_size
+from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import any_provided, prompt_for_value, select_item_interactive
 from ..utils.time_utils import format_time_ago, iso_timestamp
 
@@ -56,14 +57,6 @@ app.add_typer(secrets_app, name="secrets", rich_help_panel="Manage")
 # Variable subcommand app
 var_app = typer.Typer(help="Manage environment variables", no_args_is_help=True)
 app.add_typer(var_app, name="var", rich_help_panel="Manage")
-
-# Log cleaning pattern
-ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-
-
-def _strip_ansi(text: str) -> str:
-    """Remove ANSI escape codes from text."""
-    return ANSI_ESCAPE.sub("", text)
 
 
 def _parse_environment_slug(environment: str) -> Tuple[str, str]:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -3717,7 +3717,7 @@ def var_list(
         table.add_column("Created", style="dim")
 
         for var in variables:
-            var_id = var.get("id", "")[:8]
+            var_id = var.get("id", "")
             name = var.get("name", "")
             value = var.get("value", "")
             if len(value) > 30:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -3598,18 +3598,23 @@ def env_secret_unlink(
     """Unlink a global secret from an environment."""
     owner, env_name = _resolve_environment(environment)
 
-    if not yes:
-        confirm = typer.confirm(f"Unlink global secret {global_secret_id} from {owner}/{env_name}?")
-        if not confirm:
-            console.print("[dim]Cancelled.[/dim]")
-            raise typer.Exit()
-
     try:
+        if not yes:
+            confirm = typer.confirm(
+                f"Unlink global secret {global_secret_id} from {owner}/{env_name}?"
+            )
+            if not confirm:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
         client = APIClient()
         env_id = _get_environment_id(client, owner, env_name)
         client.delete(f"/environmentshub/{env_id}/secrets/link/{global_secret_id}")
         console.print(f"[green]✓ Unlinked global secret from {owner}/{env_name}[/green]")
 
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
@@ -3885,18 +3890,21 @@ def var_delete(
     """Delete an environment variable."""
     owner, env_name = _resolve_environment(environment)
 
-    if not yes:
-        confirm = typer.confirm(f"Delete variable {var_id} from {owner}/{env_name}?")
-        if not confirm:
-            console.print("\n[dim]Cancelled.[/dim]")
-            raise typer.Exit()
-
     try:
+        if not yes:
+            confirm = typer.confirm(f"Delete variable {var_id} from {owner}/{env_name}?")
+            if not confirm:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
         client = APIClient()
         env_id = _get_environment_id(client, owner, env_name)
         client.delete(f"/environmentshub/{env_id}/variables/{var_id}")
         console.print("[green]✓ Variable deleted[/green]")
 
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -3599,10 +3599,8 @@ def env_secret_link(
         ...,
         help="Global secret ID to link",
     ),
-    environment: Optional[str] = typer.Option(
+    environment: Optional[str] = typer.Argument(
         None,
-        "--env",
-        "-e",
         help="Environment slug (e.g., 'owner/environment-name'). Auto-detected if not provided.",
     ),
     env_var_name: Optional[str] = typer.Option(
@@ -3656,10 +3654,8 @@ def env_secret_unlink(
         ...,
         help="Global secret ID to unlink",
     ),
-    environment: Optional[str] = typer.Option(
+    environment: Optional[str] = typer.Argument(
         None,
-        "--env",
-        "-e",
         help="Environment slug (e.g., 'owner/environment-name'). Auto-detected if not provided.",
     ),
     yes: bool = typer.Option(
@@ -3689,62 +3685,6 @@ def env_secret_unlink(
     except KeyboardInterrupt:
         console.print("\n[dim]Cancelled.[/dim]")
         raise typer.Exit()
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-
-
-@secret_app.command("settings")
-def env_secret_settings(
-    environment: Optional[str] = typer.Argument(
-        None,
-        help="Environment slug (e.g., 'owner/environment-name'). Auto-detected if not provided.",
-    ),
-    auto_apply: Optional[bool] = typer.Option(
-        None,
-        "--auto-apply/--no-auto-apply",
-        help="Enable/disable auto-applying global secrets",
-    ),
-    output: str = typer.Option(
-        "table",
-        "--output",
-        "-o",
-        help="Output format: table or json",
-    ),
-) -> None:
-    """View or update environment secret settings."""
-    validate_output_format(output, console)
-    owner, env_name = _resolve_environment(environment)
-
-    try:
-        client = APIClient()
-        env_id = _get_environment_id(client, owner, env_name)
-
-        if auto_apply is not None:
-            response = client.patch(
-                f"/environmentshub/{env_id}/settings",
-                json={"autoApplyGlobalSecrets": auto_apply},
-            )
-            settings_data = response.get("data", {})
-            if output == "json":
-                output_data_as_json(settings_data, console)
-                return
-            status = "enabled" if auto_apply else "disabled"
-            console.print(
-                f"[green]✓ Auto-apply global secrets {status} for {owner}/{env_name}[/green]"
-            )
-        else:
-            response = client.get(f"/environmentshub/{env_id}/settings")
-            settings_data = response.get("data", {})
-            if output == "json":
-                output_data_as_json(settings_data, console)
-                return
-            auto_apply_status = settings_data.get("autoApplyGlobalSecrets", False)
-            status_text = "[green]enabled[/green]" if auto_apply_status else "[dim]disabled[/dim]"
-            console.print(f"\n[bold]Settings for {owner}/{env_name}[/bold]")
-            console.print(f"  Auto-apply global secrets: {status_text}")
-            console.print()
-
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
@@ -3890,10 +3830,8 @@ def var_update(
         ...,
         help="Variable ID to update",
     ),
-    environment: Optional[str] = typer.Option(
+    environment: Optional[str] = typer.Argument(
         None,
-        "--env",
-        "-e",
         help="Environment slug (e.g., 'owner/environment-name'). Auto-detected if not provided.",
     ),
     name: Optional[str] = typer.Option(
@@ -3967,10 +3905,8 @@ def var_delete(
         ...,
         help="Variable ID to delete",
     ),
-    environment: Optional[str] = typer.Option(
+    environment: Optional[str] = typer.Argument(
         None,
-        "--env",
-        "-e",
         help="Environment slug (e.g., 'owner/environment-name'). Auto-detected if not provided.",
     ),
     yes: bool = typer.Option(

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -51,9 +51,9 @@ MAX_TARBALL_SIZE_LIMIT = 250 * 1024 * 1024  # 250MB
 action_app = typer.Typer(help="Manage environment actions (CI jobs)", no_args_is_help=True)
 app.add_typer(action_app, name="action", rich_help_panel="Manage")
 
-# Secrets subcommand app
-secrets_app = typer.Typer(help="Manage environment secrets", no_args_is_help=True)
-app.add_typer(secrets_app, name="secrets", rich_help_panel="Manage")
+# Secret subcommand app
+secret_app = typer.Typer(help="Manage environment secrets", no_args_is_help=True)
+app.add_typer(secret_app, name="secret", rich_help_panel="Manage")
 
 # Variable subcommand app
 var_app = typer.Typer(help="Manage environment variables", no_args_is_help=True)
@@ -3302,7 +3302,7 @@ def _fetch_env_secrets(client: APIClient, env_id: str) -> List[Dict[str, Any]]:
     return response.get("data", [])
 
 
-@secrets_app.command("list")
+@secret_app.command("list")
 def env_secret_list(
     environment: Optional[str] = typer.Argument(
         None,
@@ -3357,7 +3357,7 @@ def env_secret_list(
         raise typer.Exit(1)
 
 
-@secrets_app.command("create")
+@secret_app.command("create")
 def env_secret_create(
     environment: Optional[str] = typer.Argument(
         None,
@@ -3433,7 +3433,7 @@ def env_secret_create(
         raise typer.Exit(1)
 
 
-@secrets_app.command("update")
+@secret_app.command("update")
 def env_secret_update(
     environment: Optional[str] = typer.Argument(
         None,
@@ -3527,7 +3527,7 @@ def env_secret_update(
         raise typer.Exit(1)
 
 
-@secrets_app.command("delete")
+@secret_app.command("delete")
 def env_secret_delete(
     environment: Optional[str] = typer.Argument(
         None,
@@ -3587,7 +3587,7 @@ def env_secret_delete(
         raise typer.Exit(1)
 
 
-@secrets_app.command("link")
+@secret_app.command("link")
 def env_secret_link(
     global_secret_id: str = typer.Argument(
         ...,
@@ -3644,7 +3644,7 @@ def env_secret_link(
         raise typer.Exit(1)
 
 
-@secrets_app.command("unlink")
+@secret_app.command("unlink")
 def env_secret_unlink(
     global_secret_id: str = typer.Argument(
         ...,
@@ -3688,7 +3688,7 @@ def env_secret_unlink(
         raise typer.Exit(1)
 
 
-@secrets_app.command("settings")
+@secret_app.command("settings")
 def env_secret_settings(
     environment: Optional[str] = typer.Argument(
         None,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -18,19 +18,13 @@ from ..client import APIClient, APIError, ValidationError
 from ..utils import output_data_as_json, validate_output_format
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.env_vars import EnvParseError, collect_env_vars
+from ..utils.formatters import strip_ansi
 
 console = Console()
 
-# ANSI escape code pattern
-ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 # Progress bar pattern (tqdm-style progress bars)
 PROGRESS_BAR = re.compile(r".*\|[█▏▎▍▌▋▊▉ ]{10,}\|.*")
-
-
-def strip_ansi(text: str) -> str:
-    """Remove ANSI escape codes from text."""
-    return ANSI_ESCAPE.sub("", text)
 
 
 def filter_progress_bars(text: str) -> str:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1,5 +1,3 @@
-"""RL (Reinforcement Learning) training commands."""
-
 import re
 import time
 from pathlib import Path
@@ -443,7 +441,8 @@ def create_run(
 
     # Validate WANDB_API_KEY is present when W&B monitoring is configured
     wandb_configured = cfg.wandb.entity or cfg.wandb.project
-    if wandb_configured and (not secrets or "WANDB_API_KEY" not in secrets):
+    has_wandb_key = secrets and "WANDB_API_KEY" in secrets
+    if wandb_configured and not has_wandb_key:
         console.print("[red]Configuration Error:[/red]")
         console.print("  WANDB_API_KEY is required when W&B monitoring is configured.\n")
         console.print("Provide it via:")

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -1,0 +1,336 @@
+from typing import Any, Dict, List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from prime_cli.core import Config
+
+from ..client import APIClient, APIError
+from ..utils import output_data_as_json, validate_output_format
+from ..utils.prompt import prompt_for_value, select_item_interactive
+from ..utils.time_utils import format_time_ago
+
+app = typer.Typer(help="Manage global secrets", no_args_is_help=True)
+console = Console()
+
+
+def _fetch_secrets(client: APIClient, config: Config) -> List[Dict[str, Any]]:
+    """Fetch secrets for the current user/team context."""
+    params: Dict[str, Any] = {}
+    if config.team_id:
+        params["teamId"] = config.team_id
+    response = client.get("/secrets/", params=params if params else None)
+    return response.get("data", [])
+
+
+@app.command("list")
+def secret_list(
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json",
+    ),
+) -> None:
+    """List your global secrets."""
+    validate_output_format(output, console)
+
+    try:
+        client = APIClient()
+        config = Config()
+        secrets = _fetch_secrets(client, config)
+
+        if output == "json":
+            output_data_as_json({"secrets": secrets}, console)
+            return
+
+        if not secrets:
+            scope = "team" if config.team_id else "personal"
+            console.print(f"[yellow]No {scope} secrets found.[/yellow]")
+            return
+
+        title = "Team Secrets" if config.team_id else "Personal Secrets"
+        table = Table(title=title)
+        table.add_column("ID", style="dim", no_wrap=True)
+        table.add_column("Name", style="cyan")
+        table.add_column("Description", style="dim")
+        table.add_column("Created", style="dim")
+
+        for secret in secrets:
+            secret_id = secret.get("id", "")
+            name = secret.get("name", "")
+            description = secret.get("description") or ""
+            created = secret.get("createdAt", "")
+            if created:
+                created = format_time_ago(created)
+            table.add_row(secret_id, name, description, created)
+
+        console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@app.command("create")
+def secret_create(
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Secret name (used as environment variable name)",
+    ),
+    value: Optional[str] = typer.Option(
+        None,
+        "--value",
+        "-v",
+        help="Secret value",
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help="Secret description",
+    ),
+    is_file: bool = typer.Option(
+        False,
+        "--file",
+        "-f",
+        help="Treat value as file content (base64 encoded)",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json",
+    ),
+) -> None:
+    """Create a new global secret."""
+    validate_output_format(output, console)
+
+    try:
+        if not name:
+            name = prompt_for_value("Secret name")
+            if not name:
+                console.print("[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        if not value:
+            value = prompt_for_value("Secret value", hide_input=True)
+            if not value:
+                console.print("[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        client = APIClient()
+        config = Config()
+
+        payload: Dict[str, Any] = {"name": name, "value": value}
+        if description:
+            payload["description"] = description
+        if is_file:
+            payload["isFile"] = True
+        if config.team_id:
+            payload["teamId"] = config.team_id
+
+        response = client.post("/secrets/", json=payload)
+        secret = response.get("data", {})
+
+        if output == "json":
+            output_data_as_json(secret, console)
+            return
+
+        stored_name = secret.get("name", name)
+        scope = "team" if config.team_id else "personal"
+        console.print(f"[green]✓ Created {scope} secret '{stored_name}'[/green]")
+        if stored_name != name:
+            console.print(f"[dim]Note: Name was normalized from '{name}'[/dim]")
+        console.print(f"[dim]ID: {secret.get('id')}[/dim]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@app.command("update")
+def secret_update(
+    secret_id: Optional[str] = typer.Argument(
+        None,
+        help="Secret ID to update (interactive selection if not provided)",
+    ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="New secret name",
+    ),
+    value: Optional[str] = typer.Option(
+        None,
+        "--value",
+        "-v",
+        help="New secret value",
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help="New secret description",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json",
+    ),
+) -> None:
+    """Update an existing global secret."""
+    validate_output_format(output, console)
+
+    try:
+        client = APIClient()
+        config = Config()
+
+        if not secret_id:
+            secrets = _fetch_secrets(client, config)
+            if not secrets:
+                scope = "team" if config.team_id else "personal"
+                console.print(f"[yellow]No {scope} secrets to update.[/yellow]")
+                raise typer.Exit()
+
+            selected = select_item_interactive(secrets, "update")
+            if not selected:
+                console.print("[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+            secret_id = selected.get("id")
+
+        if not any([name, value, description]):
+            console.print("\n[bold]What would you like to update?[/bold]")
+            new_value = prompt_for_value("New value", required=False, hide_input=True)
+            if new_value:
+                value = new_value
+
+            if not value:
+                console.print("[dim]No changes made.[/dim]")
+                raise typer.Exit()
+
+        payload: Dict[str, Any] = {}
+        if name:
+            payload["name"] = name
+        if value:
+            payload["value"] = value
+        if description is not None:
+            payload["description"] = description
+
+        response = client.patch(
+            f"/secrets/{secret_id}",
+            json=payload,
+        )
+        secret = response.get("data", {})
+
+        if output == "json":
+            output_data_as_json(secret, console)
+            return
+
+        console.print(f"[green]✓ Updated secret '{secret.get('name')}'[/green]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@app.command("delete")
+def secret_delete(
+    secret_id: Optional[str] = typer.Argument(
+        None,
+        help="Secret ID to delete (interactive selection if not provided)",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt",
+    ),
+) -> None:
+    """Delete a global secret."""
+    try:
+        client = APIClient()
+        config = Config()
+
+        if not secret_id:
+            secrets = _fetch_secrets(client, config)
+            if not secrets:
+                scope = "team" if config.team_id else "personal"
+                console.print(f"[yellow]No {scope} secrets to delete.[/yellow]")
+                raise typer.Exit()
+
+            selected = select_item_interactive(secrets, "delete")
+            if not selected:
+                console.print("[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+            secret_id = selected.get("id")
+            secret_name = selected.get("name")
+        else:
+            secret_name = secret_id
+
+        if not yes:
+            confirm = typer.confirm(f"Delete secret '{secret_name}'?")
+            if not confirm:
+                console.print("[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        client.delete(f"/secrets/{secret_id}")
+        console.print(f"[green]✓ Deleted secret '{secret_name}'[/green]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@app.command("get")
+def secret_get(
+    secret_id: str = typer.Argument(
+        ...,
+        help="Secret ID to get",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json",
+    ),
+) -> None:
+    """Get details of a specific secret."""
+    validate_output_format(output, console)
+
+    try:
+        client = APIClient()
+
+        response = client.get(f"/secrets/{secret_id}")
+        secret = response.get("data", {})
+
+        if output == "json":
+            output_data_as_json(secret, console)
+            return
+
+        console.print("\n[bold]Secret Details[/bold]")
+        console.print(f"  ID:          {secret.get('id')}")
+        console.print(f"  Name:        {secret.get('name')}")
+        console.print(f"  Description: {secret.get('description') or '-'}")
+        console.print(f"  Created:     {format_time_ago(secret.get('createdAt', ''))}")
+        console.print(f"  Updated:     {format_time_ago(secret.get('updatedAt', ''))}")
+        console.print()
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -11,7 +11,7 @@ from ..utils import output_data_as_json, validate_output_format
 from ..utils.prompt import (
     any_provided,
     prompt_for_value,
-    select_item_interactive,
+    require_selection,
     validate_env_var_name,
 )
 from ..utils.time_utils import format_time_ago
@@ -200,16 +200,8 @@ def secret_update(
 
         if not secret_id:
             secrets = _fetch_secrets(client, config)
-            if not secrets:
-                scope = "team" if config.team_id else "personal"
-                console.print(f"[yellow]No {scope} secrets to update.[/yellow]")
-                raise typer.Exit()
-
-            selected = select_item_interactive(secrets, "update", item_type="secret")
-            if not selected:
-                console.print("\n[dim]Cancelled.[/dim]")
-                raise typer.Exit()
-
+            scope = "team" if config.team_id else "personal"
+            selected = require_selection(secrets, "update", f"No {scope} secrets to update.")
             secret_id = selected.get("id")
 
         if not any_provided(name, value, description):
@@ -273,16 +265,8 @@ def secret_delete(
 
         if not secret_id:
             secrets = _fetch_secrets(client, config)
-            if not secrets:
-                scope = "team" if config.team_id else "personal"
-                console.print(f"[yellow]No {scope} secrets to delete.[/yellow]")
-                raise typer.Exit()
-
-            selected = select_item_interactive(secrets, "delete", item_type="secret")
-            if not selected:
-                console.print("\n[dim]Cancelled.[/dim]")
-                raise typer.Exit()
-
+            scope = "team" if config.team_id else "personal"
+            selected = require_selection(secrets, "delete", f"No {scope} secrets to delete.")
             secret_id = selected.get("id")
             secret_name = selected.get("name")
         else:

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -222,6 +222,9 @@ def secret_update(
                 console.print("\n[dim]No changes made.[/dim]")
                 raise typer.Exit()
 
+        if name is not None and not validate_env_var_name(name, "secret"):
+            raise typer.Exit(1)
+
         payload: Dict[str, Any] = {}
         if name is not None:
             payload["name"] = name

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -8,7 +8,7 @@ from prime_cli.core import Config
 
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
-from ..utils.prompt import prompt_for_value, select_item_interactive
+from ..utils.prompt import any_provided, prompt_for_value, select_item_interactive
 from ..utils.time_utils import format_time_ago
 
 app = typer.Typer(help="Manage global secrets", no_args_is_help=True)
@@ -207,7 +207,7 @@ def secret_update(
 
             secret_id = selected.get("id")
 
-        if not any([name, value, description]):
+        if not any_provided(name, value, description):
             console.print("\n[bold]What would you like to update?[/bold]")
             new_value = prompt_for_value("New value", required=False, hide_input=True)
             if new_value:
@@ -218,9 +218,9 @@ def secret_update(
                 raise typer.Exit()
 
         payload: Dict[str, Any] = {}
-        if name:
+        if name is not None:
             payload["name"] = name
-        if value:
+        if value is not None:
             payload["value"] = value
         if description is not None:
             payload["description"] = description

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -113,13 +113,13 @@ def secret_create(
         if not name:
             name = prompt_for_value("Secret name")
             if not name:
-                console.print("[dim]Cancelled.[/dim]")
+                console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
         if not value:
             value = prompt_for_value("Secret value", hide_input=True)
             if not value:
-                console.print("[dim]Cancelled.[/dim]")
+                console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
         client = APIClient()
@@ -200,9 +200,9 @@ def secret_update(
                 console.print(f"[yellow]No {scope} secrets to update.[/yellow]")
                 raise typer.Exit()
 
-            selected = select_item_interactive(secrets, "update")
+            selected = select_item_interactive(secrets, "update", item_type="secret")
             if not selected:
-                console.print("[dim]Cancelled.[/dim]")
+                console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
             secret_id = selected.get("id")
@@ -214,7 +214,7 @@ def secret_update(
                 value = new_value
 
             if not value:
-                console.print("[dim]No changes made.[/dim]")
+                console.print("\n[dim]No changes made.[/dim]")
                 raise typer.Exit()
 
         payload: Dict[str, Any] = {}
@@ -270,20 +270,22 @@ def secret_delete(
                 console.print(f"[yellow]No {scope} secrets to delete.[/yellow]")
                 raise typer.Exit()
 
-            selected = select_item_interactive(secrets, "delete")
+            selected = select_item_interactive(secrets, "delete", item_type="secret")
             if not selected:
-                console.print("[dim]Cancelled.[/dim]")
+                console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
             secret_id = selected.get("id")
             secret_name = selected.get("name")
         else:
-            secret_name = secret_id
+            response = client.get(f"/secrets/{secret_id}")
+            secret_data = response.get("data", {})
+            secret_name = secret_data.get("name", secret_id)
 
         if not yes:
             confirm = typer.confirm(f"Delete secret '{secret_name}'?")
             if not confirm:
-                console.print("[dim]Cancelled.[/dim]")
+                console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
         client.delete(f"/secrets/{secret_id}")

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -8,7 +8,12 @@ from prime_cli.core import Config
 
 from ..client import APIClient, APIError
 from ..utils import output_data_as_json, validate_output_format
-from ..utils.prompt import any_provided, prompt_for_value, select_item_interactive
+from ..utils.prompt import (
+    any_provided,
+    prompt_for_value,
+    select_item_interactive,
+    validate_env_var_name,
+)
 from ..utils.time_utils import format_time_ago
 
 app = typer.Typer(help="Manage global secrets", no_args_is_help=True)
@@ -116,6 +121,9 @@ def secret_create(
                 console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
+        if not validate_env_var_name(name, "secret"):
+            raise typer.Exit(1)
+
         if not value:
             value = prompt_for_value("Secret value", hide_input=True)
             if not value:
@@ -140,11 +148,8 @@ def secret_create(
             output_data_as_json(secret, console)
             return
 
-        stored_name = secret.get("name", name)
         scope = "team" if config.team_id else "personal"
-        console.print(f"[green]✓ Created {scope} secret '{stored_name}'[/green]")
-        if stored_name != name:
-            console.print(f"[dim]Note: Name was normalized from '{name}'[/dim]")
+        console.print(f"[green]✓ Created {scope} secret '{name}'[/green]")
         console.print(f"[dim]ID: {secret.get('id')}[/dim]")
 
     except KeyboardInterrupt:

--- a/packages/prime/src/prime_cli/core/client.py
+++ b/packages/prime/src/prime_cli/core/client.py
@@ -246,6 +246,9 @@ class AsyncAPIClient:
 
             response.raise_for_status()
 
+            if response.status_code == 204 or not response.content:
+                return {}
+
             result = response.json()
             if not isinstance(result, dict):
                 raise APIError("API response was not a dictionary")

--- a/packages/prime/src/prime_cli/core/client.py
+++ b/packages/prime/src/prime_cli/core/client.py
@@ -115,7 +115,7 @@ class APIClient:
             response = self.client.request(method, url, params=params, json=json, timeout=timeout)
             response.raise_for_status()
 
-            if response.status_code == 204 or not response.content:
+            if response.status_code == 204 and not response.content:
                 return {}
 
             result = response.json()
@@ -246,7 +246,7 @@ class AsyncAPIClient:
 
             response.raise_for_status()
 
-            if response.status_code == 204 or not response.content:
+            if response.status_code == 204 and not response.content:
                 return {}
 
             result = response.json()

--- a/packages/prime/src/prime_cli/core/client.py
+++ b/packages/prime/src/prime_cli/core/client.py
@@ -115,6 +115,9 @@ class APIClient:
             response = self.client.request(method, url, params=params, json=json, timeout=timeout)
             response.raise_for_status()
 
+            if response.status_code == 204 or not response.content:
+                return {}
+
             result = response.json()
             if not isinstance(result, dict):
                 raise APIError("API response was not a dictionary")

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -19,7 +19,7 @@ from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
 from .commands.rl import app as rl_app
 from .commands.sandbox import app as sandbox_app
-from .commands.secrets import app as secrets_app
+from .commands.secrets import app as secret_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
@@ -56,7 +56,7 @@ app.add_typer(login_app, name="login", rich_help_panel="Account")
 app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")
 app.add_typer(teams_app, name="teams", rich_help_panel="Account")
-app.add_typer(secrets_app, name="secrets", rich_help_panel="Account")
+app.add_typer(secret_app, name="secret", rich_help_panel="Account")
 app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 
 

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -18,6 +18,7 @@ from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
 from .commands.rl import app as rl_app
 from .commands.sandbox import app as sandbox_app
+from .commands.secrets import app as secrets_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
@@ -53,6 +54,7 @@ app.add_typer(login_app, name="login", rich_help_panel="Account")
 app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")
 app.add_typer(teams_app, name="teams", rich_help_panel="Account")
+app.add_typer(secrets_app, name="secrets", rich_help_panel="Account")
 app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 
 

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -15,6 +15,7 @@ from .prompt import (
     any_provided,
     confirm_or_skip,
     prompt_for_value,
+    require_selection,
     select_item_interactive,
     validate_env_var_name,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "confirm_or_skip",
     "prompt_for_value",
     "select_item_interactive",
+    "require_selection",
     "validate_env_var_name",
     "load_toml",
     "BaseConfig",

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -11,7 +11,13 @@ from .formatters import (
     obfuscate_secrets,
     strip_ansi,
 )
-from .prompt import any_provided, confirm_or_skip, prompt_for_value, select_item_interactive
+from .prompt import (
+    any_provided,
+    confirm_or_skip,
+    prompt_for_value,
+    select_item_interactive,
+    validate_env_var_name,
+)
 from .time_utils import human_age, iso_timestamp, sort_by_created
 
 __all__ = [
@@ -32,6 +38,7 @@ __all__ = [
     "confirm_or_skip",
     "prompt_for_value",
     "select_item_interactive",
+    "validate_env_var_name",
     "load_toml",
     "BaseConfig",
 ]

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -9,6 +9,7 @@ from .formatters import (
     format_resources,
     obfuscate_env_vars,
     obfuscate_secrets,
+    strip_ansi,
 )
 from .prompt import any_provided, confirm_or_skip, prompt_for_value, select_item_interactive
 from .time_utils import human_age, iso_timestamp, sort_by_created
@@ -26,6 +27,7 @@ __all__ = [
     "format_ip_display",
     "format_price",
     "format_resources",
+    "strip_ansi",
     "any_provided",
     "confirm_or_skip",
     "prompt_for_value",

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -10,7 +10,7 @@ from .formatters import (
     obfuscate_env_vars,
     obfuscate_secrets,
 )
-from .prompt import confirm_or_skip, prompt_for_value, select_item_interactive
+from .prompt import any_provided, confirm_or_skip, prompt_for_value, select_item_interactive
 from .time_utils import human_age, iso_timestamp, sort_by_created
 
 __all__ = [
@@ -26,6 +26,7 @@ __all__ = [
     "format_ip_display",
     "format_price",
     "format_resources",
+    "any_provided",
     "confirm_or_skip",
     "prompt_for_value",
     "select_item_interactive",

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -10,7 +10,7 @@ from .formatters import (
     obfuscate_env_vars,
     obfuscate_secrets,
 )
-from .prompt import confirm_or_skip
+from .prompt import confirm_or_skip, prompt_for_value, select_item_interactive
 from .time_utils import human_age, iso_timestamp, sort_by_created
 
 __all__ = [
@@ -27,6 +27,8 @@ __all__ = [
     "format_price",
     "format_resources",
     "confirm_or_skip",
+    "prompt_for_value",
+    "select_item_interactive",
     "load_toml",
     "BaseConfig",
 ]

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -1,6 +1,12 @@
-"""Value formatting utilities."""
-
+import re
 from typing import Any, Dict, List, Optional, Union
+
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return ANSI_ESCAPE.sub("", text)
 
 
 def obfuscate_env_vars(env_vars: Dict[str, Any]) -> Dict[str, str]:

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -1,9 +1,24 @@
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 import typer
 from rich.console import Console
 
 console = Console()
+
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def validate_env_var_name(name: str, item_type: str = "secret") -> bool:
+    if _ENV_VAR_NAME_PATTERN.match(name):
+        return True
+
+    console.print(f"[red]Invalid {item_type} name: '{name}'[/red]")
+    console.print(
+        f"[dim]{item_type.capitalize()} names must be uppercase letters, digits, "
+        "and underscores, starting with a letter (e.g., MY_SECRET, API_KEY_2).[/dim]"
+    )
+    return False
 
 
 def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool:

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -39,6 +39,25 @@ def _default_display_fn(item: Dict[str, Any]) -> str:
     return f"{name} - {desc}" if desc else name
 
 
+def require_selection(
+    items: List[Dict[str, Any]],
+    action: str,
+    empty_message: str,
+    item_type: str = "item",
+    display_fn: Optional[Callable[[Dict[str, Any]], str]] = None,
+) -> Dict[str, Any]:
+    if not items:
+        console.print(f"[yellow]{empty_message}[/yellow]")
+        raise typer.Exit()
+
+    selected = select_item_interactive(items, action, item_type=item_type, display_fn=display_fn)
+    if not selected:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+
+    return selected
+
+
 def select_item_interactive(
     items: List[Dict[str, Any]],
     action: str = "select",

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -13,9 +13,17 @@ def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool
     return bool(typer.confirm(message, default=default))
 
 
+def _default_display_fn(item: Dict[str, Any]) -> str:
+    """Default display function for interactive selection."""
+    name = item.get("name", "")
+    desc = item.get("description") or ""
+    return f"{name} - {desc}" if desc else name
+
+
 def select_item_interactive(
     items: List[Dict[str, Any]],
     action: str = "select",
+    item_type: str = "item",
     display_fn: Optional[Callable[[Dict[str, Any]], str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Display items and let user select one interactively.
@@ -23,6 +31,7 @@ def select_item_interactive(
     Args:
         items: List of items to select from
         action: Action verb for the prompt (e.g., "delete", "update")
+        item_type: Type of item being selected (e.g., "secret", "variable")
         display_fn: Function to format each item for display.
                    Defaults to showing 'name' and 'description' fields.
 
@@ -32,16 +41,11 @@ def select_item_interactive(
     if not items:
         return None
 
-    if display_fn is None:
+    formatter = display_fn or _default_display_fn
 
-        def display_fn(item: Dict[str, Any]) -> str:
-            name = item.get("name", "")
-            desc = item.get("description") or ""
-            return f"{name} - {desc}" if desc else name
-
-    console.print(f"\n[bold]Select an item to {action}:[/bold]\n")
+    console.print(f"\n[bold]Select a {item_type} to {action}:[/bold]\n")
     for i, item in enumerate(items, 1):
-        console.print(f"  {i}. {display_fn(item)}")
+        console.print(f"  {i}. {formatter(item)}")
     console.print()
 
     while True:

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -13,6 +13,10 @@ def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool
     return bool(typer.confirm(message, default=default))
 
 
+def any_provided(*values: Any) -> bool:
+    return any(v is not None for v in values)
+
+
 def _default_display_fn(item: Dict[str, Any]) -> str:
     """Default display function for interactive selection."""
     name = item.get("name", "")

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -1,6 +1,9 @@
-"""Prompt utilities for user interaction."""
+from typing import Any, Callable, Dict, List, Optional
 
 import typer
+from rich.console import Console
+
+console = Console()
 
 
 def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool:
@@ -8,3 +11,74 @@ def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool
     if yes_flag:
         return True
     return bool(typer.confirm(message, default=default))
+
+
+def select_item_interactive(
+    items: List[Dict[str, Any]],
+    action: str = "select",
+    display_fn: Optional[Callable[[Dict[str, Any]], str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Display items and let user select one interactively.
+
+    Args:
+        items: List of items to select from
+        action: Action verb for the prompt (e.g., "delete", "update")
+        display_fn: Function to format each item for display.
+                   Defaults to showing 'name' and 'description' fields.
+
+    Returns:
+        Selected item or None if cancelled
+    """
+    if not items:
+        return None
+
+    if display_fn is None:
+
+        def display_fn(item: Dict[str, Any]) -> str:
+            name = item.get("name", "")
+            desc = item.get("description") or ""
+            return f"{name} - {desc}" if desc else name
+
+    console.print(f"\n[bold]Select an item to {action}:[/bold]\n")
+    for i, item in enumerate(items, 1):
+        console.print(f"  {i}. {display_fn(item)}")
+    console.print()
+
+    while True:
+        try:
+            selection_str = typer.prompt("Select (empty to cancel)", default="")
+            if not selection_str:
+                return None
+            selection = int(selection_str)
+            if 1 <= selection <= len(items):
+                return items[selection - 1]
+            console.print(f"[red]Please enter a number between 1 and {len(items)}[/red]")
+        except ValueError:
+            console.print("[red]Please enter a valid number[/red]")
+        except KeyboardInterrupt:
+            return None
+
+
+def prompt_for_value(
+    prompt_text: str,
+    required: bool = True,
+    hide_input: bool = False,
+) -> Optional[str]:
+    """Prompt for a value with optional cancellation.
+
+    Args:
+        prompt_text: Text to display for the prompt
+        required: If True, empty input cancels. If False, empty input is allowed.
+        hide_input: If True, hide the input (for passwords/secrets)
+
+    Returns:
+        The entered value, or None if cancelled
+    """
+    try:
+        suffix = " (empty to cancel)" if required else ""
+        value = typer.prompt(f"{prompt_text}{suffix}", default="", hide_input=hide_input)
+        if required and not value:
+            return None
+        return value
+    except KeyboardInterrupt:
+        return None

--- a/packages/prime/tests/test_env_secret.py
+++ b/packages/prime/tests/test_env_secret.py
@@ -1,0 +1,598 @@
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+from prime_cli.main import app
+from prime_cli.utils import strip_ansi
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_env_secret_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock the API client for environment secret endpoints."""
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+    sample_env_detail = {
+        "id": "env-uuid-12345",
+        "name": "test-env",
+        "owner": {"name": "testuser", "type": "user"},
+    }
+
+    sample_secrets: List[Dict[str, Any]] = [
+        {
+            "id": "esecret-id-001",
+            "name": "DB_PASSWORD",
+            "source": "environment",
+            "description": "Database password",
+            "createdAt": "2026-01-15T10:00:00Z",
+            "updatedAt": "2026-01-15T10:00:00Z",
+        },
+        {
+            "id": "esecret-id-002",
+            "name": "OPENAI_KEY",
+            "source": "global-linked",
+            "description": None,
+            "createdAt": "2026-01-10T08:00:00Z",
+            "updatedAt": "2026-01-10T08:00:00Z",
+        },
+    ]
+
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/@latest" in endpoint:
+            return {"data": sample_env_detail}
+        elif "/secrets" in endpoint and "/link/" not in endpoint:
+            if endpoint.endswith("/secrets"):
+                return {"data": sample_secrets}
+            # Individual secret
+            secret_id = endpoint.split("/")[-1]
+            for s in sample_secrets:
+                if s["id"] == secret_id:
+                    return {"data": s}
+            return {"data": sample_secrets[0]}
+        return {"data": {}}
+
+    def mock_post(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/secrets/link/" in endpoint:
+            global_id = endpoint.split("/link/")[-1]
+            return {
+                "data": {
+                    "id": "link-id-12345",
+                    "secretId": global_id,
+                    "secretName": json.get("envVarName", "LINKED_SECRET")
+                    if json
+                    else "LINKED_SECRET",
+                    "environmentId": "env-uuid-12345",
+                    "createdAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        elif "/secrets" in endpoint:
+            return {
+                "data": {
+                    "id": "new-esecret-id-001",
+                    "name": json.get("name") if json else "NEW_SECRET",
+                    "value": "[encrypted]",
+                    "description": json.get("description") if json else None,
+                    "source": "environment",
+                    "createdAt": "2026-02-01T12:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_patch(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/secrets/" in endpoint:
+            return {
+                "data": {
+                    "id": "esecret-id-001",
+                    "name": json.get("name", "DB_PASSWORD") if json else "DB_PASSWORD",
+                    "description": json.get("description") if json else None,
+                    "source": "environment",
+                    "createdAt": "2026-01-15T10:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_delete(self: Any, endpoint: str) -> None:
+        pass
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+    monkeypatch.setattr("prime_cli.core.APIClient.post", mock_post)
+    monkeypatch.setattr("prime_cli.core.APIClient.patch", mock_patch)
+    monkeypatch.setattr("prime_cli.core.APIClient.delete", mock_delete)
+
+
+class TestEnvSecretList:
+    """Tests for the env secret list command."""
+
+    def test_list_secrets_table_output(self, mock_env_secret_api: None) -> None:
+        """Test listing env secrets with table output."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "list", "testuser/test-env"],
+            env={"COLUMNS": "200", "LINES": "50"},
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Secrets for testuser/test-env" in result.output
+        assert "DB_PASSWORD" in result.output
+        assert "OPENAI_KEY" in result.output
+
+    def test_list_secrets_json_output(self, mock_env_secret_api: None) -> None:
+        """Test listing env secrets with JSON output."""
+        result = runner.invoke(app, ["env", "secret", "list", "testuser/test-env", "-o", "json"])
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "secrets" in output
+        assert len(output["secrets"]) == 2
+        assert output["secrets"][0]["name"] == "DB_PASSWORD"
+
+    def test_list_secrets_shows_source(self, mock_env_secret_api: None) -> None:
+        """Test that list output contains the source column."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "list", "testuser/test-env"],
+            env={"COLUMNS": "200", "LINES": "50"},
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "environment" in result.output
+        assert "global-linked" in result.output
+
+    def test_list_empty_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test listing when no env secrets exist."""
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            if "/@latest" in endpoint:
+                return {"data": {"id": "env-uuid-12345"}}
+            return {"data": []}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+        result = runner.invoke(app, ["env", "secret", "list", "testuser/test-env"])
+        assert result.exit_code == 0
+        assert "No secrets found" in result.output
+
+    def test_list_secrets_invalid_output_format(self, mock_env_secret_api: None) -> None:
+        """Test listing secrets with an invalid output format."""
+        result = runner.invoke(app, ["env", "secret", "list", "testuser/test-env", "-o", "xml"])
+        assert result.exit_code != 0
+        assert "Invalid output format" in result.output
+
+
+class TestEnvSecretCreate:
+    """Tests for the env secret create command."""
+
+    def test_create_secret_success(self, mock_env_secret_api: None) -> None:
+        """Test creating an env secret successfully."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "create",
+                "testuser/test-env",
+                "-n",
+                "NEW_SECRET",
+                "-v",
+                "secret-value",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created secret 'NEW_SECRET'" in result.output
+        assert "testuser/test-env" in result.output
+        assert "ID:" in result.output
+
+    def test_create_secret_with_description(self, mock_env_secret_api: None) -> None:
+        """Test creating an env secret with a description."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "create",
+                "testuser/test-env",
+                "-n",
+                "NEW_SECRET",
+                "-v",
+                "secret-value",
+                "-d",
+                "A test secret",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created secret 'NEW_SECRET'" in result.output
+
+    def test_create_secret_json_output(self, mock_env_secret_api: None) -> None:
+        """Test creating an env secret with JSON output."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "create",
+                "testuser/test-env",
+                "-n",
+                "NEW_SECRET",
+                "-v",
+                "value",
+                "-o",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["name"] == "NEW_SECRET"
+        assert "id" in output
+
+    def test_create_secret_interactive(self, mock_env_secret_api: None) -> None:
+        """Test creating an env secret interactively."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env"],
+            input="MY_NEW_SECRET\nsecret-value\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created secret" in result.output
+
+    def test_create_secret_interactive_cancel_name(self, mock_env_secret_api: None) -> None:
+        """Test that create can be cancelled during name prompt."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_create_secret_interactive_cancel_value(self, mock_env_secret_api: None) -> None:
+        """Test that create can be cancelled during value prompt."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env", "-n", "NEW_SECRET"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_create_secret_invalid_name_lowercase(self, mock_env_secret_api: None) -> None:
+        """Test that lowercase secret names are rejected."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env", "-n", "my_secret", "-v", "value"],
+        )
+        assert result.exit_code != 0
+        assert "Invalid secret name" in result.output
+
+    def test_create_secret_invalid_name_starts_with_number(self, mock_env_secret_api: None) -> None:
+        """Test that names starting with a number are rejected."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env", "-n", "1BAD_NAME", "-v", "value"],
+        )
+        assert result.exit_code != 0
+        assert "Invalid secret name" in result.output
+
+    def test_create_secret_invalid_name_special_chars(self, mock_env_secret_api: None) -> None:
+        """Test that names with special characters are rejected."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "create", "testuser/test-env", "-n", "MY-SECRET", "-v", "value"],
+        )
+        assert result.exit_code != 0
+        assert "Invalid secret name" in result.output
+
+
+class TestEnvSecretUpdate:
+    """Tests for the env secret update command."""
+
+    def test_update_secret_with_id_and_name(self, mock_env_secret_api: None) -> None:
+        """Test updating a secret name by ID."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "update",
+                "testuser/test-env",
+                "--id",
+                "esecret-id-001",
+                "-n",
+                "RENAMED_SECRET",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_with_value(self, mock_env_secret_api: None) -> None:
+        """Test updating a secret value by ID."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "update",
+                "testuser/test-env",
+                "--id",
+                "esecret-id-001",
+                "-v",
+                "new-secret-value",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_with_description(self, mock_env_secret_api: None) -> None:
+        """Test updating a secret description."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "update",
+                "testuser/test-env",
+                "--id",
+                "esecret-id-001",
+                "-d",
+                "Updated description",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_json_output(self, mock_env_secret_api: None) -> None:
+        """Test updating a secret with JSON output."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "update",
+                "testuser/test-env",
+                "--id",
+                "esecret-id-001",
+                "-n",
+                "NEW_NAME",
+                "-o",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "id" in output
+
+    def test_update_secret_no_changes_cancel(self, mock_env_secret_api: None) -> None:
+        """Test that update with no changes and empty interactive input cancels."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "update", "testuser/test-env", "--id", "esecret-id-001"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "No changes made" in result.output
+
+    def test_update_secret_interactive_select(self, mock_env_secret_api: None) -> None:
+        """Test interactive secret selection for update."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "update", "testuser/test-env"],
+            # Select item 1, then provide new value
+            input="1\nnew-secret-value\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_interactive_cancel_selection(self, mock_env_secret_api: None) -> None:
+        """Test cancelling interactive selection for update."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "update", "testuser/test-env"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+
+class TestEnvSecretDelete:
+    """Tests for the env secret delete command."""
+
+    def test_delete_secret_with_confirm(self, mock_env_secret_api: None) -> None:
+        """Test deleting an env secret with --yes flag."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "delete", "testuser/test-env", "--id", "esecret-id-001", "-y"],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Deleted secret" in result.output
+        assert "testuser/test-env" in result.output
+
+    def test_delete_secret_cancelled(self, mock_env_secret_api: None) -> None:
+        """Test cancelling env secret deletion."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "delete", "testuser/test-env", "--id", "esecret-id-001"],
+            input="n\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_delete_secret_interactive_select(self, mock_env_secret_api: None) -> None:
+        """Test interactive secret selection for delete."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "delete", "testuser/test-env"],
+            # Select item 1, then confirm
+            input="1\ny\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Deleted secret" in result.output
+
+    def test_delete_secret_interactive_cancel_selection(self, mock_env_secret_api: None) -> None:
+        """Test cancelling interactive selection for delete."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "delete", "testuser/test-env"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_delete_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test delete when no secrets exist."""
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            if "/@latest" in endpoint:
+                return {"data": {"id": "env-uuid-12345"}}
+            return {"data": []}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+        result = runner.invoke(app, ["env", "secret", "delete", "testuser/test-env"])
+        assert result.exit_code == 0
+        assert "No secrets to delete" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Link
+# ---------------------------------------------------------------------------
+
+
+class TestEnvSecretLink:
+    """Tests for the env secret link command."""
+
+    def test_link_secret_success(self, mock_env_secret_api: None) -> None:
+        """Test linking a global secret to an environment."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "link", "global-secret-id-123", "testuser/test-env"],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Linked global secret" in result.output
+        assert "testuser/test-env" in result.output
+
+    def test_link_secret_with_custom_name(self, mock_env_secret_api: None) -> None:
+        """Test linking with a custom env var name override."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "link",
+                "global-secret-id-123",
+                "testuser/test-env",
+                "-n",
+                "CUSTOM_ENV_NAME",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Linked global secret" in result.output
+
+    def test_link_secret_json_output(self, mock_env_secret_api: None) -> None:
+        """Test linking a secret with JSON output."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "secret",
+                "link",
+                "global-secret-id-123",
+                "testuser/test-env",
+                "-o",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "secretId" in output or "id" in output
+
+
+class TestEnvSecretUnlink:
+    """Tests for the env secret unlink command."""
+
+    def test_unlink_secret_success(self, mock_env_secret_api: None) -> None:
+        """Test unlinking a global secret from an environment."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env", "-y"],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Unlinked global secret" in result.output
+        assert "testuser/test-env" in result.output
+
+    def test_unlink_secret_cancelled(self, mock_env_secret_api: None) -> None:
+        """Test cancelling unlink confirmation."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"],
+            input="n\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_unlink_secret_confirmed_interactively(self, mock_env_secret_api: None) -> None:
+        """Test confirming unlink interactively."""
+        result = runner.invoke(
+            app,
+            ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"],
+            input="y\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Unlinked global secret" in result.output
+
+
+class TestEnvSecretHelp:
+    """Tests for help output."""
+
+    def test_env_secret_help(self) -> None:
+        """Test that env secret help lists all subcommands."""
+        result = runner.invoke(app, ["env", "secret", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "list" in output
+        assert "create" in output
+        assert "update" in output
+        assert "delete" in output
+        assert "link" in output
+        assert "unlink" in output
+
+    def test_env_secret_list_help(self) -> None:
+        """Test that env secret list help shows options."""
+        result = runner.invoke(app, ["env", "secret", "list", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "--output" in output
+
+    def test_env_secret_create_help(self) -> None:
+        """Test that env secret create help shows options."""
+        result = runner.invoke(app, ["env", "secret", "create", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "--name" in output
+        assert "--value" in output
+        assert "--description" in output
+
+    def test_env_secret_link_help(self) -> None:
+        """Test that env secret link help shows arguments."""
+        result = runner.invoke(app, ["env", "secret", "link", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "GLOBAL_SECRET_ID" in output
+
+    def test_env_secret_unlink_help(self) -> None:
+        """Test that env secret unlink help shows arguments."""
+        result = runner.invoke(app, ["env", "secret", "unlink", "--help"])
+        assert result.exit_code == 0
+        output = strip_ansi(result.output)
+        assert "GLOBAL_SECRET_ID" in output

--- a/packages/prime/tests/test_env_secret.py
+++ b/packages/prime/tests/test_env_secret.py
@@ -482,23 +482,6 @@ class TestEnvSecretLink:
         assert "Linked global secret" in result.output
         assert "testuser/test-env" in result.output
 
-    def test_link_secret_with_custom_name(self, mock_env_secret_api: None) -> None:
-        """Test linking with a custom env var name override."""
-        result = runner.invoke(
-            app,
-            [
-                "env",
-                "secret",
-                "link",
-                "global-secret-id-123",
-                "testuser/test-env",
-                "-n",
-                "CUSTOM_ENV_NAME",
-            ],
-        )
-        assert result.exit_code == 0, f"Failed: {result.output}"
-        assert "Linked global secret" in result.output
-
     def test_link_secret_json_output(self, mock_env_secret_api: None) -> None:
         """Test linking a secret with JSON output."""
         result = runner.invoke(

--- a/packages/prime/tests/test_env_var.py
+++ b/packages/prime/tests/test_env_var.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 from prime_cli.main import app
+from prime_cli.utils import strip_ansi
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -335,13 +336,15 @@ class TestEnvVarHelp:
         result = runner.invoke(app, ["env", "var", "list", "--help"])
 
         assert result.exit_code == 0
-        assert "--output" in result.output
+        output = strip_ansi(result.output)
+        assert "--output" in output
 
     def test_env_var_create_help(self) -> None:
         """Test that env var create help works."""
         result = runner.invoke(app, ["env", "var", "create", "--help"])
 
         assert result.exit_code == 0
-        assert "--name" in result.output
-        assert "--value" in result.output
-        assert "--description" in result.output
+        output = strip_ansi(result.output)
+        assert "--name" in output
+        assert "--value" in output
+        assert "--description" in output

--- a/packages/prime/tests/test_env_var.py
+++ b/packages/prime/tests/test_env_var.py
@@ -199,23 +199,48 @@ class TestEnvVarCreate:
         assert output["name"] == "NEW_VAR"
         assert "id" in output
 
-    def test_create_variable_missing_name(self) -> None:
-        """Test that create fails without name."""
+    def test_create_variable_interactive_cancel_name(self) -> None:
+        """Test that create can be cancelled during name prompt."""
         result = runner.invoke(
             app,
-            ["env", "var", "create", "testuser/test-env", "-v", "value"],
+            ["env", "var", "create", "testuser/test-env"],
+            input="\n",
         )
 
-        assert result.exit_code != 0
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
 
-    def test_create_variable_missing_value(self) -> None:
-        """Test that create fails without value."""
+    def test_create_variable_interactive_cancel_value(self, mock_env_var_api: None) -> None:
+        """Test that create can be cancelled during value prompt."""
         result = runner.invoke(
             app,
             ["env", "var", "create", "testuser/test-env", "-n", "NEW_VAR"],
+            input="\n",
+        )
+
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_create_variable_interactive(self, mock_env_var_api: None) -> None:
+        """Test creating a variable interactively."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "create", "testuser/test-env"],
+            input="NEW_VAR\nmy-value\n",
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created variable 'NEW_VAR'" in result.output
+
+    def test_create_variable_invalid_name(self, mock_env_var_api: None) -> None:
+        """Test that create rejects invalid variable names."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "create", "testuser/test-env", "-n", "lowercase", "-v", "value"],
         )
 
         assert result.exit_code != 0
+        assert "Invalid variable name" in result.output
 
 
 class TestEnvVarUpdate:

--- a/packages/prime/tests/test_env_var.py
+++ b/packages/prime/tests/test_env_var.py
@@ -1,0 +1,344 @@
+import json
+from typing import Any, Dict, Optional
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_env_var_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock the API client for environment variable endpoints."""
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+    sample_env_detail = {
+        "id": "env-uuid-12345",
+        "name": "test-env",
+        "owner": {"name": "testuser", "type": "user"},
+    }
+
+    sample_variables = [
+        {
+            "id": "var-id-1234567890",
+            "name": "DEBUG",
+            "value": "true",
+            "description": "Enable debug mode",
+            "createdAt": "2026-01-15T10:00:00Z",
+            "updatedAt": "2026-01-15T10:00:00Z",
+        },
+        {
+            "id": "var-id-0987654321",
+            "name": "LOG_LEVEL",
+            "value": "info",
+            "description": None,
+            "createdAt": "2026-01-10T08:00:00Z",
+            "updatedAt": "2026-01-10T08:00:00Z",
+        },
+    ]
+
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/@latest" in endpoint:
+            return {"data": sample_env_detail}
+        elif "/variables" in endpoint:
+            if endpoint.endswith("/variables"):
+                return {"data": sample_variables}
+            var_id = endpoint.split("/")[-1]
+            for v in sample_variables:
+                if v["id"] == var_id or v["id"].startswith(var_id):
+                    return {"data": v}
+            return {"data": sample_variables[0]}
+        return {"data": {}}
+
+    def mock_post(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/variables" in endpoint:
+            return {
+                "data": {
+                    "id": "new-var-id-12345",
+                    "name": json.get("name") if json else "NEW_VAR",
+                    "value": json.get("value") if json else "value",
+                    "description": json.get("description") if json else None,
+                    "createdAt": "2026-02-01T12:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_patch(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if "/variables/" in endpoint:
+            return {
+                "data": {
+                    "id": "var-id-1234567890",
+                    "name": json.get("name", "DEBUG") if json else "DEBUG",
+                    "value": json.get("value", "true") if json else "true",
+                    "description": json.get("description") if json else None,
+                    "createdAt": "2026-01-15T10:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_delete(self: Any, endpoint: str) -> None:
+        pass
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+    monkeypatch.setattr("prime_cli.core.APIClient.post", mock_post)
+    monkeypatch.setattr("prime_cli.core.APIClient.patch", mock_patch)
+    monkeypatch.setattr("prime_cli.core.APIClient.delete", mock_delete)
+
+
+class TestEnvVarList:
+    """Tests for the env var list command."""
+
+    def test_list_variables_table_output(self, mock_env_var_api: None) -> None:
+        """Test listing variables with table output."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "list", "testuser/test-env"],
+            env={"COLUMNS": "200", "LINES": "50"},
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Variables for testuser/test-env" in result.output
+        assert "DEBUG" in result.output
+        assert "LOG_LEVEL" in result.output
+        assert "true" in result.output
+
+    def test_list_variables_json_output(self, mock_env_var_api: None) -> None:
+        """Test listing variables with JSON output."""
+        result = runner.invoke(app, ["env", "var", "list", "testuser/test-env", "-o", "json"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "variables" in output
+        assert len(output["variables"]) == 2
+        assert output["variables"][0]["name"] == "DEBUG"
+
+    def test_list_empty_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test listing when no variables exist."""
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            if "/@latest" in endpoint:
+                return {"data": {"id": "env-uuid-12345"}}
+            return {"data": []}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+        result = runner.invoke(app, ["env", "var", "list", "testuser/test-env"])
+
+        assert result.exit_code == 0
+        assert "No variables found" in result.output
+
+
+class TestEnvVarCreate:
+    """Tests for the env var create command."""
+
+    def test_create_variable_success(self, mock_env_var_api: None) -> None:
+        """Test creating a variable successfully."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "create", "testuser/test-env", "-n", "NEW_VAR", "-v", "value"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created variable 'NEW_VAR'" in result.output
+        assert "ID:" in result.output
+
+    def test_create_variable_with_description(self, mock_env_var_api: None) -> None:
+        """Test creating a variable with a description."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "var",
+                "create",
+                "testuser/test-env",
+                "-n",
+                "NEW_VAR",
+                "-v",
+                "value",
+                "-d",
+                "My description",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created variable 'NEW_VAR'" in result.output
+
+    def test_create_variable_json_output(self, mock_env_var_api: None) -> None:
+        """Test creating a variable with JSON output."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "var",
+                "create",
+                "testuser/test-env",
+                "-n",
+                "NEW_VAR",
+                "-v",
+                "value",
+                "-o",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["name"] == "NEW_VAR"
+        assert "id" in output
+
+    def test_create_variable_missing_name(self) -> None:
+        """Test that create fails without name."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "create", "testuser/test-env", "-v", "value"],
+        )
+
+        assert result.exit_code != 0
+
+    def test_create_variable_missing_value(self) -> None:
+        """Test that create fails without value."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "create", "testuser/test-env", "-n", "NEW_VAR"],
+        )
+
+        assert result.exit_code != 0
+
+
+class TestEnvVarUpdate:
+    """Tests for the env var update command."""
+
+    def test_update_variable_name(self, mock_env_var_api: None) -> None:
+        """Test updating a variable's name."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "var",
+                "update",
+                "testuser/test-env",
+                "var-id-1234567890",
+                "-n",
+                "RENAMED_VAR",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated variable" in result.output
+
+    def test_update_variable_value(self, mock_env_var_api: None) -> None:
+        """Test updating a variable's value."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "var",
+                "update",
+                "testuser/test-env",
+                "var-id-1234567890",
+                "-v",
+                "new-value",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated variable" in result.output
+
+    def test_update_variable_no_changes(self, mock_env_var_api: None) -> None:
+        """Test that update fails when no changes are provided."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "update", "testuser/test-env", "var-id-1234567890"],
+        )
+
+        assert result.exit_code == 1
+        assert "At least one of --name, --value, or --description is required" in result.output
+
+    def test_update_variable_json_output(self, mock_env_var_api: None) -> None:
+        """Test updating a variable with JSON output."""
+        result = runner.invoke(
+            app,
+            [
+                "env",
+                "var",
+                "update",
+                "testuser/test-env",
+                "var-id-1234567890",
+                "-n",
+                "NEW_NAME",
+                "-o",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "id" in output
+
+
+class TestEnvVarDelete:
+    """Tests for the env var delete command."""
+
+    def test_delete_variable_with_confirm(self, mock_env_var_api: None) -> None:
+        """Test deleting a variable with confirmation."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "delete", "testuser/test-env", "var-id-1234567890", "-y"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Variable deleted" in result.output
+
+    def test_delete_variable_cancelled(self, mock_env_var_api: None) -> None:
+        """Test cancelling variable deletion."""
+        result = runner.invoke(
+            app,
+            ["env", "var", "delete", "testuser/test-env", "var-id-1234567890"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+
+class TestEnvVarHelp:
+    """Tests for help output."""
+
+    def test_env_var_help(self) -> None:
+        """Test that env var help works."""
+        result = runner.invoke(app, ["env", "var", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage environment variables" in result.output
+        assert "list" in result.output
+        assert "create" in result.output
+        assert "update" in result.output
+        assert "delete" in result.output
+
+    def test_env_var_list_help(self) -> None:
+        """Test that env var list help works."""
+        result = runner.invoke(app, ["env", "var", "list", "--help"])
+
+        assert result.exit_code == 0
+        assert "--output" in result.output
+
+    def test_env_var_create_help(self) -> None:
+        """Test that env var create help works."""
+        result = runner.invoke(app, ["env", "var", "create", "--help"])
+
+        assert result.exit_code == 0
+        assert "--name" in result.output
+        assert "--value" in result.output
+        assert "--description" in result.output

--- a/packages/prime/tests/test_env_var.py
+++ b/packages/prime/tests/test_env_var.py
@@ -228,8 +228,9 @@ class TestEnvVarUpdate:
                 "env",
                 "var",
                 "update",
-                "testuser/test-env",
                 "var-id-1234567890",
+                "--env",
+                "testuser/test-env",
                 "-n",
                 "RENAMED_VAR",
             ],
@@ -246,8 +247,9 @@ class TestEnvVarUpdate:
                 "env",
                 "var",
                 "update",
-                "testuser/test-env",
                 "var-id-1234567890",
+                "--env",
+                "testuser/test-env",
                 "-v",
                 "new-value",
             ],
@@ -260,7 +262,7 @@ class TestEnvVarUpdate:
         """Test that update fails when no changes are provided."""
         result = runner.invoke(
             app,
-            ["env", "var", "update", "testuser/test-env", "var-id-1234567890"],
+            ["env", "var", "update", "var-id-1234567890", "--env", "testuser/test-env"],
         )
 
         assert result.exit_code == 1
@@ -274,8 +276,9 @@ class TestEnvVarUpdate:
                 "env",
                 "var",
                 "update",
-                "testuser/test-env",
                 "var-id-1234567890",
+                "--env",
+                "testuser/test-env",
                 "-n",
                 "NEW_NAME",
                 "-o",
@@ -295,7 +298,7 @@ class TestEnvVarDelete:
         """Test deleting a variable with confirmation."""
         result = runner.invoke(
             app,
-            ["env", "var", "delete", "testuser/test-env", "var-id-1234567890", "-y"],
+            ["env", "var", "delete", "var-id-1234567890", "--env", "testuser/test-env", "-y"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -305,7 +308,7 @@ class TestEnvVarDelete:
         """Test cancelling variable deletion."""
         result = runner.invoke(
             app,
-            ["env", "var", "delete", "testuser/test-env", "var-id-1234567890"],
+            ["env", "var", "delete", "var-id-1234567890", "--env", "testuser/test-env"],
             input="n\n",
         )
 

--- a/packages/prime/tests/test_secrets.py
+++ b/packages/prime/tests/test_secrets.py
@@ -1,0 +1,340 @@
+import json
+from typing import Any, Dict, Optional
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_secrets_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock the API client for secrets endpoints."""
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+    sample_secrets = [
+        {
+            "id": "secret-id-1234567890",
+            "name": "MY_SECRET",
+            "description": "Test secret",
+            "isFile": False,
+            "userId": "user-123",
+            "teamId": None,
+            "createdAt": "2026-01-15T10:00:00Z",
+            "updatedAt": "2026-01-15T10:00:00Z",
+        },
+        {
+            "id": "secret-id-0987654321",
+            "name": "API_KEY",
+            "description": None,
+            "isFile": False,
+            "userId": "user-123",
+            "teamId": None,
+            "createdAt": "2026-01-10T08:00:00Z",
+            "updatedAt": "2026-01-10T08:00:00Z",
+        },
+    ]
+
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if endpoint == "/secrets/" or endpoint == "/secrets":
+            return {"data": sample_secrets, "totalCount": 2}
+        elif endpoint.startswith("/secrets/"):
+            secret_id = endpoint.split("/")[-1]
+            for s in sample_secrets:
+                if s["id"] == secret_id or s["id"].startswith(secret_id):
+                    return {"data": s}
+            return {"data": sample_secrets[0]}
+        return {"data": []}
+
+    def mock_post(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if endpoint == "/secrets/" or endpoint == "/secrets":
+            return {
+                "data": {
+                    "id": "new-secret-id-12345",
+                    "name": json.get("name") if json else "NEW_SECRET",
+                    "description": json.get("description") if json else None,
+                    "isFile": json.get("isFile", False) if json else False,
+                    "userId": "user-123",
+                    "teamId": json.get("teamId") if json else None,
+                    "createdAt": "2026-02-01T12:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_patch(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if endpoint.startswith("/secrets/"):
+            return {
+                "data": {
+                    "id": "secret-id-1234567890",
+                    "name": json.get("name", "MY_SECRET") if json else "MY_SECRET",
+                    "description": json.get("description") if json else None,
+                    "isFile": False,
+                    "userId": "user-123",
+                    "teamId": None,
+                    "createdAt": "2026-01-15T10:00:00Z",
+                    "updatedAt": "2026-02-01T12:00:00Z",
+                }
+            }
+        return {"data": {}}
+
+    def mock_delete(self: Any, endpoint: str) -> None:
+        pass
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+    monkeypatch.setattr("prime_cli.core.APIClient.post", mock_post)
+    monkeypatch.setattr("prime_cli.core.APIClient.patch", mock_patch)
+    monkeypatch.setattr("prime_cli.core.APIClient.delete", mock_delete)
+
+
+class TestSecretsList:
+    """Tests for the secrets list command."""
+
+    def test_list_secrets_table_output(self, mock_secrets_api: None) -> None:
+        """Test listing secrets with table output."""
+        result = runner.invoke(app, ["secrets", "list"], env={"COLUMNS": "200", "LINES": "50"})
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Personal Secrets" in result.output
+        assert "MY_SECRET" in result.output
+        assert "API_KEY" in result.output
+        assert "Test secret" in result.output
+
+    def test_list_secrets_json_output(self, mock_secrets_api: None) -> None:
+        """Test listing secrets with JSON output."""
+        result = runner.invoke(app, ["secrets", "list", "-o", "json"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "secrets" in output
+        assert len(output["secrets"]) == 2
+        assert output["secrets"][0]["name"] == "MY_SECRET"
+
+    def test_list_empty_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test listing when no secrets exist."""
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            return {"data": [], "totalCount": 0}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+        result = runner.invoke(app, ["secrets", "list"])
+
+        assert result.exit_code == 0
+        assert "No personal secrets found" in result.output
+
+
+class TestSecretsCreate:
+    """Tests for the secrets create command."""
+
+    def test_create_secret_success(self, mock_secrets_api: None) -> None:
+        """Test creating a secret successfully."""
+        result = runner.invoke(
+            app,
+            ["secrets", "create", "-n", "NEW_SECRET", "-v", "secret-value"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created personal secret 'NEW_SECRET'" in result.output
+        assert "ID:" in result.output
+
+    def test_create_secret_with_description(self, mock_secrets_api: None) -> None:
+        """Test creating a secret with a description."""
+        result = runner.invoke(
+            app,
+            [
+                "secrets",
+                "create",
+                "-n",
+                "NEW_SECRET",
+                "-v",
+                "secret-value",
+                "-d",
+                "My description",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created personal secret 'NEW_SECRET'" in result.output
+
+    def test_create_secret_json_output(self, mock_secrets_api: None) -> None:
+        """Test creating a secret with JSON output."""
+        result = runner.invoke(
+            app,
+            ["secrets", "create", "-n", "NEW_SECRET", "-v", "value", "-o", "json"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["name"] == "NEW_SECRET"
+        assert "id" in output
+
+    def test_create_secret_interactive_cancel_name(self, mock_secrets_api: None) -> None:
+        """Test that create can be cancelled during name prompt."""
+        result = runner.invoke(
+            app,
+            ["secrets", "create"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+    def test_create_secret_interactive(self, mock_secrets_api: None) -> None:
+        """Test creating a secret interactively."""
+        result = runner.invoke(
+            app,
+            ["secrets", "create"],
+            input="MY_NEW_SECRET\nsecret-value\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Created personal secret" in result.output
+
+
+class TestSecretsUpdate:
+    """Tests for the secrets update command."""
+
+    def test_update_secret_name(self, mock_secrets_api: None) -> None:
+        """Test updating a secret's name."""
+        result = runner.invoke(
+            app,
+            ["secrets", "update", "secret-id-1234567890", "-n", "RENAMED_SECRET"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_value(self, mock_secrets_api: None) -> None:
+        """Test updating a secret's value."""
+        result = runner.invoke(
+            app,
+            ["secrets", "update", "secret-id-1234567890", "-v", "new-value"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_no_changes(self, mock_secrets_api: None) -> None:
+        """Test that update prompts when no changes are provided."""
+        result = runner.invoke(
+            app,
+            ["secrets", "update", "secret-id-1234567890"],
+            input="\n",
+        )
+        assert result.exit_code == 0
+        assert "No changes made" in result.output
+
+    def test_update_secret_interactive(self, mock_secrets_api: None) -> None:
+        """Test updating a secret interactively."""
+        result = runner.invoke(
+            app,
+            ["secrets", "update", "secret-id-1234567890"],
+            input="new-secret-value\n",
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Updated secret" in result.output
+
+    def test_update_secret_json_output(self, mock_secrets_api: None) -> None:
+        """Test updating a secret with JSON output."""
+        result = runner.invoke(
+            app,
+            ["secrets", "update", "secret-id-1234567890", "-n", "NEW_NAME", "-o", "json"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert "id" in output
+
+
+class TestSecretsDelete:
+    """Tests for the secrets delete command."""
+
+    def test_delete_secret_with_confirm(self, mock_secrets_api: None) -> None:
+        """Test deleting a secret with confirmation."""
+        result = runner.invoke(
+            app,
+            ["secrets", "delete", "secret-id-1234567890", "-y"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Deleted secret" in result.output
+
+    def test_delete_secret_cancelled(self, mock_secrets_api: None) -> None:
+        """Test cancelling secret deletion."""
+        result = runner.invoke(
+            app,
+            ["secrets", "delete", "secret-id-1234567890"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
+
+class TestSecretsGet:
+    """Tests for the secrets get command."""
+
+    def test_get_secret_table_output(self, mock_secrets_api: None) -> None:
+        """Test getting a secret with table output."""
+        result = runner.invoke(
+            app,
+            ["secrets", "get", "secret-id-1234567890"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Secret Details" in result.output
+        assert "MY_SECRET" in result.output
+
+    def test_get_secret_json_output(self, mock_secrets_api: None) -> None:
+        """Test getting a secret with JSON output."""
+        result = runner.invoke(
+            app,
+            ["secrets", "get", "secret-id-1234567890", "-o", "json"],
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["name"] == "MY_SECRET"
+        assert output["id"] == "secret-id-1234567890"
+
+
+class TestSecretsHelp:
+    """Tests for help output."""
+
+    def test_secrets_help(self) -> None:
+        """Test that secrets help works."""
+        result = runner.invoke(app, ["secrets", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage global secrets" in result.output
+        assert "list" in result.output
+        assert "create" in result.output
+        assert "update" in result.output
+        assert "delete" in result.output
+        assert "get" in result.output
+
+    def test_secrets_list_help(self) -> None:
+        """Test that secrets list help works."""
+        result = runner.invoke(app, ["secrets", "list", "--help"])
+
+        assert result.exit_code == 0
+        assert "--output" in result.output
+
+    def test_secrets_create_help(self) -> None:
+        """Test that secrets create help works."""
+        result = runner.invoke(app, ["secrets", "create", "--help"])
+
+        assert result.exit_code == 0
+        assert "--name" in result.output
+        assert "--value" in result.output
+        assert "--description" in result.output
+        assert "--file" in result.output

--- a/packages/prime/tests/test_secrets.py
+++ b/packages/prime/tests/test_secrets.py
@@ -101,7 +101,7 @@ class TestSecretsList:
 
     def test_list_secrets_table_output(self, mock_secrets_api: None) -> None:
         """Test listing secrets with table output."""
-        result = runner.invoke(app, ["secrets", "list"], env={"COLUMNS": "200", "LINES": "50"})
+        result = runner.invoke(app, ["secret", "list"], env={"COLUMNS": "200", "LINES": "50"})
 
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Personal Secrets" in result.output
@@ -111,7 +111,7 @@ class TestSecretsList:
 
     def test_list_secrets_json_output(self, mock_secrets_api: None) -> None:
         """Test listing secrets with JSON output."""
-        result = runner.invoke(app, ["secrets", "list", "-o", "json"])
+        result = runner.invoke(app, ["secret", "list", "-o", "json"])
 
         assert result.exit_code == 0, f"Failed: {result.output}"
         output = json.loads(result.output)
@@ -131,7 +131,7 @@ class TestSecretsList:
 
         monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
-        result = runner.invoke(app, ["secrets", "list"])
+        result = runner.invoke(app, ["secret", "list"])
 
         assert result.exit_code == 0
         assert "No personal secrets found" in result.output
@@ -144,7 +144,7 @@ class TestSecretsCreate:
         """Test creating a secret successfully."""
         result = runner.invoke(
             app,
-            ["secrets", "create", "-n", "NEW_SECRET", "-v", "secret-value"],
+            ["secret", "create", "-n", "NEW_SECRET", "-v", "secret-value"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -156,7 +156,7 @@ class TestSecretsCreate:
         result = runner.invoke(
             app,
             [
-                "secrets",
+                "secret",
                 "create",
                 "-n",
                 "NEW_SECRET",
@@ -174,7 +174,7 @@ class TestSecretsCreate:
         """Test creating a secret with JSON output."""
         result = runner.invoke(
             app,
-            ["secrets", "create", "-n", "NEW_SECRET", "-v", "value", "-o", "json"],
+            ["secret", "create", "-n", "NEW_SECRET", "-v", "value", "-o", "json"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -186,7 +186,7 @@ class TestSecretsCreate:
         """Test that create can be cancelled during name prompt."""
         result = runner.invoke(
             app,
-            ["secrets", "create"],
+            ["secret", "create"],
             input="\n",
         )
         assert result.exit_code == 0
@@ -196,7 +196,7 @@ class TestSecretsCreate:
         """Test creating a secret interactively."""
         result = runner.invoke(
             app,
-            ["secrets", "create"],
+            ["secret", "create"],
             input="MY_NEW_SECRET\nsecret-value\n",
         )
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -210,7 +210,7 @@ class TestSecretsUpdate:
         """Test updating a secret's name."""
         result = runner.invoke(
             app,
-            ["secrets", "update", "secret-id-1234567890", "-n", "RENAMED_SECRET"],
+            ["secret", "update", "secret-id-1234567890", "-n", "RENAMED_SECRET"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -220,7 +220,7 @@ class TestSecretsUpdate:
         """Test updating a secret's value."""
         result = runner.invoke(
             app,
-            ["secrets", "update", "secret-id-1234567890", "-v", "new-value"],
+            ["secret", "update", "secret-id-1234567890", "-v", "new-value"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -230,7 +230,7 @@ class TestSecretsUpdate:
         """Test that update prompts when no changes are provided."""
         result = runner.invoke(
             app,
-            ["secrets", "update", "secret-id-1234567890"],
+            ["secret", "update", "secret-id-1234567890"],
             input="\n",
         )
         assert result.exit_code == 0
@@ -240,7 +240,7 @@ class TestSecretsUpdate:
         """Test updating a secret interactively."""
         result = runner.invoke(
             app,
-            ["secrets", "update", "secret-id-1234567890"],
+            ["secret", "update", "secret-id-1234567890"],
             input="new-secret-value\n",
         )
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -250,7 +250,7 @@ class TestSecretsUpdate:
         """Test updating a secret with JSON output."""
         result = runner.invoke(
             app,
-            ["secrets", "update", "secret-id-1234567890", "-n", "NEW_NAME", "-o", "json"],
+            ["secret", "update", "secret-id-1234567890", "-n", "NEW_NAME", "-o", "json"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -265,7 +265,7 @@ class TestSecretsDelete:
         """Test deleting a secret with confirmation."""
         result = runner.invoke(
             app,
-            ["secrets", "delete", "secret-id-1234567890", "-y"],
+            ["secret", "delete", "secret-id-1234567890", "-y"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -275,7 +275,7 @@ class TestSecretsDelete:
         """Test cancelling secret deletion."""
         result = runner.invoke(
             app,
-            ["secrets", "delete", "secret-id-1234567890"],
+            ["secret", "delete", "secret-id-1234567890"],
             input="n\n",
         )
 
@@ -290,7 +290,7 @@ class TestSecretsGet:
         """Test getting a secret with table output."""
         result = runner.invoke(
             app,
-            ["secrets", "get", "secret-id-1234567890"],
+            ["secret", "get", "secret-id-1234567890"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -301,7 +301,7 @@ class TestSecretsGet:
         """Test getting a secret with JSON output."""
         result = runner.invoke(
             app,
-            ["secrets", "get", "secret-id-1234567890", "-o", "json"],
+            ["secret", "get", "secret-id-1234567890", "-o", "json"],
         )
 
         assert result.exit_code == 0, f"Failed: {result.output}"
@@ -315,7 +315,7 @@ class TestSecretsHelp:
 
     def test_secrets_help(self) -> None:
         """Test that secrets help works."""
-        result = runner.invoke(app, ["secrets", "--help"])
+        result = runner.invoke(app, ["secret", "--help"])
 
         assert result.exit_code == 0
         assert "Manage global secrets" in result.output
@@ -327,7 +327,7 @@ class TestSecretsHelp:
 
     def test_secrets_list_help(self) -> None:
         """Test that secrets list help works."""
-        result = runner.invoke(app, ["secrets", "list", "--help"])
+        result = runner.invoke(app, ["secret", "list", "--help"])
 
         assert result.exit_code == 0
         output = strip_ansi(result.output)
@@ -335,7 +335,7 @@ class TestSecretsHelp:
 
     def test_secrets_create_help(self) -> None:
         """Test that secrets create help works."""
-        result = runner.invoke(app, ["secrets", "create", "--help"])
+        result = runner.invoke(app, ["secret", "create", "--help"])
 
         assert result.exit_code == 0
         output = strip_ansi(result.output)

--- a/packages/prime/tests/test_secrets.py
+++ b/packages/prime/tests/test_secrets.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 import pytest
 from prime_cli.main import app
+from prime_cli.utils import strip_ansi
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -12,6 +13,7 @@ runner = CliRunner()
 def mock_secrets_api(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mock the API client for secrets endpoints."""
     monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr("prime_cli.core.Config.team_id", None)
 
     sample_secrets = [
         {
@@ -120,6 +122,7 @@ class TestSecretsList:
     def test_list_empty_secrets(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test listing when no secrets exist."""
         monkeypatch.setenv("PRIME_API_KEY", "test-key")
+        monkeypatch.setattr("prime_cli.core.Config.team_id", None)
 
         def mock_get(
             self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
@@ -327,14 +330,16 @@ class TestSecretsHelp:
         result = runner.invoke(app, ["secrets", "list", "--help"])
 
         assert result.exit_code == 0
-        assert "--output" in result.output
+        output = strip_ansi(result.output)
+        assert "--output" in output
 
     def test_secrets_create_help(self) -> None:
         """Test that secrets create help works."""
         result = runner.invoke(app, ["secrets", "create", "--help"])
 
         assert result.exit_code == 0
-        assert "--name" in result.output
-        assert "--value" in result.output
-        assert "--description" in result.output
-        assert "--file" in result.output
+        output = strip_ansi(result.output)
+        assert "--name" in output
+        assert "--value" in output
+        assert "--description" in output
+        assert "--file" in output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that create/update/delete secrets and variables via API calls, so mistakes could impact user/team configuration; logic is straightforward and covered by extensive CLI tests.
> 
> **Overview**
> Adds new Prime CLI management commands for **global secrets** (`prime secret`) and **environment-scoped secrets/variables** (`prime env secret`, `prime env var`) including list/create/update/delete plus link/unlink for attaching global secrets to environments, with interactive prompts, validation, and table/JSON output.
> 
> Extends `prime env` with a deprecated `eval` wrapper that runs `vf-eval` against Prime Inference (API-key injection, model existence check, job-id tracing headers) and optionally auto-pushes results to the hub; also hardens the HTTP client to gracefully handle `204 No Content` responses and centralizes ANSI stripping/prompt helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c09c7939036335396ac3b6e7f875818648f2a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->