### PR TITLE
team tunnels

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -91,10 +91,11 @@ class TunnelClient:
         method: str,
         url: str,
         json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, str]] = None,
     ) -> httpx.Response:
         """Make async HTTP request with retry on transient connection errors."""
         client = await self._get_client()
-        return await client.request(method, url, json=json)
+        return await client.request(method, url, json=json, params=params)
 
     async def _handle_response(self, response: httpx.Response, operation: str) -> Dict[str, Any]:
         """Handle response and raise appropriate errors."""
@@ -240,11 +241,10 @@ class TunnelClient:
             team_id = self.config.team_id
 
         url = f"{self.base_url}/api/v1/tunnel"
-        if team_id:
-            url = f"{url}?teamId={team_id}"
+        params = {"teamId": team_id} if team_id else None
 
         try:
-            response = await self._request_with_retry("GET", url)
+            response = await self._request_with_retry("GET", url, params=params)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -120,6 +120,7 @@ class TunnelClient:
         self,
         local_port: int,
         name: Optional[str] = None,
+        team_id: Optional[str] = None,
     ) -> TunnelInfo:
         """
         Register a new tunnel with the backend.
@@ -127,6 +128,7 @@ class TunnelClient:
         Args:
             local_port: Local port the tunnel will forward to
             name: Optional friendly name for the tunnel
+            team_id: Optional team ID for team tunnels
 
         Returns:
             TunnelInfo with connection details
@@ -137,10 +139,15 @@ class TunnelClient:
         """
         self._check_auth_required()
 
+        if team_id is None:
+            team_id = self.config.team_id
+
         url = f"{self.base_url}/api/v1/tunnel"
         payload: Dict[str, Any] = {"local_port": local_port}
         if name:
             payload["name"] = name
+        if team_id:
+            payload["teamId"] = team_id
 
         try:
             response = await self._request_with_retry("POST", url, json=payload)
@@ -217,16 +224,24 @@ class TunnelClient:
         await self._handle_response(response, "delete tunnel")
         return True
 
-    async def list_tunnels(self) -> list[TunnelInfo]:
+    async def list_tunnels(self, team_id: Optional[str] = None) -> list[TunnelInfo]:
         """
         List all tunnels for the current user.
+
+        Args:
+            team_id: Optional team ID to include team tunnels
 
         Returns:
             List of TunnelInfo objects
         """
         self._check_auth_required()
 
+        if team_id is None:
+            team_id = self.config.team_id
+
         url = f"{self.base_url}/api/v1/tunnel"
+        if team_id:
+            url = f"{url}?teamId={team_id}"
 
         try:
             response = await self._request_with_retry("GET", url)

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -259,7 +259,7 @@ log.level = "{self.log_level}"
 
 # HTTP proxy configuration
 [[proxies]]
-name = "http"
+name = "{self._tunnel_info.tunnel_id}"
 type = "http"
 localIP = "{self.local_addr}"
 localPort = {self.local_port}

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -22,9 +22,9 @@ class Tunnel:
         local_port: int,
         local_addr: str = "127.0.0.1",
         name: Optional[str] = None,
-        team_id: Optional[str] = None,
         connection_timeout: float = 30.0,
         log_level: str = "info",
+        team_id: Optional[str] = None,
     ):
         """
         Initialize a tunnel.

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -22,6 +22,7 @@ class Tunnel:
         local_port: int,
         local_addr: str = "127.0.0.1",
         name: Optional[str] = None,
+        team_id: Optional[str] = None,
         connection_timeout: float = 30.0,
         log_level: str = "info",
     ):
@@ -32,12 +33,14 @@ class Tunnel:
             local_port: Local port to tunnel
             local_addr: Local address to tunnel (default: 127.0.0.1)
             name: Optional friendly name for the tunnel
+            team_id: Optional team ID for team tunnels
             connection_timeout: Timeout for establishing connection (seconds)
             log_level: frpc log level (trace, debug, info, warn, error)
         """
         self.local_port = local_port
         self.local_addr = local_addr
         self.name = name
+        self.team_id = team_id
         self.connection_timeout = connection_timeout
         self.log_level = log_level
 
@@ -93,6 +96,7 @@ class Tunnel:
             self._tunnel_info = await self._client.create_tunnel(
                 local_port=self.local_port,
                 name=self.name,
+                team_id=self.team_id,
             )
         except BaseException as e:
             await self._cleanup()

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -16,11 +16,14 @@ console = Console()
 def start_tunnel(
     port: int = typer.Option(8765, "--port", "-p", help="Local port to tunnel"),
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Friendly name for the tunnel"),
+    team_id: Optional[str] = typer.Option(
+        None, "--team-id", help="Team ID for team tunnels (uses config team_id if not specified)"
+    ),
 ) -> None:
     """Start a tunnel to expose a local port."""
 
     async def run_tunnel():
-        tunnel = Tunnel(local_port=port, name=name)
+        tunnel = Tunnel(local_port=port, name=name, team_id=team_id)
 
         shutdown_event = asyncio.Event()
 
@@ -60,13 +63,19 @@ def start_tunnel(
 
 
 @app.command("list")
-def list_tunnels() -> None:
+def list_tunnels(
+    team_id: Optional[str] = typer.Option(
+        None,
+        "--team-id",
+        help="Team ID to list team tunnels (uses config team_id if not specified)",
+    ),
+) -> None:
     """List active tunnels."""
 
     async def fetch_tunnels():
         client = TunnelClient()
         try:
-            tunnels = await client.list_tunnels()
+            tunnels = await client.list_tunnels(team_id=team_id)
             return tunnels
         finally:
             await client.close()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes request shapes/parameters for tunnel creation and listing and may affect which tunnels users see or create if `team_id` is set in config or passed via CLI.
> 
> **Overview**
> Adds **team tunnel support** by threading an optional `team_id` through the SDK and CLI and passing it to the API as `teamId`.
> 
> `TunnelClient.create_tunnel` now includes `teamId` in the POST payload and `list_tunnels` can filter/include team tunnels via a `teamId` query param; both default to `Config.team_id` when not explicitly provided. The CLI `tunnel start`/`tunnel list` commands add a `--team-id` option, and generated `frpc` config now uses the tunnel ID as the proxy `name` (instead of a fixed `"http"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7786eb0f8815cff1efe52f48ed7b8a18842db4b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->