### PR TITLE
tune frpc config

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -304,7 +304,8 @@ metadatas.binding_secret = "{self._tunnel_info.binding_secret}"
 # Transport settings
 transport.tcpMux = true
 transport.tcpMuxKeepaliveInterval = 30
-transport.poolCount = 5
+transport.poolCount = 10
+transport.dialServerKeepalive = 60
 
 # Logging - always use console so we can detect connection via stdout
 log.to = "console"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts frpc connection pooling and keepalive behavior, which can affect tunnel stability and client resource usage under load.
> 
> **Overview**
> Updates the generated `frpc` config in `Tunnel._write_frpc_config` to **increase** `transport.poolCount` from 5 to 10 and to **enable** `transport.dialServerKeepalive = 60` for more persistent server connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ce1cef118919eb617a91070ce6149bcf493529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->