### PR TITLE
Add [checkpoints] config for interval and cloud retention

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -114,6 +114,7 @@ class RLClient:
         lora_alpha: Optional[int] = None,
         oversampling_factor: Optional[float] = None,
         max_async_level: Optional[int] = None,
+        checkpoints_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -177,6 +178,9 @@ class RLClient:
 
             if max_async_level is not None:
                 payload["max_async_level"] = max_async_level
+
+            if checkpoints_config:
+                payload["checkpoints"] = checkpoints_config
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))


### PR DESCRIPTION
- Add `CheckpointsConfig` to `RLConfig`
- Add `checkpoints_config` param to `create_run` API
- Update TOML template with checkpoints section

```toml
[checkpoints]
interval = 100    # Save every N steps
keep_cloud = 5    # Keep N in cloud (-1 = keep all)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive CLI/API payload change gated behind an optional config; main risk is backend schema mismatch or unintended defaults if `checkpoints` is interpreted differently server-side.
> 
> **Overview**
> Adds optional checkpoint settings to RL run creation, allowing users to set a save `interval` and cloud retention (`keep_cloud`) via a new `[checkpoints]` block in the generated TOML template.
> 
> Plumbs this config through the CLI config model (`CheckpointsConfig` on `RLConfig`) into `RLClient.create_run`, which now accepts `checkpoints_config` and sends it to the backend as `checkpoints` in the `/rft/runs` payload when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78573d0bfb51619e4c86d92c989e5b8485507cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->