### PR TITLE
Release: Bump prime cli and prime evals version

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.1.11"
+__version__ = "0.2.0"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.46"
+__version__ = "0.5.47"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only bumps package `__version__` strings; low risk aside from downstream release/versioning expectations.
> 
> **Overview**
> Bumps released versions by updating `__version__` in `prime_evals` from `0.1.11` to `0.2.0` and in `prime_cli` from `0.5.46` to `0.5.47`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f0b4b126615f05aeba4349dbca4f219ebc55742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->