### PR TITLE
Release: Bump prime cli to 0.5.41

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.40"
+__version__ = "0.5.41"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no functional code modifications.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.40` to `0.5.41` by updating `__version__` in `packages/prime/src/prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 465eca23827a26a66b329fc654424376deef1ce5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->