### PR TITLE
Add prime rl restart command

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -206,6 +206,20 @@ class RLClient:
                 raise APIError(f"Failed to delete RL run: {e.response.text}")
             raise APIError(f"Failed to delete RL run: {str(e)}")
 
+    def restart_run(self, run_id: str) -> RLRun:
+        """Restart a running RL training run from its latest checkpoint.
+
+        Only RUNNING runs can be restarted (checkpoints still on PVC).
+        For STOPPED/FAILED/COMPLETED runs, checkpoints have been cleaned up.
+        """
+        try:
+            response = self.client.request("PUT", f"/rft/runs/{run_id}/restart")
+            return RLRun.model_validate(response.get("run"))
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(f"Failed to restart RL run: {e.response.text}")
+            raise APIError(f"Failed to restart RL run: {str(e)}")
+
     def get_run(self, run_id: str) -> RLRun:
         """Get details of a specific RL run."""
         try:


### PR DESCRIPTION
- Add `restart_run` method to `RLClient`
- Add `prime rl restart` command

Requires platform PR for the backend endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI operation that triggers server-side run restarts; correctness depends on the new backend endpoint and may impact running jobs if misused.
> 
> **Overview**
> Adds support for restarting an in-progress hosted RL training run from its latest checkpoint.
> 
> Introduces `RLClient.restart_run()` calling `PUT /rft/runs/{run_id}/restart`, and wires it into a new `prime rl restart <run_id>` command with an optional confirmation bypass (`--force`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 730d7684f740b57a82868d052cefcb60116294db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->