### PR TITLE
Remove unnecessary arg for command execution

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/rpc_command_session.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/rpc_command_session.py
@@ -73,7 +73,7 @@ def build_command_session_start_request(
 ) -> Message:
     command_spec = _COMMAND_SPEC_FACTORY(
         cmd="/bin/bash",
-        args=["-l", "-c", command],
+        args=["-c", command],
         envs=env or {},
     )
     if working_dir is not None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-argument change to subprocess invocation; main risk is behavior differences for commands that relied on login-shell environment/profile initialization.
> 
> **Overview**
> Updates command-session startup to invoke `/bin/bash` without `-l`, changing the executed args from `[-l, -c, <command>]` to `[-c, <command>]` so commands no longer run as a login shell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a444975e745f32305c4f41775ce5fbd9e3d4788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->