### PR TITLE
prime tunnel proxy name

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -193,6 +193,7 @@ class TunnelClient:
             hostname=data["hostname"],
             url=data["url"],
             frp_token="",  # Token not returned on status check
+            proxy_name=data["proxy_name"],
             server_host="",
             server_port=7000,
             expires_at=data["expires_at"],
@@ -276,6 +277,7 @@ class TunnelClient:
                     hostname=t["hostname"],
                     url=t["url"],
                     frp_token="",
+                    proxy_name=t["proxy_name"],
                     server_host="",
                     server_port=7000,
                     expires_at=t["expires_at"],

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -12,6 +12,9 @@ class TunnelInfo(BaseModel):
     url: str = Field(..., description="Full HTTPS URL")
     frp_token: str = Field(..., description="Authentication token for frpc")
     binding_secret: str = Field("", description="Per-tunnel secret for frpc metadata")
+    proxy_name: Optional[str] = Field(
+        None, description="Server-assigned FRP proxy name for metrics"
+    )
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     expires_at: datetime = Field(..., description="Token expiration time")

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -12,9 +12,7 @@ class TunnelInfo(BaseModel):
     url: str = Field(..., description="Full HTTPS URL")
     frp_token: str = Field(..., description="Authentication token for frpc")
     binding_secret: str = Field("", description="Per-tunnel secret for frpc metadata")
-    proxy_name: Optional[str] = Field(
-        None, description="Server-assigned FRP proxy name for metrics"
-    )
+    proxy_name: str = Field(..., description="Server-assigned FRP proxy name for metrics")
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     expires_at: datetime = Field(..., description="Token expiration time")

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -275,6 +275,7 @@ class Tunnel:
 
         server_host = self._tunnel_info.server_host
         server_port = self._tunnel_info.server_port
+        proxy_name = self._tunnel_info.proxy_name or self._tunnel_info.tunnel_id
 
         # Generate config content
         config = f"""# Prime Tunnel frpc configuration
@@ -302,7 +303,7 @@ log.level = "{self.log_level}"
 
 # HTTP proxy configuration
 [[proxies]]
-name = "{self._tunnel_info.tunnel_id}"
+name = "{proxy_name}"
 type = "http"
 localIP = "{self.local_addr}"
 localPort = {self.local_port}

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -72,6 +72,7 @@ def _make_started_tunnel() -> Tunnel:
         hostname="t-test123.tunnel.example.com",
         url="https://t-test123.tunnel.example.com",
         frp_token="tok",
+        proxy_name="test-user",
         server_host="frp.example.com",
         server_port=7000,
         expires_at=datetime.now(timezone.utc),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new required model field that can break clients if the API doesn’t return `proxy_name` consistently, and it changes the generated FRP proxy name which can affect routing/metrics expectations.
> 
> **Overview**
> Adds a required `proxy_name` field to `TunnelInfo` and plumbs it through `TunnelClient.get_tunnel()` and `list_tunnels()` responses.
> 
> Updates `Tunnel._write_frpc_config()` to name the FRP proxy using the server-assigned `proxy_name` (falling back to `tunnel_id`), and adjusts tests to construct `TunnelInfo` with the new field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e67796550e2f72d9ecbf72872e8404845be4507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->