### PR TITLE
add missing tunnel retries

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -14,11 +14,16 @@ from prime_tunnel.exceptions import TunnelAuthError, TunnelError, TunnelTimeoutE
 from prime_tunnel.models import TunnelInfo
 
 # Retry configuration for transient connection errors
+# Note: TimeoutException is NOT included because the request may have been processed
 RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,
     httpx.ConnectError,
     httpx.PoolTimeout,
 )
+
+# Idempotent requests (GET, DELETE) can also retry on timeouts since
+# re-issuing the same request has no side effects
+IDEMPOTENT_RETRYABLE_EXCEPTIONS = RETRYABLE_EXCEPTIONS + (httpx.TimeoutException,)
 
 
 def _default_user_agent() -> str:
@@ -93,7 +98,32 @@ class TunnelClient:
         json: Optional[Dict[str, Any]] = None,
         params: Optional[Dict[str, str]] = None,
     ) -> httpx.Response:
-        """Make async HTTP request with retry on transient connection errors."""
+        """Make async HTTP request with retry on transient connection errors.
+
+        Used for non-idempotent requests (POST) where timeouts are NOT retried
+        because the server may have already processed the request.
+        """
+        client = await self._get_client()
+        return await client.request(method, url, json=json, params=params)
+
+    @retry(
+        retry=retry_if_exception_type(IDEMPOTENT_RETRYABLE_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    async def _idempotent_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, str]] = None,
+    ) -> httpx.Response:
+        """Make async HTTP request with retry on transient errors including timeouts.
+
+        Used for idempotent requests (GET, DELETE) where retrying after a timeout
+        is safe because the operation has no additional side effects.
+        """
         client = await self._get_client()
         return await client.request(method, url, json=json, params=params)
 
@@ -178,7 +208,7 @@ class TunnelClient:
         url = f"{self.base_url}/api/v1/tunnel/{tunnel_id}"
 
         try:
-            response = await self._request_with_retry("GET", url)
+            response = await self._idempotent_request_with_retry("GET", url)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
@@ -214,7 +244,7 @@ class TunnelClient:
         url = f"{self.base_url}/api/v1/tunnel/{tunnel_id}"
 
         try:
-            response = await self._request_with_retry("DELETE", url)
+            response = await self._idempotent_request_with_retry("DELETE", url)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
@@ -234,7 +264,7 @@ class TunnelClient:
         payload = {"tunnel_ids": tunnel_ids}
 
         try:
-            response = await self._request_with_retry("DELETE", url, json=payload)
+            response = await self._idempotent_request_with_retry("DELETE", url, json=payload)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
@@ -261,7 +291,7 @@ class TunnelClient:
         params = {"teamId": team_id} if team_id else None
 
         try:
-            response = await self._request_with_retry("GET", url, params=params)
+            response = await self._idempotent_request_with_retry("GET", url, params=params)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:


### PR DESCRIPTION
adds retry on a missing time oute exception and distinguishes between idempotent requests similarly to `GET` vs. `POST` in sandbox packgage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry behavior for `GET`/`DELETE` calls to include timeouts, which can alter client-side failure modes and potentially repeat server work if the endpoint is not truly idempotent.
> 
> **Overview**
> Improves tunnel client resiliency by **splitting retry behavior by request type**.
> 
> `TunnelClient` now keeps timeouts *non-retryable* for non-idempotent requests (e.g., `POST create_tunnel`), but **retries `GET`/`DELETE` operations on `httpx.TimeoutException`** via a new `_idempotent_request_with_retry`, and routes `get_tunnel`, `list_tunnels`, `delete_tunnel`, and `bulk_delete_tunnels` through it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b000f06a8058218ccdc4142b94b578427aaec4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->