### PR TITLE
Add adapter upload configuration support

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -131,6 +131,7 @@ class RLClient:
         oversampling_factor: Optional[float] = None,
         max_async_level: Optional[int] = None,
         checkpoints_config: Optional[Dict[str, Any]] = None,
+        adapters_config: Optional[Dict[str, Any]] = None,
         checkpoint_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
     ) -> RLRun:
@@ -196,6 +197,9 @@ class RLClient:
 
             if checkpoints_config:
                 payload["checkpoints"] = checkpoints_config
+
+            if adapters_config:
+                payload["adapters"] = adapters_config
 
             if checkpoint_id:
                 payload["checkpoint_id"] = checkpoint_id

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -197,6 +197,11 @@ id = "{env_value}"
 # [checkpoints]
 # interval = 100              # Save checkpoint every N steps
 # keep_cloud = 5              # Keep N checkpoints in cloud (-1 = keep all)
+
+# Optional: adapter upload configuration
+# [adapters]
+# interval = 0                # Upload adapter every N steps (0 = only at run end)
+# keep_last = 3               # Keep N adapters in cloud (-1 = keep all)
 '''
 
 
@@ -369,6 +374,21 @@ class CheckpointsConfig(BaseModel):
         return result if result else None
 
 
+class AdaptersConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    interval: int | None = None  # Upload adapter every N steps (0 = only at run end)
+    keep_last: int | None = None  # Keep N adapters in cloud (-1 = keep all)
+
+    def to_api_dict(self) -> Dict[str, Any] | None:
+        result: Dict[str, Any] = {}
+        if self.interval is not None:
+            result["interval"] = self.interval
+        if self.keep_last is not None:
+            result["keep_last"] = self.keep_last
+        return result if result else None
+
+
 class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -390,6 +410,7 @@ class RLConfig(BaseModel):
     buffer: BufferConfig = Field(default_factory=BufferConfig)
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
+    adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
 
@@ -724,6 +745,7 @@ def create_run(
             oversampling_factor=cfg.oversampling_factor,
             max_async_level=cfg.max_async_level,
             checkpoints_config=cfg.checkpoints.to_api_dict(),
+            adapters_config=cfg.adapters.to_api_dict(),
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
         )


### PR DESCRIPTION
## Summary
- Add AdaptersConfig class with interval and keep_last settings
- Add adapters_config parameter to create_run API
- Update config template with [adapters] section

## Config Example
```toml
[adapters]
interval = 100  # Upload adapter every 100 steps (0 = only at run end)
keep_last = 3   # Keep 3 adapters in cloud (-1 = keep all)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional CLI/API payload fields to configure adapter uploads; main risk is backend schema mismatch if the new `adapters` payload is not supported.
> 
> **Overview**
> Adds optional **adapter upload configuration** for hosted RL runs via a new `[adapters]` block (with `interval` and `keep_last`) in the generated RL TOML template.
> 
> Plumbs this config through the CLI into the API: introduces `AdaptersConfig` on `RLConfig`, passes `adapters_config` to `RLClient.create_run`, and includes an `adapters` object in the `/rft/runs` create-run payload when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50dda36d80a562e8c41087e617a63a49047156a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->