### PR TITLE
support for hosted evals

### DIFF
--- a/packages/prime/src/prime_cli/utils/display.py
+++ b/packages/prime/src/prime_cli/utils/display.py
@@ -1,11 +1,13 @@
 """Display utilities for table and JSON output."""
 
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import typer
 from rich.console import Console
 from rich.table import Table
+
+from ..core.config import Config
 
 
 def validate_output_format(output: str, console: Console) -> None:
@@ -74,3 +76,11 @@ DISK_STATUS_COLORS = {
     "ERROR": "red",
     "TERMINATED": "white",
 }
+
+
+def get_eval_viewer_url(eval_id: str, viewer_url: Optional[str] = None) -> str:
+    """Return viewer URL for an evaluation."""
+    if viewer_url:
+        return viewer_url
+    config = Config()
+    return f"{config.frontend_url}/dashboard/evaluations/{eval_id}"

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,0 +1,337 @@
+import asyncio
+import re
+from typing import Any
+
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.text import Text
+
+from prime_cli.core import APIError, AsyncAPIClient
+from prime_cli.utils.display import get_eval_viewer_url
+from prime_cli.utils.schemas import (
+    EvalStatus,
+    HostedEvalConfig,
+    HostedEvalCreationResult,
+    HostedEvalResult,
+)
+
+console = Console()
+
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+PROGRESS_BAR = re.compile(r".*\|[█▏▎▍▌▋▊▉ ]{10,}\|.*")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE.sub("", text)
+
+
+def filter_progress_bars(text: str) -> str:
+    lines = text.splitlines()
+    filtered = []
+    for line in lines:
+        if PROGRESS_BAR.search(line) or re.search(r"\d+%\|", line):
+            if "100%" in line:
+                match = re.search(r"([^|]*100%\|[█▏▎▍▌▋▊▉ ]+\|[^\n]*?)(?=\d+%\||$)", line)
+                if match:
+                    filtered.append(match.group(1).strip())
+                else:
+                    filtered.append(line)
+            continue
+        if line.strip():
+            filtered.append(line)
+    return "\n".join(filtered)
+
+
+STATUS_MESSAGES = {
+    "Waiting for container to start...",
+    "No logs available",
+    "Unable to retrieve logs",
+    "Failed to fetch logs from sandbox",
+}
+
+
+def is_status_message(text: str) -> bool:
+    stripped = text.strip()
+    return any(stripped.startswith(msg) for msg in STATUS_MESSAGES)
+
+
+def clean_logs(text: str) -> str:
+    cleaned = filter_progress_bars(strip_ansi(text))
+    if is_status_message(cleaned):
+        return ""
+    return cleaned
+
+
+def get_new_log_lines(old_logs: str, new_logs: str) -> list[str]:
+    old_lines = old_logs.splitlines() if old_logs else []
+    new_lines = new_logs.splitlines()
+
+    if not old_logs:
+        return new_lines
+
+    overlap = 0
+    max_overlap = min(len(old_lines), len(new_lines))
+    for i in range(1, max_overlap + 1):
+        if old_lines[-i:] == new_lines[:i]:
+            overlap = i
+    return new_lines[overlap:]
+
+
+def parse_eval_status(status_str: str) -> EvalStatus | None:
+    try:
+        return EvalStatus(status_str)
+    except ValueError:
+        return None
+
+
+async def create_hosted_evaluation(
+    client: AsyncAPIClient,
+    config: HostedEvalConfig,
+) -> dict[str, Any]:
+    eval_config: dict[str, Any] = {
+        "num_examples": config.num_examples,
+        "rollouts_per_example": config.rollouts_per_example,
+        "allow_sandbox_access": config.allow_sandbox_access,
+        "allow_instances_access": config.allow_instances_access,
+    }
+
+    if config.env_args:
+        eval_config["env_args"] = config.env_args
+
+    if config.timeout_minutes:
+        eval_config["timeout_minutes"] = config.timeout_minutes
+
+    if config.custom_secrets:
+        eval_config["custom_secrets"] = config.custom_secrets
+
+    payload: dict[str, Any] = {
+        "environment_ids": [config.environment_id],
+        "inference_model": config.inference_model,
+        "eval_config": eval_config,
+    }
+
+    if config.name:
+        payload["name"] = config.name
+
+    return await client.post("/hosted-evaluations", json=payload)
+
+
+async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str, Any]:
+    return await client.get(f"/evaluations/{evaluation_id}")
+
+
+async def get_evaluation_logs(client: AsyncAPIClient, evaluation_id: str) -> str:
+    try:
+        response = await client.get(f"/hosted-evaluations/{evaluation_id}/logs")
+        return response.get("logs") or ""
+    except APIError:
+        return ""
+
+
+async def create_and_return_hosted_evaluation(
+    config: HostedEvalConfig,
+) -> HostedEvalCreationResult:
+    async with AsyncAPIClient() as client:
+        console.print(
+            f"[cyan]Creating hosted evaluation for environment {config.environment_id}[/cyan]"
+        )
+        console.print(f"[dim]Model: {config.inference_model}[/dim]")
+        console.print(
+            f"[dim]Configuration: num_examples={config.num_examples}, "
+            f"rollouts_per_example={config.rollouts_per_example}[/dim]"
+        )
+        console.print()
+
+        result = await create_hosted_evaluation(client, config)
+        evaluation_id = result.get("evaluation_id")
+
+        if not evaluation_id:
+            raise APIError(f"Failed to get evaluation ID from response. Response: {result}")
+
+        return HostedEvalCreationResult(
+            evaluation_id=evaluation_id,
+            viewer_url=result.get("viewer_url"),
+        )
+
+
+async def follow_hosted_evaluation(
+    evaluation_id: str,
+    poll_interval: float = 10.0,
+    stream_logs: bool = True,
+) -> HostedEvalResult:
+    async with AsyncAPIClient() as client:
+        last_logs = ""
+        consecutive_errors = 0
+
+        with Live(
+            Panel(
+                Text.assemble(
+                    "[cyan]⠋[/cyan]",
+                    " Waiting for evaluation to start...",
+                ),
+                title="[bold]Hosted Evaluation[/bold]",
+                border_style="blue",
+            ),
+            refresh_per_second=4,
+            console=console,
+        ) as live:
+            first_poll = True
+            while True:
+                if not first_poll:
+                    await asyncio.sleep(poll_interval)
+                first_poll = False
+
+                try:
+                    eval_data = await get_evaluation(client, evaluation_id)
+                    status_str = str(eval_data.get("status", ""))
+                    status = parse_eval_status(status_str)
+                    consecutive_errors = 0
+
+                    status_color = status.color if status else "white"
+                    total_samples = eval_data.get("total_samples", 0)
+                    status_text = Text.assemble(
+                        "Status: ",
+                        (status_str, status_color),
+                        f" | Samples: {total_samples}",
+                    )
+                    live.update(
+                        Panel(
+                            status_text,
+                            title="[bold]Hosted Evaluation[/bold]",
+                            border_style="blue",
+                        )
+                    )
+
+                    if stream_logs and status in EvalStatus.has_logs_statuses():
+                        raw_logs = await get_evaluation_logs(client, evaluation_id)
+                        logs = clean_logs(raw_logs) if raw_logs else ""
+
+                        if logs and logs != last_logs:
+                            for line in get_new_log_lines(last_logs, logs):
+                                live.console.print(line)
+                            last_logs = logs
+
+                    if status in EvalStatus.terminal_statuses():
+                        live.stop()
+                        break
+
+                except APIError as e:
+                    consecutive_errors += 1
+                    if "429" in str(e):
+                        if consecutive_errors >= 3:
+                            live.console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
+                            await asyncio.sleep(30)
+                        else:
+                            await asyncio.sleep(10)
+                        continue
+                    raise
+
+        eval_data = await get_evaluation(client, evaluation_id)
+        final_logs = await get_evaluation_logs(client, evaluation_id)
+        final_status = parse_eval_status(eval_data.get("status", "")) or EvalStatus.FAILED
+
+        return HostedEvalResult(
+            evaluation_id=evaluation_id,
+            status=final_status,
+            viewer_url=eval_data.get("viewer_url"),
+            total_samples=eval_data.get("total_samples", 0),
+            avg_score=eval_data.get("avg_score"),
+            min_score=eval_data.get("min_score"),
+            max_score=eval_data.get("max_score"),
+            error_message=eval_data.get("error_message"),
+            logs=final_logs,
+        )
+
+
+async def run_hosted_evaluation(
+    config: HostedEvalConfig,
+    poll_interval: float = 10.0,
+    stream_logs: bool = True,
+    follow: bool = True,
+) -> HostedEvalResult:
+    creation_result = await create_and_return_hosted_evaluation(config)
+    evaluation_id = creation_result.evaluation_id
+
+    console.print(f"[green]✓ Created hosted evaluation:[/green] {evaluation_id}")
+    console.print()
+
+    if not follow:
+        return HostedEvalResult(
+            evaluation_id=evaluation_id,
+            status=EvalStatus.PENDING,
+            viewer_url=creation_result.viewer_url,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+            error_message=None,
+            logs=None,
+        )
+
+    return await follow_hosted_evaluation(
+        evaluation_id=evaluation_id,
+        poll_interval=poll_interval,
+        stream_logs=stream_logs,
+    )
+
+
+def print_hosted_result(result: HostedEvalResult) -> None:
+    console.print()
+    console.rule("[bold]Hosted Evaluation Results[/bold]")
+    console.print()
+
+    if result.status == EvalStatus.COMPLETED:
+        console.print("[bold green]✓ Evaluation completed successfully![/bold green]")
+    elif result.status == EvalStatus.FAILED:
+        console.print("[bold red]✗ Evaluation failed[/bold red]")
+    elif result.status == EvalStatus.CANCELLED:
+        console.print("[bold yellow]○ Evaluation was cancelled[/bold yellow]")
+
+    console.print()
+    console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
+
+    status_color = result.status.color
+    console.print(f"[cyan]Status:[/cyan] [{status_color}]{result.status.value}[/{status_color}]")
+    console.print(f"[cyan]Total samples:[/cyan] {result.total_samples}")
+
+    if result.avg_score is not None:
+        console.print(f"[cyan]Average score:[/cyan] {result.avg_score:.4f}")
+    if result.min_score is not None:
+        console.print(f"[cyan]Min score:[/cyan] {result.min_score:.4f}")
+    if result.max_score is not None:
+        console.print(f"[cyan]Max score:[/cyan] {result.max_score:.4f}")
+
+    console.print()
+
+    viewer_url = get_eval_viewer_url(result.evaluation_id, result.viewer_url)
+    console.print(f"[bold green]View results:[/bold green] {viewer_url}")
+
+    if result.error_message:
+        console.print(f"\n[red]Error:[/red] {result.error_message}")
+
+    console.print()
+    console.print("[dim]CLI commands:[/dim]")
+    console.print(f"  prime eval get {result.evaluation_id}")
+    console.print(f"  prime eval samples {result.evaluation_id}")
+    console.print(f"  prime eval logs {result.evaluation_id}")
+    console.print()
+
+
+def stop_hosted_evaluation(eval_id: str) -> None:
+    try:
+
+        async def do_stop():
+            async with AsyncAPIClient() as client:
+                return await client.post(f"/hosted-evaluations/{eval_id}/cancel")
+
+        asyncio.run(do_stop())
+        console.print(f"[green]✓ Evaluation {eval_id} cancelled.[/green]")
+        console.print(f"[dim]View results: prime eval get {eval_id}[/dim]")
+    except APIError as e:
+        detail = re.sub(r"^HTTP \d+:\s*", "", str(e))
+        console.print(f"[yellow]{detail}[/yellow]")
+        raise SystemExit(1)
+    except Exception as e:
+        console.print(f"[red]Failed to stop evaluation: {e}[/red]")
+        raise SystemExit(1)

