### PR TITLE
Add deployable-models check to prime-cli

### DIFF
--- a/packages/prime/src/prime_cli/api/deployments.py
+++ b/packages/prime/src/prime_cli/api/deployments.py
@@ -81,13 +81,17 @@ class DeploymentsClient:
                 raise APIError(f"Failed to unload adapter: {e.response.text}")
             raise APIError(f"Failed to unload adapter: {str(e)}")
 
-    def get_deployable_models(self) -> Optional[List[str]]:
-        """Get list of base models that support LoRA deployment.
-
-        Returns None on error (fail-open).
-        """
+    def get_deployable_models(self) -> List[str]:
+        """Get list of base models that support LoRA deployment."""
         try:
             response = self.client.get("/rft/deployable-models")
-            return response.get("models")
-        except Exception:
-            return None
+            return response.get("models") or []
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(
+                    f"Failed to get deployable models:"
+                    f" {e.response.text}"
+                )
+            raise APIError(
+                f"Failed to get deployable models: {str(e)}"
+            )

--- a/packages/prime/src/prime_cli/api/deployments.py
+++ b/packages/prime/src/prime_cli/api/deployments.py
@@ -80,3 +80,14 @@ class DeploymentsClient:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to unload adapter: {e.response.text}")
             raise APIError(f"Failed to unload adapter: {str(e)}")
+
+    def get_deployable_models(self) -> Optional[List[str]]:
+        """Get list of base models that support LoRA deployment.
+
+        Returns None on error (fail-open).
+        """
+        try:
+            response = self.client.get("/rft/deployable-models")
+            return response.get("models")
+        except Exception:
+            return None

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -47,13 +47,12 @@ def list_deployments(
         deployable_models = deployments_client.get_deployable_models()
 
         if output == "json":
-            output_data_as_json(
-                {
-                    "models": [m.model_dump() for m in models],
-                    "deployable_models": deployable_models,
-                },
-                console,
-            )
+            models_data = []
+            for m in models:
+                data = m.model_dump()
+                data["deployable"] = m.base_model in deployable_models
+                models_data.append(data)
+            output_data_as_json({"models": models_data}, console)
             return
 
         if not models:

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -142,9 +142,15 @@ def create_deployment(
         # Check if base model supports LoRA deployment
         deployable_models = deployments_client.get_deployable_models()
         if deployable_models is None:
-            console.print("[dim]Warning: Could not verify base model deployability. Proceeding anyway.[/dim]")
+            console.print(
+                "[dim]Warning: Could not verify base model"
+                " deployability. Proceeding anyway.[/dim]"
+            )
         elif model.base_model not in deployable_models:
-            console.print("[red]Error:[/red] Base model is not currently available for LoRA deployment.")
+            console.print(
+                "[red]Error:[/red] Base model is not currently"
+                " available for LoRA deployment."
+            )
             console.print(f"  Base model: [yellow]{model.base_model}[/yellow]")
             raise typer.Exit(1)
 


### PR DESCRIPTION
## Summary
- Adds `get_deployable_models()` to `DeploymentsClient` — calls `GET /rft/deployable-models`, raises `APIError` on failure (consistent with other methods)
- `deployments create`: blocks deploy when base model isn't in the deployable list with a clear error message
- `deployments list`: adds a "Deployable" column (Yes/No) to table output; adds inline `"deployable": true/false` per model in JSON output
- Matches frontend PR #649 which hides the Deploy button for non-deployable adapters

## Test plan
- [x] `prime -c dev deployments list` — Deployable column shows with correct Yes/No values
- [x] `prime -c dev deployments list -o json` — each model has `"deployable": true/false` field
- [x] `prime -c dev deployments create <deployable-adapter-id>` — passes check, shows confirmation prompt

## Testing done
```
$ prime -c dev deployments list
                              Adapter Deployments
┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┓
┃ ID                 ┃ Name    ┃ Base     ┃ Status  ┃          ┃ Deploy… ┃
┃                    ┃         ┃ Model    ┃         ┃ Deploya… ┃ At      ┃
┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━┩
│ gw3zytpj9den6zgp4… │ single… │ PrimeIn… │ NOT_DE… │ Yes      │ 2026-0… │
└────────────────────┴─────────┴──────────┴─────────┴──────────┴─────────┘

$ prime -c dev deployments list -o json
# Each model now has "deployable": true/false inline

$ prime -c dev deployments create gw3zytpj9den6zgp4w9xosnk
Deploying model:
  ID: gw3zytpj9den6zgp4w9xosnk
  Name: single-turn---qwen3-0.6b-reverse-t--w81me3
  Base Model: PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT

Are you sure you want to deploy this model? [y/N]: Cancelled.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new API call and introduces pre-deploy gating based on server-provided deployability; incorrect/unstable endpoint responses could block deployments or degrade CLI output, but failures are handled with warnings in non-critical paths.
> 
> **Overview**
> Prime CLI now queries `GET /rft/deployable-models` via a new `DeploymentsClient.get_deployable_models()` helper.
> 
> `deployments list` annotates each adapter with deployability (new **Deployable** table column and optional `"deployable": true/false` in JSON), falling back to a warning and `-` when the allowlist can’t be fetched.
> 
> `deployments create` adds a preflight check that **blocks deployment** when an adapter’s `base_model` isn’t in the deployable list, with a warning-only fallback if verification fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f039d30c0aca8c97671a242cb184b553d0e4882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->