### PR TITLE
Add compute_size support to CLI

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -134,6 +134,7 @@ class RLClient:
         adapters_config: Optional[Dict[str, Any]] = None,
         checkpoint_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
+        infrastructure_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -206,6 +207,10 @@ class RLClient:
 
             if cluster_name:
                 payload["cluster_name"] = cluster_name
+
+            if infrastructure_config:
+                if "compute_size" in infrastructure_config:
+                    payload["compute_size"] = infrastructure_config["compute_size"]
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -202,6 +202,10 @@ id = "{env_value}"
 # [adapters]
 # interval = 0                # Upload adapter every N steps (0 = only at run end)
 # keep_last = 3               # Keep N adapters in cloud (-1 = keep all)
+
+# Optional: infrastructure configuration
+# [infrastructure]
+# compute_size = "standard"   # "standard" (default) or "large" for more CPU/memory
 '''
 
 
@@ -389,6 +393,18 @@ class AdaptersConfig(BaseModel):
         return result if result else None
 
 
+class InfrastructureConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    compute_size: str | None = None
+
+    def to_api_dict(self) -> Dict[str, Any] | None:
+        d: Dict[str, Any] = {}
+        if self.compute_size is not None:
+            d["compute_size"] = self.compute_size
+        return d if d else None
+
+
 class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -411,6 +427,7 @@ class RLConfig(BaseModel):
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
+    infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
 
@@ -661,6 +678,11 @@ def create_run(
             if cfg.val.interval:
                 console.print(f"  Interval:     {cfg.val.interval}")
 
+        # Infrastructure
+        if cfg.infrastructure.compute_size:
+            console.print("\n[cyan]Infrastructure[/cyan]")
+            console.print(f"  Compute Size: {cfg.infrastructure.compute_size}")
+
         # Checkpoint warm-start
         if cfg.checkpoint_id:
             console.print(f"\n[cyan]Warm-start from checkpoint:[/cyan] {cfg.checkpoint_id}")
@@ -748,6 +770,7 @@ def create_run(
             adapters_config=cfg.adapters.to_api_dict(),
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
+            infrastructure_config=cfg.infrastructure.to_api_dict(),
         )
 
         if output == "json":

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -205,7 +205,7 @@ id = "{env_value}"
 
 # Optional: infrastructure configuration
 # [infrastructure]
-# compute_size = "standard"   # "standard" (default) or "large" for more CPU/memory
+# compute_size = "M"          # S, M (default), or L
 '''
 
 


### PR DESCRIPTION
CLI side of compute_size (t-shirt sizing) for RFT containers.

- Adds `InfrastructureConfig` with `compute_size` field
- New `[infrastructure]` section in TOML config template
- Passes `compute_size` through API client to backend
- Displays compute size in run config output

Companion PR: https://github.com/PrimeIntellect-ai/platform/pull/840

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only introduces an optional config field and passes it through to the run-create API payload.
> 
> **Overview**
> Adds optional infrastructure sizing to RL run creation via a new `[infrastructure]` TOML section and `InfrastructureConfig` (currently exposing `compute_size`).
> 
> When present, the CLI now prints the selected compute size in the pre-run configuration summary and forwards it through `RLClient.create_run` as `compute_size` in the `/rft/runs` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce10ce3a816392b528f02cf5d8e3f1d0d6d62805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->