### PR TITLE
expand variables in secrets .env

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -411,9 +411,7 @@ def _remove_deprecated_config_keys(data: Dict[str, Any]) -> None:
             removed = True
 
     if removed:
-        console.print(
-            "[yellow]Warning:[/yellow] `trajectory_strategy` is deprecated and ignored."
-        )
+        console.print("[yellow]Warning:[/yellow] `trajectory_strategy` is deprecated and ignored.")
 
 
 def load_config(path: str) -> RLConfig:
@@ -522,7 +520,7 @@ def create_run(
     env_file: Optional[List[str]] = typer.Option(
         None,
         "--env-file",
-        help="Path to .env file containing secrets.",
+        help="Path to .env file containing secrets. Supports ${VAR} expansion from local env.",
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
     skip_action_check: bool = typer.Option(

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -72,9 +72,10 @@ def parse_env_file(
             key, _, value = line.partition("=")
             key = key.strip()
             value = value.strip()
-            if (value.startswith('"') and value.endswith('"')) or (
+            was_single_quoted = (
                 value.startswith("'") and value.endswith("'")
-            ):
+            )
+            if (value.startswith('"') and value.endswith('"')) or was_single_quoted:
                 value = value[1:-1]
             if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", key):
                 if on_warning:
@@ -83,7 +84,8 @@ def parse_env_file(
                         f"must start with letter/underscore, contain only alphanumeric/underscore"
                     )
                 continue
-            value = _expand_env_var_references(value, file_path=file_path, line_num=line_num)
+            if not was_single_quoted:
+                value = _expand_env_var_references(value, file_path=file_path, line_num=line_num)
             env_vars[key] = value
     return env_vars
 

--- a/packages/prime/src/prime_cli/utils/env_vars.py
+++ b/packages/prime/src/prime_cli/utils/env_vars.py
@@ -76,7 +76,6 @@ def parse_env_file(
                 value.startswith("'") and value.endswith("'")
             ):
                 value = value[1:-1]
-            value = _expand_env_var_references(value, file_path=file_path, line_num=line_num)
             if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", key):
                 if on_warning:
                     on_warning(
@@ -84,6 +83,7 @@ def parse_env_file(
                         f"must start with letter/underscore, contain only alphanumeric/underscore"
                     )
                 continue
+            value = _expand_env_var_references(value, file_path=file_path, line_num=line_num)
             env_vars[key] = value
     return env_vars
 

--- a/packages/prime/tests/test_env_vars_util.py
+++ b/packages/prime/tests/test_env_vars_util.py
@@ -41,6 +41,18 @@ def test_parse_env_file_raises_for_missing_braced_variable(
         parse_env_file(env_file)
 
 
+def test_parse_env_file_keeps_single_quoted_values_literal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WANDB_API_KEY", "secret-123")
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text("WANDB_API_KEY='${WANDB_API_KEY}'\n")
+
+    parsed = parse_env_file(env_file)
+
+    assert parsed["WANDB_API_KEY"] == "${WANDB_API_KEY}"
+
+
 def test_parse_env_file_keeps_unbraced_dollar_reference_literal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/prime/tests/test_env_vars_util.py
+++ b/packages/prime/tests/test_env_vars_util.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+from prime_cli.utils.env_vars import EnvParseError, parse_env_file
+
+
+def test_parse_env_file_expands_braced_variable_references(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WANDB_API_KEY", "secret-123")
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text("WANDB_API_KEY=${WANDB_API_KEY}\n")
+
+    parsed = parse_env_file(env_file)
+
+    assert parsed["WANDB_API_KEY"] == "secret-123"
+
+
+def test_parse_env_file_expands_references_inside_quoted_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PRIME_TEST_PREFIX", "alpha")
+    monkeypatch.setenv("PRIME_TEST_SUFFIX", "omega")
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text('COMBINED="start-${PRIME_TEST_PREFIX}-${PRIME_TEST_SUFFIX}-end"\n')
+
+    parsed = parse_env_file(env_file)
+
+    assert parsed["COMBINED"] == "start-alpha-omega-end"
+
+
+def test_parse_env_file_raises_for_missing_braced_variable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_var = "PRIME_TEST_MISSING_ENV_VAR"
+    monkeypatch.delenv(missing_var, raising=False)
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text(f"WANDB_API_KEY=${{{missing_var}}}\n")
+
+    with pytest.raises(EnvParseError, match=missing_var):
+        parse_env_file(env_file)
+
+
+def test_parse_env_file_keeps_unbraced_dollar_reference_literal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WANDB_API_KEY", "secret-123")
+    env_file = tmp_path / "secrets.env"
+    env_file.write_text("WANDB_API_KEY=$WANDB_API_KEY\n")
+
+    parsed = parse_env_file(env_file)
+
+    assert parsed["WANDB_API_KEY"] == "$WANDB_API_KEY"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to CLI-side `.env` parsing; behavior changes are covered by new tests and primarily affect how secrets files are interpreted.
> 
> **Overview**
> Adds `${VAR}` expansion support when parsing `.env` secret files so users can reference locally-set environment variables; missing referenced variables now raise `EnvParseError` with file/line context.
> 
> Single-quoted values are treated as literals (no expansion), and `prime rl run --env-file` help text is updated accordingly; includes new unit tests covering expansion, quoting behavior, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edce16cd4920f45d2e1ce983a465ad6f7d02316f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->