### PR TITLE
Release: Bump prime cli to 0.5.42

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.41"
+__version__ = "0.5.42"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Changes since v0.5.41:

- Add pagination to deployments list command + step field (#409)
- Add adapter upload configuration support (#384)
- Add deployable-models check (#408)
- Fix setting role when changing team (#395)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the exposed package version string, with no functional or behavioral changes.
> 
> **Overview**
> Bumps the Prime CLI version constant in `prime_cli/__init__.py` from `0.5.41` to `0.5.42` so commands that display/report `__version__` (e.g., upgrade checks and user-agent strings) reflect the new release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa3ca48a6776b80fa1e6b4c85eb4c073d14cae3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->