### PR TITLE
Add support for specifying env versions for hosted RL

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -146,7 +146,7 @@ class EnvConfig(BaseModel):
         if "@" in self.id:
             id_part, version_part = self.id.rsplit("@", 1)
             self.id = id_part
-            if self.version is None:
+            if self.version is None and version_part:
                 self.version = version_part
         return self
 
@@ -177,7 +177,7 @@ class EvalEnvConfig(BaseModel):
         if "@" in self.id:
             id_part, version_part = self.id.rsplit("@", 1)
             self.id = id_part
-            if self.version is None:
+            if self.version is None and version_part:
                 self.version = version_part
         return self
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import toml
 import typer
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console
 from rich.table import Table
@@ -138,6 +138,17 @@ class EnvConfig(BaseModel):
     id: str
     name: str | None = None
     args: Dict[str, Any] = Field(default_factory=dict)
+    version: str | None = None
+
+    @model_validator(mode="after")
+    def parse_version_from_id(self) -> "EnvConfig":
+        """Extract version from id if specified as 'owner/name@version'."""
+        if "@" in self.id and self.version is None:
+            # Parse inline version syntax: "owner/name@0.2.3" -> id="owner/name", version="0.2.3"
+            id_part, version_part = self.id.rsplit("@", 1)
+            self.id = id_part
+            self.version = version_part
+        return self
 
     def to_api_dict(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {"id": self.id}
@@ -145,6 +156,8 @@ class EnvConfig(BaseModel):
             result["name"] = self.name
         if self.args:
             result["args"] = self.args
+        if self.version is not None:
+            result["version"] = self.version
         return result
 
 
@@ -156,6 +169,17 @@ class EvalEnvConfig(BaseModel):
     args: Dict[str, Any] = Field(default_factory=dict)
     num_examples: int | None = None
     rollouts_per_example: int | None = None
+    version: str | None = None
+
+    @model_validator(mode="after")
+    def parse_version_from_id(self) -> "EvalEnvConfig":
+        """Extract version from id if specified as 'owner/name@version'."""
+        if "@" in self.id and self.version is None:
+            # Parse inline version syntax: "owner/name@0.2.3" -> id="owner/name", version="0.2.3"
+            id_part, version_part = self.id.rsplit("@", 1)
+            self.id = id_part
+            self.version = version_part
+        return self
 
     def to_api_dict(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {"id": self.id}
@@ -167,6 +191,8 @@ class EvalEnvConfig(BaseModel):
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:
             result["rollouts_per_example"] = self.rollouts_per_example
+        if self.version is not None:
+            result["version"] = self.version
         return result
 
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -143,11 +143,11 @@ class EnvConfig(BaseModel):
     @model_validator(mode="after")
     def parse_version_from_id(self) -> "EnvConfig":
         """Extract version from id if specified as 'owner/name@version'."""
-        if "@" in self.id and self.version is None:
-            # Parse inline version syntax: "owner/name@0.2.3" -> id="owner/name", version="0.2.3"
+        if "@" in self.id:
             id_part, version_part = self.id.rsplit("@", 1)
             self.id = id_part
-            self.version = version_part
+            if self.version is None:
+                self.version = version_part
         return self
 
     def to_api_dict(self) -> Dict[str, Any]:
@@ -174,11 +174,11 @@ class EvalEnvConfig(BaseModel):
     @model_validator(mode="after")
     def parse_version_from_id(self) -> "EvalEnvConfig":
         """Extract version from id if specified as 'owner/name@version'."""
-        if "@" in self.id and self.version is None:
-            # Parse inline version syntax: "owner/name@0.2.3" -> id="owner/name", version="0.2.3"
+        if "@" in self.id:
             id_part, version_part = self.id.rsplit("@", 1)
             self.id = id_part
-            self.version = version_part
+            if self.version is None:
+                self.version = version_part
         return self
 
     def to_api_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive config parsing that only affects RL environment identifiers and the request payload sent to the API; low risk aside from potential edge cases when `@` appears in an env id.
> 
> **Overview**
> Hosted RL configs can now pin specific environment versions.
> 
> `EnvConfig` and `EvalEnvConfig` add an optional `version` field, accept `owner/name@version` in `id` via a Pydantic `model_validator`, and include `version` in the environment payload sent to `RLClient.create_run` (and eval environments) when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c1af03c3369d3c1e3f81a935a751a9c00bacdab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->