### PR TITLE
Respect .gitignore in prime env push

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "cryptography>=41.0.0",
     "verifiers>=0.1.10",
     "build>=1.0.0",
+    "gitignore-parser>=0.1.13",
     "toml>=0.10.0",
 ]
 keywords = ["cli", "gpu", "cloud", "compute"]

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -469,21 +469,22 @@ def _collect_archive_files(env_path: Path) -> List[Path]:
         for file_path in sorted(env_path.glob(pattern), key=lambda p: p.name):
             maybe_add_file(file_path)
 
-    def is_dir_included(dir_path: Path) -> bool:
-        if not should_include_directory_in_archive(dir_path):
-            return False
+    def is_nested_dir_ignored(dir_path: Path) -> bool:
+        """Check if a nested directory should be pruned from traversal (gitignore only)."""
         if ignore_matcher is not None and ignore_matcher(str(dir_path)):
-            return False
-        return True
+            return True
+        return False
 
     for subdir in sorted(env_path.iterdir(), key=lambda path: path.name):
-        if not is_dir_included(subdir):
+        if not should_include_directory_in_archive(subdir):
+            continue
+        if is_nested_dir_ignored(subdir):
             continue
 
         for root, dirnames, filenames in os.walk(subdir):
             root_path = Path(root)
             dirnames[:] = sorted(
-                dirname for dirname in dirnames if is_dir_included(root_path / dirname)
+                dirname for dirname in dirnames if not is_nested_dir_ignored(root_path / dirname)
             )
             for filename in sorted(filenames):
                 maybe_add_file(root_path / filename)

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -469,16 +469,21 @@ def _collect_archive_files(env_path: Path) -> List[Path]:
         for file_path in sorted(env_path.glob(pattern), key=lambda p: p.name):
             maybe_add_file(file_path)
 
+    def is_dir_included(dir_path: Path) -> bool:
+        if not should_include_directory_in_archive(dir_path):
+            return False
+        if ignore_matcher is not None and ignore_matcher(str(dir_path)):
+            return False
+        return True
+
     for subdir in sorted(env_path.iterdir(), key=lambda path: path.name):
-        if not should_include_directory_in_archive(subdir):
+        if not is_dir_included(subdir):
             continue
 
         for root, dirnames, filenames in os.walk(subdir):
             root_path = Path(root)
             dirnames[:] = sorted(
-                dirname
-                for dirname in dirnames
-                if should_include_directory_in_archive(root_path / dirname)
+                dirname for dirname in dirnames if is_dir_included(root_path / dirname)
             )
             for filename in sorted(filenames):
                 maybe_add_file(root_path / filename)

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -470,7 +470,9 @@ def _collect_archive_files(env_path: Path) -> List[Path]:
             maybe_add_file(file_path)
 
     def is_nested_dir_ignored(dir_path: Path) -> bool:
-        """Check if a nested directory should be pruned from traversal (gitignore only)."""
+        """Check if a nested directory should be pruned from traversal."""
+        if not should_include_directory_in_archive(dir_path):
+            return True
         if ignore_matcher is not None and ignore_matcher(str(dir_path)):
             return True
         return False

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -13,12 +14,13 @@ from datetime import datetime
 # Wheel METADATA files use RFC 822 format (PEP 566), same as email headers
 from email.parser import Parser as EmailParser
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
 import toml
 import typer
+from gitignore_parser import parse_gitignore
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
@@ -408,12 +410,14 @@ def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:
     if file_path.is_symlink():
         return False
 
+    rel_path = file_path.relative_to(base_path)
+
     # Skip hidden files
     if file_path.name.startswith("."):
         return False
 
     # Skip files in __pycache__ directories
-    if "__pycache__" in str(file_path.relative_to(base_path)):
+    if "__pycache__" in rel_path.parts:
         return False
 
     return True
@@ -439,6 +443,49 @@ def should_include_directory_in_archive(dir_path: Path) -> bool:
     return True
 
 
