### PR TITLE
registry creds cli

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -126,6 +126,9 @@ class APIClient:
             )
             response.raise_for_status()
 
+            if response.status_code == 204 and not response.content:
+                return {}
+
             result = response.json()
             if not isinstance(result, dict):
                 raise APIError("API response was not a dictionary")
@@ -236,6 +239,9 @@ class AsyncAPIClient:
                 method, url, params=params, json=json, timeout=timeout
             )
             response.raise_for_status()
+
+            if response.status_code == 204 and not response.content:
+                return {}
 
             result = response.json()
             if not isinstance(result, dict):

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -170,6 +170,7 @@ class RegistryCredentialSummary(BaseModel):
 
     id: str
     name: str
+    username: Optional[str] = None
     server: str
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: datetime = Field(..., alias="updatedAt")

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1970,6 +1970,10 @@ class TemplateClient:
             payload["password"] = password
         if server is not None:
             payload["server"] = server
+        if not payload:
+            raise ValueError(
+                "At least one field (name, username, password, server) must be provided to update"
+            )
         params: Dict[str, str] = {}
         if team_id:
             params["teamId"] = team_id
@@ -2074,6 +2078,10 @@ class AsyncTemplateClient:
             payload["password"] = password
         if server is not None:
             payload["server"] = server
+        if not payload:
+            raise ValueError(
+                "At least one field (name, username, password, server) must be provided to update"
+            )
         params: Dict[str, str] = {}
         if team_id:
             params["teamId"] = team_id

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1919,6 +1919,70 @@ class TemplateClient:
         )
         return DockerImageCheckResponse.model_validate(response)
 
+    def create_registry_credential(
+        self,
+        name: str,
+        username: str,
+        password: str,
+        server: str,
+        team_id: Optional[str] = None,
+    ) -> RegistryCredentialSummary:
+        payload: Dict[str, Any] = {
+            "name": name,
+            "username": username,
+            "password": password,
+            "server": server,
+        }
+        if team_id:
+            payload["teamId"] = team_id
+        response = self.client.request("POST", "/template/registry-credentials", json=payload)
+        data = response.get("data", response)
+        return RegistryCredentialSummary.model_validate(data)
+
+    def update_registry_credential(
+        self,
+        credential_id: str,
+        name: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        server: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> RegistryCredentialSummary:
+        payload: Dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if username is not None:
+            payload["username"] = username
+        if password is not None:
+            payload["password"] = password
+        if server is not None:
+            payload["server"] = server
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        response = self.client.request(
+            "PATCH",
+            f"/template/registry-credentials/{credential_id}",
+            json=payload,
+            params=params or None,
+        )
+        data = response.get("data", response)
+        return RegistryCredentialSummary.model_validate(data)
+
+    def delete_registry_credential(
+        self,
+        credential_id: str,
+        team_id: Optional[str] = None,
+    ) -> None:
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        self.client.request(
+            "DELETE",
+            f"/template/registry-credentials/{credential_id}",
+            params=params or None,
+        )
+
 
 class AsyncTemplateClient:
     """Async client for template/registry helper APIs."""
@@ -1943,6 +2007,70 @@ class AsyncTemplateClient:
             json=payload,
         )
         return DockerImageCheckResponse.model_validate(response)
