### PR TITLE
Pass team_id to /models for reservation-aware capacity

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -80,10 +80,13 @@ class RLClient:
     def __init__(self, client: APIClient) -> None:
         self.client = client
 
-    def list_models(self) -> List[RLModel]:
+    def list_models(self, team_id: Optional[str] = None) -> List[RLModel]:
         """List available models for RL training."""
         try:
-            response = self.client.get("/rft/models")
+            params = {}
+            if team_id:
+                params["team_id"] = team_id
+            response = self.client.get("/rft/models", params=params if params else None)
             models_data = response.get("models", [])
             return [RLModel.model_validate(model) for model in models_data]
         except Exception as e:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -767,8 +767,9 @@ def list_models(
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
+        config = Config()
 
-        models = rl_client.list_models()
+        models = rl_client.list_models(team_id=config.team_id)
 
         if output == "json":
             output_data_as_json({"models": [m.model_dump() for m in models]}, console)


### PR DESCRIPTION
- Passes the configured team_id to the /models endpoint as a query param
- Lets reserved teams see accurate at_capacity status based on their guaranteed slots

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backwards-compatible change that only adds an optional query parameter to a read-only models listing call.
> 
> **Overview**
> Updates the RL CLI `models` command to include the configured `team_id` when calling `/rft/models`, enabling model availability/`at_capacity` results to be computed in a team-aware (reservation-aware) way.
> 
> This changes `RLClient.list_models` to accept an optional `team_id` and conditionally send it as a query parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b312dc2487e272d133bdfa4512c92197a74dcfec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->