### PR TITLE
Fix preflight inference check for prime evals

### DIFF
--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -796,7 +796,6 @@ def _preflight_inference_billing(
             {
                 "model": model,
                 "messages": [{"role": "user", "content": "Reply with OK."}],
-                "max_tokens": 1,
             }
         )
     except InferencePaymentRequiredError as exc:

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -96,6 +96,48 @@ def test_eval_run_blocks_when_inference_billing_is_missing(monkeypatch, error_me
     assert exc_info.value.exit_code == 1
 
 
+def test_eval_preflight_omits_max_tokens(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
+        lambda self, model: {"id": model},
+    )
+
+    seen_payloads = []
+
+    def fake_chat_completion(self, payload, stream=False):
+        seen_payloads.append(payload)
+        return {"id": "cmpl-123", "choices": []}
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
+        fake_chat_completion,
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="single_turn_math",
+            passthrough_args=["-m", "openai/gpt-4.1-mini"],
+            skip_upload=False,
+            env_path=None,
+        )
+
+    assert exc_info.value.exit_code == 0
+    assert seen_payloads == [
+        {
+            "model": "openai/gpt-4.1-mini",
+            "messages": [{"role": "user", "content": "Reply with OK."}],
+        }
+    ]
+
+
 def test_streaming_error_reads_response_before_formatting(monkeypatch):
     client = InferenceClient.__new__(InferenceClient)
     client.inference_url = "https://api.pinference.ai/api/v1"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the payload used for the eval billing preflight request and adds a regression test; main eval execution flow is unchanged.
> 
> **Overview**
> Fixes the `prime eval` inference billing preflight to stop sending `max_tokens` in the `chat_completion` payload, avoiding provider/model incompatibilities during the “Reply with OK.” check.
> 
> Adds a regression test (`test_eval_preflight_omits_max_tokens`) to assert the preflight request body no longer includes `max_tokens` and that the flow proceeds past preflight.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a558e1a30f9ecbf62584b6569b4ea56079a989e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->