### PR TITLE
short flags to sandbox delete and tunnel stop commands

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -538,7 +538,7 @@ def delete(
     sandbox_ids: Optional[List[str]] = typer.Argument(
         None, help="Sandbox ID(s) to delete (space or comma-separated)"
     ),
-    all: bool = typer.Option(False, "--all", help="Delete all sandboxes"),
+    all: bool = typer.Option(False, "--all", "-a", help="Delete all sandboxes"),
     labels: Optional[List[str]] = typer.Option(
         None, "--label", "-l", help="Delete all sandboxes with ALL these labels"
     ),
@@ -546,6 +546,7 @@ def delete(
     only_mine: bool = typer.Option(
         True,
         "--only-mine/--all-users",
+        "-m/-A",
         help="Restrict '--all' deletes to only your sandboxes",
         show_default=True,
     ),

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -141,7 +141,7 @@ def stop_tunnel(
     tunnel_ids: Optional[List[str]] = typer.Argument(
         None, help="Tunnel ID(s) to stop (space or comma-separated)"
     ),
-    all: bool = typer.Option(False, "--all", help="Stop all tunnels"),
+    all: bool = typer.Option(False, "--all", "-a", help="Stop all tunnels"),
     team_id: Optional[str] = typer.Option(
         None,
         "--team-id",
@@ -151,7 +151,8 @@ def stop_tunnel(
     only_mine: bool = typer.Option(
         True,
         "--only-mine/--all-users",
-        help="Restrict '--all' deletes to only your tunnels (default: only yours)",
+        "-m/-A",
+        help="Restrict '--all' deletes to only your tunnels",
         show_default=True,
     ),
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds additional flag aliases and a help string change; behavior of deletion/stop logic is unchanged aside from new CLI entry points.
> 
> **Overview**
> Adds short option aliases to destructive CLI commands: `prime sandbox delete` now supports `-a` for `--all` and `-m/-A` for `--only-mine/--all-users`, and `prime tunnel stop` mirrors the same `-a` and `-m/-A` flags (with a minor help-text tweak).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e29e113ed6fe3c7144e7a166b73a88c187dd544. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->