### PR TITLE
Feature: Hosted evals support

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -891,7 +891,7 @@ def stop_cmd(
     """Stop a running hosted evaluation."""
     try:
         client = APIClient()
-        result = client.post(f"/hosted-evaluations/{eval_id}/cancel")
+        result = client.patch(f"/hosted-evaluations/{eval_id}/cancel")
         message = result.get("message") or f"Evaluation {eval_id} cancelled."
         console.print(f"[green]✓ {message}[/green]")
         console.print(f"[dim]View results:[/dim] {get_eval_viewer_url(eval_id)}")

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1,8 +1,10 @@
+import asyncio
 import json
 import re
+import time
 from functools import wraps
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from prime_evals import EvalsAPIError, EvalsClient, InvalidEvaluationError
@@ -11,11 +13,29 @@ from rich.syntax import Syntax
 from rich.table import Table
 from typer.core import TyperGroup
 
-from ..client import APIClient
+from ..client import APIClient, APIError, AsyncAPIClient
 from ..core import Config
 from ..utils import output_data_as_json
+from ..utils.display import get_eval_viewer_url
+from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import load_results_jsonl
+from ..utils.hosted_eval import (
+    EvalStatus,
+    HostedEvalConfig,
+    clean_logs,
+    get_evaluation,
+    get_evaluation_logs,
+    get_new_log_lines,
+    run_hosted_evaluation,
+    stop_hosted_evaluation,
+)
 from ..verifiers_bridge import (
+    DEFAULT_ENV_DIR_PATH,
+    DEFAULT_MODEL,
+    _is_config_target,
+    _parse_value_option,
+    _resolve_environment_reference,
+    _split_owner_and_name,
     is_help_request,
     print_eval_run_help,
     run_eval_passthrough,
@@ -82,6 +102,231 @@ def format_output(data: dict, output: str) -> None:
     else:
         syntax = Syntax(json.dumps(data, indent=2), "json", theme="monokai")
         console.print(syntax)
+
+
+def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[str, str]]:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Error:[/red] invalid {option_name}: {exc}")
+        raise typer.Exit(1) from exc
+
+    if type(parsed) is not dict:
+        console.print(f"[red]Error:[/red] {option_name} must be a JSON object")
+        raise typer.Exit(1)
+
+    for key, value in parsed.items():
+        if type(key) is not str or type(value) is not str:
+            console.print(
+                f"[red]Error:[/red] {option_name} must contain only string keys and values"
+            )
+            raise typer.Exit(1)
+
+    return parsed
+
+
+def _fetch_eval_status(eval_id: str) -> dict[str, Any]:
+    async def _fetch() -> dict[str, Any]:
+        async with AsyncAPIClient() as client:
+            return await get_evaluation(client, eval_id)
+
+    return asyncio.run(_fetch())
+
+
+def _fetch_logs(eval_id: str) -> str:
+    async def _fetch() -> str:
+        async with AsyncAPIClient() as client:
+            return await get_evaluation_logs(client, eval_id)
+
+    return asyncio.run(_fetch())
+
+
+def _print_eval_status(eval_data: dict[str, Any]) -> None:
+    status_str, status = _parse_eval_status(eval_data)
+    color = status.color if status else "white"
+
+    console.print(f"[{color}]Status: {status_str}[/{color}]")
+
+    error_message = eval_data.get("error_message")
+    if error_message:
+        console.print(f"[red]Error:[/red] {error_message}")
+
+    viewer_url = eval_data.get("viewer_url")
+    if viewer_url:
+        console.print(f"[dim]View: {viewer_url}[/dim]")
+        return
+
+    eval_id = eval_data.get("evaluation_id")
+    if eval_id:
+        console.print(f"[dim]View: {get_eval_viewer_url(eval_id)}[/dim]")
+
+
+def _parse_eval_status(eval_data: dict[str, Any]) -> tuple[str, EvalStatus | None]:
+    raw_status = eval_data.get("status")
+    status_str = raw_status if type(raw_status) is str else "UNKNOWN"
+
+    try:
+        return status_str, EvalStatus(status_str)
+    except ValueError:
+        return status_str, None
+
+
+def _print_new_log_lines(previous_logs: str, current_logs: str) -> str:
+    if current_logs and current_logs != previous_logs:
+        for line in get_new_log_lines(previous_logs, current_logs):
+            console.print(line)
+        return current_logs
+    return previous_logs
+
+
+def _handle_log_poll_error(eval_id: str, exc: APIError, consecutive_errors: int) -> None:
+    if "404" in str(exc):
+        console.print(f"\n[red]Evaluation {eval_id} not found.[/red]")
+        raise typer.Exit(1) from exc
+
+    if "429" not in str(exc):
+        raise exc
+
+    if consecutive_errors >= 3:
+        console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
+        time.sleep(30)
+    else:
+        time.sleep(10)
+
+
+def _display_logs_follow(eval_id: str) -> None:
+    console.print(f"[dim]Watching logs for evaluation {eval_id}... (Ctrl+C to stop)[/dim]\n")
+
+    last_logs = ""
+    consecutive_errors = 0
+    no_logs_polls = 0
+
+    while True:
+        try:
+            eval_data = _fetch_eval_status(eval_id)
+            status_str, status = _parse_eval_status(eval_data)
+
+            if status and status in EvalStatus.terminal_statuses():
+                final_logs = clean_logs(_fetch_logs(eval_id))
+                _print_new_log_lines(last_logs, final_logs)
+                console.print()
+                _print_eval_status(eval_data)
+                if status != EvalStatus.COMPLETED:
+                    raise typer.Exit(1)
+                return
+
+            raw_logs = _fetch_logs(eval_id)
+            logs = clean_logs(raw_logs) if raw_logs else ""
+            consecutive_errors = 0
+
+            if logs:
+                last_logs = _print_new_log_lines(last_logs, logs)
+                no_logs_polls = 0
+            else:
+                no_logs_polls += 1
+
+            if no_logs_polls > 0 and no_logs_polls % 6 == 0:
+                console.print(f"[dim]Evaluation status: {status_str} (waiting for logs...)[/dim]")
+        except APIError as exc:
+            consecutive_errors += 1
+            _handle_log_poll_error(eval_id, exc, consecutive_errors)
+            continue
+
+        time.sleep(5)
+
+
+def _display_logs_once(eval_id: str, tail: int) -> None:
+    eval_data = _fetch_eval_status(eval_id)
+    raw_logs = _fetch_logs(eval_id)
+    logs = clean_logs(raw_logs) if raw_logs else ""
+
+    if logs:
+        for line in logs.splitlines()[-tail:]:
+            console.print(line)
+    else:
+        console.print("[yellow]No logs available.[/yellow]")
+
+    console.print()
+    _print_eval_status(eval_data)
+
+
+def _display_logs(eval_id: str, tail: int, follow: bool) -> None:
+    try:
+        if follow:
+            _display_logs_follow(eval_id)
+        else:
+            _display_logs_once(eval_id, tail)
+    except KeyboardInterrupt:
+        console.print("\n[dim]Stopped watching logs. Evaluation continues running.[/dim]")
+    except typer.Exit:
+        raise
+    except APIError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
+def _resolve_hosted_environment(
+    environment: str,
+    *,
+    env_dir_path: Optional[str],
+    env_path: Optional[str],
+) -> tuple[str, str]:
+    resolved = _resolve_environment_reference(environment, env_dir_path or DEFAULT_ENV_DIR_PATH)
+
+    if resolved.recommend_push:
+        console.print(
+            "[red]Error:[/red] hosted evaluations require an environment "
+            "that is published to the platform"
+        )
+        if resolved.platform_slug:
+            console.print(
+                "[yellow]Publish the latest local changes for "
+                f"{resolved.platform_slug} first.[/yellow]"
+            )
+        else:
+            console.print("[yellow]Publish the environment with `prime env push` first.[/yellow]")
+        raise typer.Exit(1)
+
+    platform_slug = resolved.platform_slug or resolved.upstream_slug
+    if platform_slug is None and env_path:
+        metadata = find_environment_metadata(
+            env_name=resolved.env_name,
+            env_path=Path(env_path),
+            module_name=resolved.env_name.replace("-", "_"),
+        )
+        owner = metadata.get("owner") if metadata else None
+        name = metadata.get("name") if metadata else None
+        if owner and name:
+            platform_slug = f"{owner}/{name}"
+
+    if platform_slug is None:
+        console.print(
+            "[red]Error:[/red] hosted evaluations require an upstream environment on the platform"
+        )
+        console.print(
+            "[yellow]Use an environment slug or publish the local environment "
+            "with `prime env push`.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    parts = _split_owner_and_name(platform_slug)
+    if parts is None:
+        console.print(f"[red]Error:[/red] invalid environment slug: {platform_slug}")
+        raise typer.Exit(1)
+
+    owner, env_name = parts
+    api_client = APIClient()
+    response = api_client.get(f"/environmentshub/{owner}/{env_name}/@latest")
+    details = response.get("data", response)
+    environment_id = details.get("id")
+    if not environment_id:
+        console.print(f"[red]Error:[/red] could not resolve environment id for {platform_slug}")
+        raise typer.Exit(1)
+
+    console.print(f"[dim]Using hosted environment {platform_slug}[/dim]")
+    return platform_slug, str(environment_id)
 
 
 @subcommands_app.command("list")
@@ -558,6 +803,31 @@ app = typer.Typer(
 app.add_typer(subcommands_app, name="")
 
 
+@app.command("logs", no_args_is_help=True)
+def logs_cmd(
+    eval_id: str = typer.Argument(..., help="Evaluation id to get logs for"),
+    tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
+) -> None:
+    """Get logs for a hosted evaluation."""
+    _display_logs(eval_id, tail, follow)
+
+
+@app.command("stop", no_args_is_help=True)
+def stop_cmd(
+    eval_id: str = typer.Argument(..., help="Evaluation id to stop"),
+) -> None:
+    """Stop a running hosted evaluation."""
+    try:
+        result = asyncio.run(stop_hosted_evaluation(eval_id))
+        message = result.get("message") or f"Evaluation {eval_id} cancelled."
+        console.print(f"[green]✓ {message}[/green]")
+        console.print(f"[dim]View results:[/dim] {get_eval_viewer_url(eval_id)}")
+    except APIError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
 @app.command(
     "run",
     help="Run an evaluation with API models (default provider = Prime Inference)",
@@ -587,6 +857,46 @@ def run_eval_cmd(
             "(used to locate .prime/.env-metadata.json for upstream resolution)"
         ),
     ),
+    hosted: bool = typer.Option(
+        False,
+        "--hosted",
+        help="Run the evaluation on the platform instead of locally",
+    ),
+    poll_interval: float = typer.Option(
+        10.0,
+        "--poll-interval",
+        help="Polling interval in seconds for hosted evaluation status",
+    ),
+    follow: bool = typer.Option(
+        False,
+        "--follow",
+        help="Follow hosted evaluation status and stream logs until completion",
+    ),
+    timeout_minutes: Optional[int] = typer.Option(
+        None,
+        "--timeout-minutes",
+        help="Timeout in minutes for hosted evaluation",
+    ),
+    allow_sandbox_access: bool = typer.Option(
+        False,
+        "--allow-sandbox-access",
+        help="Allow sandbox read/write access for hosted evaluations",
+    ),
+    allow_instances_access: bool = typer.Option(
+        False,
+        "--allow-instances-access",
+        help="Allow instance creation and management for hosted evaluations",
+    ),
+    custom_secrets: Optional[str] = typer.Option(
+        None,
+        "--custom-secrets",
+        help='Custom secrets for hosted eval as JSON (e.g. \'{"API_KEY":"xxx"}\')',
+    ),
+    eval_name: Optional[str] = typer.Option(
+        None,
+        "--eval-name",
+        help="Custom name for the hosted evaluation",
+    ),
 ) -> None:
     """Run an evaluation with local-first environment resolution."""
     passthrough_args = list(ctx.args)
@@ -604,6 +914,104 @@ def run_eval_cmd(
         console.print("[red]Error:[/red] Environment/config must be the first argument.")
         console.print("[dim]Example: prime eval run gsm8k -n 10[/dim]")
         raise typer.Exit(2)
+
+    env_dir_path = _parse_value_option(passthrough_args, "--env-dir-path", "-p")
+
+    if not hosted:
+        hosted_only_args = {
+            "--follow": follow,
+            "--poll-interval": poll_interval != 10.0,
+            "--timeout-minutes": timeout_minutes is not None,
+            "--allow-sandbox-access": allow_sandbox_access,
+            "--allow-instances-access": allow_instances_access,
+            "--custom-secrets": custom_secrets is not None,
+            "--eval-name": eval_name is not None,
+        }
+        used_hosted_only_args = [flag for flag, used in hosted_only_args.items() if used]
+        if used_hosted_only_args:
+            console.print(
+                "[red]Error:[/red] hosted-only options require `--hosted`: "
+                + ", ".join(used_hosted_only_args)
+            )
+            raise typer.Exit(1)
+
+    if hosted:
+        if _is_config_target(environment):
+            console.print(
+                "[red]Error:[/red] hosted evaluations require a single environment, "
+                "not a TOML config"
+            )
+            raise typer.Exit(1)
+
+        platform_slug, environment_id = _resolve_hosted_environment(
+            environment,
+            env_dir_path=env_dir_path,
+            env_path=env_path,
+        )
+        model = _parse_value_option(passthrough_args, "--model", "-m") or DEFAULT_MODEL
+        raw_num_examples = _parse_value_option(passthrough_args, "--num-examples", "-n")
+        raw_rollouts = _parse_value_option(
+            passthrough_args,
+            "--rollouts-per-example",
+            "-r",
+        )
+        raw_env_args = _parse_value_option(passthrough_args, "--env-args", "")
+
+        try:
+            num_examples = int(raw_num_examples) if raw_num_examples is not None else 5
+            rollouts_per_example = int(raw_rollouts) if raw_rollouts is not None else 3
+        except ValueError as exc:
+            console.print(
+                "[red]Error:[/red] --num-examples and --rollouts-per-example must be integers"
+            )
+            raise typer.Exit(1) from exc
+
+        if num_examples < -1 or rollouts_per_example < 1:
+            console.print(
+                "[red]Error:[/red] --num-examples must be >= -1 and "
+                "--rollouts-per-example must be >= 1"
+            )
+            raise typer.Exit(1)
+
+        hosted_config = HostedEvalConfig(
+            environment_id=environment_id,
+            inference_model=model,
+            num_examples=num_examples,
+            rollouts_per_example=rollouts_per_example,
+            env_args=_parse_json_option(raw_env_args, "--env-args"),
+            name=eval_name,
+            timeout_minutes=timeout_minutes,
+            allow_sandbox_access=allow_sandbox_access,
+            allow_instances_access=allow_instances_access,
+            custom_secrets=_parse_json_option(custom_secrets, "--custom-secrets"),
+        )
+
+        try:
+            result = asyncio.run(
+                run_hosted_evaluation(
+                    config=hosted_config,
+                    poll_interval=poll_interval,
+                    follow=False,
+                )
+            )
+        except APIError as exc:
+            console.print(f"[red]Hosted evaluation failed:[/red] {exc}")
+            raise typer.Exit(1) from exc
+
+        if follow:
+            console.print("[green]✓ Hosted evaluation started[/green]")
+            console.print(f"[cyan]Environment:[/cyan] {platform_slug}")
+            console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
+            console.print()
+            _display_logs(result.evaluation_id, tail=1000, follow=True)
+            return
+
+        console.print("[green]✓ Hosted evaluation started[/green]")
+        console.print(f"[cyan]Environment:[/cyan] {platform_slug}")
+        console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
+        console.print(f"[green]View results:[/green] {get_eval_viewer_url(result.evaluation_id)}")
+        console.print("[dim]View logs:[/dim] prime eval logs " + result.evaluation_id + " -f")
+        return
 
     run_eval_passthrough(
         environment=environment,

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -40,6 +40,18 @@ from ..verifiers_bridge import (
 
 console = Console()
 
+HOSTED_LOGS_DEFAULT_TAIL_LINES = 1000
+HOSTED_LOGS_DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+HOSTED_RUN_DEFAULT_POLL_INTERVAL_SECONDS = 10.0
+HOSTED_RUN_DEFAULT_NUM_EXAMPLES = 5
+HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE = 3
+HOSTED_LOGS_RATE_LIMIT_THRESHOLD = 3
+HOSTED_LOGS_RATE_LIMIT_WAIT_SECONDS = 30
+HOSTED_LOGS_RETRY_WAIT_SECONDS = 10
+HOSTED_LOGS_STATUS_UPDATE_EVERY_POLLS = 6
+EVAL_TABLE_MAX_TEXT_WIDTH = 30
+EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k -n 10"
+
 
 class DefaultGroup(TyperGroup):
     def __init__(self, *args, default_cmd_name: str = "run", **kwargs):
@@ -221,11 +233,13 @@ def _handle_log_poll_error(eval_id: str, exc: APIError, consecutive_errors: int)
     if "429" not in str(exc):
         raise exc
 
-    if consecutive_errors >= 3:
-        console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
-        time.sleep(30)
+    if consecutive_errors >= HOSTED_LOGS_RATE_LIMIT_THRESHOLD:
+        console.print(
+            f"[yellow]Rate limited. Waiting {HOSTED_LOGS_RATE_LIMIT_WAIT_SECONDS:.0f}s...[/yellow]"
+        )
+        time.sleep(HOSTED_LOGS_RATE_LIMIT_WAIT_SECONDS)
     else:
-        time.sleep(10)
+        time.sleep(HOSTED_LOGS_RETRY_WAIT_SECONDS)
 
 
 def _display_logs_follow(eval_id: str, poll_interval: float) -> None:
@@ -260,7 +274,7 @@ def _display_logs_follow(eval_id: str, poll_interval: float) -> None:
             else:
                 no_logs_polls += 1
 
-            if no_logs_polls > 0 and no_logs_polls % 6 == 0:
+            if no_logs_polls > 0 and no_logs_polls % HOSTED_LOGS_STATUS_UPDATE_EVERY_POLLS == 0:
                 console.print(f"[dim]Evaluation status: {status_str} (waiting for logs...)[/dim]")
         except APIError as exc:
             consecutive_errors += 1
@@ -290,7 +304,7 @@ def _display_logs(
     eval_id: str,
     tail: int,
     follow: bool,
-    poll_interval: float = 5.0,
+    poll_interval: float = HOSTED_LOGS_DEFAULT_POLL_INTERVAL_SECONDS,
 ) -> None:
     try:
         if follow:
@@ -436,8 +450,8 @@ def list_evals(
 
             table.add_row(
                 eval_id if eval_id else "",
-                str(env_name)[:30],
-                str(e.get("model_name", ""))[:30],
+                str(env_name)[:EVAL_TABLE_MAX_TEXT_WIDTH],
+                str(e.get("model_name", ""))[:EVAL_TABLE_MAX_TEXT_WIDTH],
                 str(e.get("status", "")),
                 str(num_examples),
                 str(rollouts_per_example),
@@ -845,10 +859,15 @@ app.add_typer(subcommands_app, name="")
 @app.command("logs", no_args_is_help=True)
 def logs_cmd(
     eval_id: str = typer.Argument(..., help="Evaluation id to get logs for"),
-    tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
+    tail: int = typer.Option(
+        HOSTED_LOGS_DEFAULT_TAIL_LINES,
+        "--tail",
+        "-n",
+        help="Number of lines to show",
+    ),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
     poll_interval: float = typer.Option(
-        5.0,
+        HOSTED_LOGS_DEFAULT_POLL_INTERVAL_SECONDS,
         "--poll-interval",
         help="Polling interval in seconds when following logs",
     ),
@@ -908,7 +927,7 @@ def run_eval_cmd(
         help="Run the evaluation on the platform instead of locally",
     ),
     poll_interval: float = typer.Option(
-        10.0,
+        HOSTED_RUN_DEFAULT_POLL_INTERVAL_SECONDS,
         "--poll-interval",
         help="Polling interval in seconds for hosted evaluation status",
     ),
@@ -952,12 +971,12 @@ def run_eval_cmd(
 
     if environment is None:
         console.print("[red]Error:[/red] Missing argument 'ENVIRONMENT'.")
-        console.print("[dim]Example: prime eval run gsm8k -n 10[/dim]")
+        console.print(f"[dim]Example: {EVAL_RUN_EXAMPLE_COMMAND}[/dim]")
         raise typer.Exit(2)
 
     if environment.startswith("-"):
         console.print("[red]Error:[/red] Environment/config must be the first argument.")
-        console.print("[dim]Example: prime eval run gsm8k -n 10[/dim]")
+        console.print(f"[dim]Example: {EVAL_RUN_EXAMPLE_COMMAND}[/dim]")
         raise typer.Exit(2)
 
     env_dir_path = _parse_value_option(passthrough_args, "--env-dir-path", "-p")
@@ -965,7 +984,7 @@ def run_eval_cmd(
     if not hosted:
         hosted_only_args = {
             "--follow": follow,
-            "--poll-interval": poll_interval != 10.0,
+            "--poll-interval": poll_interval != HOSTED_RUN_DEFAULT_POLL_INTERVAL_SECONDS,
             "--timeout-minutes": timeout_minutes is not None,
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
@@ -1003,8 +1022,16 @@ def run_eval_cmd(
         raw_env_args = _parse_value_option(passthrough_args, "--env-args", "")
 
         try:
-            num_examples = int(raw_num_examples) if raw_num_examples is not None else 5
-            rollouts_per_example = int(raw_rollouts) if raw_rollouts is not None else 3
+            num_examples = (
+                int(raw_num_examples)
+                if raw_num_examples is not None
+                else HOSTED_RUN_DEFAULT_NUM_EXAMPLES
+            )
+            rollouts_per_example = (
+                int(raw_rollouts)
+                if raw_rollouts is not None
+                else HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE
+            )
         except ValueError as exc:
             console.print(
                 "[red]Error:[/red] --num-examples and --rollouts-per-example must be integers"
@@ -1044,7 +1071,7 @@ def run_eval_cmd(
             console.print()
             _display_logs(
                 result.evaluation_id,
-                tail=1000,
+                tail=HOSTED_LOGS_DEFAULT_TAIL_LINES,
                 follow=True,
                 poll_interval=poll_interval,
             )

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -52,6 +52,8 @@ HOSTED_LOGS_RETRY_WAIT_SECONDS = 10
 HOSTED_LOGS_STATUS_UPDATE_EVERY_POLLS = 6
 EVAL_TABLE_MAX_TEXT_WIDTH = 30
 EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k -n 10"
+EVAL_HOSTED_LABEL = "HOSTED"
+EVAL_LOCAL_LABEL = "LOCAL"
 
 
 class DefaultGroup(TyperGroup):
@@ -435,6 +437,7 @@ def list_evals(
         table.add_column("Environment", style="blue")
         table.add_column("Model", style="magenta")
         table.add_column("Status", style="yellow")
+        table.add_column("Type", style="green", justify="center")
         table.add_column("Examples", style="dim", justify="right")
         table.add_column("Rollouts", style="dim", justify="right")
 
@@ -449,11 +452,15 @@ def list_evals(
             if environment_names and len(environment_names) > 0:
                 env_name = environment_names[0]
 
+            is_hosted = bool(e.get("is_hosted"))
+            execution_mode = EVAL_HOSTED_LABEL if is_hosted else EVAL_LOCAL_LABEL
+
             table.add_row(
                 eval_id if eval_id else "",
                 str(env_name)[:EVAL_TABLE_MAX_TEXT_WIDTH],
                 str(e.get("model_name", ""))[:EVAL_TABLE_MAX_TEXT_WIDTH],
                 str(e.get("status", "")),
+                execution_mode,
                 str(num_examples),
                 str(rollouts_per_example),
             )

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -226,14 +226,6 @@ def _parse_eval_status(eval_data: dict[str, Any]) -> tuple[str, EvalStatus | Non
         return status_str, None
 
 
-def _print_new_log_lines(previous_logs: str, current_logs: str) -> str:
-    if current_logs and current_logs != previous_logs:
-        for line in get_new_log_lines(previous_logs, current_logs):
-            console.print(line)
-        return current_logs
-    return previous_logs
-
-
 def _handle_log_poll_error(eval_id: str, exc: APIError, consecutive_errors: int) -> None:
     if "404" in str(exc):
         console.print(f"\n[red]Evaluation {eval_id} not found.[/red]")
@@ -266,7 +258,10 @@ def _display_logs_follow(eval_id: str, poll_interval: float) -> None:
 
             if status and status in EvalStatus.terminal_statuses():
                 final_logs = clean_logs(_fetch_logs(client, eval_id))
-                _print_new_log_lines(last_logs, final_logs)
+                if final_logs and final_logs != last_logs:
+                    for line in get_new_log_lines(last_logs, final_logs):
+                        console.print(line)
+                    last_logs = final_logs
                 console.print()
                 _print_eval_status(eval_data)
                 if status != EvalStatus.COMPLETED:
@@ -277,8 +272,10 @@ def _display_logs_follow(eval_id: str, poll_interval: float) -> None:
             logs = clean_logs(raw_logs) if raw_logs else ""
             consecutive_errors = 0
 
-            if logs:
-                last_logs = _print_new_log_lines(last_logs, logs)
+            if logs and logs != last_logs:
+                for line in get_new_log_lines(last_logs, logs):
+                    console.print(line)
+                last_logs = logs
                 no_logs_polls = 0
             else:
                 no_logs_polls += 1

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import typer
+from click.core import ParameterSource
 from prime_evals import EvalsAPIError, EvalsClient, InvalidEvaluationError
 from rich.console import Console
 from rich.syntax import Syntax
@@ -980,11 +981,14 @@ def run_eval_cmd(
         raise typer.Exit(2)
 
     env_dir_path = _parse_value_option(passthrough_args, "--env-dir-path", "-p")
+    poll_interval_was_provided = (
+        ctx.get_parameter_source("poll_interval") == ParameterSource.COMMANDLINE
+    )
 
     if not hosted:
         hosted_only_args = {
             "--follow": follow,
-            "--poll-interval": poll_interval != HOSTED_RUN_DEFAULT_POLL_INTERVAL_SECONDS,
+            "--poll-interval": poll_interval_was_provided,
             "--timeout-minutes": timeout_minutes is not None,
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
@@ -1007,11 +1011,15 @@ def run_eval_cmd(
             )
             raise typer.Exit(1)
 
-        platform_slug, environment_id = _resolve_hosted_environment(
-            environment,
-            env_dir_path=env_dir_path,
-            env_path=env_path,
-        )
+        try:
+            platform_slug, environment_id = _resolve_hosted_environment(
+                environment,
+                env_dir_path=env_dir_path,
+                env_path=env_path,
+            )
+        except APIError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1) from exc
         model = _parse_value_option(passthrough_args, "--model", "-m") or DEFAULT_MODEL
         raw_num_examples = _parse_value_option(passthrough_args, "--num-examples", "-n")
         raw_rollouts = _parse_value_option(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import re
 import time
@@ -13,7 +12,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from typer.core import TyperGroup
 
-from ..client import APIClient, APIError, AsyncAPIClient
+from ..client import APIClient, APIError
 from ..core import Config
 from ..utils import output_data_as_json
 from ..utils.display import get_eval_viewer_url
@@ -22,12 +21,9 @@ from ..utils.eval_push import load_results_jsonl
 from ..utils.hosted_eval import (
     EvalStatus,
     HostedEvalConfig,
+    HostedEvalResult,
     clean_logs,
-    get_evaluation,
-    get_evaluation_logs,
     get_new_log_lines,
-    run_hosted_evaluation,
-    stop_hosted_evaluation,
 )
 from ..verifiers_bridge import (
     DEFAULT_ENV_DIR_PATH,
@@ -127,20 +123,56 @@ def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[st
     return parsed
 
 
-def _fetch_eval_status(eval_id: str) -> dict[str, Any]:
-    async def _fetch() -> dict[str, Any]:
-        async with AsyncAPIClient() as client:
-            return await get_evaluation(client, eval_id)
-
-    return asyncio.run(_fetch())
+def _fetch_eval_status(client: APIClient, eval_id: str) -> dict[str, Any]:
+    return client.get(f"/evaluations/{eval_id}")
 
 
-def _fetch_logs(eval_id: str) -> str:
-    async def _fetch() -> str:
-        async with AsyncAPIClient() as client:
-            return await get_evaluation_logs(client, eval_id)
+def _fetch_logs(client: APIClient, eval_id: str) -> str:
+    response = client.get(f"/hosted-evaluations/{eval_id}/logs")
+    return response.get("logs") or ""
 
-    return asyncio.run(_fetch())
+
+def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]:
+    eval_config: dict[str, Any] = {
+        "num_examples": config.num_examples,
+        "rollouts_per_example": config.rollouts_per_example,
+        "allow_sandbox_access": config.allow_sandbox_access,
+        "allow_instances_access": config.allow_instances_access,
+    }
+
+    if config.env_args:
+        eval_config["env_args"] = config.env_args
+    if config.timeout_minutes is not None:
+        eval_config["timeout_minutes"] = config.timeout_minutes
+    if config.custom_secrets:
+        eval_config["custom_secrets"] = config.custom_secrets
+
+    payload: dict[str, Any] = {
+        "environment_ids": [config.environment_id],
+        "inference_model": config.inference_model,
+        "eval_config": eval_config,
+    }
+    if config.name:
+        payload["name"] = config.name
+
+    return payload
+
+
+def _create_hosted_evaluation(config: HostedEvalConfig) -> HostedEvalResult:
+    client = APIClient()
+    created = client.post("/hosted-evaluations", json=_build_hosted_evaluation_payload(config))
+    evaluation_id = created.get("evaluation_id")
+    if not evaluation_id:
+        raise APIError(f"Failed to get evaluation ID from response: {created}")
+
+    return HostedEvalResult(
+        evaluation_id=evaluation_id,
+        status=EvalStatus.PENDING,
+        total_samples=0,
+        avg_score=None,
+        min_score=None,
+        max_score=None,
+    )
 
 
 def _print_eval_status(eval_data: dict[str, Any]) -> None:
@@ -196,20 +228,21 @@ def _handle_log_poll_error(eval_id: str, exc: APIError, consecutive_errors: int)
         time.sleep(10)
 
 
-def _display_logs_follow(eval_id: str) -> None:
+def _display_logs_follow(eval_id: str, poll_interval: float) -> None:
     console.print(f"[dim]Watching logs for evaluation {eval_id}... (Ctrl+C to stop)[/dim]\n")
 
+    client = APIClient()
     last_logs = ""
     consecutive_errors = 0
     no_logs_polls = 0
 
     while True:
         try:
-            eval_data = _fetch_eval_status(eval_id)
+            eval_data = _fetch_eval_status(client, eval_id)
             status_str, status = _parse_eval_status(eval_data)
 
             if status and status in EvalStatus.terminal_statuses():
-                final_logs = clean_logs(_fetch_logs(eval_id))
+                final_logs = clean_logs(_fetch_logs(client, eval_id))
                 _print_new_log_lines(last_logs, final_logs)
                 console.print()
                 _print_eval_status(eval_data)
@@ -217,7 +250,7 @@ def _display_logs_follow(eval_id: str) -> None:
                     raise typer.Exit(1)
                 return
 
-            raw_logs = _fetch_logs(eval_id)
+            raw_logs = _fetch_logs(client, eval_id)
             logs = clean_logs(raw_logs) if raw_logs else ""
             consecutive_errors = 0
 
@@ -234,12 +267,13 @@ def _display_logs_follow(eval_id: str) -> None:
             _handle_log_poll_error(eval_id, exc, consecutive_errors)
             continue
 
-        time.sleep(5)
+        time.sleep(poll_interval)
 
 
 def _display_logs_once(eval_id: str, tail: int) -> None:
-    eval_data = _fetch_eval_status(eval_id)
-    raw_logs = _fetch_logs(eval_id)
+    client = APIClient()
+    eval_data = _fetch_eval_status(client, eval_id)
+    raw_logs = _fetch_logs(client, eval_id)
     logs = clean_logs(raw_logs) if raw_logs else ""
 
     if logs:
@@ -252,10 +286,15 @@ def _display_logs_once(eval_id: str, tail: int) -> None:
     _print_eval_status(eval_data)
 
 
-def _display_logs(eval_id: str, tail: int, follow: bool) -> None:
+def _display_logs(
+    eval_id: str,
+    tail: int,
+    follow: bool,
+    poll_interval: float = 5.0,
+) -> None:
     try:
         if follow:
-            _display_logs_follow(eval_id)
+            _display_logs_follow(eval_id, poll_interval)
         else:
             _display_logs_once(eval_id, tail)
     except KeyboardInterrupt:
@@ -808,9 +847,14 @@ def logs_cmd(
     eval_id: str = typer.Argument(..., help="Evaluation id to get logs for"),
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
+    poll_interval: float = typer.Option(
+        5.0,
+        "--poll-interval",
+        help="Polling interval in seconds when following logs",
+    ),
 ) -> None:
     """Get logs for a hosted evaluation."""
-    _display_logs(eval_id, tail, follow)
+    _display_logs(eval_id, tail, follow, poll_interval=poll_interval)
 
 
 @app.command("stop", no_args_is_help=True)
@@ -819,7 +863,8 @@ def stop_cmd(
 ) -> None:
     """Stop a running hosted evaluation."""
     try:
-        result = asyncio.run(stop_hosted_evaluation(eval_id))
+        client = APIClient()
+        result = client.post(f"/hosted-evaluations/{eval_id}/cancel")
         message = result.get("message") or f"Evaluation {eval_id} cancelled."
         console.print(f"[green]✓ {message}[/green]")
         console.print(f"[dim]View results:[/dim] {get_eval_viewer_url(eval_id)}")
@@ -987,13 +1032,7 @@ def run_eval_cmd(
         )
 
         try:
-            result = asyncio.run(
-                run_hosted_evaluation(
-                    config=hosted_config,
-                    poll_interval=poll_interval,
-                    follow=False,
-                )
-            )
+            result = _create_hosted_evaluation(hosted_config)
         except APIError as exc:
             console.print(f"[red]Hosted evaluation failed:[/red] {exc}")
             raise typer.Exit(1) from exc
@@ -1003,7 +1042,12 @@ def run_eval_cmd(
             console.print(f"[cyan]Environment:[/cyan] {platform_slug}")
             console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
             console.print()
-            _display_logs(result.evaluation_id, tail=1000, follow=True)
+            _display_logs(
+                result.evaluation_id,
+                tail=1000,
+                follow=True,
+                poll_interval=poll_interval,
+            )
             return
 
         console.print("[green]✓ Hosted evaluation started[/green]")

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -175,8 +175,14 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
 
 def _create_hosted_evaluation(config: HostedEvalConfig) -> HostedEvalResult:
     client = APIClient()
-    created = client.post("/hosted-evaluations", json=_build_hosted_evaluation_payload(config))
+    payload = _build_hosted_evaluation_payload(config)
+
+    if client.config.team_id:
+        payload["team_id"] = client.config.team_id
+
+    created = client.post("/hosted-evaluations", json=payload)
     evaluation_id = created.get("evaluation_id")
+
     if not evaluation_id:
         raise APIError(f"Failed to get evaluation ID from response: {created}")
 

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -2,7 +2,13 @@
 
 # Re-export the most commonly used functions
 from .config import BaseConfig, load_toml
-from .display import build_table, output_data_as_json, status_color, validate_output_format
+from .display import (
+    build_table,
+    get_eval_viewer_url,
+    output_data_as_json,
+    status_color,
+    validate_output_format,
+)
 from .formatters import (
     format_ip_display,
     format_price,
@@ -27,6 +33,7 @@ __all__ = [
     "validate_output_format",
     "build_table",
     "status_color",
+    "get_eval_viewer_url",
     "human_age",
     "iso_timestamp",
     "sort_by_created",

--- a/packages/prime/src/prime_cli/utils/display.py
+++ b/packages/prime/src/prime_cli/utils/display.py
@@ -7,6 +7,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from prime_cli.core import Config
+
 
 def validate_output_format(output: str, console: Console) -> None:
     """Validate that output format is supported."""
@@ -40,6 +42,12 @@ def build_table(title: str, columns: List[Tuple[str, str]], show_lines: bool = T
 def status_color(status: str, mapping: Dict[str, str], default: str = "white") -> str:
     """Get color for status based on mapping with fallback to default."""
     return mapping.get(status, default)
+
+
+def get_eval_viewer_url(evaluation_id: str) -> str:
+    """Build the dashboard URL for an evaluation."""
+    frontend_url = Config().frontend_url.rstrip("/")
+    return f"{frontend_url}/dashboard/evaluations/{evaluation_id}"
 
 
 # Common status color mappings

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 from prime_cli.core import APIClient
 
+from .display import get_eval_viewer_url
 from .env_metadata import find_environment_metadata
 
 console = Console()
@@ -214,7 +215,6 @@ def push_eval_results_to_hub(
 
     console.print("[green]✓ Successfully uploaded evaluation results[/green]")
 
-    frontend_url = api_client.config.frontend_url
-    eval_url = f"{frontend_url}/dashboard/evaluations/{eval_id}"
+    eval_url = get_eval_viewer_url(eval_id)
     console.print("\n[green]View results at:[/green]")
     console.print(f"  [link={eval_url}]{eval_url}[/link]")

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -3,11 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from rich.console import Console
-
 from .formatters import strip_ansi
-
-console = Console()
 
 PROGRESS_BAR_MIN_WIDTH = 10
 PROGRESS_BAR = re.compile(rf".*\|[█▏▎▍▌▋▊▉ ]{{{PROGRESS_BAR_MIN_WIDTH},}}\|.*")
@@ -24,10 +20,6 @@ class EvalStatus(str, Enum):
     @classmethod
     def terminal_statuses(cls) -> set["EvalStatus"]:
         return {cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
-
-    @classmethod
-    def has_logs_statuses(cls) -> set["EvalStatus"]:
-        return {cls.RUNNING, cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
 
     @property
     def color(self) -> str:

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,12 +1,9 @@
-import asyncio
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Optional
 
 from rich.console import Console
-
-from prime_cli.client import APIError, AsyncAPIClient
 
 from .formatters import strip_ansi
 
@@ -117,85 +114,3 @@ def get_new_log_lines(old_logs: str, new_logs: str) -> list[str]:
         if old_lines[-i:] == new_lines[:i]:
             overlap = i
     return new_lines[overlap:]
-
-
-async def create_hosted_evaluation(
-    client: AsyncAPIClient,
-    config: HostedEvalConfig,
-) -> dict[str, Any]:
-    eval_config: dict[str, Any] = {
-        "num_examples": config.num_examples,
-        "rollouts_per_example": config.rollouts_per_example,
-        "allow_sandbox_access": config.allow_sandbox_access,
-        "allow_instances_access": config.allow_instances_access,
-    }
-
-    if config.env_args:
-        eval_config["env_args"] = config.env_args
-    if config.timeout_minutes is not None:
-        eval_config["timeout_minutes"] = config.timeout_minutes
-    if config.custom_secrets:
-        eval_config["custom_secrets"] = config.custom_secrets
-
-    payload: dict[str, Any] = {
-        "environment_ids": [config.environment_id],
-        "inference_model": config.inference_model,
-        "eval_config": eval_config,
-    }
-    if config.name:
-        payload["name"] = config.name
-
-    return await client.post("/hosted-evaluations", json=payload)
-
-
-async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str, Any]:
-    return await client.get(f"/evaluations/{evaluation_id}")
-
-
-async def get_evaluation_logs(client: AsyncAPIClient, evaluation_id: str) -> str:
-    response = await client.get(f"/hosted-evaluations/{evaluation_id}/logs")
-    return response.get("logs") or ""
-
-
-async def stop_hosted_evaluation(evaluation_id: str) -> dict[str, Any]:
-    async with AsyncAPIClient() as client:
-        return await client.post(f"/hosted-evaluations/{evaluation_id}/cancel")
-
-
-async def run_hosted_evaluation(
-    config: HostedEvalConfig,
-    poll_interval: float = 10.0,
-    follow: bool = True,
-) -> HostedEvalResult:
-    async with AsyncAPIClient() as client:
-        created = await create_hosted_evaluation(client, config)
-        evaluation_id = created.get("evaluation_id")
-        if not evaluation_id:
-            raise APIError(f"Failed to get evaluation ID from response: {created}")
-
-        if not follow:
-            return HostedEvalResult(
-                evaluation_id=evaluation_id,
-                status=EvalStatus.PENDING,
-                total_samples=0,
-                avg_score=None,
-                min_score=None,
-                max_score=None,
-            )
-
-        while True:
-            eval_data = await get_evaluation(client, evaluation_id)
-            status = EvalStatus(str(eval_data.get("status", EvalStatus.FAILED.value)))
-            if status in EvalStatus.terminal_statuses():
-                logs = await get_evaluation_logs(client, evaluation_id)
-                return HostedEvalResult(
-                    evaluation_id=evaluation_id,
-                    status=status,
-                    total_samples=eval_data.get("total_samples", 0),
-                    avg_score=eval_data.get("avg_score"),
-                    min_score=eval_data.get("min_score"),
-                    max_score=eval_data.get("max_score"),
-                    error_message=eval_data.get("error_message"),
-                    logs=logs,
-                )
-            await asyncio.sleep(poll_interval)

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -9,7 +9,8 @@ from .formatters import strip_ansi
 
 console = Console()
 
-PROGRESS_BAR = re.compile(r".*\|[█▏▎▍▌▋▊▉ ]{10,}\|.*")
+PROGRESS_BAR_MIN_WIDTH = 10
+PROGRESS_BAR = re.compile(rf".*\|[█▏▎▍▌▋▊▉ ]{{{PROGRESS_BAR_MIN_WIDTH},}}\|.*")
 
 
 class EvalStatus(str, Enum):

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,0 +1,201 @@
+import asyncio
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+from rich.console import Console
+
+from prime_cli.client import APIError, AsyncAPIClient
+
+from .formatters import strip_ansi
+
+console = Console()
+
+PROGRESS_BAR = re.compile(r".*\|[█▏▎▍▌▋▊▉ ]{10,}\|.*")
+
+
+class EvalStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    TIMEOUT = "TIMEOUT"
+    CANCELLED = "CANCELLED"
+
+    @classmethod
+    def terminal_statuses(cls) -> set["EvalStatus"]:
+        return {cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
+
+    @classmethod
+    def has_logs_statuses(cls) -> set["EvalStatus"]:
+        return {cls.RUNNING, cls.COMPLETED, cls.FAILED, cls.TIMEOUT, cls.CANCELLED}
+
+    @property
+    def color(self) -> str:
+        return {
+            EvalStatus.PENDING: "yellow",
+            EvalStatus.RUNNING: "cyan",
+            EvalStatus.COMPLETED: "green",
+            EvalStatus.FAILED: "red",
+            EvalStatus.TIMEOUT: "red",
+            EvalStatus.CANCELLED: "yellow",
+        }.get(self, "white")
+
+
+@dataclass
+class HostedEvalConfig:
+    environment_id: str
+    inference_model: str
+    num_examples: int
+    rollouts_per_example: int
+    env_args: Optional[dict[str, str]] = None
+    name: Optional[str] = None
+    timeout_minutes: Optional[int] = None
+    allow_sandbox_access: bool = False
+    allow_instances_access: bool = False
+    custom_secrets: Optional[dict[str, str]] = None
+
+
+@dataclass
+class HostedEvalResult:
+    evaluation_id: str
+    status: EvalStatus
+    total_samples: int
+    avg_score: Optional[float]
+    min_score: Optional[float]
+    max_score: Optional[float]
+    error_message: Optional[str] = None
+    logs: Optional[str] = None
+
+
+def filter_progress_bars(text: str) -> str:
+    lines = text.splitlines()
+    filtered: list[str] = []
+    for line in lines:
+        if PROGRESS_BAR.search(line) or re.search(r"\d+%\|", line):
+            if "100%" in line:
+                match = re.search(r"([^|]*100%\|[█▏▎▍▌▋▊▉ ]+\|[^\n]*?)(?=\d+%\||$)", line)
+                filtered.append((match.group(1) if match else line).strip())
+            continue
+        if line.strip():
+            filtered.append(line)
+    return "\n".join(filtered)
+
+
+STATUS_MESSAGES = {
+    "Waiting for container to start...",
+    "No logs available",
+    "Unable to retrieve logs",
+    "Failed to fetch logs from sandbox",
+    "The hosted eval is still initializing",
+}
+
+
+def is_status_message(text: str) -> bool:
+    stripped = text.strip()
+    return any(stripped.startswith(msg) for msg in STATUS_MESSAGES)
+
+
+def clean_logs(text: str) -> str:
+    cleaned = filter_progress_bars(strip_ansi(text))
+    if is_status_message(cleaned):
+        return ""
+    return cleaned
+
+
+def get_new_log_lines(old_logs: str, new_logs: str) -> list[str]:
+    old_lines = old_logs.splitlines() if old_logs else []
+    new_lines = new_logs.splitlines()
+
+    if not old_logs:
+        return new_lines
+
+    overlap = 0
+    max_overlap = min(len(old_lines), len(new_lines))
+    for i in range(1, max_overlap + 1):
+        if old_lines[-i:] == new_lines[:i]:
+            overlap = i
+    return new_lines[overlap:]
+
+
+async def create_hosted_evaluation(
+    client: AsyncAPIClient,
+    config: HostedEvalConfig,
+) -> dict[str, Any]:
+    eval_config: dict[str, Any] = {
+        "num_examples": config.num_examples,
+        "rollouts_per_example": config.rollouts_per_example,
+        "allow_sandbox_access": config.allow_sandbox_access,
+        "allow_instances_access": config.allow_instances_access,
+    }
+
+    if config.env_args:
+        eval_config["env_args"] = config.env_args
+    if config.timeout_minutes is not None:
+        eval_config["timeout_minutes"] = config.timeout_minutes
+    if config.custom_secrets:
+        eval_config["custom_secrets"] = config.custom_secrets
+
+    payload: dict[str, Any] = {
+        "environment_ids": [config.environment_id],
+        "inference_model": config.inference_model,
+        "eval_config": eval_config,
+    }
+    if config.name:
+        payload["name"] = config.name
+
+    return await client.post("/hosted-evaluations", json=payload)
+
+
+async def get_evaluation(client: AsyncAPIClient, evaluation_id: str) -> dict[str, Any]:
+    return await client.get(f"/evaluations/{evaluation_id}")
+
+
+async def get_evaluation_logs(client: AsyncAPIClient, evaluation_id: str) -> str:
+    response = await client.get(f"/hosted-evaluations/{evaluation_id}/logs")
+    return response.get("logs") or ""
+
+
+async def stop_hosted_evaluation(evaluation_id: str) -> dict[str, Any]:
+    async with AsyncAPIClient() as client:
+        return await client.post(f"/hosted-evaluations/{evaluation_id}/cancel")
+
+
+async def run_hosted_evaluation(
+    config: HostedEvalConfig,
+    poll_interval: float = 10.0,
+    follow: bool = True,
+) -> HostedEvalResult:
+    async with AsyncAPIClient() as client:
+        created = await create_hosted_evaluation(client, config)
+        evaluation_id = created.get("evaluation_id")
+        if not evaluation_id:
+            raise APIError(f"Failed to get evaluation ID from response: {created}")
+
+        if not follow:
+            return HostedEvalResult(
+                evaluation_id=evaluation_id,
+                status=EvalStatus.PENDING,
+                total_samples=0,
+                avg_score=None,
+                min_score=None,
+                max_score=None,
+            )
+
+        while True:
+            eval_data = await get_evaluation(client, evaluation_id)
+            status = EvalStatus(str(eval_data.get("status", EvalStatus.FAILED.value)))
+            if status in EvalStatus.terminal_statuses():
+                logs = await get_evaluation_logs(client, evaluation_id)
+                return HostedEvalResult(
+                    evaluation_id=evaluation_id,
+                    status=status,
+                    total_samples=eval_data.get("total_samples", 0),
+                    avg_score=eval_data.get("avg_score"),
+                    min_score=eval_data.get("min_score"),
+                    max_score=eval_data.get("max_score"),
+                    error_message=eval_data.get("error_message"),
+                    logs=logs,
+                )
+            await asyncio.sleep(poll_interval)

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -118,11 +118,22 @@ def _write_help(text: str) -> None:
 
 def _append_eval_options(help_text: str) -> str:
     extra_lines = [
-        "  --skip-upload        Skip uploading evaluation results to the platform.",
-        "  --env-path PATH      Explicit path for upstream environment metadata.",
+        "  --skip-upload               Skip uploading evaluation results to the platform.",
+        "  --env-path PATH             Explicit path for upstream environment metadata.",
+        "  --hosted                    Run the evaluation on the platform instead of locally.",
+        "  stop EVAL_ID                Cancel a running hosted evaluation.",
+        "  --poll-interval FLOAT       Polling interval in seconds for hosted evaluations.",
+        "  --follow                    Follow hosted evaluation logs until completion.",
+        "  --timeout-minutes INTEGER   Timeout in minutes for hosted evaluations.",
+        "  --allow-sandbox-access      Allow sandbox read/write access for hosted evaluations.",
+        "  --allow-instances-access    "
+        "Allow instance creation and management for hosted evaluations.",
+        "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
+        "  --eval-name TEXT            Custom name for the hosted evaluation.",
     ]
     lines = help_text.rstrip("\n").splitlines()
-    if any("--skip-upload" in line or "--env-path" in line for line in lines):
+    required_flags = ("--skip-upload", "--env-path", "--hosted")
+    if all(any(flag in line for line in lines) for flag in required_flags):
         return help_text.rstrip() + "\n"
     lines.extend(extra_lines)
     return "\n".join(lines) + "\n"

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -132,10 +132,9 @@ def _append_eval_options(help_text: str) -> str:
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
     ]
     lines = help_text.rstrip("\n").splitlines()
-    required_flags = ("--skip-upload", "--env-path", "--hosted")
-    if all(any(flag in line for line in lines) for flag in required_flags):
-        return help_text.rstrip() + "\n"
-    lines.extend(extra_lines)
+    for extra_line in extra_lines:
+        if extra_line not in lines:
+            lines.append(extra_line)
     return "\n".join(lines) + "\n"
 
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,3 +1,4 @@
+from prime_cli.client import APIError
 from prime_cli.main import app
 from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
 from typer.testing import CliRunner
@@ -170,6 +171,16 @@ def test_eval_run_rejects_hosted_only_flags_without_hosted():
     assert "hosted-only options require `--hosted`" in result.output
 
 
+def test_eval_run_rejects_explicit_poll_interval_without_hosted():
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--poll-interval", "10"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "hosted-only options require `--hosted`" in result.output
+
+
 def test_eval_run_hosted_passes_env_dir_path_to_resolver(monkeypatch):
     captured = {}
 
@@ -264,6 +275,24 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
         "env_dir_path": None,
         "env_path": "/tmp/local-env",
     }
+
+
+def test_eval_run_hosted_reports_resolve_api_errors(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (_ for _ in ()).throw(
+            APIError("lookup failed")
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "lookup failed" in result.output
 
 
 def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -79,7 +79,7 @@ def test_eval_list_shows_hosted_checkbox(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert "Mode" in result.output
+    assert "Type" in result.output
     assert "HOSTED" in result.output
     assert "LOCAL" in result.output
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -345,11 +345,11 @@ def test_eval_run_hosted_reports_resolve_api_errors(monkeypatch):
 def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):
     captured = {}
 
-    def fake_post(self, endpoint, json=None):
+    def fake_patch(self, endpoint, json=None, params=None):
         captured["endpoint"] = endpoint
         return {"message": "Evaluation cancelled", "evaluation_id": "eval-123"}
 
-    monkeypatch.setattr("prime_cli.commands.evals.APIClient.post", fake_post)
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient.patch", fake_patch)
 
     result = runner.invoke(
         app,

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -37,6 +37,53 @@ class TestLogCleaning:
         assert clean_logs("The hosted eval is still initializing") == ""
 
 
+def test_eval_list_shows_hosted_checkbox(monkeypatch):
+    class DummyConfig:
+        team_id = None
+
+    class DummyClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def list_evaluations(self, **_kwargs):
+            return {
+                "evaluations": [
+                    {
+                        "evaluation_id": "hosted-1",
+                        "environment_names": ["aime2024"],
+                        "model_name": "openai/gpt-4.1-mini",
+                        "status": "RUNNING",
+                        "is_hosted": True,
+                        "metadata": {"num_examples": 3, "rollouts_per_example": 2},
+                    },
+                    {
+                        "evaluation_id": "local-1",
+                        "environment_names": ["gsm8k"],
+                        "model_name": "openai/gpt-4.1-mini",
+                        "status": "COMPLETED",
+                        "is_hosted": False,
+                        "metadata": {"num_examples": 5, "rollouts_per_example": 1},
+                    },
+                ],
+                "total": 2,
+            }
+
+    monkeypatch.setattr("prime_cli.commands.evals.Config", lambda: DummyConfig())
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+    monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyClient)
+
+    result = runner.invoke(
+        app,
+        ["eval", "list"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Mode" in result.output
+    assert "HOSTED" in result.output
+    assert "LOCAL" in result.output
+
+
 def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
     captured = {}
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -134,6 +134,40 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
     assert "prime eval logs eval-123 -f" in result.output
 
 
+def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
+    captured = {}
+
+    class DummyConfig:
+        team_id = "team-123"
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    from prime_cli.commands.evals import _create_hosted_evaluation
+    from prime_cli.utils.hosted_eval import HostedEvalConfig
+
+    result = _create_hosted_evaluation(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+        )
+    )
+
+    assert result.evaluation_id == "eval-123"
+    assert captured["endpoint"] == "/hosted-evaluations"
+    assert captured["json"]["team_id"] == "team-123"
+
+
 def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     captured = {}
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,0 +1,376 @@
+from prime_cli.main import app
+from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestLogCleaning:
+    def test_strip_ansi_basic(self):
+        assert strip_ansi("\x1b[31mRed text\x1b[0m") == "Red text"
+
+    def test_filter_progress_bars_keeps_100_percent(self):
+        text = "Progress: 100%|██████████| 10/10 [00:01<00:00]"
+        result = filter_progress_bars(text)
+        assert "100%" in result
+
+    def test_filter_progress_bars_drops_partial_updates(self):
+        text = "Progress: 50%|█████     | 5/10 [00:01<00:01]"
+        assert filter_progress_bars(text) == ""
+
+    def test_clean_logs_removes_ansi_and_progress(self):
+        text = (
+            "\x1b[32mStarting evaluation\x1b[0m\n"
+            "Progress: 50%|█████     | 5/10 [00:01<00:01]\n"
+            "\x1b[1mProgress: 100%|██████████| 10/10 [00:02<00:00]\x1b[0m\n"
+            "\x1b[32m✓ Evaluation complete\x1b[0m"
+        )
+        result = clean_logs(text)
+        assert "Starting evaluation" in result
+        assert "✓ Evaluation complete" in result
+        assert "100%" in result
+        assert "50%" not in result
+        assert "\x1b" not in result
+
+    def test_clean_logs_hides_status_messages(self):
+        assert clean_logs("The hosted eval is still initializing") == ""
+
+
+def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+        captured["environment_id"] = config.environment_id
+        captured["inference_model"] = config.inference_model
+        captured["num_examples"] = config.num_examples
+        captured["rollouts_per_example"] = config.rollouts_per_example
+        captured["poll_interval"] = poll_interval
+        captured["follow"] = follow
+
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=14,
+            avg_score=0.75,
+            min_score=0.5,
+            max_score=1.0,
+            error_message=None,
+            logs="done",
+        )
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.run_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "primeintellect/gsm8k", "--hosted", "-m", "openai/gpt-4.1-mini"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["environment_id"] == "env-123"
+    assert captured["inference_model"] == "openai/gpt-4.1-mini"
+    assert captured["num_examples"] == 5
+    assert captured["rollouts_per_example"] == 3
+    assert captured["follow"] is False
+    assert "Hosted evaluation started" in result.output
+    assert "prime eval logs eval-123 -f" in result.output
+
+
+def test_eval_run_hosted_follow_streams_logs(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+        captured["num_examples"] = config.num_examples
+        captured["rollouts_per_example"] = config.rollouts_per_example
+        captured["follow"] = follow
+
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+        )
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.run_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
+    def fake_display_logs(eval_id, tail, follow):
+        captured["display_eval_id"] = eval_id
+        captured["display_tail"] = tail
+        captured["display_follow"] = follow
+
+    monkeypatch.setattr("prime_cli.commands.evals._display_logs", fake_display_logs)
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "primeintellect/gsm8k",
+            "--hosted",
+            "--follow",
+            "-n",
+            "7",
+            "-r",
+            "2",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["num_examples"] == 7
+    assert captured["rollouts_per_example"] == 2
+    assert captured["follow"] is False
+    assert captured["display_eval_id"] == "eval-123"
+    assert captured["display_tail"] == 1000
+    assert captured["display_follow"] is True
+
+
+def test_eval_run_hosted_rejects_config_target():
+    result = runner.invoke(
+        app,
+        ["eval", "run", "config.toml", "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "single environment" in result.output
+
+
+def test_eval_run_rejects_hosted_only_flags_without_hosted():
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--follow"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "hosted-only options require `--hosted`" in result.output
+
+
+def test_eval_run_hosted_passes_env_dir_path_to_resolver(monkeypatch):
+    captured = {}
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        captured["environment"] = environment
+        captured["env_dir_path"] = env_dir_path
+        captured["env_path"] = env_path
+        return ("primeintellect/gsm8k", "env-123")
+
+    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.run_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "gsm8k",
+            "--hosted",
+            "--env-dir-path",
+            "/tmp/custom-envs",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "env_dir_path": "/tmp/custom-envs",
+        "env_path": None,
+    }
+
+
+def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
+    captured = {}
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        captured["environment"] = environment
+        captured["env_dir_path"] = env_dir_path
+        captured["env_path"] = env_path
+        return ("primeintellect/gsm8k", "env-123")
+
+    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.run_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "gsm8k",
+            "--hosted",
+            "--env-path",
+            "/tmp/local-env",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "env_dir_path": None,
+        "env_path": "/tmp/local-env",
+    }
+
+
+def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):
+    captured = {}
+
+    async def fake_stop_hosted_evaluation(eval_id):
+        captured["eval_id"] = eval_id
+        return {"message": "Evaluation cancelled", "evaluation_id": eval_id}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.stop_hosted_evaluation",
+        fake_stop_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "stop", "eval-123"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {"eval_id": "eval-123"}
+    assert "Evaluation cancelled" in result.output
+    assert "dashboard/evaluations/eval-123" in result.output
+
+
+def test_print_eval_status_prefers_returned_viewer_url(monkeypatch, capsys):
+    from prime_cli.commands.evals import _print_eval_status
+
+    called = {"used": False}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.get_eval_viewer_url",
+        lambda eval_id: called.__setitem__("used", True) or f"fallback/{eval_id}",
+    )
+
+    _print_eval_status(
+        {
+            "status": "RUNNING",
+            "evaluation_id": "eval-123",
+            "viewer_url": "http://localhost:3000/dashboard/evaluations/eval-123",
+            "error_message": None,
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "http://localhost:3000/dashboard/evaluations/eval-123" in output
+    assert called["used"] is False
+
+
+def test_print_eval_status_falls_back_to_eval_id_when_viewer_url_missing(monkeypatch, capsys):
+    from prime_cli.commands.evals import _print_eval_status
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.get_eval_viewer_url",
+        lambda eval_id: f"fallback/{eval_id}",
+    )
+
+    _print_eval_status(
+        {
+            "status": "CANCELLED",
+            "evaluation_id": "eval-123",
+            "viewer_url": None,
+            "error_message": "Stopped",
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "Status: CANCELLED" in output
+    assert "Error:" in output
+    assert "fallback/eval-123" in output
+
+
+def test_eval_logs_command_follows_incremental_output(monkeypatch):
+    statuses = iter(
+        [
+            {"status": "RUNNING", "evaluation_id": "eval-123"},
+            {"status": "COMPLETED", "evaluation_id": "eval-123", "total_samples": 2},
+        ]
+    )
+    logs = iter(
+        [
+            "Line 1\nLine 2",
+            "Line 1\nLine 2\nLine 3",
+        ]
+    )
+
+    monkeypatch.setattr("prime_cli.commands.evals.time.sleep", lambda _: None)
+    monkeypatch.setattr("prime_cli.commands.evals._fetch_eval_status", lambda _: next(statuses))
+    monkeypatch.setattr("prime_cli.commands.evals._fetch_logs", lambda _: next(logs))
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.get_eval_viewer_url",
+        lambda eval_id: f"https://app.primeintellect.ai/dashboard/evaluations/{eval_id}",
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "logs", "eval-123", "--follow"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Line 1" in result.output
+    assert "Line 2" in result.output
+    assert "Line 3" in result.output
+    assert result.output.count("Line 1") == 1
+    assert "Status: COMPLETED" in result.output

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -481,3 +481,46 @@ def test_eval_logs_command_follows_incremental_output(monkeypatch):
     assert "Line 3" in result.output
     assert result.output.count("Line 1") == 1
     assert "Status: COMPLETED" in result.output
+
+
+def test_eval_logs_command_emits_waiting_status_when_logs_are_unchanged(monkeypatch):
+    statuses = iter(
+        [
+            {"status": "RUNNING", "evaluation_id": "eval-123"},
+            {"status": "RUNNING", "evaluation_id": "eval-123"},
+            {"status": "COMPLETED", "evaluation_id": "eval-123", "total_samples": 1},
+        ]
+    )
+    logs = iter(
+        [
+            "Line 1",
+            "Line 1",
+            "Line 1",
+        ]
+    )
+
+    monkeypatch.setattr("prime_cli.commands.evals.time.sleep", lambda _: None)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.HOSTED_LOGS_STATUS_UPDATE_EVERY_POLLS",
+        1,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._fetch_eval_status",
+        lambda _client, _: next(statuses),
+    )
+    monkeypatch.setattr("prime_cli.commands.evals._fetch_logs", lambda _client, _: next(logs))
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.get_eval_viewer_url",
+        lambda eval_id: f"https://app.primeintellect.ai/dashboard/evaluations/{eval_id}",
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "logs", "eval-123", "--follow"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("Line 1") == 1
+    assert "Evaluation status: RUNNING (waiting for logs...)" in result.output
+    assert "Status: COMPLETED" in result.output

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -47,13 +47,11 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
         ),
     )
 
-    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+    def fake_run_hosted_evaluation(config):
         captured["environment_id"] = config.environment_id
         captured["inference_model"] = config.inference_model
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
-        captured["poll_interval"] = poll_interval
-        captured["follow"] = follow
 
         from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
 
@@ -69,7 +67,7 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals.run_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluation",
         fake_run_hosted_evaluation,
     )
 
@@ -84,7 +82,6 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
     assert captured["inference_model"] == "openai/gpt-4.1-mini"
     assert captured["num_examples"] == 5
     assert captured["rollouts_per_example"] == 3
-    assert captured["follow"] is False
     assert "Hosted evaluation started" in result.output
     assert "prime eval logs eval-123 -f" in result.output
 
@@ -100,10 +97,9 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
         ),
     )
 
-    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+    def fake_run_hosted_evaluation(config):
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
-        captured["follow"] = follow
 
         from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
 
@@ -117,14 +113,15 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals.run_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluation",
         fake_run_hosted_evaluation,
     )
 
-    def fake_display_logs(eval_id, tail, follow):
+    def fake_display_logs(eval_id, tail, follow, poll_interval=5.0):
         captured["display_eval_id"] = eval_id
         captured["display_tail"] = tail
         captured["display_follow"] = follow
+        captured["display_poll_interval"] = poll_interval
 
     monkeypatch.setattr("prime_cli.commands.evals._display_logs", fake_display_logs)
 
@@ -147,10 +144,10 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["num_examples"] == 7
     assert captured["rollouts_per_example"] == 2
-    assert captured["follow"] is False
     assert captured["display_eval_id"] == "eval-123"
     assert captured["display_tail"] == 1000
     assert captured["display_follow"] is True
+    assert captured["display_poll_interval"] == 10.0
 
 
 def test_eval_run_hosted_rejects_config_target():
@@ -182,7 +179,7 @@ def test_eval_run_hosted_passes_env_dir_path_to_resolver(monkeypatch):
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+    def fake_run_hosted_evaluation(config):
         from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
 
         return HostedEvalResult(
@@ -196,7 +193,7 @@ def test_eval_run_hosted_passes_env_dir_path_to_resolver(monkeypatch):
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals.run_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluation",
         fake_run_hosted_evaluation,
     )
 
@@ -230,7 +227,7 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    async def fake_run_hosted_evaluation(config, poll_interval, follow):
+    def fake_run_hosted_evaluation(config):
         from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
 
         return HostedEvalResult(
@@ -244,7 +241,7 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals.run_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluation",
         fake_run_hosted_evaluation,
     )
 
@@ -272,14 +269,11 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
 def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):
     captured = {}
 
-    async def fake_stop_hosted_evaluation(eval_id):
-        captured["eval_id"] = eval_id
-        return {"message": "Evaluation cancelled", "evaluation_id": eval_id}
+    def fake_post(self, endpoint, json=None):
+        captured["endpoint"] = endpoint
+        return {"message": "Evaluation cancelled", "evaluation_id": "eval-123"}
 
-    monkeypatch.setattr(
-        "prime_cli.commands.evals.stop_hosted_evaluation",
-        fake_stop_hosted_evaluation,
-    )
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient.post", fake_post)
 
     result = runner.invoke(
         app,
@@ -288,7 +282,7 @@ def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert captured == {"eval_id": "eval-123"}
+    assert captured == {"endpoint": "/hosted-evaluations/eval-123/cancel"}
     assert "Evaluation cancelled" in result.output
     assert "dashboard/evaluations/eval-123" in result.output
 
@@ -355,8 +349,11 @@ def test_eval_logs_command_follows_incremental_output(monkeypatch):
     )
 
     monkeypatch.setattr("prime_cli.commands.evals.time.sleep", lambda _: None)
-    monkeypatch.setattr("prime_cli.commands.evals._fetch_eval_status", lambda _: next(statuses))
-    monkeypatch.setattr("prime_cli.commands.evals._fetch_logs", lambda _: next(logs))
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._fetch_eval_status",
+        lambda _client, _: next(statuses),
+    )
+    monkeypatch.setattr("prime_cli.commands.evals._fetch_logs", lambda _client, _: next(logs))
     monkeypatch.setattr(
         "prime_cli.commands.evals.get_eval_viewer_url",
         lambda eval_id: f"https://app.primeintellect.ai/dashboard/evaluations/{eval_id}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new CLI flows that create/cancel hosted evaluations and poll/stream logs via new API endpoints, which could impact UX and error handling if API responses/statuses differ from expectations.
> 
> **Overview**
> Adds **hosted evaluation support** to `prime eval`, including `--hosted` execution with hosted-only flags (`--follow`, `--poll-interval`, `--timeout-minutes`, access toggles, `--custom-secrets`, `--eval-name`) and validation to prevent misuse without `--hosted`.
> 
> Introduces new `prime eval logs` (tail/follow with rate-limit handling, incremental log streaming, final status display) and `prime eval stop` (cancel hosted eval) commands, plus hosted environment resolution to platform environment IDs.
> 
> Updates eval listing to show a **Type** column (`HOSTED` vs `LOCAL`), centralizes evaluation viewer URL construction via `get_eval_viewer_url`, adds hosted log-cleaning utilities in `utils/hosted_eval.py`, and includes a comprehensive new test suite covering hosted run/log/stop behavior and log cleaning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb464081852674c6c149a3caa420812e34831894. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->