### PR TITLE
Release: Bump prime cli version to 0.5.28

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.27"
+__version__ = "0.5.28"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- Bump prime-cli from 0.5.27 to 0.5.28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple version string bump only; no functional or behavioral changes.
> 
> **Overview**
> Bumps `prime_cli` package version from `0.5.27` to `0.5.28` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9be223139f8a1a5328304af96295fd52ee146895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->