### PR TITLE
Add cluster_name parameter to RL run creation

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -132,6 +132,7 @@ class RLClient:
         max_async_level: Optional[int] = None,
         checkpoints_config: Optional[Dict[str, Any]] = None,
         checkpoint_id: Optional[str] = None,
+        cluster_name: Optional[str] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -198,6 +199,9 @@ class RLClient:
 
             if checkpoint_id:
                 payload["checkpoint_id"] = checkpoint_id
+
+            if cluster_name:
+                payload["cluster_name"] = cluster_name
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -382,6 +382,7 @@ class RLConfig(BaseModel):
     oversampling_factor: float | None = None
     max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
+    cluster_name: str | None = None  # Admin-only: target a specific cluster by name
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
@@ -724,6 +725,7 @@ def create_run(
             max_async_level=cfg.max_async_level,
             checkpoints_config=cfg.checkpoints.to_api_dict(),
             checkpoint_id=cfg.checkpoint_id,
+            cluster_name=cfg.cluster_name,
         )
 
         if output == "json":


### PR DESCRIPTION
CLI support for the admin-only cluster_name param added in platform.

- adds `cluster_name` to TOML config model
- passes it through to the API payload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional passthrough field to the CLI/API payload; minimal behavioral impact beyond targeting a specific cluster when set.
> 
> **Overview**
> Adds an optional admin-only `cluster_name` setting to RL run configuration and propagates it through `RLClient.create_run` so it is included in the `/rft/runs` create payload when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e86f0332751c747ac8ecd2f5fea57fc42fd3321d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->