### PR TITLE
Bump prime CLI to 0.5.42

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.40"
+__version__ = "0.5.42"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- add cluster_name param to RL run creation (admin-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple version constant update with no functional logic changes; impact limited to version display and User-Agent metadata.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.40` to `0.5.42` by updating `prime_cli.__version__`, affecting version reporting and the default User-Agent string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2802ceae5d7ce6175d017c37ddd97572271b8971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->