### PR TITLE
feat(tunnel): add bulk delete

### DIFF
--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -240,7 +240,7 @@ def stop_tunnel(
         console.print(f"[red]Error:[/red] {e}", style="bold")
         raise typer.Exit(1)
 
-    if len(parsed_ids) == 1 and succeeded:
+    if len(parsed_ids) == 1 and succeeded and not all:
         console.print(f"[green]Tunnel deleted:[/green] {parsed_ids[0]}")
         return
 


### PR DESCRIPTION
adds bulk delete option to `prime tunnel stop` via `--all` and `--yes` similar to sandbox bulk delete.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new destructive CLI flows (`--all` bulk stop) and changes argument parsing/confirmation behavior, which could lead to unintended deletions or scripting breakage if misused.
> 
> **Overview**
> `prime tunnel stop` now supports **bulk deletion**: it accepts multiple tunnel IDs (space- or comma-separated) and adds `--all` to stop every active tunnel (optionally scoped with `--team-id`).
> 
> The command now prompts for confirmation (or skips with `--yes` via `confirm_or_skip`), shows a spinner while deleting, and reports per-tunnel outcomes (succeeded / not found / failed) with a non-zero exit when any deletion fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4059bea5d0cfca7ab1050241e051d6cef051b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->