### PR TITLE
Bump prime-cli to 0.5.29

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.28"
+__version__ = "0.5.29"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- bump cli version from 0.5.28 to 0.5.29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change; no behavior or API surface is modified.
> 
> **Overview**
> Bumps the `prime_cli` package version constant from `0.5.28` to `0.5.29` (no functional code changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14216435585c106189dfcccf3c3b5f0414c5541c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->