### PR TITLE
Release: Bump prime CLI version to 0.5.38

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.37"
+__version__ = "0.5.38"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI version to 0.5.38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string version bump with no behavioral changes; low risk aside from release/versioning correctness.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.37` to `0.5.38` by updating `__version__` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 040a897c1e2edc9086404159da8611aabcab0e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->