### PR TITLE
`prime sandbox delete` CLI: Simplify sandbox delete help text

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -484,7 +484,7 @@ def delete(
     only_mine: bool = typer.Option(
         True,
         "--only-mine/--all-users",
-        help="Restrict '--all' deletes to only your sandboxes (default: only yours)",
+        help="Restrict '--all' deletes to only your sandboxes",
         show_default=True,
     ),
 ) -> None:


### PR DESCRIPTION
with `show_default=True` the default is already printed.

thus it was displayed twice before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998fdc192b083318fa48d810deb6c91)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text-only change with no impact to sandbox deletion logic or API calls.
> 
> **Overview**
> Simplifies the `prime sandbox delete` CLI help by removing the redundant “(default: only yours)” wording from the `--only-mine/--all-users` option description, keeping the same behavior but clearer output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5985652b4d083b51274424321a5c267783e4a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->