### PR TITLE
Release: Bump prime cli to 0.5.43

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.42"
+__version__ = "0.5.43"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Changes since v0.5.42:

- Add compute_size infrastructure config support (#415)
- Streamline backend help (#413)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string only change with no functional code modifications.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.42` to `0.5.43` in `packages/prime/src/prime_cli/__init__.py` for the next release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad5751eb08888f5433117f15532c948d6278522b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->