### PR TITLE
better tunnel error reporting

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -4,9 +4,11 @@ __version__ = "0.1.4"
 
 from prime_tunnel.core import Config, TunnelClient
 from prime_tunnel.exceptions import (
+    BinaryDownloadError,
     TunnelAuthError,
-    TunnelConnectionError,
     TunnelError,
+    TunnelLimitReachedError,
+    TunnelNotRunningError,
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
@@ -22,8 +24,10 @@ __all__ = [
     # Models
     "TunnelInfo",
     # Exceptions
-    "TunnelError",
+    "BinaryDownloadError",
     "TunnelAuthError",
-    "TunnelConnectionError",
+    "TunnelError",
+    "TunnelLimitReachedError",
+    "TunnelNotRunningError",
     "TunnelTimeoutError",
 ]

--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -6,9 +6,9 @@ from prime_tunnel.core import Config, TunnelClient
 from prime_tunnel.exceptions import (
     BinaryDownloadError,
     TunnelAuthError,
+    TunnelConnectionError,
     TunnelError,
     TunnelLimitReachedError,
-    TunnelNotRunningError,
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
@@ -28,6 +28,6 @@ __all__ = [
     "TunnelAuthError",
     "TunnelError",
     "TunnelLimitReachedError",
-    "TunnelNotRunningError",
+    "TunnelConnectionError",
     "TunnelTimeoutError",
 ]

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -168,6 +168,8 @@ class TunnelClient:
             response = await self._request_with_retry("POST", url, json=payload)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except TimeoutError as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
             raise TunnelError(f"Failed to connect to API: {e}") from e
 
@@ -194,6 +196,8 @@ class TunnelClient:
         try:
             response = await self._request_with_retry("GET", url)
         except httpx.TimeoutException as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except TimeoutError as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
             raise TunnelError(f"Failed to connect to API: {e}") from e
@@ -232,6 +236,8 @@ class TunnelClient:
             response = await self._request_with_retry("DELETE", url)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except TimeoutError as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
             raise TunnelError(f"Failed to connect to API: {e}") from e
 
@@ -251,6 +257,8 @@ class TunnelClient:
         try:
             response = await self._request_with_retry("DELETE", url, json=payload)
         except httpx.TimeoutException as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except TimeoutError as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
             raise TunnelError(f"Failed to connect to API: {e}") from e
@@ -278,6 +286,8 @@ class TunnelClient:
         try:
             response = await self._request_with_retry("GET", url, params=params)
         except httpx.TimeoutException as e:
+            raise TunnelTimeoutError(f"Request timed out: {e}") from e
+        except TimeoutError as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
             raise TunnelError(f"Failed to connect to API: {e}") from e

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -10,7 +10,12 @@ from tenacity import (
 )
 
 from prime_tunnel.core.config import Config
-from prime_tunnel.exceptions import TunnelAuthError, TunnelError, TunnelTimeoutError
+from prime_tunnel.exceptions import (
+    TunnelAuthError,
+    TunnelError,
+    TunnelLimitReachedError,
+    TunnelTimeoutError,
+)
 from prime_tunnel.models import TunnelInfo
 
 # Retry configuration for transient connection errors
@@ -105,6 +110,14 @@ class TunnelClient:
             raise TunnelAuthError("Payment required. Check billing status.")
         elif response.status_code == 404:
             return {}  # Handle 404 specially in callers
+        elif response.status_code == 400:
+            try:
+                error_detail = response.json().get("detail", response.text)
+            except Exception:
+                error_detail = response.text
+            if "maximum number of" in error_detail.lower():
+                raise TunnelLimitReachedError(error_detail)
+            raise TunnelError(f"Failed to {operation}: {error_detail}")
         elif response.status_code >= 400:
             try:
                 error_detail = response.json().get("detail", response.text)
@@ -197,6 +210,7 @@ class TunnelClient:
             server_port=7000,
             expires_at=data["expires_at"],
             user_id=data.get("user_id"),
+            status=data.get("status"),
         )
 
     async def delete_tunnel(self, tunnel_id: str) -> bool:
@@ -280,6 +294,7 @@ class TunnelClient:
                     server_port=7000,
                     expires_at=t["expires_at"],
                     user_id=t.get("user_id"),
+                    status=t.get("status"),
                 )
             )
         return tunnels

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -115,6 +115,7 @@ class TunnelClient:
                 error_detail = response.json().get("detail", response.text)
             except Exception:
                 error_detail = response.text
+            error_detail = str(error_detail)
             if "maximum number of" in error_detail.lower():
                 raise TunnelLimitReachedError(error_detail)
             raise TunnelError(f"Failed to {operation}: {error_detail}")

--- a/packages/prime-tunnel/src/prime_tunnel/exceptions.py
+++ b/packages/prime-tunnel/src/prime_tunnel/exceptions.py
@@ -4,7 +4,7 @@ class TunnelError(Exception):
     pass
 
 
