### PR TITLE
feat(prime-sandboxes): retry gateway requests on 5xx status codes

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -81,6 +81,8 @@ def _is_retryable_gateway_error(exc: BaseException) -> bool:
         isinstance(exc, httpx.HTTPStatusError)
         and exc.response.status_code in RETRYABLE_5XX_STATUSES
     ):
+        if _is_gateway_sandbox_not_found(exc.response):
+            return False
         return True
     return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ members = ["packages/*"]
 [tool.uv]
 dev-dependencies = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
     "ruff>=0.13.1",
     "ty>=0.0.1a21",
     "pre-commit>=3.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
 dev = [
     { name = "pre-commit", specifier = ">=3.5.0" },
     { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.13.1" },
     { name = "ty", specifier = ">=0.0.1a21" },
 ]


### PR DESCRIPTION
The Sandbox API sits behind Cloudflare, which has a ~100s proxy timeout. Under concurrent load (e.g. 100+ sandboxes), gateway response times can exceed this threshold, producing Cloudflare 524 (timeout) or 502 (bad gateway) errors. These are transient, as the sandbox itself is fine, but the proxy just gave up waiting.

Currently, `_gateway_retry` only retries connection-level exceptions (`RemoteProtocolError`, `ConnectError`, `PoolTimeout`), not HTTP 5xx responses. This means a single 524 from Cloudflare can kill an entire rollout.
The `mini-swe-agent-plus` env works around this by wrapping every sandbox call with application-level tenacity retry, retrying on 502/503/ConnectError. This works but means every consumer of prime_sandboxes needs to reimplement the same retry logic.

The `opencode-swe` env, for example – but also other CliAgentEnv-based envs – have no such retry, which lead to 524 errors on `execute_command` or `poll_job_completion` causing cascading rollout failures during synthetic data generation.

The fix belongs in the SDK so all consumers get 5xx retry for free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core gateway retry behavior to treat select HTTP 5xx (incl. Cloudflare 524) as transient and increases backoff/attempts, which can alter latency and error-surfacing across all sandbox operations. While POST retries are constrained to connection errors to avoid duplicate side effects, misclassification of retryable statuses could still impact request load and rollout behavior.
> 
> **Overview**
> Adds **HTTP 5xx-aware retries** for idempotent sandbox gateway calls by treating select statuses (`500`, `502`, `503`, `504`, `524`) as retryable, while explicitly *not* retrying `502` responses that indicate `sandbox_not_found`.
> 
> Splits retry strategy into `_gateway_retry` (GET/other idempotent paths: connection errors + retryable 5xx via `HTTPStatusError`) and `_gateway_post_retry` (POST: connection errors only), and updates `_gateway_get` to raise on retryable 5xx so tenacity can retry.
> 
> Expands and adjusts tests to cover 5xx retry/no-retry cases and updates dev deps to include `pytest-asyncio`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2c310b88ec63f4aa8dc4b43a76c4f05babd2463. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->