+
+    async def create_registry_credential(
+        self,
+        name: str,
+        username: str,
+        password: str,
+        server: str,
+        team_id: Optional[str] = None,
+    ) -> RegistryCredentialSummary:
+        payload: Dict[str, Any] = {
+            "name": name,
+            "username": username,
+            "password": password,
+            "server": server,
+        }
+        if team_id:
+            payload["teamId"] = team_id
+        response = await self.client.request("POST", "/template/registry-credentials", json=payload)
+        data = response.get("data", response)
+        return RegistryCredentialSummary.model_validate(data)
+
+    async def update_registry_credential(
+        self,
+        credential_id: str,
+        name: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        server: Optional[str] = None,
+        team_id: Optional[str] = None,
+    ) -> RegistryCredentialSummary:
+        payload: Dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if username is not None:
+            payload["username"] = username
+        if password is not None:
+            payload["password"] = password
+        if server is not None:
+            payload["server"] = server
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        response = await self.client.request(
+            "PATCH",
+            f"/template/registry-credentials/{credential_id}",
+            json=payload,
+            params=params or None,
+        )
+        data = response.get("data", response)
+        return RegistryCredentialSummary.model_validate(data)
+
+    async def delete_registry_credential(
+        self,
+        credential_id: str,
+        team_id: Optional[str] = None,
+    ) -> None:
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        await self.client.request(
+            "DELETE",
+            f"/template/registry-credentials/{credential_id}",
+            params=params or None,
+        )
 
     async def aclose(self) -> None:
         """Close the async client"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1901,8 +1901,17 @@ class TemplateClient:
     def __init__(self, api_client: Optional[APIClient] = None):
         self.client = api_client or APIClient()
 
-    def list_registry_credentials(self) -> List[RegistryCredentialSummary]:
-        response = self.client.request("GET", "/template/registry-credentials")
+    def list_registry_credentials(
+        self, team_id: Optional[str] = None
+    ) -> List[RegistryCredentialSummary]:
+        if team_id is None:
+            team_id = self.client.config.team_id
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        response = self.client.request(
+            "GET", "/template/registry-credentials", params=params or None
+        )
         credentials = response.get("credentials", [])
         return [RegistryCredentialSummary.model_validate(item) for item in credentials]
 
@@ -1927,6 +1936,8 @@ class TemplateClient:
         server: str,
         team_id: Optional[str] = None,
     ) -> RegistryCredentialSummary:
+        if team_id is None:
+            team_id = self.client.config.team_id
         payload: Dict[str, Any] = {
             "name": name,
             "username": username,
@@ -1948,6 +1959,8 @@ class TemplateClient:
         server: Optional[str] = None,
         team_id: Optional[str] = None,
     ) -> RegistryCredentialSummary:
+        if team_id is None:
+            team_id = self.client.config.team_id
         payload: Dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -1974,6 +1987,8 @@ class TemplateClient:
         credential_id: str,
         team_id: Optional[str] = None,
     ) -> None:
+        if team_id is None:
+            team_id = self.client.config.team_id
         params: Dict[str, str] = {}
         if team_id:
             params["teamId"] = team_id
@@ -1990,8 +2005,17 @@ class AsyncTemplateClient:
     def __init__(self, api_client: Optional[AsyncAPIClient] = None):
         self.client = api_client or AsyncAPIClient()
 
-    async def list_registry_credentials(self) -> List[RegistryCredentialSummary]:
-        response = await self.client.request("GET", "/template/registry-credentials")
+    async def list_registry_credentials(
+        self, team_id: Optional[str] = None
+    ) -> List[RegistryCredentialSummary]:
+        if team_id is None:
+            team_id = self.client.config.team_id
+        params: Dict[str, str] = {}
+        if team_id:
+            params["teamId"] = team_id
+        response = await self.client.request(
+            "GET", "/template/registry-credentials", params=params or None
+        )
         credentials = response.get("credentials", [])
         return [RegistryCredentialSummary.model_validate(item) for item in credentials]
 
@@ -2016,6 +2040,8 @@ class AsyncTemplateClient:
         server: str,
         team_id: Optional[str] = None,
     ) -> RegistryCredentialSummary:
+        if team_id is None:
+            team_id = self.client.config.team_id
         payload: Dict[str, Any] = {
             "name": name,
             "username": username,
@@ -2037,6 +2063,8 @@ class AsyncTemplateClient:
         server: Optional[str] = None,
         team_id: Optional[str] = None,
     ) -> RegistryCredentialSummary:
+        if team_id is None:
+            team_id = self.client.config.team_id
         payload: Dict[str, Any] = {}
         if name is not None:
             payload["name"] = name
@@ -2063,6 +2091,8 @@ class AsyncTemplateClient:
         credential_id: str,
         team_id: Optional[str] = None,
     ) -> None:
+        if team_id is None:
+            team_id = self.client.config.team_id
         params: Dict[str, str] = {}
         if team_id:
             params["teamId"] = team_id

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -215,6 +215,7 @@ def create_registry_credential(
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
@@ -247,12 +248,21 @@ def update_registry_credential(
             credential_id = selected["id"]
 
         if not any_provided(name, username, password, server):
-            console.print("\n[bold]What would you like to update?[/bold]")
+            console.print("\n[bold]Update fields (press Enter to skip):[/bold]")
+            new_name = prompt_for_value("New name", required=False)
+            if new_name:
+                name = new_name
+            new_username = prompt_for_value("New username", required=False)
+            if new_username:
+                username = new_username
             new_password = prompt_for_value("New password", required=False, hide_input=True)
             if new_password:
                 password = new_password
+            new_server = prompt_for_value("New server", required=False)
+            if new_server:
+                server = new_server
 
-            if not password:
+            if not any_provided(name, username, password, server):
                 console.print("\n[dim]No changes made.[/dim]")
                 raise typer.Exit()
 
@@ -283,6 +293,7 @@ def update_registry_credential(
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)
 
 
@@ -338,4 +349,5 @@ def delete_registry_credential(
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -199,7 +199,7 @@ def create_registry_credential(
             return
 
         scope = "team" if config.team_id else "personal"
-        console.print(f"[green]Created {scope} registry credential '{name}'[/green]")
+        console.print(f"[green]✓ Created {scope} registry credential '{name}'[/green]")
         console.print(f"[dim]ID: {credential.id}[/dim]")
 
     except KeyboardInterrupt:
@@ -215,7 +215,7 @@ def create_registry_credential(
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
-        console.print_exception(show_locals=True)
+        console.print_exception()
         raise typer.Exit(1)
 
 
@@ -280,7 +280,7 @@ def update_registry_credential(
             output_data_as_json(_format_registry_row(credential), console)
             return
 
-        console.print(f"[green]Updated registry credential '{credential.name}'[/green]")
+        console.print(f"[green]✓ Updated registry credential '{credential.name}'[/green]")
 
     except KeyboardInterrupt:
         console.print("\n[dim]Cancelled.[/dim]")
@@ -295,7 +295,7 @@ def update_registry_credential(
         raise typer.Exit(1)
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
-        console.print_exception(show_locals=True)
+        console.print_exception()
         raise typer.Exit(1)
 
 
@@ -322,10 +322,7 @@ def delete_registry_credential(
             credential_id = selected["id"]
             credential_name = selected["name"]
         else:
-            # Fetch credential name for confirmation
-            credentials = _fetch_credentials(client)
-            match = next((c for c in credentials if c["id"] == credential_id), None)
-            credential_name = match["name"] if match else credential_id
+            credential_name = credential_id
 
         if not yes:
             confirm = typer.confirm(f"Delete registry credential '{credential_name}'?")
@@ -336,7 +333,7 @@ def delete_registry_credential(
         client.delete_registry_credential(
             credential_id=credential_id,
         )
-        console.print(f"[green]Deleted registry credential '{credential_name}'[/green]")
+        console.print(f"[green]✓ Deleted registry credential '{credential_name}'[/green]")
 
     except KeyboardInterrupt:
         console.print("\n[dim]Cancelled.[/dim]")

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -35,6 +35,7 @@ def _format_registry_row(credential: RegistryCredentialSummary) -> dict:
     return {
         "id": credential.id,
         "name": credential.name,
+        "username": credential.username,
         "server": server,
         "scope": scope,
         "team_id": credential.team_id,

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 from prime_sandboxes import (
@@ -20,6 +20,7 @@ from ..utils import (
     output_data_as_json,
     validate_output_format,
 )
+from ..utils.prompt import any_provided, prompt_for_value, require_selection
 
 app = typer.Typer(help="Manage registry credentials and private images", no_args_is_help=True)
 console = Console()
@@ -133,4 +134,210 @@ def check_docker_image(
     except Exception as e:
         console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
         console.print_exception(show_locals=True)
+        raise typer.Exit(1)
+
+
+def _fetch_credentials(client: TemplateClient) -> List[Dict[str, Any]]:
+    """Fetch registry credentials as dicts for interactive selection."""
+    credentials = client.list_registry_credentials()
+    return [{"id": c.id, "name": c.name, "server": c.server} for c in credentials]
+
+
+def _credential_display(item: Dict[str, Any]) -> str:
+    return f"{item['name']} ({item['server']})"
+
+
+@app.command("create")
+def create_registry_credential(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Credential name"),
+    username: Optional[str] = typer.Option(None, "--username", "-u", help="Registry username"),
+    password: Optional[str] = typer.Option(None, "--password", "-p", help="Registry password"),
+    server: Optional[str] = typer.Option(
+        None, "--server", "-s", help="Registry server (e.g. ghcr.io)"
+    ),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Create a new registry credential."""
+    validate_output_format(output, console)
+
+    try:
+        if not name:
+            name = prompt_for_value("Credential name")
+            if not name:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        if not username:
+            username = prompt_for_value("Registry username")
+            if not username:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        if not password:
+            password = prompt_for_value("Registry password", hide_input=True)
+            if not password:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        if not server:
+            server = prompt_for_value("Registry server (e.g. ghcr.io, docker.io)")
+            if not server:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        client = TemplateClient(APIClient())
+        credential = client.create_registry_credential(
+            name=name,
+            username=username,
+            password=password,
+            server=server,
+            team_id=config.team_id,
+        )
+
+        if output == "json":
+            output_data_as_json(_format_registry_row(credential), console)
+            return
+
+        scope = "team" if config.team_id else "personal"
+        console.print(f"[green]Created {scope} registry credential '{name}'[/green]")
+        console.print(f"[dim]ID: {credential.id}[/dim]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except typer.Exit:
+        raise
+    except UnauthorizedError as e:
+        console.print(f"[red]Unauthorized:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        raise typer.Exit(1)
+
+
+@app.command("update")
+def update_registry_credential(
+    credential_id: Optional[str] = typer.Argument(
+        None, help="Credential ID to update (interactive selection if not provided)"
+    ),
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="New credential name"),
+    username: Optional[str] = typer.Option(None, "--username", "-u", help="New registry username"),
+    password: Optional[str] = typer.Option(None, "--password", "-p", help="New registry password"),
+    server: Optional[str] = typer.Option(None, "--server", "-s", help="New registry server"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Update an existing registry credential."""
+    validate_output_format(output, console)
+
+    try:
+        client = TemplateClient(APIClient())
+
+        if not credential_id:
+            credentials = _fetch_credentials(client)
+            selected = require_selection(
+                credentials,
+                "update",
+                "No registry credentials to update.",
+                item_type="credential",
+                display_fn=_credential_display,
+            )
+            credential_id = selected["id"]
+
+        if not any_provided(name, username, password, server):
+            console.print("\n[bold]What would you like to update?[/bold]")
+            new_password = prompt_for_value("New password", required=False, hide_input=True)
+            if new_password:
+                password = new_password
+
+            if not password:
+                console.print("\n[dim]No changes made.[/dim]")
+                raise typer.Exit()
+
+        credential = client.update_registry_credential(
+            credential_id=credential_id,
+            name=name,
+            username=username,
+            password=password,
+            server=server,
+            team_id=config.team_id,
+        )
+
+        if output == "json":
+            output_data_as_json(_format_registry_row(credential), console)
+            return
+
+        console.print(f"[green]Updated registry credential '{credential.name}'[/green]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except typer.Exit:
+        raise
+    except UnauthorizedError as e:
+        console.print(f"[red]Unauthorized:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        raise typer.Exit(1)
+
+
+@app.command("delete")
+def delete_registry_credential(
+    credential_id: Optional[str] = typer.Argument(
+        None, help="Credential ID to delete (interactive selection if not provided)"
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a registry credential."""
+    try:
+        client = TemplateClient(APIClient())
+
+        if not credential_id:
+            credentials = _fetch_credentials(client)
+            selected = require_selection(
+                credentials,
+                "delete",
+                "No registry credentials to delete.",
+                item_type="credential",
+                display_fn=_credential_display,
+            )
+            credential_id = selected["id"]
+            credential_name = selected["name"]
+        else:
+            # Fetch credential name for confirmation
+            credentials = _fetch_credentials(client)
+            match = next((c for c in credentials if c["id"] == credential_id), None)
+            credential_name = match["name"] if match else credential_id
+
+        if not yes:
+            confirm = typer.confirm(f"Delete registry credential '{credential_name}'?")
+            if not confirm:
+                console.print("\n[dim]Cancelled.[/dim]")
+                raise typer.Exit()
+
+        client.delete_registry_credential(
+            credential_id=credential_id,
+            team_id=config.team_id,
+        )
+        console.print(f"[green]Deleted registry credential '{credential_name}'[/green]")
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+    except typer.Exit:
+        raise
+    except UnauthorizedError as e:
+        console.print(f"[red]Unauthorized:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -191,7 +191,6 @@ def create_registry_credential(
             username=username,
             password=password,
             server=server,
-            team_id=config.team_id,
         )
 
         if output == "json":
@@ -262,7 +261,6 @@ def update_registry_credential(
             username=username,
             password=password,
             server=server,
-            team_id=config.team_id,
         )
 
         if output == "json":
@@ -323,7 +321,6 @@ def delete_registry_credential(
 
         client.delete_registry_credential(
             credential_id=credential_id,
-            team_id=config.team_id,
         )
         console.print(f"[green]Deleted registry credential '{credential_name}'[/green]")
 

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -255,7 +255,9 @@ def update_registry_credential(
             new_username = prompt_for_value("New username", required=False)
             if new_username:
                 username = new_username
-            new_password = prompt_for_value("New password", required=False, hide_input=True)
+            new_password = prompt_for_value(
+                "New password (input hidden, Enter to skip)", required=False, hide_input=True
+            )
             if new_password:
                 password = new_password
             new_server = prompt_for_value("New server", required=False)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new SDK and CLI flows that create/update/delete registry credentials and handle passwords, which can affect users’ ability to access private images if request/response handling is incorrect. Also changes HTTP response parsing to treat empty 204 responses as `{}`, which could mask unexpected server behavior if misapplied.
> 
> **Overview**
> Adds **create/update/delete** support for registry credentials in the SDK (`TemplateClient`/`AsyncTemplateClient`) and exposes it via new `prime registry create|update|delete` commands with interactive prompting/selection when arguments are omitted.
> 
> Extends `RegistryCredentialSummary` with optional `username`, passes optional `teamId` when listing/mutating credentials, and updates the core HTTP client(s) to return `{}` for empty `204 No Content` responses instead of attempting JSON parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d3f63af93876477fc4f682e2cecaf4ca8eb74c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->