### PR TITLE
Show login URL before attempting to open browser

### DIFF
--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -170,19 +170,18 @@ def login(
             f"[bold yellow]1.[/bold yellow] Open the following link in your browser:\n"
             f"[link={challenge_url}]{challenge_url}[/link]"
         )
-
-        # Try to open the browser automatically
-        if not headless:
-            try:
-                webbrowser.open(challenge_url, new=2)
-            except Exception:
-                pass
-
         console.print(
             f"[bold yellow]2.[/bold yellow] Your code should be pre-filled. Code:\n\n"
             f"[bold green]{challenge_code}[/bold green]\n"
         )
         console.print("[dim]Waiting for authentication...[/dim]")
+
+        # Try to open the browser automatically (after all prints to avoid errors polluting output)
+        if not headless:
+            try:
+                webbrowser.open(challenge_url, new=2)
+            except Exception:
+                pass
 
         challenge_auth_header = f"Bearer {challenge_response['status_auth_token']}"
         while True:

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -123,7 +123,9 @@ def decrypt_challenge_response(
 
 
 @app.callback(invoke_without_command=True)
-def login() -> None:
+def login(
+    headless: bool = typer.Option(False, "--headless", help="Don't attempt to open browser"),
+) -> None:
     """Login to Prime Intellect"""
     config = Config()
     settings = config.view()
@@ -170,10 +172,11 @@ def login() -> None:
         )
 
         # Try to open the browser automatically
-        try:
-            webbrowser.open(challenge_url, new=2)
-        except Exception:
-            pass
+        if not headless:
+            try:
+                webbrowser.open(challenge_url, new=2)
+            except Exception:
+                pass
 
         console.print(
             f"[bold yellow]2.[/bold yellow] Your code should be pre-filled. Code:\n\n"

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -164,19 +164,16 @@ def login() -> None:
         console.print("\n[bold blue]🔐 Login Required[/bold blue]")
         console.print("\n[bold]Follow these steps to authenticate:[/bold]\n")
 
-        # Try to open the browser automatically
-        try:
-            webbrowser.open(challenge_url, new=2)
-            console.print(
-                "[bold yellow]1.[/bold yellow] We've opened the login page in your browser."
-            )
-        except Exception:
-            pass
-
         console.print(
             f"[bold yellow]1.[/bold yellow] Open the following link in your browser:\n"
             f"[link={challenge_url}]{challenge_url}[/link]"
         )
+
+        # Try to open the browser automatically
+        try:
+            webbrowser.open(challenge_url, new=2)
+        except Exception:
+            pass
 
         console.print(
             f"[bold yellow]2.[/bold yellow] Your code should be pre-filled. Code:\n\n"


### PR DESCRIPTION
Print the login URL first, then try to open the browser. If `webbrowser.open()` spews proxy/SSH errors, the user already has the URL to copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI UX change with no changes to authentication logic or token handling; risk is limited to the browser-open flow and flag parsing.
> 
> **Overview**
> Adjusts `prime login` UX so the challenge URL/code are printed *before* attempting `webbrowser.open()`, preventing browser-launch errors from obscuring the copyable link.
> 
> Adds a `--headless` option to skip auto-opening the browser entirely for SSH/proxy/headless environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53df709d648c51ea39fa1cb4db6eeb8940ba20f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->