### PR TITLE
bump verifiers to v0.1.10

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.3.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.10.dev5",
+    "verifiers>=0.1.10",
     "build>=1.0.0",
     "toml>=0.10.0",
 ]
@@ -57,7 +57,7 @@ dev = [
 prime-sandboxes = { workspace = true }
 prime-evals = { workspace = true }
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev5" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10" }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/prime/tests/test_env_push_path.py
+++ b/packages/prime/tests/test_env_push_path.py
@@ -1,0 +1,41 @@
+from prime_cli.commands.env import _resolve_push_environment_path
+
+
+def test_defaults_to_current_directory_without_env_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    resolved = _resolve_push_environment_path(path=None, env_id=None)
+
+    assert resolved == tmp_path.resolve()
+
+
+def test_uses_environments_parent_when_env_id_is_provided(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    resolved = _resolve_push_environment_path(path=None, env_id="my-env")
+
+    assert resolved == (tmp_path / "environments" / "my_env").resolve()
+
+
+def test_appends_env_id_to_custom_parent_path(tmp_path):
+    custom_parent = tmp_path / "custom"
+
+    resolved = _resolve_push_environment_path(path=str(custom_parent), env_id="env-name")
+
+    assert resolved == (custom_parent / "env_name").resolve()
+
+
+def test_uses_final_segment_for_owner_prefixed_env_id(tmp_path):
+    custom_parent = tmp_path / "custom"
+
+    resolved = _resolve_push_environment_path(path=str(custom_parent), env_id="owner/env-name")
+
+    assert resolved == (custom_parent / "env_name").resolve()
+
+
+def test_respects_explicit_path_without_env_id(tmp_path):
+    custom_path = tmp_path / "single-env-dir"
+
+    resolved = _resolve_push_environment_path(path=str(custom_path), env_id=None)
+
+    assert resolved == custom_path.resolve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10.dev5" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.10" }
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/uv.lock
+++ b/uv.lock
@@ -1746,7 +1746,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev5" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10" },
 ]
 provides-extras = ["dev"]
 
@@ -2893,8 +2893,8 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.10.dev5"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10.dev5#0df300be0321ae9efc04c323159fb69d687d3c5e" }
+version = "0.1.10"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.10#ccef04486cda1759981dfc41b81b3939e5b69a9f" }
 dependencies = [
     { name = "datasets" },
     { name = "gepa" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI argument/path resolution change plus a dependency version bump; main risk is minor behavior changes in `prime env push` defaults or upstream differences in `verifiers` `v0.1.10`.
> 
> **Overview**
> Updates the `verifiers` dependency from `v0.1.10.dev5` to the released `v0.1.10` across workspace config (`pyproject.toml`, `packages/prime/pyproject.toml`) and refreshes `uv.lock` accordingly.
> 
> Changes `prime env push` to accept an optional positional `env_id` and uses it to resolve the local environment directory (defaulting to `./environments/<env_id>` with hyphens mapped to underscores, and supporting `owner/name` by using the final segment). Adds unit tests covering the new path resolution behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf672309baf9c6b53e1c3aec3e2de5ec385562f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->