### PR TITLE
feat(tunnel): add synchronous stop

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -169,6 +169,7 @@ class Tunnel:
                     self._process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     self._process.kill()
+                    self._process.wait(timeout=2)
             except Exception:
                 pass
             finally:

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
 from prime_tunnel import Config, Tunnel, TunnelClient
+from prime_tunnel.models import TunnelInfo
 
 
 def test_tunnel_init():
@@ -56,3 +60,67 @@ def test_tunnel_client_init():
     client = TunnelClient(api_key="test-key")
     assert client.api_key == "test-key"
     assert client.base_url == Config.DEFAULT_BASE_URL
+
+
+def _make_started_tunnel() -> Tunnel:
+    """Create a Tunnel that looks like it was started."""
+    tunnel = Tunnel(local_port=8080)
+    tunnel._started = True
+    tunnel._process = MagicMock()
+    tunnel._tunnel_info = TunnelInfo(
+        tunnel_id="t-test123",
+        hostname="t-test123.tunnel.example.com",
+        url="https://t-test123.tunnel.example.com",
+        frp_token="tok",
+        server_host="frp.example.com",
+        server_port=7000,
+        expires_at=datetime.now(timezone.utc),
+    )
+    tunnel._config_file = MagicMock()
+    tunnel._config_file.exists.return_value = True
+    return tunnel
+
+
+def test_sync_stop_noop_when_not_started():
+    tunnel = Tunnel(local_port=8080)
+    tunnel.sync_stop()  # should not raise
+
+
+def test_sync_stop_terminates_process_and_deletes_registration():
+    tunnel = _make_started_tunnel()
+    process_mock = tunnel._process
+
+    with patch("prime_tunnel.tunnel.httpx.delete") as mock_delete:
+        tunnel.sync_stop()
+
+    process_mock.terminate.assert_called_once()
+    mock_delete.assert_called_once()
+    assert "t-test123" in mock_delete.call_args[0][0]
+    assert tunnel._started is False
+    assert tunnel._tunnel_info is None
+    assert tunnel._process is None
+
+
+def test_sync_stop_kills_on_timeout():
+    tunnel = _make_started_tunnel()
+    process_mock = tunnel._process
+    import subprocess
+
+    process_mock.wait.side_effect = subprocess.TimeoutExpired(cmd="frpc", timeout=5)
+
+    with patch("prime_tunnel.tunnel.httpx.delete"):
+        tunnel.sync_stop()
+
+    process_mock.terminate.assert_called_once()
+    process_mock.kill.assert_called_once()
+    assert tunnel._started is False
+
+
+def test_sync_stop_survives_delete_failure():
+    tunnel = _make_started_tunnel()
+
+    with patch("prime_tunnel.tunnel.httpx.delete", side_effect=Exception("network")):
+        tunnel.sync_stop()  # should not raise
+
+    assert tunnel._started is False
+    assert tunnel._tunnel_info is None


### PR DESCRIPTION
Fix tunnel registration leaks during process exit by adding `Tunnel.sync_stop()` — a synchronous cleanup method that survives signal handlers and atexit, matching the pattern already used by sandbox teardown

use in your env:
```diff
-                    await self._tunnel.stop()
+                    self._tunnel.sync_stop()
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new teardown path that directly issues HTTP DELETEs and bypasses async client cleanup, which could change shutdown behavior and leak resources if misused, though it’s isolated to stopping logic.
> 
> **Overview**
> Adds `Tunnel.sync_stop()` to perform best-effort synchronous teardown (terminate/kill `frpc`, delete the tunnel registration via `httpx.delete`, and remove the temp config file) so cleanup can run reliably from signal handlers/`atexit` without awaiting.
> 
> Extends tests to cover `sync_stop()` behavior including no-op when not started, kill-on-timeout, and resilience to API deletion failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fed9fd29e726effb82cbe2ae7d66902df505f99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->