### PR TITLE
Lab trajectory strategy removal

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -33,7 +33,6 @@ class RLRun(BaseModel):
     max_steps: int = Field(..., alias="maxSteps")
     max_tokens: Optional[int] = Field(None, alias="maxTokens")
     batch_size: int = Field(..., alias="batchSize")
-    trajectory_strategy: Optional[str] = Field(None, alias="trajectoryStrategy")
     base_model: str = Field(..., alias="baseModel")
     environments: List[Dict[str, Any]] = Field(default_factory=list)
     run_config: Optional[Dict[str, Any]] = Field(None, alias="runConfig")
@@ -100,7 +99,6 @@ class RLClient:
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
         batch_size: int = 128,
-        trajectory_strategy: Optional[str] = None,
         name: Optional[str] = None,
         wandb_entity: Optional[str] = None,
         wandb_project: Optional[str] = None,
@@ -131,9 +129,6 @@ class RLClient:
                 "batch_size": batch_size,
                 "secrets": secrets_list,
             }
-
-            if trajectory_strategy:
-                payload["trajectory_strategy"] = trajectory_strategy
 
             if name:
                 payload["name"] = name

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -402,6 +402,20 @@ def _format_validation_errors(errors: list[dict]) -> list[str]:
     return messages
 
 
+def _remove_deprecated_config_keys(data: Dict[str, Any]) -> None:
+    """Remove deprecated config keys while warning users."""
+    removed = False
+    for key in ("trajectory_strategy", "trajectoryStrategy"):
+        if key in data:
+            data.pop(key, None)
+            removed = True
+
+    if removed:
+        console.print(
+            "[yellow]Warning:[/yellow] `trajectory_strategy` is deprecated and ignored."
+        )
+
+
 def load_config(path: str) -> RLConfig:
     """Load config from TOML file."""
     p = Path(path)
@@ -413,6 +427,9 @@ def load_config(path: str) -> RLConfig:
     except toml.TomlDecodeError as e:
         console.print(f"[red]Error:[/red] Invalid TOML in {path}: {e}")
         raise typer.Exit(1)
+
+    if isinstance(data, dict):
+        _remove_deprecated_config_keys(data)
 
     try:
         return RLConfig.model_validate(data)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -136,7 +136,6 @@ max_steps = 100
 # Training
 batch_size = 128
 rollouts_per_example = 8
-# trajectory_strategy = "interleaved"  # or "branching"
 # learning_rate = 1e-6
 # lora_alpha = 16
 # oversampling_factor = 1.0
@@ -375,7 +374,6 @@ class RLConfig(BaseModel):
     max_steps: int = 100
     batch_size: int = 128
     rollouts_per_example: int = 8
-    trajectory_strategy: str | None = None
     learning_rate: float | None = None
     lora_alpha: int | None = None
     oversampling_factor: float | None = None
@@ -688,7 +686,6 @@ def create_run(
             max_tokens=cfg.sampling.max_tokens,
             temperature=cfg.sampling.temperature,
             batch_size=cfg.batch_size,
-            trajectory_strategy=cfg.trajectory_strategy,
             name=cfg.name,
             wandb_entity=cfg.wandb.entity,
             wandb_project=cfg.wandb.project,

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+from prime_cli.commands.rl import load_config
+
+
+def test_load_config_warns_and_ignores_deprecated_trajectory_strategy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        'trajectory_strategy = "interleaved"\n'
+    )
+
+    printed: list[str] = []
+
+    def capture_print(*args: object, **_: object) -> None:
+        printed.append(" ".join(str(arg) for arg in args))
+
+    monkeypatch.setattr("prime_cli.commands.rl.console.print", capture_print)
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.model == "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+    assert "trajectory_strategy" not in cfg.model_dump()
+    assert any("trajectory_strategy" in line and "deprecated" in line.lower() for line in printed)
+
+
+def test_load_config_still_rejects_other_unknown_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        "unknown_field = 123\n"
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 import typer
-
 from prime_cli.commands.rl import load_config
 
 


### PR DESCRIPTION
Remove all mentions of `trajectory_strategy` from the RL lab flow.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1f47f245-b763-4f8d-b176-da2f7c56e0f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f47f245-b763-4f8d-b176-da2f7c56e0f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI/API payload change that only removes a deprecated option and adds a warning; primary risk is unexpected behavior for users who still rely on the removed field.
> 
> **Overview**
> Removes `trajectory_strategy` from the RL lab flow end-to-end: it is no longer part of the CLI config (`RLConfig`), template output, or forwarded in `RLClient.create_run` payloads.
> 
> To preserve backward compatibility, `load_config` now strips `trajectory_strategy`/`trajectoryStrategy` from TOML configs and prints a deprecation warning, while still rejecting other unknown keys; new tests cover both behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aae336303641e8e5cd2ea00d5009d6825d641a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->