### PR TITLE
sandbox ssh shells

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1274,13 +1274,16 @@ def ssh_connect(
         if key_path:
             ssh_cmd.extend(["-i", key_path])
 
+        # Force PTY allocation when a remote command is specified
+        if shell:
+            ssh_cmd.append("-t")
+
         # Add any additional SSH arguments
         if ssh_args:
             ssh_cmd.extend(ssh_args)
 
         # Add shell if specified
         if shell:
-            ssh_cmd.append("-t")
             ssh_cmd.append(shell)
 
         # Connect via SSH (this will be interactive)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1280,6 +1280,7 @@ def ssh_connect(
 
         # Add shell if specified
         if shell:
+            ssh_cmd.append("-t")
             ssh_cmd.append(shell)
 
         # Connect via SSH (this will be interactive)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1274,13 +1274,13 @@ def ssh_connect(
         if key_path:
             ssh_cmd.extend(["-i", key_path])
 
-        # Add shell if specified
-        if shell:
-            ssh_cmd.append(shell)
-
         # Add any additional SSH arguments
         if ssh_args:
             ssh_cmd.extend(ssh_args)
+
+        # Add shell if specified
+        if shell:
+            ssh_cmd.append(shell)
 
         # Connect via SSH (this will be interactive)
         result = subprocess.run(ssh_cmd)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -1155,6 +1155,12 @@ def ssh_connect(
     ssh_args: Optional[List[str]] = typer.Argument(
         None, help="Additional SSH arguments (e.g., -- -v for verbose)"
     ),
+    shell: Optional[str] = typer.Option(
+        None,
+        "--shell",
+        "-s",
+        help="Shell to use (e.g., bash, zsh, sh). Auto-detected if not specified.",
+    ),
 ) -> None:
     """Connect to a sandbox via SSH.
 
@@ -1163,6 +1169,7 @@ def ssh_connect(
     \b
     Examples:
         prime sandbox ssh sb_abc123
+        prime sandbox ssh sb_abc123 --shell bash
         prime sandbox ssh sb_abc123 -- -L 3000:localhost:3000
     """
     session_id: Optional[str] = None
@@ -1266,6 +1273,10 @@ def ssh_connect(
         # Add identity file if specified
         if key_path:
             ssh_cmd.extend(["-i", key_path])
+
+        # Add shell if specified
+        if shell:
+            ssh_cmd.append(shell)
 
         # Add any additional SSH arguments
         if ssh_args:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, isolated CLI change that only affects how the local `ssh` command is constructed when an optional flag is used.
> 
> **Overview**
> `prime sandbox ssh` now accepts a `--shell/-s` option to run a specific shell (e.g., `bash`) when connecting.
> 
> When `--shell` is provided, the generated `ssh` invocation forces PTY allocation (`-t`) and appends the shell as the remote command; the command help/examples are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b97712dae61998390630100746e63b3a890aa425. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->