### PR TITLE
bump version, move setup utils to verifiers

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.3.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.10.dev4",
+    "verifiers>=0.1.10.dev5",
     "build>=1.0.0",
     "toml>=0.10.0",
 ]
@@ -57,7 +57,7 @@ dev = [
 prime-sandboxes = { workspace = true }
 prime-evals = { workspace = true }
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev4" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev5" }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/prime/src/prime_cli/commands/lab.py
+++ b/packages/prime/src/prime_cli/commands/lab.py
@@ -1,133 +1,27 @@
 """Lab commands for verifiers development."""
 
 import subprocess
-import sys
-from pathlib import Path
-from typing import Optional
 
 import typer
 from rich.console import Console
 
-from ..verifiers_bridge import print_lab_setup_help
 from ..verifiers_plugin import load_verifiers_prime_plugin
 
 app = typer.Typer(help="Lab commands for verifiers development", no_args_is_help=True)
 console = Console()
 
-SUPPORTED_AGENTS = ("codex", "claude", "cursor", "opencode")
-
-
-def _parse_agents_csv(raw_agents: str) -> list[str]:
-    selected: list[str] = []
-    seen: set[str] = set()
-
-    for raw in raw_agents.split(","):
-        agent = raw.strip().lower()
-        if not agent:
-            continue
-        if agent not in SUPPORTED_AGENTS:
-            allowed = ", ".join(SUPPORTED_AGENTS)
-            raise typer.BadParameter(f"Unsupported agent '{agent}'. Supported values: {allowed}")
-        if agent in seen:
-            continue
-        seen.add(agent)
-        selected.append(agent)
-
-    return selected
-
-
-def _prompt_agents() -> list[str]:
-    console.print(
-        "Supported coding agents: [cyan]codex[/cyan], [cyan]claude[/cyan], "
-        "[cyan]cursor[/cyan], [cyan]opencode[/cyan]"
-    )
-    while True:
-        primary = typer.prompt("Primary coding agent", default="codex").strip().lower()
-        if primary in SUPPORTED_AGENTS:
-            break
-        console.print("[red]Invalid agent.[/red] Choose one of: " + ", ".join(SUPPORTED_AGENTS))
-
-    selected = [primary]
-    if typer.confirm("Using multiple coding agents?", default=False):
-        additional = typer.prompt(
-            "Additional agents (comma-separated)",
-            default="",
-        )
-        for agent in _parse_agents_csv(additional):
-            if agent not in selected:
-                selected.append(agent)
-
-    return selected
-
-
-def _create_skill_dirs(agents: list[str]) -> None:
-    for agent in agents:
-        skills_dir = Path(f".{agent}") / "skills"
-        skills_dir.mkdir(parents=True, exist_ok=True)
-        console.print(f"[dim]Prepared {skills_dir}[/dim]")
-
 
 @app.command(
+    add_help_option=False,
     context_settings={
         "allow_extra_args": True,
         "ignore_unknown_options": True,
-    }
+    },
 )
-def setup(
-    ctx: typer.Context,
-    prime_rl: bool = typer.Option(
-        False, "--prime-rl", help="Install prime-rl and download prime-rl configs"
-    ),
-    agents: Optional[str] = typer.Option(
-        None,
-        "--agents",
-        help="Comma-separated coding agents to scaffold (codex,claude,cursor,opencode)",
-    ),
-    no_interactive: bool = typer.Option(
-        False,
-        "--no-interactive",
-        help="Disable interactive agent prompts",
-    ),
-    backend_help: bool = typer.Option(
-        False,
-        "--backend-help",
-        help="Show backend vf-setup help (all passthrough flags/options)",
-    ),
-    skip_agents_md: bool = typer.Option(
-        False,
-        "--skip-agents-md",
-        help="Skip downloading AGENTS.md, CLAUDE.md, and environments/AGENTS.md",
-    ),
-    skip_install: bool = typer.Option(
-        False,
-        "--skip-install",
-        help="Skip uv project initialization and verifiers installation",
-    ),
-) -> None:
+def setup(ctx: typer.Context) -> None:
     """Set up a verifiers training workspace."""
-    if backend_help:
-        print_lab_setup_help()
-        raise typer.Exit(0)
-
-    selected_agents: list[str] = []
-    if agents:
-        selected_agents = _parse_agents_csv(agents)
-    elif not no_interactive and sys.stdin.isatty():
-        selected_agents = _prompt_agents()
-
     plugin = load_verifiers_prime_plugin(console=console)
-    setup_args: list[str] = list(ctx.args)
-    if prime_rl:
-        setup_args.append("--prime-rl")
-    if skip_agents_md:
-        setup_args.append("--skip-agents-md")
-    if skip_install:
-        setup_args.append("--skip-install")
-
-    command = plugin.build_module_command(plugin.setup_module, setup_args)
+    command = plugin.build_module_command(plugin.setup_module, list(ctx.args))
     result = subprocess.run(command)
     if result.returncode != 0:
         raise typer.Exit(result.returncode)
-
-    if selected_agents:
-        _create_skill_dirs(selected_agents)

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -159,23 +159,6 @@ def print_env_build_help() -> None:
     _write_help(help_text)
 
 
-def print_lab_setup_help() -> None:
-    try:
-        help_text = _load_help_text(
-            load_verifiers_prime_plugin(console=console).setup_module,
-            "prime lab setup",
-        )
-    except Exception as exc:
-        console.print(f"[red]Failed to load help for prime lab setup:[/red] {exc}")
-        raise typer.Exit(1) from exc
-    _write_help(help_text)
-    _write_help(
-        "\nPrime-only options:\n"
-        "  --agents TEXT       Comma-separated coding agents to scaffold.\n"
-        "  --no-interactive    Disable interactive coding-agent prompts.\n"
-    )
-
-
 def run_eval_tui(env_dir: Optional[str], outputs_dir: Optional[str]) -> None:
     plugin = load_verifiers_prime_plugin(console=console)
     env = os.environ.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev4" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev5" }
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/uv.lock
+++ b/uv.lock
@@ -1746,7 +1746,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev4" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev5" },
 ]
 provides-extras = ["dev"]
 
@@ -2893,8 +2893,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.10.dev4"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev4#56676d642fb275bdc1bd61921df5519a6b70def3" }
+version = "0.1.10.dev5"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev5#0df300be0321ae9efc04c323159fb69d687d3c5e" }
 dependencies = [
     { name = "datasets" },
     { name = "gepa" },


### PR DESCRIPTION
Proposed sequence of operations:
- Get this in (+ release?), test prime CLI with latest verifiers (rc for v0.1.10)
- If good, release verifiers v0.1.10
- Bump prime CLI again to depend on verifiers v0.1.10, release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a dependency bump plus removal of CLI wrapper logic; risk is limited to potential behavior/help/flag-compatibility changes for `prime lab setup` when using the newer `verifiers` version.
> 
> **Overview**
> Bumps the `verifiers` dependency from `v0.1.10.dev4` to `v0.1.10.dev5` across `packages/prime/pyproject.toml`, workspace `pyproject.toml`, and `uv.lock`.
> 
> Simplifies `prime lab setup` to a pure passthrough to the verifiers `setup` module: removes Prime-specific flags/interactive agent scaffolding and deletes the associated help bridge (`print_lab_setup_help`) from `verifiers_bridge.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b096724af4e283c52ac13594dc2d0cb48b2835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->