### PR TITLE
sandbox delete by name

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -155,6 +155,7 @@ class BulkDeleteSandboxRequest(BaseModel):
 
     sandbox_ids: Optional[List[str]] = None
     labels: Optional[List[str]] = None
+    name: Optional[str] = None
 
 
 class BulkDeleteSandboxResponse(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -482,9 +482,10 @@ class SandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        name: Optional[str] = None,
     ) -> BulkDeleteSandboxResponse:
-        """Bulk delete multiple sandboxes by IDs or labels (must specify one, not both)"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        """Bulk delete multiple sandboxes by IDs, labels, or name (must specify exactly one)"""
+        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels, name=name)
         response = self.client.request(
             "DELETE",
             "/sandbox",

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1240,9 +1240,10 @@ class AsyncSandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        name: Optional[str] = None,
     ) -> BulkDeleteSandboxResponse:
-        """Bulk delete multiple sandboxes by IDs or labels"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        """Bulk delete multiple sandboxes by IDs, labels, or name (must specify exactly one)"""
+        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels, name=name)
         response = await self.client.request(
             "DELETE",
             "/sandbox",

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -642,6 +642,14 @@ def delete(
                 )
                 for sandbox_id in result.succeeded:
                     console.print(f"  ✓ {sandbox_id}")
+            if result.failed:
+                console.print(
+                    f"\n[bold red]Failed to delete {len(result.failed)} sandbox(es):[/bold red]"
+                )
+                for failure in result.failed:
+                    sandbox_id = failure.get("sandbox_id", "unknown")
+                    error = failure.get("error", "unknown error")
+                    console.print(f"  ✗ {sandbox_id}: {error}")
 
         elif name:
             confirmation_msg = (
@@ -663,6 +671,14 @@ def delete(
                 )
                 for sandbox_id in result.succeeded:
                     console.print(f"  ✓ {sandbox_id}")
+            if result.failed:
+                console.print(
+                    f"\n[bold red]Failed to delete {len(result.failed)} sandbox(es):[/bold red]"
+                )
+                for failure in result.failed:
+                    sandbox_id = failure.get("sandbox_id", "unknown")
+                    error = failure.get("error", "unknown error")
+                    console.print(f"  ✗ {sandbox_id}: {error}")
 
         elif len(sandbox_ids) == 1 and not all:
             sandbox_id = sandbox_ids[0]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new bulk-deletion selector (`name`) to both the SDK and CLI, which can delete multiple sandboxes at once if misused. Risk is moderated by mutual-exclusion validation and explicit confirmation prompts, but it depends on backend support for the new request field.
> 
> **Overview**
> Enables bulk sandbox deletion by exact `name` in addition to existing ID/label-based deletes.
> 
> Updates the prime-sandboxes SDK `BulkDeleteSandboxRequest` and `SandboxClient.bulk_delete()` (sync + async) to accept `name` and include it in the `DELETE /sandbox` payload.
> 
> Extends `prime sandbox delete` with a `--name/-n` option, updates argument exclusivity/required checks, and adds output for per-sandbox failures when deleting by labels or name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81d94ea62ce0f58b7acf256b4cc2b1315d65b0fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->