### PR TITLE
Add pagination to deployments list command

### DIFF
--- a/packages/prime/src/prime_cli/api/deployments.py
+++ b/packages/prime/src/prime_cli/api/deployments.py
@@ -1,7 +1,7 @@
 """Adapter deployments API client."""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -37,15 +37,25 @@ class DeploymentsClient:
     def __init__(self, client: APIClient) -> None:
         self.client = client
 
-    def list_adapters(self, team_id: Optional[str] = None) -> List[Adapter]:
-        """List adapters and their deployment status."""
+    def list_adapters(
+        self,
+        team_id: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Tuple[List[Adapter], int]:
+        """List adapters and their deployment status. Returns (adapters, total_count)."""
         try:
-            params = {}
+            params: dict = {}
             if team_id:
                 params["team_id"] = team_id
+            if limit is not None:
+                params["limit"] = limit
+            if offset:
+                params["offset"] = offset
             response = self.client.get("/rft/adapters", params=params if params else None)
             adapters_data = response.get("adapters", [])
-            return [Adapter.model_validate(adapter) for adapter in adapters_data]
+            total = response.get("total", len(adapters_data))
+            return [Adapter.model_validate(adapter) for adapter in adapters_data], total
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to list adapters: {e.response.text}")
@@ -88,10 +98,5 @@ class DeploymentsClient:
             return response.get("models") or []
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(
-                    f"Failed to get deployable models:"
-                    f" {e.response.text}"
-                )
-            raise APIError(
-                f"Failed to get deployable models: {str(e)}"
-            )
+                raise APIError(f"Failed to get deployable models: {e.response.text}")
+            raise APIError(f"Failed to get deployable models: {str(e)}")

--- a/packages/prime/src/prime_cli/api/deployments.py
+++ b/packages/prime/src/prime_cli/api/deployments.py
@@ -17,6 +17,7 @@ class Adapter(BaseModel):
     team_id: Optional[str] = Field(None, alias="teamId")
     rft_run_id: str = Field(..., alias="rftRunId")
     base_model: str = Field(..., alias="baseModel")
+    step: Optional[int] = Field(None, description="Training step number")
     status: str = Field(..., description="Adapter status: PENDING, UPLOADING, READY, FAILED")
     deployment_status: str = Field(
         default="NOT_DEPLOYED",

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -87,6 +87,7 @@ def list_deployments(
         table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Name", style="white")
         table.add_column("Base Model", style="magenta")
+        table.add_column("Step", style="yellow", justify="right")
         table.add_column("Status", style="white")
         table.add_column("Deployable", style="white")
         table.add_column("Deployed At", style="dim")
@@ -109,6 +110,7 @@ def list_deployments(
                 model.id,
                 model.display_name or "-",
                 base_model,
+                str(model.step) if model.step is not None else "-",
                 status,
                 deployable,
                 deployed_at,

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -129,13 +129,17 @@ def list_sandboxes_cmd(
         "-l",
         help="Filter by labels (can specify multiple, sandboxes must have ALL)",
     ),
-    page: int = typer.Option(1, help="Page number"),
-    per_page: int = typer.Option(50, help="Items per page"),
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    num: int = typer.Option(50, "--num", "-n", help="Items per page"),
     all: bool = typer.Option(False, "--all", help="Show all sandboxes including terminated ones"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """List your sandboxes (shortcut: ls)"""
     validate_output_format(output, console)
+
+    if num < 1 or page < 1:
+        console.print("[red]Error:[/red] --num and --page must be at least 1")
+        raise typer.Exit(1)
 
     try:
         base_client = APIClient()
@@ -149,7 +153,7 @@ def list_sandboxes_cmd(
             status=status,
             labels=labels,
             page=page,
-            per_page=per_page,
+            per_page=num,
             exclude_terminated=exclude_terminated,
         )
 
@@ -190,7 +194,7 @@ def list_sandboxes_cmd(
                 "sandboxes": sandboxes_data,
                 "total": sandbox_list.total,
                 "page": sandbox_list.page,
-                "per_page": sandbox_list.per_page,
+                "per_page": num,
                 "has_next": sandbox_list.has_next,
             }
             output_data_as_json(output_data, console)


### PR DESCRIPTION
Adds --num/-n flag to `prime deployments list` (default 20), matching the pattern from `prime rl list`.

- CLI: new `--num` option, defaults to 20 most recent
- API client: passes limit/offset params to backend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing CLI flags and JSON output shapes change (e.g., replacing `--offset/--limit` or `--skip` with `--page/--num`), which may break existing scripts despite being straightforward pagination logic.
> 
> **Overview**
> Adds **page-based pagination** (`--num/--page`) across several CLI list commands (deployments, env list/actions, evals list, RL runs, sandbox list), including input validation and a consistent "no more results" UX.
> 
> Updates the deployments API/client to send `limit`/`offset` and return `(adapters, total)`, and extends adapter listings to surface `step` (new model field + table column) and include pagination metadata (`total`, `page`, `per_page`) in JSON output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b089e1d16ba284fccb0a9c7a42ed2179c0c9640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->