### PR TITLE
streamline backend help

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -35,7 +35,7 @@ from ..utils.prompt import (
     validate_env_var_name,
 )
 from ..utils.time_utils import format_time_ago, iso_timestamp
-from ..verifiers_bridge import print_env_build_help, print_env_init_help
+from ..verifiers_bridge import is_help_request, print_env_build_help, print_env_init_help
 from ..verifiers_plugin import load_verifiers_prime_plugin, resolve_workspace_python
 
 app = typer.Typer(help="Manage verifiers environments", no_args_is_help=True)
@@ -1403,22 +1403,24 @@ def push(
     context_settings={
         "allow_extra_args": True,
         "ignore_unknown_options": True,
+        "help_option_names": [],
     },
 )
 def init(
     ctx: typer.Context,
-    name: str = typer.Argument(..., help="Name of the new environment"),
-    backend_help: bool = typer.Option(
-        False,
-        "--backend-help",
-        help="Show backend vf-init help (all passthrough flags/options)",
-    ),
+    name: Optional[str] = typer.Argument(None, help="Name of the new environment"),
 ) -> None:
     """Initialize a new environment."""
     passthrough_args = list(ctx.args)
-    if backend_help:
+
+    if is_help_request(name or "", passthrough_args):
         print_env_init_help()
         raise typer.Exit(0)
+
+    if name is None:
+        console.print("[red]Error:[/red] Missing argument 'NAME'.")
+        console.print("[dim]Example: prime env init my-env --path ./environments[/dim]")
+        raise typer.Exit(2)
 
     if name.startswith("-"):
         console.print("[red]Error:[/red] Environment name must be the first argument.")
