### PR TITLE
Add fallback for eval_list team_id missing #375

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -110,12 +110,21 @@ def list_evals(
         client = EvalsClient(api_client)
 
         skip = (page - 1) * num
-        data = client.list_evaluations(
-            env_name=env,
-            team_id=config.team_id,
-            skip=skip,
-            limit=num,
-        )
+        try:
+            data = client.list_evaluations(
+                env_name=env,
+                team_id=config.team_id,
+                skip=skip,
+                limit=num,
+            )
+        except TypeError as e:
+            if "team_id" not in str(e):
+                raise
+            data = client.list_evaluations(
+                env_name=env,
+                skip=skip,
+                limit=num,
+            )
 
         if output == "json":
             output_data_as_json(data, console)

--- a/packages/prime/tests/test_eval_list_compat.py
+++ b/packages/prime/tests/test_eval_list_compat.py
@@ -63,7 +63,7 @@ def test_list_evals_passes_team_id_when_client_supports_it(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(evals_cmd, "APIClient", lambda: object())
-    monkeypatch.setattr(evals_cmd, "Config", lambda: _ConfigNoTeam())
+    monkeypatch.setattr(evals_cmd, "Config", lambda: _ConfigWithTeam())
     monkeypatch.setattr(evals_cmd, "EvalsClient", lambda _api: client)
     monkeypatch.setattr(evals_cmd, "output_data_as_json", lambda data, _console: captured.update(data))
 
@@ -75,5 +75,5 @@ def test_list_evals_passes_team_id_when_client_supports_it(monkeypatch):
         "suite_id": None,
         "skip": 0,
         "limit": 50,
-        "team_id": None,
+        "team_id": "team-123",
     }

--- a/packages/prime/tests/test_eval_list_compat.py
+++ b/packages/prime/tests/test_eval_list_compat.py
@@ -1,0 +1,79 @@
+from prime_cli.commands import evals as evals_cmd
+
+
+class _OldEvalsClient:
+    def __init__(self) -> None:
+        self.called_kwargs = None
+
+    def list_evaluations(self, env_name=None, suite_id=None, skip=0, limit=50):
+        self.called_kwargs = {
+            "env_name": env_name,
+            "suite_id": suite_id,
+            "skip": skip,
+            "limit": limit,
+        }
+        return {"evaluations": [], "total": 0}
+
+
+class _NewEvalsClient:
+    def __init__(self) -> None:
+        self.called_kwargs = None
+
+    def list_evaluations(self, env_name=None, suite_id=None, skip=0, limit=50, *, team_id=None):
+        self.called_kwargs = {
+            "env_name": env_name,
+            "suite_id": suite_id,
+            "skip": skip,
+            "limit": limit,
+            "team_id": team_id,
+        }
+        return {"evaluations": [], "total": 0}
+
+
+class _ConfigWithTeam:
+    team_id = "team-123"
+
+
+class _ConfigNoTeam:
+    team_id = None
+
+
+def test_list_evals_falls_back_when_client_does_not_support_team_id(monkeypatch):
+    client = _OldEvalsClient()
+    captured = {}
+
+    monkeypatch.setattr(evals_cmd, "APIClient", lambda: object())
+    monkeypatch.setattr(evals_cmd, "Config", lambda: _ConfigWithTeam())
+    monkeypatch.setattr(evals_cmd, "EvalsClient", lambda _api: client)
+    monkeypatch.setattr(evals_cmd, "output_data_as_json", lambda data, _console: captured.update(data))
+
+    evals_cmd.list_evals(output="json", num=10, page=3, env="hubert-marek/agent-diff-bench")
+
+    assert captured == {"evaluations": [], "total": 0}
+    assert client.called_kwargs == {
+        "env_name": "hubert-marek/agent-diff-bench",
+        "suite_id": None,
+        "skip": 20,
+        "limit": 10,
+    }
+
+
+def test_list_evals_passes_team_id_when_client_supports_it(monkeypatch):
+    client = _NewEvalsClient()
+    captured = {}
+
+    monkeypatch.setattr(evals_cmd, "APIClient", lambda: object())
+    monkeypatch.setattr(evals_cmd, "Config", lambda: _ConfigNoTeam())
+    monkeypatch.setattr(evals_cmd, "EvalsClient", lambda _api: client)
+    monkeypatch.setattr(evals_cmd, "output_data_as_json", lambda data, _console: captured.update(data))
+
+    evals_cmd.list_evals(output="json", num=50, page=1, env="hubert-marek/agent-diff-bench")
+
+    assert captured == {"evaluations": [], "total": 0}
+    assert client.called_kwargs == {
+        "env_name": "hubert-marek/agent-diff-bench",
+        "suite_id": None,
+        "skip": 0,
+        "limit": 50,
+        "team_id": None,
+    }


### PR DESCRIPTION
Hi, I’m adding a fix for backward compatibility with previous prime-evals versions. On Prime CLI v0.5.42 I hit:

<img width="916" height="100" alt="image" src="https://github.com/user-attachments/assets/cadb1f84-7bb8-4ca6-a3a5-6ab69b647a26" />

I added a fallback + regression test (feel free to remove) in the PR.

I think prime-evals already has the root fix in the repo, but it hasn’t been released yet. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized CLI compatibility change plus tests; main risk is masking unrelated `TypeError`s if the error message differs from expectations.
> 
> **Overview**
> Makes `prime eval list` **backward compatible** with older `prime-evals` clients by retrying `list_evaluations` *without* `team_id` when passing `team_id` raises a `TypeError` mentioning that argument.
> 
> Adds regression tests covering both behaviors: passing `team_id` when supported and falling back when it is not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e83d0eb08ceb27d114e3268a0840faf0f07492d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->