### PR TITLE
Bump prime-cli version to 0.5.31

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.30"
+__version__ = "0.5.31"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- Bump version from 0.5.30 to 0.5.31

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the exposed version string; no runtime logic changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.30` to `0.5.31` by updating `__version__` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 903524f177dc2e22ebffaffd9e82c5abc17a4e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->