@@ -1438,22 +1440,26 @@ def init(
     context_settings={
         "allow_extra_args": True,
         "ignore_unknown_options": True,
+        "help_option_names": [],
     },
 )
 def build(
     ctx: typer.Context,
-    env_id: str = typer.Argument(..., help="Environment ID (hyphenated, e.g. openenv-echo)"),
-    backend_help: bool = typer.Option(
-        False,
-        "--backend-help",
-        help="Show backend vf-build help (all passthrough flags/options)",
+    env_id: Optional[str] = typer.Argument(
+        None, help="Environment ID (hyphenated, e.g. openenv-echo)"
     ),
 ) -> None:
     """Build an OpenEnv-backed environment image."""
     passthrough_args = list(ctx.args)
-    if backend_help:
+
+    if is_help_request(env_id or "", passthrough_args):
         print_env_build_help()
         raise typer.Exit(0)
+
+    if env_id is None:
+        console.print("[red]Error:[/red] Missing argument 'ENV_ID'.")
+        console.print("[dim]Example: prime env build openenv-echo --path ./environments[/dim]")
+        raise typer.Exit(2)
 
     if env_id.startswith("-"):
         console.print("[red]Error:[/red] Environment ID must be the first argument.")
@@ -1519,8 +1525,7 @@ def pull(
                 target_dir = base_dir.parent / f"{base_dir.name}-{index}"
                 index += 1
             console.print(
-                f"[yellow]Directory {base_dir} already exists. "
-                f"Using {target_dir} instead.[/yellow]"
+                f"[yellow]Directory {base_dir} already exists. Using {target_dir} instead.[/yellow]"
             )
 
         try:

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -16,6 +16,7 @@ from ..core import Config
 from ..utils import output_data_as_json
 from ..utils.eval_push import load_results_jsonl
 from ..verifiers_bridge import (
+    is_help_request,
     print_eval_run_help,
     run_eval_passthrough,
     run_eval_tui,
@@ -553,18 +554,14 @@ app.add_typer(subcommands_app, name="")
     context_settings={
         "allow_extra_args": True,
         "ignore_unknown_options": True,
+        "help_option_names": [],
     },
 )
 def run_eval_cmd(
     ctx: typer.Context,
-    environment: str = typer.Argument(
-        ...,
+    environment: Optional[str] = typer.Argument(
+        None,
         help="Environment name/slug or TOML config path",
-    ),
-    backend_help: bool = typer.Option(
-        False,
-        "--backend-help",
-        help="Show backend vf-eval help (all passthrough flags/options)",
     ),
     skip_upload: bool = typer.Option(
         False,
@@ -582,9 +579,15 @@ def run_eval_cmd(
 ) -> None:
     """Run an evaluation with local-first environment resolution."""
     passthrough_args = list(ctx.args)
-    if backend_help:
+
+    if is_help_request(environment or "", passthrough_args):
         print_eval_run_help()
         raise typer.Exit(0)
+
+    if environment is None:
+        console.print("[red]Error:[/red] Missing argument 'ENVIRONMENT'.")
+        console.print("[dim]Example: prime eval run gsm8k -n 10[/dim]")
+        raise typer.Exit(2)
 
     if environment.startswith("-"):
         console.print("[red]Error:[/red] Environment/config must be the first argument.")

--- a/packages/prime/src/prime_cli/commands/gepa.py
+++ b/packages/prime/src/prime_cli/commands/gepa.py
@@ -4,7 +4,7 @@ import typer
 from rich.console import Console
 from typer.core import TyperGroup
 
-from ..verifiers_bridge import print_gepa_run_help, run_gepa_passthrough
+from ..verifiers_bridge import is_help_request, print_gepa_run_help, run_gepa_passthrough
 
 console = Console()
 
@@ -44,25 +44,27 @@ app = typer.Typer(
     context_settings={
         "allow_extra_args": True,
         "ignore_unknown_options": True,
+        "help_option_names": [],
     },
 )
 def run_gepa_cmd(
     ctx: typer.Context,
-    environment_or_config: str = typer.Argument(
-        ...,
+    environment_or_config: str | None = typer.Argument(
+        None,
         help="Environment name/slug or TOML config path",
-    ),
-    backend_help: bool = typer.Option(
-        False,
-        "--backend-help",
-        help="Show backend vf-gepa help (all passthrough flags/options)",
     ),
 ) -> None:
     """Run optimization with local-first environment resolution."""
     passthrough_args = list(ctx.args)
-    if backend_help:
+
+    if is_help_request(environment_or_config or "", passthrough_args):
         print_gepa_run_help()
         raise typer.Exit(0)
+
+    if environment_or_config is None:
+        console.print("[red]Error:[/red] Missing argument 'ENV_OR_CONFIG'.")
+        console.print("[dim]Example: prime gepa run wordle --max-calls 100[/dim]")
+        raise typer.Exit(2)
 
     if environment_or_config.startswith("-"):
         console.print("[red]Error:[/red] Environment/config must be the first argument.")

--- a/packages/prime/src/prime_cli/commands/lab.py
+++ b/packages/prime/src/prime_cli/commands/lab.py
@@ -5,6 +5,7 @@ import subprocess
 import typer
 from rich.console import Console
 
+from ..verifiers_bridge import is_help_request, print_lab_setup_help
 from ..verifiers_plugin import load_verifiers_prime_plugin
 
 app = typer.Typer(help="Lab commands for verifiers development", no_args_is_help=True)
@@ -20,8 +21,13 @@ console = Console()
 )
 def setup(ctx: typer.Context) -> None:
     """Set up a verifiers training workspace."""
+    passthrough_args = list(ctx.args)
+    if is_help_request("", passthrough_args):
+        print_lab_setup_help()
+        raise typer.Exit(0)
+
     plugin = load_verifiers_prime_plugin(console=console)
-    command = plugin.build_module_command(plugin.setup_module, list(ctx.args))
+    command = plugin.build_module_command(plugin.setup_module, passthrough_args)
     result = subprocess.run(command)
     if result.returncode != 0:
         raise typer.Exit(result.returncode)

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -67,8 +67,16 @@ def _sanitize_help_text(help_text: str, module_name: str, prime_command: str) ->
     for idx, line in enumerate(lines):
         if line.lower().startswith("usage:"):
             suffix = line.split(":", 1)[1].strip()
-            parts = suffix.split(maxsplit=1)
-            suffix = parts[1] if len(parts) > 1 else ""
+            python_module_prefix = re.compile(
+                rf"^python(?:\d+(?:\.\d+)?)?\s+-m\s+{re.escape(module_name)}(?:\s+|$)"
+            )
+            module_prefix = re.compile(rf"^{re.escape(module_name)}(?:\s+|$)")
+            match = python_module_prefix.match(suffix) or module_prefix.match(suffix)
+            if match is not None:
+                suffix = suffix[match.end() :].lstrip()
+            else:
+                parts = suffix.split(maxsplit=1)
+                suffix = parts[1] if len(parts) > 1 else ""
             lines[idx] = f"Usage: {prime_command}{(' ' + suffix) if suffix else ''}"
             break
 
@@ -82,6 +90,8 @@ def _sanitize_help_text(help_text: str, module_name: str, prime_command: str) ->
         sanitized = sanitized.replace(module_alias, command_alias)
 
     sanitized = re.sub(r"\bvf-[a-z0-9-]+\b", prime_command, sanitized)
+    if prime_command in {"prime eval run", "prime gepa run"}:
+        sanitized = re.sub(r"\benv_id_or_config\b", "environment", sanitized)
     return sanitized.rstrip() + "\n"
 
 
@@ -155,6 +165,18 @@ def print_env_build_help() -> None:
         )
     except Exception as exc:
         console.print(f"[red]Failed to load help for prime env build:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    _write_help(help_text)
+
+
+def print_lab_setup_help() -> None:
+    try:
+        help_text = _load_help_text(
+            load_verifiers_prime_plugin(console=console).setup_module,
+            "prime lab setup",
+        )
+    except Exception as exc:
+        console.print(f"[red]Failed to load help for prime lab setup:[/red] {exc}")
         raise typer.Exit(1) from exc
     _write_help(help_text)
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -116,6 +116,18 @@ def _write_help(text: str) -> None:
     sys.stdout.flush()
 
 
+def _append_eval_options(help_text: str) -> str:
+    extra_lines = [
+        "  --skip-upload        Skip uploading evaluation results to the platform.",
+        "  --env-path PATH      Explicit path for upstream environment metadata.",
+    ]
+    lines = help_text.rstrip("\n").splitlines()
+    if any("--skip-upload" in line or "--env-path" in line for line in lines):
+        return help_text.rstrip() + "\n"
+    lines.extend(extra_lines)
+    return "\n".join(lines) + "\n"
+
+
 def print_eval_run_help() -> None:
     try:
         help_text = _load_help_text(
@@ -125,12 +137,7 @@ def print_eval_run_help() -> None:
     except Exception as exc:
         console.print(f"[red]Failed to load help for prime eval run:[/red] {exc}")
         raise typer.Exit(1) from exc
-    _write_help(help_text)
-    _write_help(
-        "\nPrime-only options:\n"
-        "  --skip-upload        Skip uploading evaluation results to the platform.\n"
-        "  --env-path PATH      Explicit path for upstream environment metadata.\n"
-    )
+    _write_help(_append_eval_options(help_text))
 
 
 def print_gepa_run_help() -> None:

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -1,0 +1,39 @@
+from prime_cli.main import app
+from prime_cli.verifiers_bridge import _sanitize_help_text
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_eval_run_help_flags_use_backend_help(monkeypatch):
+    def fake_help() -> None:
+        print("BACKEND_HELP")
+
+    monkeypatch.setattr("prime_cli.commands.evals.print_eval_run_help", fake_help)
+    for flag in ("-h", "--help"):
+        result = runner.invoke(app, ["eval", "run", flag], env={"PRIME_DISABLE_VERSION_CHECK": "1"})
+        assert result.exit_code == 0, result.output
+        assert "BACKEND_HELP" in result.output
+
+
+def test_lab_setup_help_flag_uses_backend_help(monkeypatch):
+    def fake_help() -> None:
+        print("BACKEND_HELP")
+
+    monkeypatch.setattr("prime_cli.commands.lab.print_lab_setup_help", fake_help)
+    result = runner.invoke(app, ["lab", "setup", "-h"], env={"PRIME_DISABLE_VERSION_CHECK": "1"})
+    assert result.exit_code == 0, result.output
+    assert "BACKEND_HELP" in result.output
+
+
+def test_sanitize_help_removes_vf_eval_aliases():
+    raw = (
+        "usage: python -m verifiers.cli.commands.eval [-h] env_id_or_config\n"
+        "Run vf-eval with verifiers.cli.commands.eval\n"
+    )
+    help_text = _sanitize_help_text(raw, "verifiers.cli.commands.eval", "prime eval run")
+
+    assert "Usage: prime eval run [-h] environment" in help_text
+    assert "verifiers.cli.commands.eval" not in help_text
+    assert "vf-eval" not in help_text
+    assert "env_id_or_config" not in help_text


### PR DESCRIPTION
`prime eval run --help/-h` now does a direct printout of the backend help without needing an extra hop

```
~/dev/prime-cli (feat/streamline-backend-help) uv run prime eval run --help
Usage: prime eval run [-h] [--env-args ENV_ARGS] [--env-dir-path ENV_DIR_PATH]
               [--endpoints-path ENDPOINTS_PATH] [--model MODEL]
               [--api-key-var API_KEY_VAR] [--api-base-url API_BASE_URL]
               [--header HEADER] [--num-examples NUM_EXAMPLES]
               [--rollouts-per-example ROLLOUTS_PER_EXAMPLE]
               [--max-concurrent MAX_CONCURRENT] [--max-tokens MAX_TOKENS]
               [--temperature TEMPERATURE] [--sampling-args SAMPLING_ARGS]
               [--verbose] [--no-interleave-scoring]
               [--state-columns STATE_COLUMNS] [--save-results]
               [--resume [PATH]] [--independent-scoring] [--save-to-hf-hub]
               [--hf-hub-dataset-name HF_HUB_DATASET_NAME]
               [--extra-env-kwargs EXTRA_ENV_KWARGS] [--tui] [--debug]
               [--max-retries MAX_RETRIES]
               environment
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily affects CLI help/argument parsing and help-text rewriting, with minimal impact on core execution paths; risk is limited to potential regressions in command invocation edge cases.
> 
> **Overview**
> Streamlines `prime` CLI passthrough commands so `-h/--help` prints the backend verifiers help directly (without a dedicated `--backend-help` flag) for `eval run`, `gepa run`, `env init`, `env build`, and `lab setup`.
> 
> This disables Typer’s default help option for these passthrough commands (`help_option_names: []`), makes the primary argument optional so help flags can be parsed, and adds explicit “missing argument” errors when no target is provided. Help output sanitization is improved in `verifiers_bridge` (more robust `Usage:` rewriting, eval/gepa arg rename, and idempotent injection of Prime-only eval flags), with new tests covering the help behavior and sanitization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72d7d470c6b6ef1f604d8f4d1d2c43eb7b8e5145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->