### PR TITLE
Release: Bump prime CLI version to 0.5.36

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.35"
+__version__ = "0.5.36"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- Show login URL before opening browser
- Add --headless flag to skip browser open

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string only change with no behavior or logic modifications.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.35` to `0.5.36` in `prime_cli.__init__` (propagating to places that reference `__version__`, e.g., upgrade output and User-Agent construction).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0963a5244769bd985fd2127bf375e3ba789c123. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->