-class TunnelNotRunningError(TunnelError):
+class TunnelConnectionError(TunnelError):
     """Structured error for tunnel failures with diagnostic fields."""
 
     def __init__(

--- a/packages/prime-tunnel/src/prime_tunnel/exceptions.py
+++ b/packages/prime-tunnel/src/prime_tunnel/exceptions.py
@@ -4,20 +4,43 @@ class TunnelError(Exception):
     pass
 
 
+class TunnelNotRunningError(TunnelError):
+    """Structured error for tunnel failures with diagnostic fields."""
+
+    def __init__(
+        self,
+        tunnel_id: str | None = None,
+        error_type: str | None = None,
+        message: str | None = None,
+    ):
+        self.tunnel_id = tunnel_id
+        self.error_type = error_type
+
+        if message:
+            msg = message
+        elif error_type:
+            msg = f"Tunnel {tunnel_id} failed ({error_type})"
+        elif tunnel_id:
+            msg = f"Tunnel {tunnel_id} is not running"
+        else:
+            msg = "Tunnel is not running"
+        super().__init__(msg)
+
+
 class TunnelAuthError(TunnelError):
     """Authentication failed when registering tunnel."""
 
     pass
 
 
-class TunnelConnectionError(TunnelError):
-    """Failed to establish tunnel connection."""
+class TunnelTimeoutError(TunnelError):
+    """Tunnel operation timed out."""
 
     pass
 
 
-class TunnelTimeoutError(TunnelError):
-    """Tunnel operation timed out."""
+class TunnelLimitReachedError(TunnelError):
+    """Tunnel quota exceeded."""
 
     pass
 

--- a/packages/prime-tunnel/src/prime_tunnel/exceptions.py
+++ b/packages/prime-tunnel/src/prime_tunnel/exceptions.py
@@ -5,22 +5,18 @@ class TunnelError(Exception):
 
 
 class TunnelConnectionError(TunnelError):
-    """Structured error for tunnel failures with diagnostic fields."""
+    """Tunnel connection failure with optional tunnel ID for diagnostics."""
 
     def __init__(
         self,
         message: str | None = None,
         *,  # keyword-only below for backwards compat
         tunnel_id: str | None = None,
-        error_type: str | None = None,
     ):
         self.tunnel_id = tunnel_id
-        self.error_type = error_type
 
         if message is not None:
             msg = message
-        elif error_type:
-            msg = f"Tunnel {tunnel_id} failed ({error_type})"
         elif tunnel_id:
             msg = f"Tunnel {tunnel_id} is not running"
         else:

--- a/packages/prime-tunnel/src/prime_tunnel/exceptions.py
+++ b/packages/prime-tunnel/src/prime_tunnel/exceptions.py
@@ -9,9 +9,10 @@ class TunnelConnectionError(TunnelError):
 
     def __init__(
         self,
+        message: str | None = None,
+        *,  # keyword-only below for backwards compat
         tunnel_id: str | None = None,
         error_type: str | None = None,
-        message: str | None = None,
     ):
         self.tunnel_id = tunnel_id
         self.error_type = error_type

--- a/packages/prime-tunnel/src/prime_tunnel/exceptions.py
+++ b/packages/prime-tunnel/src/prime_tunnel/exceptions.py
@@ -17,7 +17,7 @@ class TunnelConnectionError(TunnelError):
         self.tunnel_id = tunnel_id
         self.error_type = error_type
 
-        if message:
+        if message is not None:
             msg = message
         elif error_type:
             msg = f"Tunnel {tunnel_id} failed ({error_type})"

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -17,6 +17,7 @@ class TunnelInfo(BaseModel):
     expires_at: datetime = Field(..., description="Token expiration time")
     # Optional because create_tunnel response doesn't include user_id
     user_id: Optional[str] = Field(None, description="Owner user ID")
+    status: Optional[str] = Field(None, description="Current tunnel status")
 
     class Config:
         from_attributes = True

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -259,9 +259,9 @@ class Tunnel:
         if self._process is None:
             return
 
-        self._recent_output: list[str] = list(self._output_lines)
         self._output_lock = threading.Lock()
         max_lines = 50
+        self._recent_output: list[str] = list(self._output_lines[-max_lines:])
 
         def drain_pipe(pipe):
             """Read output from a pipe, retaining recent lines."""

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -432,9 +432,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                                         "login to the server failed" in line.lower()
                                         or "connect to server error" in line.lower()
                                     ):
-                                        raise _parse_frpc_error(
-                                            self._output_lines, self.tunnel_id
-                                        )
+                                        raise _parse_frpc_error(self._output_lines, self.tunnel_id)
                         except (BlockingIOError, IOError):
                             pass  # No more data available on this pipe
                 finally:

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -19,6 +19,15 @@ from prime_tunnel.exceptions import (
 )
 from prime_tunnel.models import TunnelInfo
 
+# timestamp + level + caller prefix + message
+_LOG_RE = re.compile(
+    r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s"
+    r"\[([EWIDT])\]\s"
+    r"\[.*?\]\s"
+    r"(?:\[.*?\]\s)*"
+    r"(.+)"
+)
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 def _parse_frpc_error(
     output_lines: list[str],
@@ -26,16 +35,6 @@ def _parse_frpc_error(
     return_code: int | None = None,
 ) -> TunnelConnectionError:
     """Parse frpc log output into a structured tunnel exception."""
-    # timestamp + level + caller prefix + message
-    _LOG_RE = re.compile(
-        r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s"
-        r"\[([EWIDT])\]\s"
-        r"\[.*?\]\s"
-        r"(?:\[.*?\]\s)*"
-        r"(.+)"
-    )
-    _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-
     error_messages: list[str] = []
     for raw_line in output_lines:
         line = _ANSI_RE.sub("", raw_line)

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -58,13 +58,19 @@ def _classify_frpc_error(
                 error_type="auth_failed",
                 message="Tunnel server plugin unreachable. Try again later.",
             )
+        if "already online" in combined:
+            return TunnelConnectionError(
+                tunnel_id=tunnel_id,
+                error_type="already_online",
+                message="Another client is already connected with this tunnel. Stop the existing connection first.",
+            )
         return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="auth_failed",
             message="Login failed. Tunnel may have expired or been deleted.",
         )
 
