### PR TITLE
Release: Bump prime cli version to 0.5.35

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -1,6 +1,6 @@
 """Prime Tunnel SDK - Expose local services via secure tunnels."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from prime_tunnel.core import Config, TunnelClient
 from prime_tunnel.exceptions import (

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.34"
+__version__ = "0.5.35"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump prime-cli version to 0.5.35
- Bump prime-tunnel version to 0.1.2

Changes since last releases:
- Fix team ID for patch and delete operations (#375)
- Add tunnel bulk delete support (#374, #376)
- Add secrets subcommands (#349)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only updates in `__init__.py` files; behavior should be unchanged aside from release metadata.
> 
> **Overview**
> Bumps published package versions: `prime_cli` from `0.5.34` to `0.5.35` and `prime_tunnel` from `0.1.1` to `0.1.2` (no functional code changes in this diff).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9f42d69bdeb404ac622dce7653594a3a4b7638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->