### PR TITLE
Release: Bump prime-evals to 0.1.11

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 __all__ = [
     # Core HTTP Client & Config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple version bump with no functional code changes beyond the reported package version string.
> 
> **Overview**
> Bumps the `prime-evals` SDK version from `0.1.10` to `0.1.11` by updating `__version__` in `prime_evals/__init__.py` (affecting the user-agent string that includes the package version).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a12d34c61aa7622ad9819a4958b1f1f6cb23b8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->