-    if "token in login doesn't match" in combined or "authorization failed" in combined:
+    if "token in login doesn't match" in combined:
         return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="auth_failed",

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -20,111 +20,40 @@ from prime_tunnel.exceptions import (
 from prime_tunnel.models import TunnelInfo
 
 
-def _classify_frpc_error(
+def _parse_frpc_error(
     output_lines: list[str],
     tunnel_id: str | None = None,
     return_code: int | None = None,
 ) -> TunnelConnectionError:
-    """Classify frpc output into a specific tunnel exception."""
-    combined = re.sub(r"\x1b\[[0-9;]*m", "", "\n".join(output_lines)).lower()
-
-    if "login to the server failed" in combined or "connect to server error" in combined:
-        if "not registered" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="auth_failed",
-                message=(
-                    "Tunnel no longer registered. It may have expired or been "
-                    "deleted. Create a new one."
-                ),
-            )
-        if "invalid authentication token" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="auth_failed",
-                message="Tunnel token is invalid or expired. Create a new tunnel.",
-            )
-        if "invalid binding secret" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="auth_failed",
-                message=(
-                    "Binding secret mismatch. The tunnel may have been recreated. Create a new one."
-                ),
-            )
-        if "send login request to plugin error" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="auth_failed",
-                message="Tunnel server plugin unreachable. Try again later.",
-            )
-        if "already online" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="already_online",
-                message="Another client is already connected with this tunnel."
-                " Stop the existing connection first.",
-            )
-        if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
-            return TunnelConnectionError(
-                tunnel_id=tunnel_id,
-                error_type="connection_lost",
-                message="Cannot reach tunnel server. Check internet and firewall.",
-            )
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="auth_failed",
-            message="Login failed. Tunnel may have expired or been deleted.",
-        )
-
-    if "token in login doesn't match" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="auth_failed",
-            message="Server rejected authorization. Tunnel may have expired or been deleted.",
-        )
-
-    # Connection lost
-    if "heartbeat timeout" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="connection_lost",
-            message="Lost connection to tunnel server (heartbeat timeout). Check your network.",
-        )
-    if "pong message contains error" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="connection_lost",
-            message="Tunnel server sent an error during keepalive.",
-        )
-
-    # Config errors (proxy type, custom domains, subdomain)
-    if "unsupported proxy type" in combined or "proxy type not support" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="config_error",
-            message="Only HTTP tunnels are supported.",
-        )
-    if "custom_domains not allowed" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="config_error",
-            message="Custom domains are not permitted.",
-        )
-    if "subdomain does not match" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="config_error",
-            message="Subdomain mismatch. Tunnel configuration error.",
-        )
-
-    # Fallback
-    output_text = "\n".join(output_lines) if output_lines else "(no output captured)"
-    exit_info = f" (exit code {return_code})" if return_code is not None else ""
-    return TunnelConnectionError(
-        tunnel_id=tunnel_id,
-        message=f"frpc connection failed{exit_info}\n--- frpc output ---\n{output_text}",
+    """Parse frpc log output into a structured tunnel exception."""
+    # timestamp + level + caller prefix + message
+    _LOG_RE = re.compile(
+        r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s"
+        r"\[([EWIDT])\]\s"
+        r"\[.*?\]\s"
+        r"(?:\[.*?\]\s)*"
+        r"(.+)"
     )
+    _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+    error_messages: list[str] = []
+    for raw_line in output_lines:
+        line = _ANSI_RE.sub("", raw_line)
+        m = _LOG_RE.match(line)
+        if not m:
+            continue
+        level, msg = m.group(1), m.group(2)
+        if level in ("E", "W"):
+            error_messages.append(msg)
+
+    if error_messages:
+        message = error_messages[-1]
+    else:
+        output_text = "\n".join(output_lines) if output_lines else "(no output captured)"
+        exit_info = f" (exit code {return_code})" if return_code is not None else ""
+        message = f"frpc process failed{exit_info}: {output_text}"
+
+    return TunnelConnectionError(tunnel_id=tunnel_id, message=message)
 
 
 class Tunnel:
@@ -470,7 +399,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                     remaining_output.extend(self._process.stderr.readlines())
                 self._output_lines.extend(line.strip() for line in remaining_output if line.strip())
 
-                raise _classify_frpc_error(self._output_lines, self.tunnel_id, return_code)
+                raise _parse_frpc_error(self._output_lines, self.tunnel_id, return_code)
 
             if os.name == "posix":
                 # Set both pipes to non-blocking mode to drain them without deadlock
@@ -503,7 +432,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                                         "login to the server failed" in line.lower()
                                         or "connect to server error" in line.lower()
                                     ):
