### PR TITLE
Adjust `prime env pull` default destination path behavior

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1517,7 +1517,7 @@ def pull(
 
         base_dir = _resolve_pull_environment_path(target, name)
         target_dir = base_dir
-        if target is None and target_dir.exists():
+        if not target and target_dir.exists():
             # Find the next available directory with index suffix
             index = 1
             while target_dir.exists():

--- a/packages/prime/tests/test_env_pull_path.py
+++ b/packages/prime/tests/test_env_pull_path.py
@@ -1,0 +1,26 @@
+from prime_cli.commands.env import _resolve_pull_environment_path
+
+
+def test_defaults_to_cwd_when_environments_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    resolved = _resolve_pull_environment_path(target=None, env_name="my-env")
+
+    assert resolved == tmp_path / "my_env"
+
+
+def test_defaults_to_environments_dir_when_present(tmp_path, monkeypatch):
+    (tmp_path / "environments").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    resolved = _resolve_pull_environment_path(target=None, env_name="my-env")
+
+    assert resolved == tmp_path / "environments" / "my_env"
+
+
+def test_respects_explicit_target_path(tmp_path):
+    explicit = tmp_path / "custom-target"
+
+    resolved = _resolve_pull_environment_path(target=str(explicit), env_name="my-env")
+
+    assert resolved == explicit


### PR DESCRIPTION
### Motivation

- Make `prime env pull` place pulled environments into `./environments/<env_name>` when an `./environments` folder exists in the workspace root, and otherwise fall back to the current working directory, with hyphens in env names mapped to underscores.
- Centralize default destination resolution to avoid duplication and make behavior consistent with `prime env push` which already normalizes hyphens to underscores.

### Description

- Added a helper `
  _resolve_pull_environment_path(target: Optional[str], env_name: str) -> Path
  ` to compute the local pull target, preferring `./environments` when present and converting `-` to `_` in names.
- Updated `pull()` to call `
  _resolve_pull_environment_path
  ` and preserved the existing collision handling by appending numeric suffixes when the computed default directory already exists.
- Added tests in `packages/prime/tests/test_env_pull_path.py` to validate defaulting to the CWD, defaulting to `./environments` when present, and honoring an explicit `--target`.
- Changes applied to `packages/prime/src/prime_cli/commands/env.py` and a new test file was added at `packages/prime/tests/test_env_pull_path.py`.

### Testing

- Ran `uv run pytest -q packages/prime/tests/test_env_pull_path.py packages/prime/tests/test_env_push_path.py` which reported `8 passed` and succeeded.
- Running plain `pytest -q` in the environment failed during collection due to a missing interpreter dependency (`ModuleNotFoundError: No module named 'httpx'`), which is unrelated to the new logic and resolved when using the project `uv` runtime used in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c72044508326a587cbf5d575f25f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change isolated to local path resolution for a CLI command, with explicit tests covering the new defaulting behavior and no changes to network/API interactions.
> 
> **Overview**
> Updates `prime env pull` to compute its default destination via a new `_resolve_pull_environment_path`, mapping hyphens to underscores and preferring `./environments/<env_name>` when an `environments/` directory exists (otherwise using the current working directory). The `pull()` command now uses this shared resolver while keeping existing name-collision handling (auto-suffixing `-1`, `-2`, etc. only when no explicit `--target` is provided).
> 
> Adds `test_env_pull_path.py` to cover the new default path selection and explicit target behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c06b6218c89049d991f52e222516b0424d0946f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->