### PR TITLE
move tunnel config from tmp/ to .prime/

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -2,7 +2,6 @@ import asyncio
 import fcntl
 import os
 import subprocess
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -309,9 +308,10 @@ localPort = {self.local_port}
 subdomain = "{self._tunnel_info.tunnel_id}"
 """
 
-        # Write to temp file
-        config_dir = Path(tempfile.gettempdir()) / "prime-tunnel"
+        # Write to config directory
+        config_dir = Path.home() / ".prime" / "tunnels"
         config_dir.mkdir(parents=True, exist_ok=True)
+        config_dir.chmod(0o700)
         config_file = config_dir / f"{self._tunnel_info.tunnel_id}.toml"
 
         # Create file with 0600 permissions


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes where the per-tunnel `frpc` config file is written, with minor permission-setting side effects on the created directory.
> 
> **Overview**
> Moves the generated `frpc` tunnel config file location from the system temp directory to `~/.prime/tunnels`, and ensures the directory is created with `0700` permissions.
> 
> Removes the `tempfile` dependency while keeping the config file written with `0600` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e33ef2b7866142d505c545f3cb2bbf1c4eb96c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->