+def _build_gitignore_matcher(env_path: Path) -> Optional[Callable[[str], bool]]:
+    """Build a matcher for the root .gitignore file, if present."""
+    gitignore_path = env_path / ".gitignore"
+    if not gitignore_path.exists():
+        return None
+    return parse_gitignore(str(gitignore_path), base_dir=str(env_path))
+
+
+def _collect_archive_files(env_path: Path) -> List[Path]:
+    """Collect archive file paths in deterministic order, honoring .gitignore."""
+    ignore_matcher = _build_gitignore_matcher(env_path)
+    files_by_rel_path: Dict[str, Path] = {}
+
+    def maybe_add_file(file_path: Path) -> None:
+        if not should_include_file_in_archive(file_path, env_path):
+            return
+        if ignore_matcher is not None and ignore_matcher(str(file_path)):
+            return
+
+        rel_path = str(file_path.relative_to(env_path)).replace("\\", "/")
+        files_by_rel_path[rel_path] = file_path
+
+    for pattern in ["README.md", "pyproject.toml", "*.py"]:
+        for file_path in sorted(env_path.glob(pattern), key=lambda p: p.name):
+            maybe_add_file(file_path)
+
+    for subdir in sorted(env_path.iterdir(), key=lambda path: path.name):
+        if not should_include_directory_in_archive(subdir):
+            continue
+
+        for root, dirnames, filenames in os.walk(subdir):
+            root_path = Path(root)
+            dirnames[:] = sorted(
+                dirname
+                for dirname in dirnames
+                if should_include_directory_in_archive(root_path / dirname)
+            )
+            for filename in sorted(filenames):
+                maybe_add_file(root_path / filename)
+
+    return [files_by_rel_path[rel_path] for rel_path in sorted(files_by_rel_path)]
+
+
 def compute_content_hash(env_path: Path) -> str:
     """Compute deterministic, cross-platform content hash for environment files.
 
@@ -450,45 +497,15 @@ def compute_content_hash(env_path: Path) -> str:
     """
     content_hasher = hashlib.sha256()
 
-    # Collect all items to hash in a deterministic order
-    items_to_hash = []
-
-    # Add root-level files
-    for pattern in ["pyproject.toml", "*.py", "README.md"]:
-        for file_path in env_path.glob(pattern):
-            if file_path.is_file():
-                items_to_hash.append(("file", file_path))
-
-    # Add subdirectory contents
-    for subdir in sorted(env_path.iterdir(), key=lambda x: x.name):
-        if should_include_directory_in_archive(subdir):
-            # Add directory marker
-            items_to_hash.append(("dir", subdir))
-
-            # Add files in subdirectory
-            for file_path in subdir.rglob("*"):
-                if should_include_file_in_archive(file_path, env_path):
-                    items_to_hash.append(("file", file_path))
-
-    # Sort all items by their relative path for deterministic ordering
-    items_to_hash.sort(key=lambda item: str(item[1].relative_to(env_path)).replace("\\", "/"))
-
-    # Hash items in sorted order
-    for item_type, item_path in items_to_hash:
-        rel_path = item_path.relative_to(env_path)
-        # Use forward slashes for cross-platform consistency
-        normalized_path = str(rel_path).replace("\\", "/")
-
-        if item_type == "dir":
-            content_hasher.update(f"dir:{normalized_path}".encode("utf-8"))
-        elif item_type == "file":
-            content_hasher.update(f"file:{normalized_path}".encode("utf-8"))
-            try:
-                with open(item_path, "rb") as f:
-                    content_hasher.update(f.read())
-            except IOError:
-                # Skip files that can't be read
-                pass
+    for file_path in _collect_archive_files(env_path):
+        normalized_path = str(file_path.relative_to(env_path)).replace("\\", "/")
+        content_hasher.update(f"file:{normalized_path}".encode("utf-8"))
+        try:
+            with open(file_path, "rb") as f:
+                content_hasher.update(f.read())
+        except IOError:
+            # Skip files that can't be read
+            pass
 
     return content_hasher.hexdigest()
 
