### PR TITLE
Fix eval billing check.

### DIFF
--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -12,6 +12,31 @@ class InferenceAPIError(Exception):
     pass
 
 
+class InferencePaymentRequiredError(InferenceAPIError):
+    pass
+
+
+def _extract_error_message(response: httpx.Response) -> str:
+    text = response.text.strip()
+    return text or response.reason_phrase or "Unknown error"
+
+
+def _extract_payment_error_message(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return _extract_error_message(response)
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+
+    return _extract_error_message(response)
+
+
 class InferenceClient:
     """
     Minimal client for the OpenAI-compatible Prime Inference API:
@@ -57,9 +82,13 @@ class InferenceClient:
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
-            raise InferenceAPIError(
-                f"GET {url} failed: {e.response.status_code} {e.response.text}"
-            ) from e
+            status = e.response.status_code
+            message = _extract_error_message(e.response)
+            if status == 402:
+                raise InferencePaymentRequiredError(
+                    f"Payment required. {_extract_payment_error_message(e.response)}"
+                ) from e
+            raise InferenceAPIError(f"GET {url} failed: {status} {message}") from e
         return resp.json()
 
     def retrieve_model(self, model_id: str) -> Dict[str, Any]:
@@ -69,12 +98,17 @@ class InferenceClient:
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
+            message = _extract_error_message(e.response)
             # Treat common "unknown model" responses as a dedicated error
             if status in (400, 404, 422):
                 raise InferenceAPIError(
                     f"Model '{model_id}' not found or unavailable (GET {url} → {status})."
                 ) from e
-            raise InferenceAPIError(f"GET {url} failed: {status} {e.response.text}") from e
+            if status == 402:
+                raise InferencePaymentRequiredError(
+                    f"Payment required. {_extract_payment_error_message(e.response)}"
+                ) from e
+            raise InferenceAPIError(f"GET {url} failed: {status} {message}") from e
         return resp.json()
 
     def chat_completion(
@@ -87,15 +121,28 @@ class InferenceClient:
             try:
                 resp.raise_for_status()
             except httpx.HTTPStatusError as e:
-                raise InferenceAPIError(
-                    f"POST {url} failed: {e.response.status_code} {e.response.text}"
-                ) from e
+                status = e.response.status_code
+                message = _extract_error_message(e.response)
+                if status == 402:
+                    raise InferencePaymentRequiredError(
+                        f"Payment required. {_extract_payment_error_message(e.response)}"
+                    ) from e
+                raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
             return resp.json()
 
         # Streamed (SSE-style: lines prefixed with 'data: ')
         def _stream() -> Iterator[Dict[str, Any]]:
             with self._client.stream("POST", url, json=payload) as r:
-                r.raise_for_status()
+                try:
+                    r.raise_for_status()
+                except httpx.HTTPStatusError as e:
+                    status = e.response.status_code
+                    message = _extract_error_message(e.response)
+                    if status == 402:
+                        raise InferencePaymentRequiredError(
+                            f"Payment required. {_extract_payment_error_message(e.response)}"
+                        ) from e
+                    raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
                 for line in r.iter_lines():
                     if not line:
                         continue

--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -127,6 +127,7 @@ class InferenceClient:
                 try:
                     r.raise_for_status()
                 except httpx.HTTPStatusError as e:
+                    e.response.read()
                     status = e.response.status_code
                     message = _extract_error_message(e.response)
                     if status == 402:

--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -23,18 +23,9 @@ def _extract_error_message(response: httpx.Response) -> str:
 
 def _extract_payment_error_message(response: httpx.Response) -> str:
     try:
-        payload = response.json()
-    except ValueError:
+        return response.json()["error"]["message"].strip()
+    except Exception:
         return _extract_error_message(response)
-
-    if isinstance(payload, dict):
-        error = payload.get("error")
-        if isinstance(error, dict):
-            message = error.get("message")
-            if isinstance(message, str) and message.strip():
-                return message.strip()
-
-    return _extract_error_message(response)
 
 
 class InferenceClient:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -18,7 +18,7 @@ from rich.console import Console
 
 from prime_cli.core import Config
 
-from .api.inference import InferenceAPIError, InferenceClient
+from .api.inference import InferenceAPIError, InferenceClient, InferencePaymentRequiredError
 from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
 from .utils.eval_push import push_eval_results_to_hub
@@ -784,6 +784,26 @@ def _validate_model(model: str, inference_base_url: str, configured_base_url: st
         raise typer.Exit(1) from exc
 
 
+def _preflight_inference_billing(
+    model: str, inference_base_url: str, configured_base_url: str
+) -> None:
+    if inference_base_url != configured_base_url:
+        return
+
+    client = InferenceClient()
+    try:
+        client.chat_completion(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with OK."}],
+                "max_tokens": 1,
+            }
+        )
+    except InferencePaymentRequiredError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
 def _build_job_id(env_name: str, model: str) -> str:
     eval_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     job_uuid = str(uuid.uuid4())[:8]
@@ -843,7 +863,9 @@ def run_eval_passthrough(
         raise typer.Exit(1)
 
     args, env, model, base_url = _add_default_inference_and_key_args(passthrough_args, config)
-    _validate_model(model, base_url, (config.inference_url or "").strip().rstrip("/"))
+    configured_base_url = (config.inference_url or "").strip().rstrip("/")
+    _validate_model(model, base_url, configured_base_url)
+    _preflight_inference_billing(model, base_url, configured_base_url)
 
     env_dir_path = _parse_value_option(args, "--env-dir-path", "-p") or DEFAULT_ENV_DIR_PATH
     run_target = environment

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -1,0 +1,95 @@
+import httpx
+import pytest
+import typer
+from prime_cli.api.inference import (
+    InferenceClient,
+    InferencePaymentRequiredError,
+)
+from prime_cli.verifiers_bridge import run_eval_passthrough
+
+
+class DummyConfig:
+    api_key = "test-api-key"
+    inference_url = "https://api.pinference.ai/api/v1"
+    team_id = None
+
+
+class DummyPlugin:
+    eval_module = "verifiers.cli.commands.eval"
+
+    def build_module_command(self, module: str, args: list[str]) -> list[str]:
+        return [module, *args]
+
+
+def test_inference_client_maps_402_to_billing_error(monkeypatch):
+    client = InferenceClient.__new__(InferenceClient)
+    client.inference_url = "https://api.pinference.ai/api/v1"
+
+    request = httpx.Request("GET", f"{client.inference_url}/models")
+    response = httpx.Response(
+        402,
+        request=request,
+        json={
+            "error": {
+                "message": (
+                    "Insufficient balance (including overdraft). Please add funds to continue."
+                ),
+                "type": "insufficient_quota",
+                "code": "insufficient_funds",
+                "param": None,
+            },
+            "request_id": "req-123",
+            "inference_id": "inf-123",
+        },
+    )
+
+    class DummyHTTPClient:
+        def get(self, url):
+            return response
+
+    client._client = DummyHTTPClient()
+
+    with pytest.raises(
+        InferencePaymentRequiredError,
+        match="Payment required\\. Insufficient balance",
+    ):
+        client.list_models()
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        (
+            "Payment required. Please check your billing status at "
+            "https://app.primeintellect.ai/dashboard/billing"
+        ),
+        "Insufficient balance (including overdraft). Please add funds to continue.",
+    ],
+)
+def test_eval_run_blocks_when_inference_billing_is_missing(monkeypatch, error_message):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
+        lambda self, model: {"id": model},
+    )
+
+    def fake_chat_completion(self, payload, stream=False):
+        raise InferencePaymentRequiredError(error_message)
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
+        fake_chat_completion,
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="single_turn_math",
+            passthrough_args=["-m", "deepseek/deepseek-chat"],
+            skip_upload=False,
+            env_path=None,
+        )
+
+    assert exc_info.value.exit_code == 1

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 import typer
 from prime_cli.api.inference import (
+    InferenceAPIError,
     InferenceClient,
     InferencePaymentRequiredError,
 )
@@ -93,3 +94,36 @@ def test_eval_run_blocks_when_inference_billing_is_missing(monkeypatch, error_me
         )
 
     assert exc_info.value.exit_code == 1
+
+
+def test_streaming_error_reads_response_before_formatting(monkeypatch):
+    client = InferenceClient.__new__(InferenceClient)
+    client.inference_url = "https://api.pinference.ai/api/v1"
+
+    request = httpx.Request("POST", f"{client.inference_url}/chat/completions")
+    response = httpx.Response(
+        500,
+        request=request,
+        stream=httpx.ByteStream(b"upstream boom"),
+    )
+
+    class DummyStreamResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+    class DummyHTTPClient:
+        def stream(self, method, url, json):
+            return DummyStreamResponse()
+
+    client._client = DummyHTTPClient()
+
+    with pytest.raises(InferenceAPIError, match="POST .* 500 upstream boom"):
+        next(client.chat_completion({"model": "x", "messages": []}, stream=True))
+
+    assert response.text == "upstream boom"


### PR DESCRIPTION
Closes ENG-3100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/exception handling and adds a new preflight network call that can stop eval runs early on mis-detected billing/402 responses or transient API failures.
> 
> **Overview**
> `InferenceClient` now normalizes HTTP error messages and maps HTTP `402` responses from model and chat endpoints into a dedicated `InferencePaymentRequiredError`, including improved extraction of server-provided error text (and reading streamed bodies before formatting errors).
> 
> `prime eval run` adds a preflight chat request against the configured inference base URL to fail fast with a clear billing error before kicking off an eval run. New tests cover 402-to-billing error mapping, the eval preflight exit behavior, and streamed error body handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37cea5b478a274bb2f369e7f9fc6c31baae4dc27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->