### PR TITLE
ENG-3014 Fix setting role when changing team

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -175,6 +175,7 @@ def set_team_id(
 
     config = Config()
     team_name = None
+    team_role = None
     if team_id:
         try:
             client = APIClient()
@@ -182,11 +183,12 @@ def set_team_id(
             for team in teams:
                 if team.get("teamId") == team_id:
                     team_name = team.get("name")
+                    team_role = team.get("role")
                     break
         except (APIError, Exception):
             pass
 
-    config.set_team(team_id, team_name=team_name)
+    config.set_team(team_id, team_name=team_name, team_role=team_role)
     if team_id:
         if team_name:
             console.print(f"[green]Team '{team_name}' ({team_id}) configured successfully![/green]")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CLI config change that only affects local config state; low risk aside from potentially storing an incorrect role if the team lookup fails or returns unexpected data.
> 
> **Overview**
> **Fixes missing role persistence when switching teams via config.** `prime config set-team-id` now looks up the team’s `role` from the teams list and passes it into `Config.set_team(...)`, so `team_role` is updated/cleared consistently with `team_id` (matching the login flow behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70e67dc80b21ca6348c962471c7da87c1d4546e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->