### PR TITLE
Bump prime-cli version to 0.5.33

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.32"
+__version__ = "0.5.33"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Version bump for release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string-only change with no functional or behavioral impact.
> 
> **Overview**
> Bumps `prime_cli` package version from `0.5.32` to `0.5.33` for a release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ccfef1c6ebe98877362057108c2a0ea1d1a49d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->