@@ -1162,21 +1179,9 @@ def push(
                 with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
                     temp_file_path = tmp.name
                     with tarfile.open(tmp.name, "w:gz") as tar:
-                        for pattern in ["README.md", "pyproject.toml", "*.py"]:
-                            for file in env_path.glob(pattern):
-                                if file.is_file():
-                                    tar.add(file, arcname=file.name)
-
-                        # Sort subdirectories for deterministic ordering and apply filtering
-                        for subdir in sorted(env_path.iterdir(), key=lambda x: x.name):
-                            if should_include_directory_in_archive(subdir):
-                                # Add directory with custom filtering instead of entire subdirectory
-                                for file in subdir.rglob("*"):
-                                    if should_include_file_in_archive(file, env_path):
-                                        # Calculate relative path from env_path for consistent
-                                        # archive structure
-                                        arcname = file.relative_to(env_path)
-                                        tar.add(file, arcname=str(arcname))
+                        for file_path in _collect_archive_files(env_path):
+                            arcname = file_path.relative_to(env_path)
+                            tar.add(file_path, arcname=str(arcname))
 
                     # Check tarball size
                     tarball_size = Path(tmp.name).stat().st_size

--- a/packages/prime/tests/test_env_push_archive.py
+++ b/packages/prime/tests/test_env_push_archive.py
@@ -1,0 +1,74 @@
+from prime_cli.commands.env import _collect_archive_files, compute_content_hash
+
+
+def test_collect_archive_files_respects_gitignore(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n")
+    (tmp_path / "README.md").write_text("demo\n")
+    (tmp_path / "app.py").write_text("print('ok')\n")
+    (tmp_path / "ignored.py").write_text("print('ignore me')\n")
+    (tmp_path / ".gitignore").write_text("ignored.py\nlogs/\n*.tmp\n")
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "keep.txt").write_text("keep\n")
+    (data_dir / "drop.tmp").write_text("drop\n")
+
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "run.txt").write_text("log\n")
+
+    archive_paths = {
+        file_path.relative_to(tmp_path).as_posix() for file_path in _collect_archive_files(tmp_path)
+    }
+
+    assert archive_paths == {
+        "README.md",
+        "app.py",
+        "data/keep.txt",
+        "pyproject.toml",
+    }
+
+
+def test_collect_archive_files_preserves_gitignore_negation(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n")
+    (tmp_path / "env.py").write_text("print('ok')\n")
+    (tmp_path / ".gitignore").write_text("artifacts/*\n!artifacts/keep.txt\n")
+
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "drop.txt").write_text("drop\n")
+    (artifacts_dir / "keep.txt").write_text("keep\n")
+
+    archive_paths = {
+        file_path.relative_to(tmp_path).as_posix() for file_path in _collect_archive_files(tmp_path)
+    }
+
+    assert "artifacts/keep.txt" in archive_paths
+    assert "artifacts/drop.txt" not in archive_paths
+
+
+def test_compute_content_hash_ignores_gitignored_files(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\nversion='0.1.0'\n")
+    (tmp_path / "env.py").write_text("print('ok')\n")
+    (tmp_path / ".gitignore").write_text("logs/\n")
+
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    ignored_file = logs_dir / "run.txt"
+    ignored_file.write_text("first\n")
+
+    included_dir = tmp_path / "data"
+    included_dir.mkdir()
+    included_file = included_dir / "payload.txt"
+    included_file.write_text("alpha\n")
+
+    first_hash = compute_content_hash(tmp_path)
+
+    ignored_file.write_text("second\n")
+    second_hash = compute_content_hash(tmp_path)
+
+    included_file.write_text("beta\n")
+    third_hash = compute_content_hash(tmp_path)
+
+    assert second_hash == first_hash
+    assert third_hash != second_hash

--- a/uv.lock
+++ b/uv.lock
@@ -760,6 +760,12 @@ wheels = [
 ]
 
 [[package]]
+name = "gitignore-parser"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/51/e391a1a4238f18d0abb47be479b07af265ad4519022cf51b7da47ef82487/gitignore_parser-0.1.13.tar.gz", hash = "sha256:c7e10c8190accb8ae57fb3711889e73a9c0dbc04d4222b91ace8a4bf64d2f746", size = 5603, upload-time = "2025-08-25T06:33:22.704Z" }
+
+[[package]]
 name = "griffe"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1738,6 +1744,7 @@ source = { editable = "packages/prime" }
 dependencies = [
     { name = "build" },
     { name = "cryptography" },
+    { name = "gitignore-parser" },
     { name = "httpx" },
     { name = "prime-evals" },
     { name = "prime-sandboxes" },
@@ -1761,6 +1768,7 @@ dev = [
 requires-dist = [
     { name = "build", specifier = ">=1.0.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
+    { name = "gitignore-parser", specifier = ">=0.1.13" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "prime-evals", editable = "packages/prime-evals" },
     { name = "prime-sandboxes", editable = "packages/prime-sandboxes" },


### PR DESCRIPTION
## Summary
- `prime env push` now respects `.gitignore` when building source archives, so files like `logs/` or `*.tmp` are excluded automatically
- Centralizes file collection into `_collect_archive_files()` used by both archive building and content hashing
- Adds `gitignore-parser` dependency

Closes #424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files are included in `prime env push` source archives and content hashing, which can affect version/content-hash stability and what gets uploaded. Uses a new third-party `.gitignore` parser and new traversal logic, so edge cases in ignore matching could impact uploads.
> 
> **Overview**
> `prime env push` now **honors the environment’s root `.gitignore`** when selecting files for the source tarball and when computing the environment `content_hash`, preventing ignored artifacts (e.g. `logs/`, `*.tmp`) from being uploaded or affecting versioning.
> 
> File selection is centralized into a new deterministic `_collect_archive_files()` (used by both archive creation and `compute_content_hash`), and `gitignore-parser` is added as a dependency with tests covering ignore rules and negation patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1324187004491b02cf78f8d83f7649eb3e228109. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->