--- a/packages/prime/src/prime_cli/utils/schemas.py
+++ b/packages/prime/src/prime_cli/utils/schemas.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class EvalStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    TIMEOUT = "TIMEOUT"
+    CANCELLED = "CANCELLED"
+
+    @classmethod
+    def terminal_statuses(cls) -> set["EvalStatus"]:
+        return {cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
+
+    @classmethod
+    def has_logs_statuses(cls) -> set["EvalStatus"]:
+        return {cls.RUNNING, cls.COMPLETED, cls.FAILED}
+
+    @property
+    def color(self) -> str:
+        return {
+            EvalStatus.PENDING: "yellow",
+            EvalStatus.RUNNING: "cyan",
+            EvalStatus.COMPLETED: "green",
+            EvalStatus.FAILED: "red",
+            EvalStatus.TIMEOUT: "red",
+            EvalStatus.CANCELLED: "yellow",
+        }.get(self, "white")
+
+
+@dataclass
+class HostedEvalConfig:
+    environment_id: str
+    inference_model: str
+    num_examples: int
+    rollouts_per_example: int
+    env_args: Optional[dict[str, str]] = None
+    name: Optional[str] = None
+    timeout_minutes: Optional[int] = None
+    allow_sandbox_access: bool = False
+    allow_instances_access: bool = False
+    custom_secrets: Optional[dict[str, str]] = None
+
+
+@dataclass
+class HostedEvalResult:
+    evaluation_id: str
+    status: EvalStatus
+    viewer_url: Optional[str]
+    total_samples: int
+    avg_score: Optional[float]
+    min_score: Optional[float]
+    max_score: Optional[float]
+    error_message: Optional[str] = None
+    logs: Optional[str] = None
+
+
+@dataclass
+class HostedEvalCreationResult:
+    evaluation_id: str
+    viewer_url: Optional[str] = None

--- a/packages/prime/tests/test_evals_hosted_commands.py
+++ b/packages/prime/tests/test_evals_hosted_commands.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from prime_cli.commands import evals
+
+
+def test_logs_cmd_routes_to_display(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_display(eval_id: str, tail: int, follow: bool) -> None:
+        captured["eval_id"] = eval_id
+        captured["tail"] = tail
+        captured["follow"] = follow
+
+    monkeypatch.setattr(evals, "_display_logs", fake_display)
+
+    evals.logs_cmd(eval_id="eval-123", tail=50, follow=True)
+
+    assert captured == {"eval_id": "eval-123", "tail": 50, "follow": True}
+
+
+def test_stop_cmd_routes_to_hosted_stop(monkeypatch):
+    captured: dict[str, str] = {}
+
+    def fake_stop(eval_id: str) -> None:
+        captured["eval_id"] = eval_id
+
+    monkeypatch.setattr(evals, "stop_hosted_evaluation", fake_stop)
+
+    evals.stop_cmd(eval_id="eval-999")
+
+    assert captured["eval_id"] == "eval-999"
+
+
+def test_pull_cmd_writes_verifiers_files(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(evals, "_fetch_eval_status", lambda eval_id: {"status": "COMPLETED"})
+
+    class _APIStub:
+        def get(self, endpoint: str):
+            assert endpoint == "/evaluations/eval-abc/export"
+            return {
+                "metadata": {"env_id": "primeintellect/wordle", "model": "openai/gpt-4.1-mini"},
+                "results": [{"example_id": 1, "reward": 1.0}],
+            }
+
+    monkeypatch.setattr(evals, "APIClient", lambda: _APIStub())
+
+    out_dir = tmp_path / "pulled"
+    evals.pull_cmd(eval_id="eval-abc", output_dir=str(out_dir), force=False)
+
+    metadata = json.loads((out_dir / "metadata.json").read_text())
+    results_lines = (out_dir / "results.jsonl").read_text().strip().splitlines()
+    results = [json.loads(line) for line in results_lines]
+
+    assert metadata["env_id"] == "primeintellect/wordle"
+    assert metadata["model"] == "openai/gpt-4.1-mini"
+    assert results == [{"example_id": 1, "reward": 1.0}]
+
+
+def test_pull_cmd_rejects_non_completed(monkeypatch):
+    monkeypatch.setattr(evals, "_fetch_eval_status", lambda eval_id: {"status": "RUNNING"})
+
+    with pytest.raises(typer.Exit) as exc_info:
+        evals.pull_cmd(eval_id="eval-running", output_dir=None, force=False)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_display_logs_follow_exits_nonzero_on_terminal_failure(monkeypatch):
+    monkeypatch.setattr(
+        evals,
+        "_fetch_eval_status",
+        lambda eval_id: {
+            "status": "FAILED",
+            "evaluation_id": eval_id,
+            "error_message": "boom",
+        },
+    )
+    monkeypatch.setattr(evals, "_fetch_logs", lambda eval_id: "")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        evals._display_logs("eval-failed", tail=100, follow=True)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_display_logs_follow_sleeps_once_per_iteration(monkeypatch):
+    monkeypatch.setattr(
+        evals,
+        "_fetch_eval_status",
+        lambda eval_id: {
+            "status": "RUNNING",
+            "evaluation_id": eval_id,
+            "total_samples": 0,
+        },
+    )
+    monkeypatch.setattr(evals, "_fetch_logs", lambda eval_id: "")
+
+    sleep_calls: list[int] = []
+
+    def fake_sleep(seconds: int) -> None:
+        sleep_calls.append(seconds)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(evals.time, "sleep", fake_sleep)
+
+    evals._display_logs("eval-running", tail=100, follow=True)
+
+    assert sleep_calls == [5]

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,0 +1,197 @@
+from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
+
+
+class TestLogCleaning:
+    """Test log cleaning utilities"""
+
+    def test_strip_ansi_basic(self):
+        """Test stripping basic ANSI escape codes"""
+        text = "\x1b[31mRed text\x1b[0m"
+        assert strip_ansi(text) == "Red text"
+
+    def test_strip_ansi_multiple_codes(self):
+        """Test stripping multiple ANSI codes"""
+        text = "\x1b[1m\x1b[32mBold green\x1b[0m\x1b[0m text"
+        assert strip_ansi(text) == "Bold green text"
+
+    def test_strip_ansi_no_codes(self):
+        """Test text without ANSI codes remains unchanged"""
+        text = "Plain text"
+        assert strip_ansi(text) == "Plain text"
+
+    def test_strip_ansi_empty(self):
+        """Test empty string"""
+        assert strip_ansi("") == ""
+
+    def test_filter_progress_bars_100_percent(self):
+        """Test that 100% progress bars are kept"""
+        text = "Progress: 100%|██████████| 10/10 [00:01<00:00]"
+        result = filter_progress_bars(text)
+        assert "100%" in result
+
+    def test_filter_progress_bars_partial(self):
+        """Test that partial progress bars are filtered out"""
+        text = "Progress: 50%|█████     | 5/10 [00:01<00:01]"
+        result = filter_progress_bars(text)
+        assert result == ""
+
+    def test_filter_progress_bars_mixed(self):
+        """Test mixed content with progress bars"""
+        text = """Starting evaluation
+Progress: 50%|█████     | 5/10 [00:01<00:01]
+Progress: 100%|██████████| 10/10 [00:02<00:00]
+Evaluation complete"""
+        result = filter_progress_bars(text)
+        assert "Starting evaluation" in result
+        assert "Evaluation complete" in result
+        assert "100%" in result
+        assert "50%" not in result
+
+    def test_filter_progress_bars_preserves_regular_lines(self):
+        """Test that regular log lines are preserved"""
+        text = """Model loaded successfully
+Processing batch 1
+Result: accuracy=0.95"""
+        result = filter_progress_bars(text)
+        lines = result.splitlines()
+        assert len(lines) == 3
+        assert "Model loaded successfully" in result
+        assert "Processing batch 1" in result
+        assert "Result: accuracy=0.95" in result
+
+    def test_clean_logs_combined(self):
+        """Test combined cleaning of ANSI codes and progress bars"""
+        text = """\x1b[32mStarting evaluation\x1b[0m
+Progress: 50%|█████     | 5/10 [00:01<00:01]
+\x1b[1mProgress: 100%|██████████| 10/10 [00:02<00:00]\x1b[0m
+\x1b[32m✓ Evaluation complete\x1b[0m"""
+        result = clean_logs(text)
+        assert "Starting evaluation" in result
+        assert "✓ Evaluation complete" in result
+        assert "100%" in result
+        assert "50%" not in result
+        assert "\x1b" not in result
+
+    def test_clean_logs_empty(self):
+        """Test clean_logs with empty string"""
+        assert clean_logs("") == ""
+
+    def test_clean_logs_multiline_with_empty_lines(self):
+        """Test that empty lines are filtered out"""
+        text = """Line 1
+
+Line 3
+
+Line 5"""
+        result = clean_logs(text)
+        lines = result.splitlines()
+        assert len(lines) == 3
+        assert lines[0] == "Line 1"
+        assert lines[1] == "Line 3"
+        assert lines[2] == "Line 5"
+
+
+class TestLogStreaming:
+    """Test log streaming logic"""
+
+    def test_line_comparison_first_logs(self):
+        """Test printing all lines when no previous logs exist"""
+        last_logs = ""
+        new_logs = """Line 1
+Line 2
+Line 3"""
+
+        new_lines = new_logs.splitlines()
+
+        if not last_logs:
+            assert len(new_lines) == 3
+            assert new_lines == ["Line 1", "Line 2", "Line 3"]
+
+    def test_line_comparison_new_lines(self):
+        """Test printing only new lines when logs grow"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 1
+Line 2
+Line 3
+Line 4
+Line 5"""
+
+        old_lines = last_logs.splitlines()
+        new_lines = new_logs.splitlines()
+
+        overlap = 0
+        max_overlap = min(len(old_lines), len(new_lines))
+        for i in range(1, max_overlap + 1):
+            if old_lines[-i:] == new_lines[:i]:
+                overlap = i
+
+        new_content = new_lines[overlap:]
+        assert new_content == ["Line 4", "Line 5"]
+
+    def test_line_comparison_no_new_lines(self):
+        """Test no output when logs haven't changed"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 1
+Line 2
+Line 3"""
+
+        assert last_logs == new_logs
+
+    def test_line_comparison_with_overlap(self):
+        """Test finding overlap between old and new logs"""
+        last_logs = """Line 1
+Line 2
+Line 3"""
+        new_logs = """Line 2
+Line 3
+Line 4
+Line 5"""
+
+        old_lines = last_logs.splitlines()
+        new_lines = new_logs.splitlines()
+
+        overlap = 0
+        max_overlap = min(len(old_lines), len(new_lines))
+        for i in range(1, max_overlap + 1):
+            if old_lines[-i:] == new_lines[:i]:
+                overlap = i
+
+        new_content = new_lines[overlap:]
+        assert overlap == 2
+        assert new_content == ["Line 4", "Line 5"]
+
+
+class TestProgressBarPatterns:
+    """Test various progress bar patterns from different tools"""
+
+    def test_tqdm_progress_bar(self):
+        """Test tqdm-style progress bar detection"""
+        text = "100%|██████████| 100/100 [00:10<00:00, 10.00it/s]"
+        result = filter_progress_bars(text)
+        assert "100%" in result
+
+    def test_rich_progress_bar(self):
+        """Test rich-style progress indicators"""
+        text = "Processing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%"
+        result = filter_progress_bars(text)
+        assert len(result) > 0
+
+    def test_multiple_progress_updates(self):
+        """Test multiple progress updates where only 100% is kept"""
+        text = """Task started
+25%|██▌       | 25/100 [00:02<00:06, 10.00it/s]
+50%|█████     | 50/100 [00:05<00:05, 10.00it/s]
+75%|███████▌  | 75/100 [00:07<00:02, 10.00it/s]
+100%|██████████| 100/100 [00:10<00:00, 10.00it/s]
+Task completed"""
+        result = filter_progress_bars(text)
+        assert "Task started" in result
+        assert "Task completed" in result
+        assert "100%" in result
+        assert "25%" not in result
+        assert "50%" not in result
+        assert "75%" not in result

--- a/packages/prime/tests/test_verifiers_bridge_hosted.py
+++ b/packages/prime/tests/test_verifiers_bridge_hosted.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+import typer
+from prime_cli import verifiers_bridge
+from prime_cli.verifiers_bridge import ResolvedEnvironment
+
+
+class _PluginStub:
+    eval_module = "verifiers.cli.commands.eval"
+
+    def build_module_command(self, module_name: str, args: list[str] | None = None) -> list[str]:
+        return ["python", "-m", module_name, *(args or [])]
+
+
+def test_resolve_environment_reference_preserves_version_in_display_id():
+    resolved = verifiers_bridge._resolve_environment_reference(
+        "primeintellect/wordle@2.0.0",
+        "./environments",
+    )
+
+    assert resolved.install_slug == "primeintellect/wordle@2.0.0"
+    assert resolved.env_display_id == "primeintellect/wordle@2.0.0"
+
+
+def test_add_default_inference_and_key_args_requires_base_when_local():
+    config = SimpleNamespace(api_key="test-key", inference_url="")
+
+    with pytest.raises(typer.Exit):
+        verifiers_bridge._add_default_inference_and_key_args(
+            passthrough_args=[],
+            config=config,
+            require_base_url=True,
+        )
+
+
+def test_add_default_inference_and_key_args_allows_missing_base_for_hosted():
+    config = SimpleNamespace(api_key="test-key", inference_url="")
+
+    args, env, model, base = verifiers_bridge._add_default_inference_and_key_args(
+        passthrough_args=["--hosted"],
+        config=config,
+        require_base_url=False,
+    )
+
+    assert "--hosted" in args
+    assert "-k" in args
+    assert "PRIME_API_KEY" in args
+    assert env["PRIME_API_KEY"] == "test-key"
+    assert model == verifiers_bridge.DEFAULT_MODEL
+    assert base == ""
+
+
+def test_run_eval_passthrough_hosted_skips_local_upload(monkeypatch):
+    captured: dict[str, list[str] | dict[str, str] | bool] = {
+        "command": [],
+        "env": {},
+        "uploaded": False,
+    }
+
+    monkeypatch.setattr(
+        verifiers_bridge,
+        "load_verifiers_prime_plugin",
+        lambda console=None: _PluginStub(),
+    )
+    monkeypatch.setattr(
+        verifiers_bridge,
+        "Config",
+        lambda: SimpleNamespace(api_key="test-key", inference_url="", team_id=None),
+    )
+    monkeypatch.setattr(
+        verifiers_bridge,
+        "_prepare_single_environment",
+        lambda plugin, env_ref, env_dir: ResolvedEnvironment(
+            original=env_ref,
+            env_name="wordle",
+            install_mode="remote",
+            install_slug="primeintellect/wordle@2.0.0",
+            upstream_slug="primeintellect/wordle",
+            env_display_id="primeintellect/wordle@2.0.0",
+            platform_slug="primeintellect/wordle",
+            platform_url="https://app.primeintellect.ai/dashboard/environments/primeintellect/wordle",
+        ),
+    )
+
+    def fake_run_command(command, env=None):
+        captured["command"] = command
+        captured["env"] = env or {}
+
+    monkeypatch.setattr(verifiers_bridge, "_run_command", fake_run_command)
+
+    def fake_push(**kwargs):
+        captured["uploaded"] = True
+
+    monkeypatch.setattr(verifiers_bridge, "push_eval_results_to_hub", fake_push)
+
+    verifiers_bridge.run_eval_passthrough(
+        environment="primeintellect/wordle@2.0.0",
+        passthrough_args=["--hosted"],
+        skip_upload=False,
+        env_path=None,
+    )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert "primeintellect/wordle@2.0.0" in command
+    assert "--hosted" in command
+    assert "X-Prime-Eval-Env-Display: primeintellect/wordle@2.0.0" in command
+    assert "-s" not in command
+    assert captured["uploaded"] is False


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the `prime eval run` execution path and upload behavior (skipping local upload in hosted mode) and adds new API interactions/polling loops, which could affect evaluation workflows and rate limiting if incorrect.
> 
> **Overview**
> Adds first-class **hosted evaluation management** to the `prime eval` CLI: new `logs` (with `--follow` streaming + log cleaning + basic rate-limit backoff), `stop` (cancel hosted eval), and `pull` (export a completed eval to local `metadata.json` + `results.jsonl` in verifiers format).
> 
> Introduces shared hosted-eval utilities (`hosted_eval.py`) and schemas (`EvalStatus`, hosted config/result types), plus `get_eval_viewer_url` helper for consistent deep links. Updates `verifiers_bridge.run_eval_passthrough` to support `--hosted` runs (no inference base URL required, preserve versioned env slug in display/header, skip auto `-s` + skip local results upload), with tests covering the new commands and hosted-mode behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59270d748e8f4c160d9f59a4f470909612bccb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->