### PR TITLE
image build logs

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -215,7 +215,6 @@ def list_images(
         table = Table(title="Your Docker Images")
         table.add_column("Image Reference", style="cyan")
         table.add_column("Status", justify="center")
-        table.add_column("Failure Reason", style="yellow")
         table.add_column("Size", justify="right")
         table.add_column("Created", style="dim")
 
@@ -256,14 +255,7 @@ def list_images(
                 or f"{img.get('imageName', 'unknown')}:{img.get('imageTag', 'latest')}"
             )
 
-            # Failure reason (if available)
-            failure_reason = ""
-            if status in {"FAILED", "CANCELLED"}:
-                failure_reason = img.get("errorMessage") or ""
-                if len(failure_reason) > 100:
-                    failure_reason = f"{failure_reason[:97]}..."
-
-            table.add_row(image_ref, status_display, failure_reason, size_mb, date_str)
+            table.add_row(image_ref, status_display, size_mb, date_str)
 
         console.print()
         console.print(table)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a read-only CLI command that hits a new logs endpoint and prints output; main risk is log rendering/escaping and endpoint contract mismatches.
> 
> **Overview**
> Adds `prime images logs <build_id>` to fetch and display Docker image build logs via `GET /images/build/{build_id}/logs` with a `--tail/-n` option, escaping output before printing.
> 
> Updates the `prime images push` success message to point users to the new logs command alongside `prime images list` for build monitoring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15586c7a0e2e46320daf57a0e4fffea15d6ee2a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->