### PR TITLE
Release: Bump cli to 0.5.45

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.44"
+__version__ = "0.5.45"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-string only change with no functional code modifications.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.44` to `0.5.45` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffd7d418aae65fc0b6c0104658cd6d45d7306b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->