### PR TITLE
Fix image push Dockerfile + Context Mutual Compatibility

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -5,6 +5,7 @@ import tarfile
 import tempfile
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import click
 import httpx
@@ -17,6 +18,7 @@ from ..utils import validate_output_format
 
 app = typer.Typer(help="Manage Docker images in Prime Intellect registry", no_args_is_help=True)
 console = Console()
+PACKAGED_DOCKERFILE_PATH = ".__prime_dockerfile__"
 
 config = Config()
 
@@ -27,11 +29,12 @@ def push_image(
         ..., help="Image reference (e.g., 'myapp:v1.0.0' or 'myapp:latest')"
     ),
     context: str = typer.Option(".", "--context", "-c", help="Build context directory"),
-    dockerfile: str = typer.Option(
-        "Dockerfile",
+    dockerfile: Optional[str] = typer.Option(
+        None,
         "--dockerfile",
         "-f",
-        help="Path to Dockerfile, relative to --context",
+        help="Path to Dockerfile",
+        show_default="<context>/Dockerfile",
     ),
     platform: str = typer.Option(
         "linux/amd64",
@@ -46,7 +49,7 @@ def push_image(
     \b
     Examples:
         prime images push myapp:v1.0.0
-        prime images push myapp:latest --context ./app --dockerfile Dockerfile.prod
+        prime images push myapp:latest --context ./app --dockerfile ../docker/Dockerfile.prod
         prime images push myapp:v1 --platform linux/arm64
     """
     try:
@@ -75,10 +78,23 @@ def push_image(
         # Initialize API client
         client = APIClient()
 
-        # Check if Dockerfile exists
-        dockerfile_path = Path(context) / dockerfile
+        context_path = Path(context).resolve()
+        dockerfile_path = Path(dockerfile).resolve() if dockerfile else context_path / "Dockerfile"
+
+        if not context_path.exists():
+            console.print(f"[red]Error: Build context not found at {context_path}[/red]")
+            raise typer.Exit(1)
+
+        if not context_path.is_dir():
+            console.print(f"[red]Error: Build context must be a directory: {context_path}[/red]")
+            raise typer.Exit(1)
+
         if not dockerfile_path.exists():
             console.print(f"[red]Error: Dockerfile not found at {dockerfile_path}[/red]")
+            raise typer.Exit(1)
+
+        if not dockerfile_path.is_file():
+            console.print(f"[red]Error: Dockerfile must be a file: {dockerfile_path}[/red]")
             raise typer.Exit(1)
 
         # Create tar.gz of build context
@@ -88,7 +104,8 @@ def push_image(
 
         try:
             with tarfile.open(tar_path, "w:gz") as tar:
-                tar.add(context, arcname=".")
+                tar.add(context_path, arcname=".")
+                tar.add(dockerfile_path, arcname=PACKAGED_DOCKERFILE_PATH)
 
             tar_size_mb = Path(tar_path).stat().st_size / (1024 * 1024)
             console.print(f"[green]✓[/green] Build context packaged ({tar_size_mb:.2f} MB)")
@@ -100,7 +117,7 @@ def push_image(
                 build_payload = {
                     "image_name": image_name,
                     "image_tag": image_tag,
-                    "dockerfile_path": dockerfile,
+                    "dockerfile_path": PACKAGED_DOCKERFILE_PATH,
                     "platform": platform,
                 }
                 if config.team_id:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -26,8 +26,13 @@ def push_image(
     image_reference: str = typer.Argument(
         ..., help="Image reference (e.g., 'myapp:v1.0.0' or 'myapp:latest')"
     ),
-    dockerfile: str = typer.Option("Dockerfile", "--dockerfile", "-f", help="Path to Dockerfile"),
     context: str = typer.Option(".", "--context", "-c", help="Build context directory"),
+    dockerfile: str = typer.Option(
+        "Dockerfile",
+        "--dockerfile",
+        "-f",
+        help="Path to Dockerfile, relative to --context",
+    ),
     platform: str = typer.Option(
         "linux/amd64",
         "--platform",
@@ -41,7 +46,7 @@ def push_image(
     \b
     Examples:
         prime images push myapp:v1.0.0
-        prime images push myapp:latest --dockerfile custom.Dockerfile
+        prime images push myapp:latest --context ./app --dockerfile Dockerfile.prod
         prime images push myapp:v1 --platform linux/arm64
     """
     try:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -18,6 +18,7 @@ from ..utils import validate_output_format
 
 app = typer.Typer(help="Manage Docker images in Prime Intellect registry", no_args_is_help=True)
 console = Console()
+# Use a synthetic archive path to avoid collisions with Dockerfiles already in the context.
 PACKAGED_DOCKERFILE_PATH = ".__prime_dockerfile__"
 
 config = Config()

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -1,0 +1,140 @@
+import io
+import tarfile
+
+from prime_cli.commands.images import PACKAGED_DOCKERFILE_PATH
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+def test_push_image_defaults_dockerfile_to_context(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    context_path = tmp_path / "context"
+    context_path.mkdir()
+    (context_path / "Dockerfile").write_text("FROM busybox\nCOPY run-cowsay.sh /run-cowsay.sh\n")
+    (context_path / "run-cowsay.sh").write_text("#!/bin/sh\necho hi\n")
+
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            if method == "POST" and path == "/images/build":
+                captured["build_payload"] = json
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://example.test/upload",
+                    "fullImagePath": "rehl:latest",
+                }
+
+            if method == "POST" and path == "/images/build/build-123/start":
+                return {}
+
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    class DummyUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    def fake_put(url, content, headers, timeout):
+        captured["tar_bytes"] = content.read()
+        return DummyUploadResponse()
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "rehl:latest", "--context", "context"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["build_payload"]["dockerfile_path"] == PACKAGED_DOCKERFILE_PATH
+
+    with tarfile.open(fileobj=io.BytesIO(captured["tar_bytes"]), mode="r:gz") as tar:
+        names = set(tar.getnames())
+        assert "./run-cowsay.sh" in names
+        assert PACKAGED_DOCKERFILE_PATH in names
+        dockerfile_member = tar.extractfile(PACKAGED_DOCKERFILE_PATH)
+        assert dockerfile_member is not None
+        assert dockerfile_member.read().decode() == (context_path / "Dockerfile").read_text()
+
+
+def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    context_path = tmp_path / "context"
+    context_path.mkdir()
+    (context_path / "run-cowsay.sh").write_text("#!/bin/sh\necho hi\n")
+
+    dockerfile_path = tmp_path / "dockerfiles" / "Customfile"
+    dockerfile_path.parent.mkdir()
+    dockerfile_path.write_text("FROM busybox\nCOPY run-cowsay.sh /run-cowsay.sh\n")
+
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            if method == "POST" and path == "/images/build":
+                captured["build_payload"] = json
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://example.test/upload",
+                    "fullImagePath": "rehl:latest",
+                }
+
+            if method == "POST" and path == "/images/build/build-123/start":
+                captured["start_payload"] = json
+                return {}
+
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    class DummyUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    def fake_put(url, content, headers, timeout):
+        captured["upload_url"] = url
+        captured["tar_bytes"] = content.read()
+        captured["upload_headers"] = headers
+        captured["upload_timeout"] = timeout
+        return DummyUploadResponse()
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        [
+            "images",
+            "push",
+            "rehl:latest",
+            "--context",
+            "context",
+            "--dockerfile",
+            "dockerfiles/Customfile",
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["build_payload"]["dockerfile_path"] == PACKAGED_DOCKERFILE_PATH
+    assert captured["start_payload"] == {"context_uploaded": True}
+
+    with tarfile.open(fileobj=io.BytesIO(captured["tar_bytes"]), mode="r:gz") as tar:
+        names = set(tar.getnames())
+        assert "./run-cowsay.sh" in names
+        assert PACKAGED_DOCKERFILE_PATH in names
+        dockerfile_member = tar.extractfile(PACKAGED_DOCKERFILE_PATH)
+        assert dockerfile_member is not None
+        assert dockerfile_member.read().decode() == dockerfile_path.read_text()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `prime images push` packages and references the Dockerfile (including supporting Dockerfiles outside the context), which could break remote builds if the synthetic path or tar layout is not handled as expected by the build service.
> 
> **Overview**
> Fixes `prime images push` so `--context` and `--dockerfile` work together by resolving paths, validating the context dir/Dockerfile, and always packaging the Dockerfile into the uploaded tarball under a synthetic path (`PACKAGED_DOCKERFILE_PATH`) to avoid name collisions.
> 
> Updates the build-init payload to reference the synthetic Dockerfile path, and adds tests that assert default Dockerfile selection, acceptance of Dockerfiles outside the context, and correct tar contents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ea93868f981a96e93602481922198858fe3efd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->