### PR TITLE
Bump prime CLI version to 0.5.37

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.36"
+__version__ = "0.5.37"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI version from 0.5.36 to 0.5.37.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no behavior or API modifications.
> 
> **Overview**
> Bumps the Prime CLI package version by updating `prime_cli.__version__` from `0.5.36` to `0.5.37` (no functional code changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5344e8f410a6ddfd273fa2aab6bd4d3935d614db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->