### PR TITLE
Feature: Add team switch command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,10 @@ prime eval samples <eval-id>
 # List teams
 prime teams list
 
-# Set team context
-prime config set-team-id
+# Switch context
+prime switch
+prime switch personal
+prime switch <team-slug>
 ```
 
 ## Development

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -168,17 +168,20 @@ prime sandbox delete <sandbox-id>
 
 ### Team Management
 
-Manage resources across team contexts:
+Manage resources across personal and team contexts:
 
 ```bash
 # List your teams
 prime teams list
 
-# Set team context
-prime config set-team-id <team-id>
+# Switch context directly
+prime switch
+prime switch personal
+prime switch <team-slug>
+prime switch <team-id>  # fallback for teams without a slug
 
-# All subsequent commands use team context
-prime pods list  # Shows team's pods
+# All subsequent commands use the selected context
+prime pods list
 ```
 
 ## Configuration

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -15,17 +15,20 @@ app = typer.Typer(
 )
 console = Console()
 
+PERSONAL_TARGET = "personal"
+
 
 def _select_team_by_target(teams: list[dict], target: str) -> Optional[dict]:
     normalized_target = target.strip().lower()
+
     for team in teams:
-        team_slug = str(team.get("slug", "")).strip().lower()
-        if team_slug and team_slug == normalized_target:
+        slug = team.get("slug")
+        if slug and slug.strip().lower() == normalized_target:
             return team
 
     for team in teams:
-        team_id = str(team.get("teamId", "")).strip().lower()
-        if team_id and team_id == normalized_target:
+        team_id = team.get("teamId")
+        if team_id and team_id.strip().lower() == normalized_target:
             return team
 
     return None
@@ -59,7 +62,9 @@ def _print_available_slugs(teams: list[dict]) -> None:
 
 @app.callback(invoke_without_command=True)
 def switch(
-    target: Optional[str] = typer.Argument(None, help="'personal', a team slug, or a team ID"),
+    target: Optional[str] = typer.Argument(
+        None, help=f"'{PERSONAL_TARGET}', a team slug, or a team ID"
+    ),
 ) -> None:
     """Switch the active account context."""
     config = Config()
@@ -70,6 +75,12 @@ def switch(
             "Clear it before using [bold]prime switch[/bold]."
         )
         raise typer.Exit(1)
+
+    if target is not None:
+        normalized_target = target.strip().lower()
+        if normalized_target == PERSONAL_TARGET:
+            _switch_to_personal(config)
+            return
 
     try:
         client = APIClient()
@@ -82,11 +93,6 @@ def switch(
         raise typer.Exit(1)
 
     if target is not None:
-        normalized_target = target.strip().lower()
-        if normalized_target == "personal":
-            _switch_to_personal(config)
-            return
-
         selected_team = _select_team_by_target(teams, normalized_target)
         if selected_team is None:
             console.print(f"[red]Team '{target}' not found.[/red]")

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -1,0 +1,126 @@
+from typing import Optional
+
+import typer
+from click.exceptions import Abort
+from rich.console import Console
+
+from prime_cli.core import Config
+
+from ..client import APIClient, APIError
+from .teams import fetch_teams
+
+app = typer.Typer(
+    help="Switch between your personal account and team contexts",
+    no_args_is_help=False,
+)
+console = Console()
+
+
+def _select_team_by_target(teams: list[dict], target: str) -> Optional[dict]:
+    normalized_target = target.strip().lower()
+    for team in teams:
+        team_slug = str(team.get("slug", "")).strip().lower()
+        if team_slug and team_slug == normalized_target:
+            return team
+
+    for team in teams:
+        team_id = str(team.get("teamId", "")).strip().lower()
+        if team_id and team_id == normalized_target:
+            return team
+
+    return None
+
+
+def _switch_to_personal(config: Config) -> None:
+    config.set_team(None)
+    config.update_current_environment_file()
+    console.print("[green]Switched to personal account.[/green]")
+
+
+def _switch_to_team(config: Config, team: dict) -> None:
+    team_id = team.get("teamId")
+    team_name = team.get("name", "Unknown")
+    team_role = team.get("role", "member")
+
+    if not team_id:
+        console.print("[red]Error:[/red] Selected team is missing a team ID.")
+        raise typer.Exit(1)
+
+    config.set_team(team_id, team_name=team_name, team_role=team_role)
+    config.update_current_environment_file()
+    console.print(f"[green]Switched to team '{team_name}'.[/green]")
+
+
+def _print_available_slugs(teams: list[dict]) -> None:
+    slugs = [str(team.get("slug", "")).strip() for team in teams if team.get("slug")]
+    if slugs:
+        console.print(f"[dim]Available teams: {', '.join(sorted(slugs))}[/dim]")
+
+
+@app.callback(invoke_without_command=True)
+def switch(
+    target: Optional[str] = typer.Argument(None, help="'personal', a team slug, or a team ID"),
+) -> None:
+    """Switch the active account context."""
+    config = Config()
+
+    if config.team_id_from_env:
+        console.print(
+            "[red]Error:[/red] PRIME_TEAM_ID is set in your environment. "
+            "Clear it before using [bold]prime switch[/bold]."
+        )
+        raise typer.Exit(1)
+
+    try:
+        client = APIClient()
+        teams = fetch_teams(client)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+    if target is not None:
+        normalized_target = target.strip().lower()
+        if normalized_target == "personal":
+            _switch_to_personal(config)
+            return
+
+        selected_team = _select_team_by_target(teams, normalized_target)
+        if selected_team is None:
+            console.print(f"[red]Team '{target}' not found.[/red]")
+            _print_available_slugs(teams)
+            raise typer.Exit(1)
+
+        _switch_to_team(config, selected_team)
+        return
+
+    console.print("\n[bold]Switch account:[/bold]\n")
+    current_team_id = config.team_id
+
+    personal_label = "Personal"
+    if current_team_id is None:
+        personal_label += " [green](current)[/green]"
+    console.print(f"  [cyan](1)[/cyan] {personal_label}")
+
+    for idx, team in enumerate(teams, start=2):
+        name = team.get("name", "Unknown")
+        slug = str(team.get("slug") or "").strip()
+        role = str(team.get("role", "member")).lower()
+        current_badge = " [green](current)[/green]" if team.get("teamId") == current_team_id else ""
+        details = f"slug: {slug}, role: {role}" if slug else f"role: {role}"
+        console.print(f"  [cyan]({idx})[/cyan] {name} [dim]({details})[/dim]{current_badge}")
+
+    while True:
+        try:
+            selection = typer.prompt("Select", type=int, default=1)
+            if selection == 1:
+                _switch_to_personal(config)
+                return
+            if 2 <= selection <= len(teams) + 1:
+                _switch_to_team(config, teams[selection - 2])
+                return
+            console.print(f"[red]Invalid selection. Enter 1-{len(teams) + 1}.[/red]")
+        except Abort:
+            raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -90,14 +90,15 @@ class Config:
     def team_id(self) -> Optional[str]:
         """Get team ID with precedence: env > file > None."""
         env_val = os.getenv("PRIME_TEAM_ID")
-        if env_val is not None:
-            return env_val or None
+        if env_val is not None and env_val.strip():
+            return env_val
         return self.config.get("team_id") or None
 
     @property
     def team_id_from_env(self) -> bool:
         """Check if team ID is set via environment variable."""
-        return os.getenv("PRIME_TEAM_ID") is not None
+        env_val = os.getenv("PRIME_TEAM_ID")
+        return bool(env_val and env_val.strip())
 
     @property
     def team_name(self) -> Optional[str]:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -21,6 +21,7 @@ from .commands.registry import app as registry_app
 from .commands.rl import app as rl_app
 from .commands.sandbox import app as sandbox_app
 from .commands.secrets import app as secret_app
+from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
@@ -56,6 +57,7 @@ app.add_typer(inference_app, name="inference", rich_help_panel="Compute")
 # Account commands
 app.add_typer(login_app, name="login", rich_help_panel="Account")
 app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
+app.add_typer(switch_app, name="switch", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")
 app.add_typer(teams_app, name="teams", rich_help_panel="Account")
 app.add_typer(secret_app, name="secret", rich_help_panel="Account")

--- a/packages/prime/tests/test_switch.py
+++ b/packages/prime/tests/test_switch.py
@@ -6,6 +6,13 @@ from typer.testing import CliRunner
 
 runner = CliRunner()
 
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+    "PRIME_TEAM_ID": "",
+}
+
 
 @pytest.fixture
 def temp_home(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -48,11 +55,7 @@ def mock_teams_api(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestSwitchCommand:
     def test_switch_to_personal(self, temp_home: None, mock_teams_api: None) -> None:
-        result = runner.invoke(
-            app,
-            ["switch", "personal"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "personal"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Switched to personal account." in result.output
@@ -67,31 +70,19 @@ class TestSwitchCommand:
         )
         monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
 
-        result = runner.invoke(
-            app,
-            ["switch", "personal"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "personal"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Switched to personal account." in result.output
 
     def test_switch_to_team_slug(self, temp_home: None, mock_teams_api: None) -> None:
-        result = runner.invoke(
-            app,
-            ["switch", "prime"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "prime"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Switched to team 'Prime Team'." in result.output
 
     def test_switch_to_team_id_fallback(self, temp_home: None, mock_teams_api: None) -> None:
-        result = runner.invoke(
-            app,
-            ["switch", "cmf0ohr9s0026ilerf3w68s6n"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "cmf0ohr9s0026ilerf3w68s6n"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Switched to team 'Prime Team'." in result.output
@@ -99,11 +90,7 @@ class TestSwitchCommand:
     def test_switch_to_unknown_team_slug_shows_available_teams(
         self, temp_home: None, mock_teams_api: None
     ) -> None:
-        result = runner.invoke(
-            app,
-            ["switch", "unknown"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "unknown"], env=TEST_ENV)
 
         assert result.exit_code == 1, result.output
         assert "Team 'unknown' not found." in result.output
@@ -136,22 +123,13 @@ class TestSwitchCommand:
         monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
         monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
 
-        result = runner.invoke(
-            app,
-            ["switch", "none"],
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch", "none"], env=TEST_ENV)
 
         assert result.exit_code == 1, result.output
         assert "Team 'none' not found." in result.output
 
     def test_switch_interactive_selection(self, temp_home: None, mock_teams_api: None) -> None:
-        result = runner.invoke(
-            app,
-            ["switch"],
-            input="2\n",
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch"], input="2\n", env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Switch account:" in result.output
@@ -190,12 +168,7 @@ class TestSwitchCommand:
         monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
         monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
 
-        result = runner.invoke(
-            app,
-            ["switch"],
-            input="1\n",
-            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
-        )
+        result = runner.invoke(app, ["switch"], input="1\n", env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "Personal (current)" not in result.output

--- a/packages/prime/tests/test_switch.py
+++ b/packages/prime/tests/test_switch.py
@@ -1,0 +1,165 @@
+from typing import Any, Dict, Optional
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def temp_home(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+@pytest.fixture
+def mock_teams_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+    teams = [
+        {
+            "teamId": "cmf0ohr9s0026ilerf3w68s6n",
+            "name": "Prime Team",
+            "slug": "prime",
+            "role": "admin",
+            "createdAt": "2026-01-15T10:00:00Z",
+        },
+        {
+            "teamId": "cmf0ohr9s0026ilerf3w68s6m",
+            "name": "Research Team",
+            "slug": "research",
+            "role": "member",
+            "createdAt": "2026-01-15T10:00:00Z",
+        },
+    ]
+
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if endpoint == "/user/teams":
+            return {"data": teams}
+        if endpoint == "/user/whoami":
+            return {"data": {"id": "user-123"}}
+        return {"data": []}
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+
+class TestSwitchCommand:
+    def test_switch_to_personal(self, temp_home: None, mock_teams_api: None) -> None:
+        result = runner.invoke(
+            app,
+            ["switch", "personal"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Switched to personal account." in result.output
+
+    def test_switch_to_team_slug(self, temp_home: None, mock_teams_api: None) -> None:
+        result = runner.invoke(
+            app,
+            ["switch", "prime"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Switched to team 'Prime Team'." in result.output
+
+    def test_switch_to_team_id_fallback(self, temp_home: None, mock_teams_api: None) -> None:
+        result = runner.invoke(
+            app,
+            ["switch", "cmf0ohr9s0026ilerf3w68s6n"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Switched to team 'Prime Team'." in result.output
+
+    def test_switch_to_unknown_team_slug_shows_available_teams(
+        self, temp_home: None, mock_teams_api: None
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["switch", "unknown"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "Team 'unknown' not found." in result.output
+        assert "Available teams: prime, research" in result.output
+
+    def test_switch_interactive_selection(self, temp_home: None, mock_teams_api: None) -> None:
+        result = runner.invoke(
+            app,
+            ["switch"],
+            input="2\n",
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Switch account:" in result.output
+        assert "Prime Team (slug: prime, role: admin)" in result.output
+        assert "Switched to team 'Prime Team'." in result.output
+
+    def test_switch_interactive_handles_missing_slug_without_double_current(
+        self, temp_home: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        config_dir = tmp_path / ".prime"
+        config_dir.mkdir()
+        (config_dir / "environments").mkdir()
+        (config_dir / "config.json").write_text(
+            '{"api_key":"","team_id":"cmf0ohr9s0026ilerf3w68s6n","team_name":"New team","team_role":"ADMIN","user_id":null,"base_url":"https://api.primeintellect.ai","frontend_url":"https://app.primeintellect.ai","inference_url":"https://api.pinference.ai/api/v1","ssh_key_path":"~/.ssh/id_rsa","current_environment":"production"}'
+        )
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            if endpoint == "/user/teams":
+                return {
+                    "data": [
+                        {
+                            "teamId": "cmf0ohr9s0026ilerf3w68s6n",
+                            "name": "New team",
+                            "slug": None,
+                            "role": "ADMIN",
+                            "createdAt": "2026-01-15T10:00:00Z",
+                        }
+                    ]
+                }
+            return {"data": []}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+        result = runner.invoke(
+            app,
+            ["switch"],
+            input="1\n",
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Personal (current)" not in result.output
+        assert "New team (role: admin) (current)" in result.output
+        assert "slug:" not in result.output
+
+    def test_switch_fails_when_team_is_forced_by_environment(
+        self, temp_home: None, mock_teams_api: None
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["switch", "personal"],
+            env={
+                "COLUMNS": "200",
+                "LINES": "50",
+                "PRIME_DISABLE_VERSION_CHECK": "1",
+                "PRIME_TEAM_ID": "cmf0ohr9s0026ilerf3w68s6n",
+            },
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "PRIME_TEAM_ID is set in your environment" in result.output

--- a/packages/prime/tests/test_switch.py
+++ b/packages/prime/tests/test_switch.py
@@ -57,6 +57,25 @@ class TestSwitchCommand:
         assert result.exit_code == 0, result.output
         assert "Switched to personal account." in result.output
 
+    def test_switch_to_personal_skips_team_fetch(
+        self, temp_home: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PRIME_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "prime_cli.commands.switch.fetch_teams",
+            lambda _client: pytest.fail("fetch_teams should not be called for personal switch"),
+        )
+        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+        result = runner.invoke(
+            app,
+            ["switch", "personal"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Switched to personal account." in result.output
+
     def test_switch_to_team_slug(self, temp_home: None, mock_teams_api: None) -> None:
         result = runner.invoke(
             app,
@@ -89,6 +108,42 @@ class TestSwitchCommand:
         assert result.exit_code == 1, result.output
         assert "Team 'unknown' not found." in result.output
         assert "Available teams: prime, research" in result.output
+
+    def test_switch_does_not_match_none_slug(
+        self, temp_home: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+
+        def mock_get(
+            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            if endpoint == "/user/teams":
+                return {
+                    "data": [
+                        {
+                            "teamId": "cmf0ohr9s0026ilerf3w68s6n",
+                            "name": "New team",
+                            "slug": None,
+                            "role": "ADMIN",
+                            "createdAt": "2026-01-15T10:00:00Z",
+                        }
+                    ]
+                }
+            if endpoint == "/user/whoami":
+                return {"data": {"id": "user-123"}}
+            return {"data": []}
+
+        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+        result = runner.invoke(
+            app,
+            ["switch", "none"],
+            env={"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "Team 'none' not found." in result.output
 
     def test_switch_interactive_selection(self, temp_home: None, mock_teams_api: None) -> None:
         result = runner.invoke(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how team context is selected and persisted, which can affect which account/team subsequent resource operations run against; new tests reduce regression risk but mis-switching could impact user workflows.
> 
> **Overview**
> Adds a new `prime switch` CLI command to change the active context between *personal* and a selected team, supporting interactive selection as well as `prime switch personal` and `prime switch <team-slug|team-id>`.
> 
> Updates config handling so `PRIME_TEAM_ID` only takes effect when non-empty (and blocks `prime switch` when it is set), wires the command into `main.py`, adds comprehensive tests for the new behavior, and updates both READMEs to document the new context-switching flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca94ec89bc2b5ad86878764b1850d87a4768495e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->