### PR TITLE
Fix: Fix set team id for patch and delete

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -317,6 +317,7 @@ class EvalsClient:
         self,
         env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
+        team_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
     ) -> Dict[str, Any]:
@@ -326,6 +327,8 @@ class EvalsClient:
             params["environment_name"] = env_name
         if suite_id:
             params["suite_id"] = suite_id
+        if team_id:
+            params["team_id"] = team_id
 
         response = self.client.request("GET", "/evaluations/", params=params)
         return response
@@ -659,6 +662,7 @@ class AsyncEvalsClient:
         self,
         env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
+        team_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
     ) -> Dict[str, Any]:
@@ -668,6 +672,8 @@ class AsyncEvalsClient:
             params["environment_name"] = env_name
         if suite_id:
             params["suite_id"] = suite_id
+        if team_id:
+            params["team_id"] = team_id
 
         response = await self.client.request("GET", "/evaluations/", params=params)
         return response

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -317,9 +317,10 @@ class EvalsClient:
         self,
         env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
-        team_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
+        *,
+        team_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """List evaluations with optional filters"""
         params: Dict[str, Any] = {"skip": skip, "limit": limit}
@@ -662,9 +663,10 @@ class AsyncEvalsClient:
         self,
         env_name: Optional[str] = None,
         suite_id: Optional[str] = None,
-        team_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 50,
+        *,
+        team_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """List evaluations with optional filters"""
         params: Dict[str, Any] = {"skip": skip, "limit": limit}

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -12,6 +12,7 @@ from rich.table import Table
 from typer.core import TyperGroup
 
 from ..client import APIClient
+from ..core import Config
 from ..utils import output_data_as_json
 from ..utils.eval_push import load_results_jsonl
 from ..verifiers_bridge import (
@@ -101,10 +102,12 @@ def list_evals(
 
     try:
         api_client = APIClient()
+        config = Config()
         client = EvalsClient(api_client)
 
         data = client.list_evaluations(
             env_name=env,
+            team_id=config.team_id,
             skip=skip,
             limit=limit,
         )

--- a/packages/prime/src/prime_cli/core/client.py
+++ b/packages/prime/src/prime_cli/core/client.py
@@ -168,13 +168,22 @@ class APIClient:
         """Make a POST request to the API"""
         return self.request("POST", endpoint, json=json)
 
-    def patch(self, endpoint: str, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def patch(
+        self,
+        endpoint: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make a PATCH request to the API"""
-        return self.request("PATCH", endpoint, json=json)
+        return self.request("PATCH", endpoint, json=json, params=params)
 
-    def delete(self, endpoint: str) -> Dict[str, Any]:
+    def delete(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make a DELETE request to the API"""
-        return self.request("DELETE", endpoint)
+        return self.request("DELETE", endpoint, params=params)
 
     def __str__(self) -> str:
         """For debugging"""
@@ -299,13 +308,22 @@ class AsyncAPIClient:
         """Make an async POST request to the API"""
         return await self.request("POST", endpoint, json=json)
 
-    async def patch(self, endpoint: str, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    async def patch(
+        self,
+        endpoint: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make an async PATCH request to the API"""
-        return await self.request("PATCH", endpoint, json=json)
+        return await self.request("PATCH", endpoint, json=json, params=params)
 
-    async def delete(self, endpoint: str) -> Dict[str, Any]:
+    async def delete(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Make an async DELETE request to the API"""
-        return await self.request("DELETE", endpoint)
+        return await self.request("DELETE", endpoint, params=params)
 
     async def aclose(self) -> None:
         """Close the async client"""

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -11,6 +11,7 @@ from .formatters import (
     obfuscate_secrets,
     strip_ansi,
 )
+from .params import optional_team_params
 from .prompt import (
     any_provided,
     confirm_or_skip,
@@ -43,4 +44,5 @@ __all__ = [
     "validate_env_var_name",
     "load_toml",
     "BaseConfig",
+    "optional_team_params",
 ]

--- a/packages/prime/src/prime_cli/utils/params.py
+++ b/packages/prime/src/prime_cli/utils/params.py
@@ -1,0 +1,7 @@
+from typing import Any, Dict, Optional
+
+from prime_cli.core import Config
+
+
+def optional_team_params(config: Config) -> Optional[Dict[str, Any]]:
+    return {"teamId": config.team_id} if config.team_id else None

--- a/packages/prime/tests/test_secrets.py
+++ b/packages/prime/tests/test_secrets.py
@@ -70,7 +70,10 @@ def mock_secrets_api(monkeypatch: pytest.MonkeyPatch) -> None:
         return {"data": {}}
 
     def mock_patch(
-        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+        self: Any,
+        endpoint: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         if endpoint.startswith("/secrets/"):
             return {
@@ -87,7 +90,11 @@ def mock_secrets_api(monkeypatch: pytest.MonkeyPatch) -> None:
             }
         return {"data": {}}
 
-    def mock_delete(self: Any, endpoint: str) -> None:
+    def mock_delete(
+        self: Any,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         pass
 
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, additive changes to CLI request parameterization; main risk is altered scoping if `teamId`/`team_id` is set incorrectly, affecting which resources are listed or mutated.
> 
> **Overview**
> Fixes missing team scoping in CLI/API calls by **propagating the configured team ID into more requests**.
> 
> `EvalsClient.list_evaluations` (sync/async) now accepts a keyword-only `team_id` filter, and `prime eval list` passes `Config.team_id` to list team-owned evaluations.
> 
> Secret operations now consistently include the optional `teamId` query param for list/get/update/delete via a new `optional_team_params` helper, and `APIClient`/`AsyncAPIClient` `patch` and `delete` methods are extended to accept `params` (with tests updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03cf17dae942e9b8099cfa8a8899eb9fc25195a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->