### PR TITLE
tunnel bulk delete 2.0

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -225,6 +225,22 @@ class TunnelClient:
         await self._handle_response(response, "delete tunnel")
         return True
 
+    async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict:
+        """Bulk delete multiple tunnels."""
+        self._check_auth_required()
+
+        url = f"{self.base_url}/api/v1/tunnel"
+        payload = {"tunnel_ids": tunnel_ids}
+
+        try:
+            response = await self._request_with_retry("DELETE", url, json=payload)
+        except httpx.TimeoutException as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except httpx.RequestError as e:
+            raise TunnelError(f"Failed to connect to API: {e}") from e
+
+        return await self._handle_response(response, "bulk delete tunnels")
+
     async def list_tunnels(self, team_id: Optional[str] = None) -> list[TunnelInfo]:
         """
         List all tunnels for the current user.

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -196,6 +196,7 @@ class TunnelClient:
             server_host="",
             server_port=7000,
             expires_at=data["expires_at"],
+            user_id=data.get("user_id"),
         )
 
     async def delete_tunnel(self, tunnel_id: str) -> bool:

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -278,6 +278,7 @@ class TunnelClient:
                     server_host="",
                     server_port=7000,
                     expires_at=t["expires_at"],
+                    user_id=t.get("user_id"),
                 )
             )
         return tunnels

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -15,6 +15,7 @@ class TunnelInfo(BaseModel):
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     expires_at: datetime = Field(..., description="Token expiration time")
+    # Optional because create_tunnel response doesn't include user_id
     user_id: Optional[str] = Field(None, description="Owner user ID")
 
     class Config:

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -14,6 +15,7 @@ class TunnelInfo(BaseModel):
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     expires_at: datetime = Field(..., description="Token expiration time")
+    user_id: Optional[str] = Field(None, description="Owner user ID")
 
     class Config:
         from_attributes = True

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -255,8 +255,9 @@ def stop_tunnel(
                 else:
                     failed.append({"tunnel_id": tid, "error": error})
         except Exception as e:
-            for tid in parsed_ids:
-                failed.append({"tunnel_id": tid, "error": str(e)})
+            succeeded = []
+            not_found = []
+            failed = [{"tunnel_id": tid, "error": str(e)} for tid in parsed_ids]
         finally:
             await client.close()
         return succeeded, not_found, failed

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 import typer
 from prime_tunnel import Tunnel
 from prime_tunnel.core.client import TunnelClient
-from prime_tunnel.core.config import Config
 from rich.console import Console
 from rich.table import Table
 
@@ -177,8 +176,7 @@ def stop_tunnel(
             try:
                 tunnels = await client.list_tunnels(team_id=team_id)
                 if only_mine:
-                    config = Config()
-                    current_user_id = config.user_id
+                    current_user_id = client.config.user_id
                     if not current_user_id:
                         console.print(
                             "[red]Error:[/red] Cannot filter by user - no user_id configured. "


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deletion behavior and introduces a new bulk-delete API call, so mistakes in ID selection/filtering or backend response shape could cause unexpected tunnel removals or misreported results.
> 
> **Overview**
> Adds `TunnelClient.bulk_delete_tunnels()` (DELETE `/api/v1/tunnel` with a JSON body of IDs) and updates the CLI `tunnel stop` flow to delete tunnels in one bulk request instead of per-ID calls.
> 
> Extends `TunnelInfo` to include optional `user_id` and plumbs it through `get_tunnel`/`list_tunnels`, enabling a new `--only-mine/--all-users` flag so `--all` defaults to deleting only the caller’s tunnels and errors if no local `user_id` is configured for filtering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7deef548ee849b67bdcd362a0bcf4146a69815d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->