### PR TITLE
Feature: Add public flag for eval pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ prime eval push
 # Push specific eval directory (verifiers format)
 prime eval push outputs/evals/gsm8k--gpt-4/abc123
 
+# Push a public evaluation (default is private)
+prime eval push --public
+
 # List all evaluations
 prime eval list
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -305,6 +305,7 @@ def _push_single_eval(
     env_slug: Optional[str],
     run_id: Optional[str],
     eval_id: Optional[str],
+    is_public: bool = False,
 ) -> str:
     path = _validate_eval_path(config_path)
     eval_data = _load_eval_directory(path)
@@ -364,6 +365,7 @@ def _push_single_eval(
             metadata=eval_data.get("metadata"),
             metrics=eval_data.get("metrics"),
             tags=eval_data.get("tags", []),
+            is_public=is_public,
         )
 
         eval_id = create_response.get("evaluation_id")
@@ -438,6 +440,11 @@ def push_eval(
         help="Push to existing evaluation id",
     ),
     output: str = typer.Option("pretty", "--output", "-o", help="json|pretty"),
+    is_public: bool = typer.Option(
+        False,
+        "--public",
+        help="Make the pushed evaluation public. Evaluations are private by default.",
+    ),
 ) -> None:
     """Push evaluation data to Prime Evals.
 
@@ -448,6 +455,7 @@ def push_eval(
         prime eval push                                    # Push current dir or auto-discover
         prime eval push outputs/evals/gsm8k--gpt-4/abc123  # Push specific directory
         prime eval push --env gsm8k                        # Push with environment override
+        prime eval push --public                           # Create a public evaluation
         prime eval push --eval xyz789                      # Push to existing evaluation
     """
     try:
@@ -462,7 +470,7 @@ def push_eval(
         if config_path is None:
             current_dir = Path(".")
             if _has_eval_files(current_dir):
-                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id)
+                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id, is_public)
                 if output == "json":
                     console.print()
                     output_data_as_json({"evaluation_id": result_eval_id}, console)
@@ -485,7 +493,9 @@ def push_eval(
             results = []
             for eval_dir in eval_dirs:
                 try:
-                    result_eval_id = _push_single_eval(str(eval_dir), env_id, run_id, eval_id)
+                    result_eval_id = _push_single_eval(
+                        str(eval_dir), env_id, run_id, eval_id, is_public
+                    )
                     results.append(
                         {"path": str(eval_dir), "eval_id": result_eval_id, "status": "success"}
                     )
@@ -508,7 +518,7 @@ def push_eval(
 
             return
 
-        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id)
+        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id, is_public)
 
         if output == "json":
             console.print()

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -459,6 +459,13 @@ def push_eval(
         prime eval push --eval xyz789                      # Push to existing evaluation
     """
     try:
+        if eval_id and is_public:
+            console.print(
+                "[red]Error:[/red] The --public flag cannot be used with --eval-id. "
+                "Visibility can only be set when creating a new evaluation."
+            )
+            raise typer.Exit(1)
+
         if config_path is None and eval_id:
             console.print("[red]Error:[/red] Cannot use --eval-id with auto-discovery")
             console.print()

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -4,6 +4,7 @@ import pytest
 from prime_cli.commands.evals import (
     _has_eval_files,
     _load_eval_directory,
+    _push_single_eval,
     _validate_eval_path,
 )
 
@@ -118,6 +119,62 @@ class TestValidateEvalPath:
             _validate_eval_path("/nonexistent/path/xyz123")
 
         assert "Path not found" in str(exc_info.value)
+
+
+class TestPushSingleEval:
+    def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, None)
+
+        assert eval_id == "eval-123"
+        assert captured["is_public"] is False
+
+    def test_create_evaluation_passes_public_flag(self, tmp_path, monkeypatch):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, None, is_public=True)
+
+        assert eval_id == "eval-123"
+        assert captured["is_public"] is True
 
 
 class TestLoadEvalDirectory:

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -7,6 +7,10 @@ from prime_cli.commands.evals import (
     _push_single_eval,
     _validate_eval_path,
 )
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
 
 
 class TestHasEvalFiles:
@@ -119,6 +123,23 @@ class TestValidateEvalPath:
             _validate_eval_path("/nonexistent/path/xyz123")
 
         assert "Path not found" in str(exc_info.value)
+
+
+def test_push_eval_rejects_public_with_eval_id(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    (tmp_path / "metadata.json").write_text(json.dumps({"env": "gsm8k", "model": "gpt-4"}))
+    (tmp_path / "results.jsonl").write_text("")
+
+    result = runner.invoke(
+        app,
+        ["eval", "push", ".", "--eval-id", "eval-123", "--public"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "cannot be used with --eval-id" in result.output
 
 
 class TestPushSingleEval:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the evaluation creation flow to optionally publish results, which can affect data visibility if misused. Includes a guard to prevent applying visibility changes when updating an existing evaluation.
> 
> **Overview**
> `prime eval push` now supports a `--public` flag that is forwarded as `is_public` when **creating** a new evaluation (default remains private).
> 
> The command now errors if `--public` is combined with `--eval-id` (updates), and README/tests were updated to document and validate the new visibility behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68747d92bad5338e5d136177839563b75538544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->