### PR TITLE
Bump prime CLI version to 0.5.39

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.38"
+__version__ = "0.5.39"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- Bump version 0.5.38 → 0.5.39
- Includes: checkpoint_id support for create run command (#391)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no functional logic changes; low risk aside from release/versioning consistency.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.38` to `0.5.39` by updating `__version__` in `prime_cli/__init__.py` (affecting places that display/report the installed version).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d17164b71d8c452c15f9015e8ccad37bfd85bc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->