-                                        raise _classify_frpc_error(
+                                        raise _parse_frpc_error(
                                             self._output_lines, self.tunnel_id
                                         )
                         except (BlockingIOError, IOError):

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -192,7 +192,7 @@ class Tunnel:
             )
         except BaseException as e:
             await self._cleanup()
-            if isinstance(e, asyncio.CancelledError):
+            if isinstance(e, (asyncio.CancelledError, TunnelError)):
                 raise
             raise TunnelError(f"Failed to register tunnel: {e}") from e
 

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -64,6 +64,12 @@ def _classify_frpc_error(
                 error_type="already_online",
                 message="Another client is already connected with this tunnel. Stop the existing connection first.",
             )
+        if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
+            return TunnelConnectionError(
+                tunnel_id=tunnel_id,
+                error_type="connection_lost",
+                message="Cannot reach tunnel server. Check internet and firewall.",
+            )
         return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="auth_failed",
@@ -109,14 +115,6 @@ def _classify_frpc_error(
             tunnel_id=tunnel_id,
             error_type="config_error",
             message="Subdomain mismatch. Tunnel configuration error.",
-        )
-
-    # Network errors
-    if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
-        return TunnelConnectionError(
-            tunnel_id=tunnel_id,
-            error_type="connection_lost",
-            message="Cannot reach tunnel server. Check internet and firewall.",
         )
 
     # Fallback

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -500,8 +500,8 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                                     if "start proxy success" in line.lower():
                                         return
                                     if (
-                                        "login failed" in line.lower()
-                                        or "authorization failed" in line.lower()
+                                        "login to the server failed" in line.lower()
+                                        or "connect to server error" in line.lower()
                                     ):
                                         raise _classify_frpc_error(
                                             self._output_lines, self.tunnel_id

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -29,6 +29,7 @@ _LOG_RE = re.compile(
 )
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
+
 def _parse_frpc_error(
     output_lines: list[str],
     tunnel_id: str | None = None,

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -19,7 +19,9 @@ from prime_tunnel.exceptions import (
 from prime_tunnel.models import TunnelInfo
 
 
-def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) -> TunnelError:
+def _classify_frpc_error(
+    output_lines: list[str], tunnel_id: str | None = None
+) -> TunnelConnectionError:
     """Classify frpc output into a specific tunnel exception."""
     combined = "\n".join(output_lines).lower()
 

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -1,6 +1,7 @@
 import asyncio
 import fcntl
 import os
+import re
 import subprocess
 import threading
 import time
@@ -25,11 +26,11 @@ def _classify_frpc_error(
     return_code: int | None = None,
 ) -> TunnelConnectionError:
     """Classify frpc output into a specific tunnel exception."""
-    combined = "\n".join(output_lines).lower()
+    combined = re.sub(r"\x1b\[[0-9;]*m", "", "\n".join(output_lines)).lower()
 
     # Auth failures
-    if "login failed" in combined:
-        if "tunnel not registered" in combined:
+    if "login" in combined and "failed" in combined:
+        if "not registered" in combined:
             return TunnelConnectionError(
                 tunnel_id=tunnel_id,
                 error_type="auth_failed",
@@ -75,7 +76,7 @@ def _classify_frpc_error(
         )
 
     # Config errors (proxy type, custom domains, subdomain)
-    if "unsupported proxy type" in combined:
+    if "unsupported proxy type" in combined or "proxy type not support" in combined:
         return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="config_error",

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -28,8 +28,7 @@ def _classify_frpc_error(
     """Classify frpc output into a specific tunnel exception."""
     combined = re.sub(r"\x1b\[[0-9;]*m", "", "\n".join(output_lines)).lower()
 
-    # Auth failures
-    if "login" in combined and "failed" in combined:
+    if "login to the server failed" in combined or "connect to server error" in combined:
         if "not registered" in combined:
             return TunnelConnectionError(
                 tunnel_id=tunnel_id,
@@ -52,6 +51,12 @@ def _classify_frpc_error(
                 message=(
                     "Binding secret mismatch. The tunnel may have been recreated. Create a new one."
                 ),
+            )
+        if "send login request to plugin error" in combined:
+            return TunnelConnectionError(
+                tunnel_id=tunnel_id,
+                error_type="auth_failed",
+                message="Tunnel server plugin unreachable. Try again later.",
             )
         return TunnelConnectionError(
             tunnel_id=tunnel_id,

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -53,6 +53,11 @@ def _classify_frpc_error(
                     "Binding secret mismatch. The tunnel may have been recreated. Create a new one."
                 ),
             )
+        return TunnelConnectionError(
+            tunnel_id=tunnel_id,
+            error_type="auth_failed",
+            message="Login failed. Tunnel may have expired or been deleted.",
+        )
 
     if "token in login doesn't match" in combined or "authorization failed" in combined:
         return TunnelConnectionError(

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -242,6 +242,9 @@ class Tunnel:
     def recent_output(self) -> list[str]:
         """Last N lines of frpc output (thread-safe). Falls back to startup output."""
         if hasattr(self, "_output_lock"):
+            if not self.is_running and hasattr(self, "_drain_threads"):
+                for t in self._drain_threads:
+                    t.join(timeout=2.0)
             with self._output_lock:
                 return list(self._recent_output)
         return list(self._output_lines)
@@ -256,7 +259,7 @@ class Tunnel:
         if self._process is None:
             return
 
-        self._recent_output: list[str] = []
+        self._recent_output: list[str] = list(self._output_lines)
         self._output_lock = threading.Lock()
         max_lines = 50
 
@@ -275,8 +278,11 @@ class Tunnel:
             except (OSError, ValueError):
                 pass  # Pipe closed
 
+        self._drain_threads: list[threading.Thread] = []
         for pipe in (self._process.stdout, self._process.stderr):
-            threading.Thread(target=drain_pipe, args=(pipe,), daemon=True).start()
+            t = threading.Thread(target=drain_pipe, args=(pipe,), daemon=True)
+            t.start()
+            self._drain_threads.append(t)
 
     def _write_frpc_config(self) -> Path:
         """Generate and write frpc configuration file."""

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -12,8 +12,8 @@ import httpx
 from prime_tunnel.binary import get_frpc_path
 from prime_tunnel.core.client import TunnelClient
 from prime_tunnel.exceptions import (
+    TunnelConnectionError,
     TunnelError,
-    TunnelNotRunningError,
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
@@ -26,7 +26,7 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
     # Auth failures
     if "login failed" in combined:
         if "tunnel not registered" in combined:
-            return TunnelNotRunningError(
+            return TunnelConnectionError(
                 tunnel_id=tunnel_id,
                 error_type="auth_failed",
                 message=(
@@ -35,13 +35,13 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
                 ),
             )
         if "invalid authentication token" in combined:
-            return TunnelNotRunningError(
+            return TunnelConnectionError(
                 tunnel_id=tunnel_id,
                 error_type="auth_failed",
                 message="Tunnel token is invalid or expired. Create a new tunnel.",
             )
         if "invalid binding secret" in combined:
-            return TunnelNotRunningError(
+            return TunnelConnectionError(
                 tunnel_id=tunnel_id,
                 error_type="auth_failed",
                 message=(
@@ -50,7 +50,7 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
             )
 
     if "token in login doesn't match" in combined or "authorization failed" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="auth_failed",
             message="Server rejected authorization. Tunnel may have expired or been deleted.",
@@ -58,13 +58,13 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
 
     # Connection lost
     if "heartbeat timeout" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="connection_lost",
             message="Lost connection to tunnel server (heartbeat timeout). Check your network.",
         )
     if "pong message contains error" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="connection_lost",
             message="Tunnel server sent an error during keepalive.",
@@ -72,19 +72,19 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
 
     # Config errors (proxy type, custom domains, subdomain)
     if "unsupported proxy type" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="config_error",
             message="Only HTTP tunnels are supported.",
         )
     if "custom_domains not allowed" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="config_error",
             message="Custom domains are not permitted.",
         )
     if "subdomain does not match" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="config_error",
             message="Subdomain mismatch. Tunnel configuration error.",
@@ -92,7 +92,7 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
 
     # Network errors
     if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
-        return TunnelNotRunningError(
+        return TunnelConnectionError(
             tunnel_id=tunnel_id,
             error_type="connection_lost",
             message="Cannot reach tunnel server. Check internet and firewall.",
@@ -100,7 +100,7 @@ def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) 
 
     # Fallback
     output_text = "\n".join(output_lines) if output_lines else "(no output captured)"
-    return TunnelNotRunningError(
+    return TunnelConnectionError(
         tunnel_id=tunnel_id,
         message=f"frpc connection failed\n--- frpc output ---\n{output_text}\n-------------------",
     )
@@ -174,7 +174,7 @@ class Tunnel:
 
         Raises:
             TunnelError: If tunnel registration fails
-            TunnelNotRunningError: If frpc fails to connect
+            TunnelConnectionError: If frpc fails to connect or tunnel is not running
             TunnelTimeoutError: If connection times out
         """
         if self._started:
@@ -217,7 +217,7 @@ class Tunnel:
             await self._cleanup()
             if isinstance(e, asyncio.CancelledError):
                 raise
-            raise TunnelNotRunningError(message=f"Failed to start frpc: {e}") from e
+            raise TunnelConnectionError(message=f"Failed to start frpc: {e}") from e
 
         # 5. Wait for connection
         try:
@@ -233,7 +233,7 @@ class Tunnel:
             await self._cleanup()
             if isinstance(e, asyncio.CancelledError):
                 raise
-            raise TunnelNotRunningError(message=f"Failed to start pipe drain: {e}") from e
+            raise TunnelConnectionError(message=f"Failed to start pipe drain: {e}") from e
 
         self._started = True
 
@@ -438,7 +438,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
 
         while time.time() - start_time < self.connection_timeout:
             if self._process is None:
-                raise TunnelNotRunningError(message="frpc process not running")
+                raise TunnelConnectionError(message="frpc process not running")
 
             return_code = self._process.poll()
             if return_code is not None:

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -62,7 +62,8 @@ def _classify_frpc_error(
             return TunnelConnectionError(
                 tunnel_id=tunnel_id,
                 error_type="already_online",
-                message="Another client is already connected with this tunnel. Stop the existing connection first.",
+                message="Another client is already connected with this tunnel."
+                " Stop the existing connection first.",
             )
         if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
             return TunnelConnectionError(

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -20,7 +20,9 @@ from prime_tunnel.models import TunnelInfo
 
 
 def _classify_frpc_error(
-    output_lines: list[str], tunnel_id: str | None = None
+    output_lines: list[str],
+    tunnel_id: str | None = None,
+    return_code: int | None = None,
 ) -> TunnelConnectionError:
     """Classify frpc output into a specific tunnel exception."""
     combined = "\n".join(output_lines).lower()
@@ -102,9 +104,10 @@ def _classify_frpc_error(
 
     # Fallback
     output_text = "\n".join(output_lines) if output_lines else "(no output captured)"
+    exit_info = f" (exit code {return_code})" if return_code is not None else ""
     return TunnelConnectionError(
         tunnel_id=tunnel_id,
-        message=f"frpc connection failed\n--- frpc output ---\n{output_text}\n-------------------",
+        message=f"frpc connection failed{exit_info}\n--- frpc output ---\n{output_text}",
     )
 
 
@@ -451,7 +454,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                     remaining_output.extend(self._process.stderr.readlines())
                 self._output_lines.extend(line.strip() for line in remaining_output if line.strip())
 
-                raise _classify_frpc_error(self._output_lines, self.tunnel_id)
+                raise _classify_frpc_error(self._output_lines, self.tunnel_id, return_code)
 
             if os.name == "posix":
                 # Set both pipes to non-blocking mode to drain them without deadlock

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -11,8 +11,99 @@ import httpx
 
 from prime_tunnel.binary import get_frpc_path
 from prime_tunnel.core.client import TunnelClient
-from prime_tunnel.exceptions import TunnelConnectionError, TunnelError, TunnelTimeoutError
+from prime_tunnel.exceptions import (
+    TunnelError,
+    TunnelNotRunningError,
+    TunnelTimeoutError,
+)
 from prime_tunnel.models import TunnelInfo
+
+
+def _classify_frpc_error(output_lines: list[str], tunnel_id: str | None = None) -> TunnelError:
+    """Classify frpc output into a specific tunnel exception."""
+    combined = "\n".join(output_lines).lower()
+
+    # Auth failures
+    if "login failed" in combined:
+        if "tunnel not registered" in combined:
+            return TunnelNotRunningError(
+                tunnel_id=tunnel_id,
+                error_type="auth_failed",
+                message=(
+                    "Tunnel no longer registered. It may have expired or been "
+                    "deleted. Create a new one."
+                ),
+            )
+        if "invalid authentication token" in combined:
+            return TunnelNotRunningError(
+                tunnel_id=tunnel_id,
+                error_type="auth_failed",
+                message="Tunnel token is invalid or expired. Create a new tunnel.",
+            )
+        if "invalid binding secret" in combined:
+            return TunnelNotRunningError(
+                tunnel_id=tunnel_id,
+                error_type="auth_failed",
+                message=(
+                    "Binding secret mismatch. The tunnel may have been recreated. Create a new one."
+                ),
+            )
+
+    if "token in login doesn't match" in combined or "authorization failed" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="auth_failed",
+            message="Server rejected authorization. Tunnel may have expired or been deleted.",
+        )
+
+    # Connection lost
+    if "heartbeat timeout" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="connection_lost",
+            message="Lost connection to tunnel server (heartbeat timeout). Check your network.",
+        )
+    if "pong message contains error" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="connection_lost",
+            message="Tunnel server sent an error during keepalive.",
+        )
+
+    # Config errors (proxy type, custom domains, subdomain)
+    if "unsupported proxy type" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="config_error",
+            message="Only HTTP tunnels are supported.",
+        )
+    if "custom_domains not allowed" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="config_error",
+            message="Custom domains are not permitted.",
+        )
+    if "subdomain does not match" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="config_error",
+            message="Subdomain mismatch. Tunnel configuration error.",
+        )
+
+    # Network errors
+    if "connection refused" in combined or "no such host" in combined or "dial tcp" in combined:
+        return TunnelNotRunningError(
+            tunnel_id=tunnel_id,
+            error_type="connection_lost",
+            message="Cannot reach tunnel server. Check internet and firewall.",
+        )
+
+    # Fallback
+    output_text = "\n".join(output_lines) if output_lines else "(no output captured)"
+    return TunnelNotRunningError(
+        tunnel_id=tunnel_id,
+        message=f"frpc connection failed\n--- frpc output ---\n{output_text}\n-------------------",
+    )
 
 
 class Tunnel:
@@ -83,7 +174,7 @@ class Tunnel:
 
         Raises:
             TunnelError: If tunnel registration fails
-            TunnelConnectionError: If frpc fails to connect
+            TunnelNotRunningError: If frpc fails to connect
             TunnelTimeoutError: If connection times out
         """
         if self._started:
@@ -126,7 +217,7 @@ class Tunnel:
             await self._cleanup()
             if isinstance(e, asyncio.CancelledError):
                 raise
-            raise TunnelConnectionError(f"Failed to start frpc: {e}") from e
+            raise TunnelNotRunningError(message=f"Failed to start frpc: {e}") from e
 
         # 5. Wait for connection
         try:
@@ -142,7 +233,7 @@ class Tunnel:
             await self._cleanup()
             if isinstance(e, asyncio.CancelledError):
                 raise
-            raise TunnelConnectionError(f"Failed to start pipe drain: {e}") from e
+            raise TunnelNotRunningError(message=f"Failed to start pipe drain: {e}") from e
 
         self._started = True
 
@@ -347,7 +438,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
 
         while time.time() - start_time < self.connection_timeout:
             if self._process is None:
-                raise TunnelConnectionError("frpc process not running")
+                raise TunnelNotRunningError(message="frpc process not running")
 
             return_code = self._process.poll()
             if return_code is not None:
@@ -358,14 +449,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                     remaining_output.extend(self._process.stderr.readlines())
                 self._output_lines.extend(line.strip() for line in remaining_output if line.strip())
 
-                # Build detailed error message
-                output_text = (
-                    "\n".join(self._output_lines) if self._output_lines else "(no output captured)"
-                )
-                raise TunnelConnectionError(
-                    f"frpc exited with code {return_code}\n"
-                    f"--- frpc output ---\n{output_text}\n-------------------"
-                )
+                raise _classify_frpc_error(self._output_lines, self.tunnel_id)
 
             if os.name == "posix":
                 # Set both pipes to non-blocking mode to drain them without deadlock
@@ -394,11 +478,12 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                                     # Check for success/failure indicators
                                     if "start proxy success" in line.lower():
                                         return
-                                    if "login failed" in line.lower():
-                                        raise TunnelConnectionError(f"frpc login failed: {line}")
-                                    if "authorization failed" in line.lower():
-                                        raise TunnelConnectionError(
-                                            f"frpc authorization failed: {line}"
+                                    if (
+                                        "login failed" in line.lower()
+                                        or "authorization failed" in line.lower()
+                                    ):
+                                        raise _classify_frpc_error(
+                                            self._output_lines, self.tunnel_id
                                         )
                         except (BlockingIOError, IOError):
                             pass  # No more data available on this pipe

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -57,7 +57,7 @@ def start_tunnel(
             await shutdown_event.wait()
 
         except TunnelConnectionError as e:
-            header = f"[{e.error_type}]" if e.error_type else "[tunnel error]"
+            header = f"\\[{e.error_type}]" if e.error_type else "\\[tunnel error]"
             console.print(f"\n[red]{header}[/red] {e}", style="bold")
             if e.tunnel_id:
                 console.print(f"[dim]Tunnel ID: {e.tunnel_id}[/dim]")

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -63,7 +63,6 @@ def start_tunnel(
                             f"Tunnel process exited unexpectedly\n--- frpc output ---\n{output}"
                         ),
                         tunnel_id=tunnel.tunnel_id,
-                        error_type="connection_lost",
                     )
                 try:
                     await asyncio.wait_for(shutdown_event.wait(), timeout=2.0)
@@ -71,8 +70,7 @@ def start_tunnel(
                     pass
 
         except TunnelConnectionError as e:
-            header = f"\\[{e.error_type}]" if e.error_type else "\\[tunnel error]"
-            console.print(f"\n[red]{header}[/red] {e}", style="bold")
+            console.print(f"\n[red]Tunnel error:[/red] {e}", style="bold")
             if e.tunnel_id:
                 console.print(f"[dim]Tunnel ID: {e.tunnel_id}[/dim]")
             raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -6,8 +6,8 @@ import typer
 from prime_tunnel import Tunnel
 from prime_tunnel.core.client import TunnelClient
 from prime_tunnel.exceptions import (
+    TunnelConnectionError,
     TunnelLimitReachedError,
-    TunnelNotRunningError,
     TunnelTimeoutError,
 )
 from rich.console import Console
@@ -56,7 +56,7 @@ def start_tunnel(
 
             await shutdown_event.wait()
 
-        except TunnelNotRunningError as e:
+        except TunnelConnectionError as e:
             header = f"[{e.error_type}]" if e.error_type else "[tunnel error]"
             console.print(f"\n[red]{header}[/red] {e}", style="bold")
             if e.tunnel_id:

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -57,7 +57,6 @@ def start_tunnel(
 
             # Monitor tunnel health while waiting for shutdown signal
             while not shutdown_event.is_set():
-                console.print("test")
                 if not tunnel.is_running:
                     raise _classify_frpc_error(tunnel.recent_output, tunnel.tunnel_id)
                 try:

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -10,6 +10,7 @@ from prime_tunnel.exceptions import (
     TunnelLimitReachedError,
     TunnelTimeoutError,
 )
+from prime_tunnel.tunnel import _classify_frpc_error
 from rich.console import Console
 from rich.table import Table
 
@@ -54,7 +55,15 @@ def start_tunnel(
             console.print(f"\n[dim]Forwarding to localhost:{port}[/dim]")
             console.print("[dim]Press Ctrl+C to stop the tunnel[/dim]\n")
 
-            await shutdown_event.wait()
+            # Monitor tunnel health while waiting for shutdown signal
+            while not shutdown_event.is_set():
+                console.print("test")
+                if not tunnel.is_running:
+                    raise _classify_frpc_error(tunnel.recent_output, tunnel.tunnel_id)
+                try:
+                    await asyncio.wait_for(shutdown_event.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pass
 
         except TunnelConnectionError as e:
             header = f"\\[{e.error_type}]" if e.error_type else "\\[tunnel error]"

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -10,7 +10,6 @@ from prime_tunnel.exceptions import (
     TunnelLimitReachedError,
     TunnelTimeoutError,
 )
-from prime_tunnel.tunnel import _classify_frpc_error
 from rich.console import Console
 from rich.table import Table
 
@@ -58,7 +57,14 @@ def start_tunnel(
             # Monitor tunnel health while waiting for shutdown signal
             while not shutdown_event.is_set():
                 if not tunnel.is_running:
-                    raise _classify_frpc_error(tunnel.recent_output, tunnel.tunnel_id)
+                    output = "\n".join(tunnel.recent_output) or "(no output captured)"
+                    raise TunnelConnectionError(
+                        message=(
+                            f"Tunnel process exited unexpectedly\n--- frpc output ---\n{output}"
+                        ),
+                        tunnel_id=tunnel.tunnel_id,
+                        error_type="connection_lost",
+                    )
                 try:
                     await asyncio.wait_for(shutdown_event.wait(), timeout=2.0)
                 except asyncio.TimeoutError:

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -5,6 +5,11 @@ from typing import List, Optional
 import typer
 from prime_tunnel import Tunnel
 from prime_tunnel.core.client import TunnelClient
+from prime_tunnel.exceptions import (
+    TunnelLimitReachedError,
+    TunnelNotRunningError,
+    TunnelTimeoutError,
+)
 from rich.console import Console
 from rich.table import Table
 
@@ -51,6 +56,19 @@ def start_tunnel(
 
             await shutdown_event.wait()
 
+        except TunnelNotRunningError as e:
+            header = f"[{e.error_type}]" if e.error_type else "[tunnel error]"
+            console.print(f"\n[red]{header}[/red] {e}", style="bold")
+            if e.tunnel_id:
+                console.print(f"[dim]Tunnel ID: {e.tunnel_id}[/dim]")
+            raise typer.Exit(1)
+        except TunnelLimitReachedError as e:
+            console.print(f"\n[red]Tunnel limit reached:[/red] {e}", style="bold")
+            console.print("[dim]Delete an existing tunnel before creating a new one.[/dim]")
+            raise typer.Exit(1)
+        except TunnelTimeoutError as e:
+            console.print(f"\n[red]Connection timed out:[/red] {e}", style="bold")
+            raise typer.Exit(1)
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}", style="bold")
             raise typer.Exit(1)
@@ -95,12 +113,20 @@ def list_tunnels(
     table = Table(title="Active Tunnels")
     table.add_column("Tunnel ID", style="cyan")
     table.add_column("URL", style="green")
+    table.add_column("Status")
     table.add_column("Expires At")
 
     for tunnel in tunnels:
+        status_display = tunnel.status or "unknown"
+        if status_display == "connected":
+            status_display = "[green]connected[/green]"
+        elif status_display == "pending":
+            status_display = "[yellow]pending[/yellow]"
+
         table.add_row(
             tunnel.tunnel_id,
             tunnel.url,
+            status_display,
             str(tunnel.expires_at),
         )
 
@@ -133,6 +159,7 @@ def tunnel_status(
     console.print(f"[bold]Tunnel ID:[/bold] {tunnel.tunnel_id}")
     console.print(f"[bold]URL:[/bold] {tunnel.url}")
     console.print(f"[bold]Hostname:[/bold] {tunnel.hostname}")
+    console.print(f"[bold]Status:[/bold] {tunnel.status or 'unknown'}")
     console.print(f"[bold]Expires At:[/bold] {tunnel.expires_at}")
 
 

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -130,10 +130,14 @@ def list_tunnels(
 
     for tunnel in tunnels:
         status_display = tunnel.status or "unknown"
-        if status_display == "connected":
+        if status_display == "CONNECTED":
             status_display = "[green]connected[/green]"
-        elif status_display == "pending":
+        elif status_display == "PENDING":
             status_display = "[yellow]pending[/yellow]"
+        elif status_display == "DISCONNECTED":
+            status_display = "[red]disconnected[/red]"
+        elif status_display == "EXPIRED":
+            status_display = "[dim]expired[/dim]"
 
         table.add_row(
             tunnel.tunnel_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches tunnel startup/monitoring and HTTP error mapping, so regressions could impact tunnel reliability or change the surfaced error types/messages for consumers.
> 
> **Overview**
> Improves tunnel diagnostics across the SDK and CLI by adding structured errors and surfacing richer failure details from the underlying `frpc` process.
> 
> The SDK now introduces `TunnelLimitReachedError`, enriches `TunnelConnectionError` with an optional `tunnel_id`, parses `frpc` logs to produce clearer connection failures, and preserves recent `frpc` output for post-exit inspection. The API client also maps certain `400` responses to quota errors, handles additional timeout types, and includes a `status` field on `TunnelInfo` returned by `get_tunnel`/`list_tunnels`.
> 
> The CLI now monitors tunnel process health after startup, prints tailored messages for connection/timeout/quota failures, and displays tunnel status in `list` and `status` commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deb0c8b83a8dd53636c7683e73dd88594cced82f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->