### PR TITLE
Add JSON log formatting for RL training logs

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -89,9 +89,9 @@ def format_json_log_line(line: str) -> str | None:
         style = LEVEL_STYLES.get(level, "")
 
         if style:
-            return f"[dim]{time_part}[/dim] [{style}][{level}][/{style}] {message}"
+            return f"[dim]{time_part}[/dim] [{style}]\\[{level}][/{style}] {message}"
         else:
-            return f"[dim]{time_part}[/dim] [{level}] {message}"
+            return f"[dim]{time_part}[/dim] \\[{level}] {message}"
 
     except (json.JSONDecodeError, TypeError, KeyError):
         return None


### PR DESCRIPTION
## Summary
- Parse JSON log lines and format nicely with timestamp, level, message
- Color-code log levels (green for SUCCESS, red for ERROR, etc.)
- Filter out progress logs (too spammy for terminal)
- Add `--raw` flag to show unformatted logs
- Fallback to legacy handling for non-JSON logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only log formatting changes with a fallback to legacy non-JSON handling; primary risk is minor regressions in log display/deduping.
> 
> **Overview**
> RL run log output in `prime rl logs` is updated to **detect JSON log lines**, format them with a compact timestamp/level/message display, and **color-code levels** while escaping messages for safe Rich rendering.
> 
> The log cleaner now returns a list of display lines, **filters out JSON `type=progress` entries** (and continues to suppress non-JSON tqdm progress spam), and the logs command adds a `--raw/-r` mode to bypass formatting; follow-mode output tracking is adjusted to compare line lists for overlap/deduping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccd61c3ce14281ceb869182ae74d44362b4fd7f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->