### PR TITLE
Support hosted eval runs from TOML config

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -176,7 +176,7 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
         raise typer.Exit(1)
 
     endpoints_path_obj = Path(endpoints_path)
-    if not endpoints_path_obj.is_absolute():
+    if "endpoints_path" in raw_config and not endpoints_path_obj.is_absolute():
         endpoints_path = str((config_path.parent / endpoints_path_obj).resolve())
 
     try:
@@ -1180,7 +1180,8 @@ def run_eval_cmd(
         if _is_config_target(environment):
             hosted_target_config = _load_hosted_eval_config(environment)
             hosted_target = hosted_target_config["env_id"]
-            hosted_target_env_dir_path = hosted_target_config.get("env_dir_path")
+            if hosted_target_config.get("env_dir_path") is not None:
+                hosted_target_env_dir_path = hosted_target_config["env_dir_path"]
             hosted_target_model = hosted_target_config["model"]
             hosted_target_num_examples = hosted_target_config.get(
                 "num_examples",

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -15,7 +15,7 @@ from typer.core import TyperGroup
 
 from ..client import APIClient, APIError
 from ..core import Config
-from ..utils import output_data_as_json
+from ..utils import load_toml, output_data_as_json
 from ..utils.display import get_eval_viewer_url
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.eval_push import load_results_jsonl
@@ -54,6 +54,16 @@ EVAL_TABLE_MAX_TEXT_WIDTH = 30
 EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k -n 10"
 EVAL_HOSTED_LABEL = "HOSTED"
 EVAL_LOCAL_LABEL = "LOCAL"
+HOSTED_EVAL_CONFIG_ALLOWED_FIELDS = {
+    "env_id",
+    "env_args",
+    "env_dir_path",
+    "endpoints_path",
+    "endpoint_id",
+    "model",
+    "num_examples",
+    "rollouts_per_example",
+}
 
 
 class DefaultGroup(TyperGroup):
@@ -136,6 +146,135 @@ def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[st
             raise typer.Exit(1)
 
     return parsed
+
+
+def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) -> str:
+    raw_endpoint_id = raw_config.get("endpoint_id")
+    raw_model = raw_config.get("model")
+
+    if raw_endpoint_id is not None and raw_model is not None:
+        console.print(
+            "[red]Error:[/red] hosted eval config cannot set both `endpoint_id` and `model`"
+        )
+        raise typer.Exit(1)
+
+    if raw_endpoint_id is None:
+        if raw_model is None:
+            return DEFAULT_MODEL
+        if type(raw_model) is not str or not raw_model:
+            console.print("[red]Error:[/red] `model` must be a non-empty string")
+            raise typer.Exit(1)
+        return raw_model
+
+    if type(raw_endpoint_id) is not str or not raw_endpoint_id:
+        console.print("[red]Error:[/red] `endpoint_id` must be a non-empty string")
+        raise typer.Exit(1)
+
+    endpoints_path = raw_config.get("endpoints_path", "./configs/endpoints.toml")
+    if type(endpoints_path) is not str or not endpoints_path:
+        console.print("[red]Error:[/red] `endpoints_path` must be a non-empty string")
+        raise typer.Exit(1)
+
+    endpoints_path_obj = Path(endpoints_path)
+    if not endpoints_path_obj.is_absolute():
+        endpoints_path = str((config_path.parent / endpoints_path_obj).resolve())
+
+    try:
+        from verifiers.utils.eval_utils import load_endpoints, resolve_endpoints_file
+    except ImportError as exc:
+        console.print("[red]Error:[/red] verifiers is required to resolve `endpoint_id`")
+        raise typer.Exit(1) from exc
+
+    resolved_endpoints_file = resolve_endpoints_file(endpoints_path)
+    if resolved_endpoints_file is None or resolved_endpoints_file.suffix != ".toml":
+        console.print(
+            "[red]Error:[/red] `endpoint_id` requires an endpoints.toml registry "
+            "via `endpoints_path`"
+        )
+        raise typer.Exit(1)
+
+    endpoints = load_endpoints(endpoints_path)
+    if raw_endpoint_id not in endpoints:
+        console.print(
+            f"[red]Error:[/red] endpoint_id '{raw_endpoint_id}' not found in {endpoints_path}"
+        )
+        raise typer.Exit(1)
+
+    endpoint_group = endpoints[raw_endpoint_id]
+    endpoint_models = {entry["model"] for entry in endpoint_group}
+    if len(endpoint_models) != 1:
+        console.print(
+            f"[red]Error:[/red] endpoint_id '{raw_endpoint_id}' resolves to multiple models: "
+            f"{sorted(endpoint_models)}"
+        )
+        raise typer.Exit(1)
+
+    return endpoint_group[0]["model"]
+
+
+def _load_hosted_eval_config(config_path_str: str) -> dict[str, Any]:
+    config_path = Path(config_path_str)
+    raw = load_toml(str(config_path), console)
+
+    eval_entries = raw.get("eval")
+    if not isinstance(eval_entries, list):
+        console.print(
+            "[red]Error:[/red] hosted eval config must use [[eval]] and contain exactly one entry"
+        )
+        raise typer.Exit(1)
+
+    if len(eval_entries) != 1:
+        console.print(
+            "[red]Error:[/red] hosted eval config currently supports exactly one [[eval]] entry"
+        )
+        raise typer.Exit(1)
+
+    eval_entry = eval_entries[0]
+    if not isinstance(eval_entry, dict):
+        console.print("[red]Error:[/red] [[eval]] must be a TOML table")
+        raise typer.Exit(1)
+
+    merged = {k: v for k, v in raw.items() if k != "eval"}
+    merged.update(eval_entry)
+
+    unsupported_fields = sorted(set(merged) - HOSTED_EVAL_CONFIG_ALLOWED_FIELDS)
+    if unsupported_fields:
+        console.print(
+            "[red]Error:[/red] hosted eval config does not support: "
+            + ", ".join(f"`{field}`" for field in unsupported_fields)
+        )
+        raise typer.Exit(1)
+
+    env_id = merged.get("env_id")
+    if type(env_id) is not str or not env_id:
+        console.print("[red]Error:[/red] hosted eval config requires a non-empty `env_id`")
+        raise typer.Exit(1)
+
+    env_args = merged.get("env_args")
+    if env_args is None:
+        merged["env_args"] = None
+    elif not isinstance(env_args, dict) or any(
+        type(key) is not str or type(value) is not str for key, value in env_args.items()
+    ):
+        console.print(
+            "[red]Error:[/red] hosted eval config `env_args` must contain only "
+            "string keys and values"
+        )
+        raise typer.Exit(1)
+
+    env_dir_path = merged.get("env_dir_path")
+    if env_dir_path is not None and (type(env_dir_path) is not str or not env_dir_path):
+        console.print("[red]Error:[/red] `env_dir_path` must be a non-empty string")
+        raise typer.Exit(1)
+
+    for field_name in ("num_examples", "rollouts_per_example"):
+        field_value = merged.get(field_name)
+        if field_value is not None and type(field_value) is not int:
+            console.print(f"[red]Error:[/red] `{field_name}` must be an integer")
+            raise typer.Exit(1)
+
+    merged["model"] = _resolve_hosted_config_model(merged, config_path)
+    return merged
 
 
 def _fetch_eval_status(client: APIClient, eval_id: str) -> dict[str, Any]:
@@ -1031,23 +1170,38 @@ def run_eval_cmd(
             raise typer.Exit(1)
 
     if hosted:
+        hosted_target = environment
+        hosted_target_env_dir_path = env_dir_path
+        hosted_target_model = DEFAULT_MODEL
+        hosted_target_num_examples = HOSTED_RUN_DEFAULT_NUM_EXAMPLES
+        hosted_target_rollouts = HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE
+        hosted_target_env_args: Optional[dict[str, str]] = None
+
         if _is_config_target(environment):
-            console.print(
-                "[red]Error:[/red] hosted evaluations require a single environment, "
-                "not a TOML config"
+            hosted_target_config = _load_hosted_eval_config(environment)
+            hosted_target = hosted_target_config["env_id"]
+            hosted_target_env_dir_path = hosted_target_config.get("env_dir_path")
+            hosted_target_model = hosted_target_config["model"]
+            hosted_target_num_examples = hosted_target_config.get(
+                "num_examples",
+                HOSTED_RUN_DEFAULT_NUM_EXAMPLES,
             )
-            raise typer.Exit(1)
+            hosted_target_rollouts = hosted_target_config.get(
+                "rollouts_per_example",
+                HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
+            )
+            hosted_target_env_args = hosted_target_config.get("env_args")
 
         try:
             platform_slug, environment_id = _resolve_hosted_environment(
-                environment,
-                env_dir_path=env_dir_path,
+                hosted_target,
+                env_dir_path=hosted_target_env_dir_path,
                 env_path=env_path,
             )
         except APIError as exc:
             console.print(f"[red]Error:[/red] {exc}")
             raise typer.Exit(1) from exc
-        model = _parse_value_option(passthrough_args, "--model", "-m") or DEFAULT_MODEL
+        model = _parse_value_option(passthrough_args, "--model", "-m") or hosted_target_model
         raw_num_examples = _parse_value_option(passthrough_args, "--num-examples", "-n")
         raw_rollouts = _parse_value_option(
             passthrough_args,
@@ -1060,12 +1214,10 @@ def run_eval_cmd(
             num_examples = (
                 int(raw_num_examples)
                 if raw_num_examples is not None
-                else HOSTED_RUN_DEFAULT_NUM_EXAMPLES
+                else hosted_target_num_examples
             )
             rollouts_per_example = (
-                int(raw_rollouts)
-                if raw_rollouts is not None
-                else HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE
+                int(raw_rollouts) if raw_rollouts is not None else hosted_target_rollouts
             )
         except ValueError as exc:
             console.print(
@@ -1085,7 +1237,11 @@ def run_eval_cmd(
             inference_model=model,
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
-            env_args=_parse_json_option(raw_env_args, "--env-args"),
+            env_args=(
+                _parse_json_option(raw_env_args, "--env-args")
+                if raw_env_args is not None
+                else hosted_target_env_args
+            ),
             name=eval_name,
             timeout_minutes=timeout_minutes,
             allow_sandbox_access=allow_sandbox_access,

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -295,6 +295,12 @@ def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
 
         merged = {k: v for k, v in raw.items() if k != "eval"}
         merged.update(eval_entry)
+
+        if "endpoint_id" in eval_entry and "model" not in eval_entry:
+            merged.pop("model", None)
+        if "model" in eval_entry and "endpoint_id" not in eval_entry:
+            merged.pop("endpoint_id", None)
+
         merged = _validate_single_hosted_eval_config(merged, config_path)
         merged_configs.append(merged)
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -67,6 +67,15 @@ HOSTED_EVAL_CONFIG_ALLOWED_FIELDS = {
     "allow_instances_access",
     "eval_name",
 }
+HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
+    "env_dir_path": (str, "a non-empty string"),
+    "num_examples": (int, "an integer"),
+    "rollouts_per_example": (int, "an integer"),
+    "timeout_minutes": (int, "an integer"),
+    "allow_sandbox_access": (bool, "a boolean"),
+    "allow_instances_access": (bool, "a boolean"),
+    "eval_name": (str, "a non-empty string"),
+}
 
 
 class DefaultGroup(TyperGroup):
@@ -151,6 +160,20 @@ def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[st
     return parsed
 
 
+def _validate_hosted_config_field(
+    merged: dict[str, Any], field_name: str, expected_type: type[Any], description: str
+) -> None:
+    field_value = merged.get(field_name)
+    if field_value is None:
+        return
+    if type(field_value) is not expected_type:
+        console.print(f"[red]Error:[/red] `{field_name}` must be {description}")
+        raise typer.Exit(1)
+    if expected_type is str and not field_value:
+        console.print(f"[red]Error:[/red] `{field_name}` must be {description}")
+        raise typer.Exit(1)
+
+
 def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) -> str:
     raw_endpoint_id = raw_config.get("endpoint_id")
     raw_model = raw_config.get("model")
@@ -185,7 +208,10 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
     try:
         from verifiers.utils.eval_utils import load_endpoints, resolve_endpoints_file
     except ImportError as exc:
-        console.print("[red]Error:[/red] verifiers is required to resolve `endpoint_id`")
+        console.print(
+            "[red]Error:[/red] verifiers is required to resolve `endpoint_id`. "
+            "Install the `verifiers` package or use `model` instead."
+        )
         raise typer.Exit(1) from exc
 
     resolved_endpoints_file = resolve_endpoints_file(endpoints_path)
@@ -243,27 +269,8 @@ def _validate_single_hosted_eval_config(
         )
         raise typer.Exit(1)
 
-    env_dir_path = merged.get("env_dir_path")
-    if env_dir_path is not None and (type(env_dir_path) is not str or not env_dir_path):
-        console.print("[red]Error:[/red] `env_dir_path` must be a non-empty string")
-        raise typer.Exit(1)
-
-    for field_name in ("num_examples", "rollouts_per_example", "timeout_minutes"):
-        field_value = merged.get(field_name)
-        if field_value is not None and type(field_value) is not int:
-            console.print(f"[red]Error:[/red] `{field_name}` must be an integer")
-            raise typer.Exit(1)
-
-    for field_name in ("allow_sandbox_access", "allow_instances_access"):
-        field_value = merged.get(field_name)
-        if field_value is not None and type(field_value) is not bool:
-            console.print(f"[red]Error:[/red] `{field_name}` must be a boolean")
-            raise typer.Exit(1)
-
-    eval_name = merged.get("eval_name")
-    if eval_name is not None and (type(eval_name) is not str or not eval_name):
-        console.print("[red]Error:[/red] `eval_name` must be a non-empty string")
-        raise typer.Exit(1)
+    for field_name, (expected_type, description) in HOSTED_EVAL_CONFIG_FIELD_TYPES.items():
+        _validate_hosted_config_field(merged, field_name, expected_type, description)
 
     merged["model"] = _resolve_hosted_config_model(merged, config_path)
     return merged

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -22,7 +22,6 @@ from ..utils.eval_push import load_results_jsonl
 from ..utils.hosted_eval import (
     EvalStatus,
     HostedEvalConfig,
-    HostedEvalResult,
     clean_logs,
     get_new_log_lines,
 )
@@ -63,6 +62,10 @@ HOSTED_EVAL_CONFIG_ALLOWED_FIELDS = {
     "model",
     "num_examples",
     "rollouts_per_example",
+    "timeout_minutes",
+    "allow_sandbox_access",
+    "allow_instances_access",
+    "eval_name",
 }
 
 
@@ -212,31 +215,9 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
     return endpoint_group[0]["model"]
 
 
-def _load_hosted_eval_config(config_path_str: str) -> dict[str, Any]:
-    config_path = Path(config_path_str)
-    raw = load_toml(str(config_path), console)
-
-    eval_entries = raw.get("eval")
-    if not isinstance(eval_entries, list):
-        console.print(
-            "[red]Error:[/red] hosted eval config must use [[eval]] and contain exactly one entry"
-        )
-        raise typer.Exit(1)
-
-    if len(eval_entries) != 1:
-        console.print(
-            "[red]Error:[/red] hosted eval config currently supports exactly one [[eval]] entry"
-        )
-        raise typer.Exit(1)
-
-    eval_entry = eval_entries[0]
-    if not isinstance(eval_entry, dict):
-        console.print("[red]Error:[/red] [[eval]] must be a TOML table")
-        raise typer.Exit(1)
-
-    merged = {k: v for k, v in raw.items() if k != "eval"}
-    merged.update(eval_entry)
-
+def _validate_single_hosted_eval_config(
+    merged: dict[str, Any], config_path: Path
+) -> dict[str, Any]:
     unsupported_fields = sorted(set(merged) - HOSTED_EVAL_CONFIG_ALLOWED_FIELDS)
     if unsupported_fields:
         console.print(
@@ -267,14 +248,80 @@ def _load_hosted_eval_config(config_path_str: str) -> dict[str, Any]:
         console.print("[red]Error:[/red] `env_dir_path` must be a non-empty string")
         raise typer.Exit(1)
 
-    for field_name in ("num_examples", "rollouts_per_example"):
+    for field_name in ("num_examples", "rollouts_per_example", "timeout_minutes"):
         field_value = merged.get(field_name)
         if field_value is not None and type(field_value) is not int:
             console.print(f"[red]Error:[/red] `{field_name}` must be an integer")
             raise typer.Exit(1)
 
+    for field_name in ("allow_sandbox_access", "allow_instances_access"):
+        field_value = merged.get(field_name)
+        if field_value is not None and type(field_value) is not bool:
+            console.print(f"[red]Error:[/red] `{field_name}` must be a boolean")
+            raise typer.Exit(1)
+
+    eval_name = merged.get("eval_name")
+    if eval_name is not None and (type(eval_name) is not str or not eval_name):
+        console.print("[red]Error:[/red] `eval_name` must be a non-empty string")
+        raise typer.Exit(1)
+
     merged["model"] = _resolve_hosted_config_model(merged, config_path)
     return merged
+
+
+def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
+    config_path = Path(config_path_str)
+    raw = load_toml(str(config_path), console)
+
+    eval_entries = raw.get("eval")
+    if not isinstance(eval_entries, list):
+        console.print(
+            "[red]Error:[/red] hosted eval config must use [[eval]] and contain at least one entry"
+        )
+        raise typer.Exit(1)
+
+    if not eval_entries:
+        console.print(
+            "[red]Error:[/red] hosted eval config must contain at least one [[eval]] entry"
+        )
+        raise typer.Exit(1)
+
+    merged_configs: list[dict[str, Any]] = []
+    shared_keys = {
+        "model",
+        "num_examples",
+        "rollouts_per_example",
+        "env_args",
+        "timeout_minutes",
+        "allow_sandbox_access",
+        "allow_instances_access",
+        "eval_name",
+    }
+    expected_shared: dict[str, Any] | None = None
+
+    for eval_entry in eval_entries:
+        if not isinstance(eval_entry, dict):
+            console.print("[red]Error:[/red] [[eval]] must be a TOML table")
+            raise typer.Exit(1)
+
+        merged = {k: v for k, v in raw.items() if k != "eval"}
+        merged.update(eval_entry)
+        merged = _validate_single_hosted_eval_config(merged, config_path)
+
+        shared_values = {key: merged.get(key) for key in shared_keys}
+        if expected_shared is None:
+            expected_shared = shared_values
+        elif shared_values != expected_shared:
+            console.print(
+                "[red]Error:[/red] multiple hosted [[eval]] entries must share the same "
+                "model, env_args, num_examples, rollouts_per_example, timeout_minutes, "
+                "allow_sandbox_access, allow_instances_access, and eval_name"
+            )
+            raise typer.Exit(1)
+
+        merged_configs.append(merged)
+
+    return merged_configs
 
 
 def _fetch_eval_status(client: APIClient, eval_id: str) -> dict[str, Any]:
@@ -312,9 +359,14 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
     return payload
 
 
-def _create_hosted_evaluation(config: HostedEvalConfig) -> HostedEvalResult:
+def _create_hosted_evaluations(
+    config: HostedEvalConfig, environment_ids: Optional[list[str]] = None
+) -> dict[str, Any]:
     client = APIClient()
     payload = _build_hosted_evaluation_payload(config)
+
+    if environment_ids is not None:
+        payload["environment_ids"] = environment_ids
 
     if client.config.team_id:
         payload["team_id"] = client.config.team_id
@@ -325,14 +377,7 @@ def _create_hosted_evaluation(config: HostedEvalConfig) -> HostedEvalResult:
     if not evaluation_id:
         raise APIError(f"Failed to get evaluation ID from response: {created}")
 
-    return HostedEvalResult(
-        evaluation_id=evaluation_id,
-        status=EvalStatus.PENDING,
-        total_samples=0,
-        avg_score=None,
-        min_score=None,
-        max_score=None,
-    )
+    return created
 
 
 def _print_eval_status(eval_data: dict[str, Any]) -> None:
@@ -1170,35 +1215,65 @@ def run_eval_cmd(
             raise typer.Exit(1)
 
     if hosted:
-        hosted_target = environment
-        hosted_target_env_dir_path = env_dir_path
         hosted_target_model = DEFAULT_MODEL
         hosted_target_num_examples = HOSTED_RUN_DEFAULT_NUM_EXAMPLES
         hosted_target_rollouts = HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE
         hosted_target_env_args: Optional[dict[str, str]] = None
+        hosted_target_timeout_minutes: Optional[int] = None
+        hosted_target_allow_sandbox_access = False
+        hosted_target_allow_instances_access = False
+        hosted_target_eval_name: Optional[str] = None
+        hosted_targets = [environment]
+        hosted_target_env_dir_paths = [env_dir_path]
 
         if _is_config_target(environment):
-            hosted_target_config = _load_hosted_eval_config(environment)
-            hosted_target = hosted_target_config["env_id"]
-            if hosted_target_config.get("env_dir_path") is not None:
-                hosted_target_env_dir_path = hosted_target_config["env_dir_path"]
-            hosted_target_model = hosted_target_config["model"]
-            hosted_target_num_examples = hosted_target_config.get(
+            hosted_target_configs = _load_hosted_eval_configs(environment)
+            hosted_targets = [config["env_id"] for config in hosted_target_configs]
+            hosted_target_env_dir_paths = [
+                config.get("env_dir_path") or env_dir_path for config in hosted_target_configs
+            ]
+            hosted_target_model = hosted_target_configs[0]["model"]
+            hosted_target_num_examples = hosted_target_configs[0].get(
                 "num_examples",
                 HOSTED_RUN_DEFAULT_NUM_EXAMPLES,
             )
-            hosted_target_rollouts = hosted_target_config.get(
+            hosted_target_rollouts = hosted_target_configs[0].get(
                 "rollouts_per_example",
                 HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
             )
-            hosted_target_env_args = hosted_target_config.get("env_args")
-
-        try:
-            platform_slug, environment_id = _resolve_hosted_environment(
-                hosted_target,
-                env_dir_path=hosted_target_env_dir_path,
-                env_path=env_path,
+            hosted_target_env_args = hosted_target_configs[0].get("env_args")
+            hosted_target_timeout_minutes = hosted_target_configs[0].get("timeout_minutes")
+            hosted_target_allow_sandbox_access = hosted_target_configs[0].get(
+                "allow_sandbox_access",
+                False,
             )
+            hosted_target_allow_instances_access = hosted_target_configs[0].get(
+                "allow_instances_access",
+                False,
+            )
+            hosted_target_eval_name = hosted_target_configs[0].get("eval_name")
+
+        if follow and len(hosted_targets) > 1:
+            console.print(
+                "[red]Error:[/red] `--follow` is only supported for a single hosted evaluation"
+            )
+            raise typer.Exit(1)
+
+        platform_slugs: list[str] = []
+        environment_ids: list[str] = []
+        try:
+            for hosted_target, hosted_target_env_dir_path in zip(
+                hosted_targets,
+                hosted_target_env_dir_paths,
+                strict=False,
+            ):
+                platform_slug, environment_id = _resolve_hosted_environment(
+                    hosted_target,
+                    env_dir_path=hosted_target_env_dir_path,
+                    env_path=env_path,
+                )
+                platform_slugs.append(platform_slug)
+                environment_ids.append(environment_id)
         except APIError as exc:
             console.print(f"[red]Error:[/red] {exc}")
             raise typer.Exit(1) from exc
@@ -1234,7 +1309,7 @@ def run_eval_cmd(
             raise typer.Exit(1)
 
         hosted_config = HostedEvalConfig(
-            environment_id=environment_id,
+            environment_id=environment_ids[0],
             inference_model=model,
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
@@ -1243,26 +1318,36 @@ def run_eval_cmd(
                 if raw_env_args is not None
                 else hosted_target_env_args
             ),
-            name=eval_name,
-            timeout_minutes=timeout_minutes,
-            allow_sandbox_access=allow_sandbox_access,
-            allow_instances_access=allow_instances_access,
+            name=eval_name or hosted_target_eval_name,
+            timeout_minutes=(
+                timeout_minutes if timeout_minutes is not None else hosted_target_timeout_minutes
+            ),
+            allow_sandbox_access=(
+                allow_sandbox_access if allow_sandbox_access else hosted_target_allow_sandbox_access
+            ),
+            allow_instances_access=(
+                allow_instances_access
+                if allow_instances_access
+                else hosted_target_allow_instances_access
+            ),
             custom_secrets=_parse_json_option(custom_secrets, "--custom-secrets"),
         )
 
         try:
-            result = _create_hosted_evaluation(hosted_config)
+            result = _create_hosted_evaluations(hosted_config, environment_ids=environment_ids)
         except APIError as exc:
             console.print(f"[red]Hosted evaluation failed:[/red] {exc}")
             raise typer.Exit(1) from exc
 
+        evaluation_ids = result.get("evaluation_ids") or [result["evaluation_id"]]
+
         if follow:
             console.print("[green]✓ Hosted evaluation started[/green]")
-            console.print(f"[cyan]Environment:[/cyan] {platform_slug}")
-            console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
+            console.print(f"[cyan]Environment:[/cyan] {platform_slugs[0]}")
+            console.print(f"[cyan]Evaluation ID:[/cyan] {evaluation_ids[0]}")
             console.print()
             _display_logs(
-                result.evaluation_id,
+                evaluation_ids[0],
                 tail=HOSTED_LOGS_DEFAULT_TAIL_LINES,
                 follow=True,
                 poll_interval=poll_interval,
@@ -1270,10 +1355,16 @@ def run_eval_cmd(
             return
 
         console.print("[green]✓ Hosted evaluation started[/green]")
-        console.print(f"[cyan]Environment:[/cyan] {platform_slug}")
-        console.print(f"[cyan]Evaluation ID:[/cyan] {result.evaluation_id}")
-        console.print(f"[green]View results:[/green] {get_eval_viewer_url(result.evaluation_id)}")
-        console.print("[dim]View logs:[/dim] prime eval logs " + result.evaluation_id + " -f")
+        if len(platform_slugs) == 1:
+            console.print(f"[cyan]Environment:[/cyan] {platform_slugs[0]}")
+            console.print(f"[cyan]Evaluation ID:[/cyan] {evaluation_ids[0]}")
+            console.print(f"[green]View results:[/green] {get_eval_viewer_url(evaluation_ids[0])}")
+            console.print("[dim]View logs:[/dim] prime eval logs " + evaluation_ids[0] + " -f")
+            return
+
+        console.print(f"[cyan]Environments:[/cyan] {', '.join(platform_slugs)}")
+        console.print(f"[cyan]Evaluation IDs:[/cyan] {', '.join(evaluation_ids)}")
+        console.print("[dim]View logs:[/dim] prime eval logs <evaluation-id> -f")
         return
 
     run_eval_passthrough(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -287,17 +287,6 @@ def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
         raise typer.Exit(1)
 
     merged_configs: list[dict[str, Any]] = []
-    shared_keys = {
-        "model",
-        "num_examples",
-        "rollouts_per_example",
-        "env_args",
-        "timeout_minutes",
-        "allow_sandbox_access",
-        "allow_instances_access",
-        "eval_name",
-    }
-    expected_shared: dict[str, Any] | None = None
 
     for eval_entry in eval_entries:
         if not isinstance(eval_entry, dict):
@@ -307,18 +296,6 @@ def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
         merged = {k: v for k, v in raw.items() if k != "eval"}
         merged.update(eval_entry)
         merged = _validate_single_hosted_eval_config(merged, config_path)
-
-        shared_values = {key: merged.get(key) for key in shared_keys}
-        if expected_shared is None:
-            expected_shared = shared_values
-        elif shared_values != expected_shared:
-            console.print(
-                "[red]Error:[/red] multiple hosted [[eval]] entries must share the same "
-                "model, env_args, num_examples, rollouts_per_example, timeout_minutes, "
-                "allow_sandbox_access, allow_instances_access, and eval_name"
-            )
-            raise typer.Exit(1)
-
         merged_configs.append(merged)
 
     return merged_configs
@@ -373,8 +350,9 @@ def _create_hosted_evaluations(
 
     created = client.post("/hosted-evaluations", json=payload)
     evaluation_id = created.get("evaluation_id")
+    evaluation_ids = created.get("evaluation_ids")
 
-    if not evaluation_id:
+    if not evaluation_id and not evaluation_ids:
         raise APIError(f"Failed to get evaluation ID from response: {created}")
 
     return created
@@ -1215,69 +1193,26 @@ def run_eval_cmd(
             raise typer.Exit(1)
 
     if hosted:
-        hosted_target_model = DEFAULT_MODEL
-        hosted_target_num_examples = HOSTED_RUN_DEFAULT_NUM_EXAMPLES
-        hosted_target_rollouts = HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE
-        hosted_target_env_args: Optional[dict[str, str]] = None
-        hosted_target_timeout_minutes: Optional[int] = None
-        hosted_target_allow_sandbox_access = False
-        hosted_target_allow_instances_access = False
-        hosted_target_eval_name: Optional[str] = None
-        hosted_targets = [environment]
-        hosted_target_env_dir_paths = [env_dir_path]
-
+        hosted_target_configs: list[dict[str, Any]] = []
         if _is_config_target(environment):
             hosted_target_configs = _load_hosted_eval_configs(environment)
-            hosted_targets = [config["env_id"] for config in hosted_target_configs]
-            hosted_target_env_dir_paths = [
-                config.get("env_dir_path") or env_dir_path for config in hosted_target_configs
+        else:
+            hosted_target_configs = [
+                {
+                    "env_id": environment,
+                    "env_dir_path": env_dir_path,
+                    "model": DEFAULT_MODEL,
+                    "num_examples": HOSTED_RUN_DEFAULT_NUM_EXAMPLES,
+                    "rollouts_per_example": HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
+                    "env_args": None,
+                    "timeout_minutes": None,
+                    "allow_sandbox_access": False,
+                    "allow_instances_access": False,
+                    "eval_name": None,
+                }
             ]
-            hosted_target_model = hosted_target_configs[0]["model"]
-            hosted_target_num_examples = hosted_target_configs[0].get(
-                "num_examples",
-                HOSTED_RUN_DEFAULT_NUM_EXAMPLES,
-            )
-            hosted_target_rollouts = hosted_target_configs[0].get(
-                "rollouts_per_example",
-                HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
-            )
-            hosted_target_env_args = hosted_target_configs[0].get("env_args")
-            hosted_target_timeout_minutes = hosted_target_configs[0].get("timeout_minutes")
-            hosted_target_allow_sandbox_access = hosted_target_configs[0].get(
-                "allow_sandbox_access",
-                False,
-            )
-            hosted_target_allow_instances_access = hosted_target_configs[0].get(
-                "allow_instances_access",
-                False,
-            )
-            hosted_target_eval_name = hosted_target_configs[0].get("eval_name")
 
-        if follow and len(hosted_targets) > 1:
-            console.print(
-                "[red]Error:[/red] `--follow` is only supported for a single hosted evaluation"
-            )
-            raise typer.Exit(1)
-
-        platform_slugs: list[str] = []
-        environment_ids: list[str] = []
-        try:
-            for hosted_target, hosted_target_env_dir_path in zip(
-                hosted_targets,
-                hosted_target_env_dir_paths,
-                strict=False,
-            ):
-                platform_slug, environment_id = _resolve_hosted_environment(
-                    hosted_target,
-                    env_dir_path=hosted_target_env_dir_path,
-                    env_path=env_path,
-                )
-                platform_slugs.append(platform_slug)
-                environment_ids.append(environment_id)
-        except APIError as exc:
-            console.print(f"[red]Error:[/red] {exc}")
-            raise typer.Exit(1) from exc
-        model = _parse_value_option(passthrough_args, "--model", "-m") or hosted_target_model
+        raw_model = _parse_value_option(passthrough_args, "--model", "-m")
         raw_num_examples = _parse_value_option(passthrough_args, "--num-examples", "-n")
         raw_rollouts = _parse_value_option(
             passthrough_args,
@@ -1285,69 +1220,154 @@ def run_eval_cmd(
             "-r",
         )
         raw_env_args = _parse_value_option(passthrough_args, "--env-args", "")
+        parsed_cli_env_args = (
+            _parse_json_option(raw_env_args, "--env-args") if raw_env_args is not None else None
+        )
+        parsed_custom_secrets = _parse_json_option(custom_secrets, "--custom-secrets")
 
-        try:
-            num_examples = (
-                int(raw_num_examples)
-                if raw_num_examples is not None
-                else hosted_target_num_examples
-            )
-            rollouts_per_example = (
-                int(raw_rollouts) if raw_rollouts is not None else hosted_target_rollouts
-            )
-        except ValueError as exc:
-            console.print(
-                "[red]Error:[/red] --num-examples and --rollouts-per-example must be integers"
-            )
-            raise typer.Exit(1) from exc
+        effective_targets: list[dict[str, Any]] = []
+        for target_config in hosted_target_configs:
+            try:
+                default_num_examples = int(
+                    target_config.get("num_examples", HOSTED_RUN_DEFAULT_NUM_EXAMPLES)
+                )
+                default_rollouts_per_example = int(
+                    target_config.get(
+                        "rollouts_per_example",
+                        HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
+                    )
+                )
+                num_examples = (
+                    int(raw_num_examples) if raw_num_examples is not None else default_num_examples
+                )
+                rollouts_per_example = (
+                    int(raw_rollouts) if raw_rollouts is not None else default_rollouts_per_example
+                )
+            except ValueError as exc:
+                console.print(
+                    "[red]Error:[/red] --num-examples and --rollouts-per-example must be integers"
+                )
+                raise typer.Exit(1) from exc
 
-        if num_examples < -1 or rollouts_per_example < 1:
+            if num_examples < -1 or rollouts_per_example < 1:
+                console.print(
+                    "[red]Error:[/red] --num-examples must be >= -1 and "
+                    "--rollouts-per-example must be >= 1"
+                )
+                raise typer.Exit(1)
+
+            effective_targets.append(
+                {
+                    "env_id": target_config["env_id"],
+                    "env_dir_path": target_config.get("env_dir_path") or env_dir_path,
+                    "model": raw_model or target_config["model"],
+                    "num_examples": num_examples,
+                    "rollouts_per_example": rollouts_per_example,
+                    "env_args": (
+                        parsed_cli_env_args
+                        if raw_env_args is not None
+                        else target_config.get("env_args")
+                    ),
+                    "timeout_minutes": (
+                        timeout_minutes
+                        if timeout_minutes is not None
+                        else target_config.get("timeout_minutes")
+                    ),
+                    "allow_sandbox_access": (
+                        allow_sandbox_access
+                        if allow_sandbox_access
+                        else target_config.get("allow_sandbox_access", False)
+                    ),
+                    "allow_instances_access": (
+                        allow_instances_access
+                        if allow_instances_access
+                        else target_config.get("allow_instances_access", False)
+                    ),
+                    "eval_name": eval_name or target_config.get("eval_name"),
+                }
+            )
+
+        if follow and len(effective_targets) > 1:
             console.print(
-                "[red]Error:[/red] --num-examples must be >= -1 and "
-                "--rollouts-per-example must be >= 1"
+                "[red]Error:[/red] `--follow` is only supported for a single hosted evaluation"
             )
             raise typer.Exit(1)
 
-        hosted_config = HostedEvalConfig(
-            environment_id=environment_ids[0],
-            inference_model=model,
-            num_examples=num_examples,
-            rollouts_per_example=rollouts_per_example,
-            env_args=(
-                _parse_json_option(raw_env_args, "--env-args")
-                if raw_env_args is not None
-                else hosted_target_env_args
-            ),
-            name=eval_name or hosted_target_eval_name,
-            timeout_minutes=(
-                timeout_minutes if timeout_minutes is not None else hosted_target_timeout_minutes
-            ),
-            allow_sandbox_access=(
-                allow_sandbox_access if allow_sandbox_access else hosted_target_allow_sandbox_access
-            ),
-            allow_instances_access=(
-                allow_instances_access
-                if allow_instances_access
-                else hosted_target_allow_instances_access
-            ),
-            custom_secrets=_parse_json_option(custom_secrets, "--custom-secrets"),
-        )
+        grouped_targets: dict[tuple[Any, ...], dict[str, Any]] = {}
+        target_order: list[tuple[Any, ...]] = []
+        for target in effective_targets:
+            env_args = target.get("env_args")
+            env_args_key = tuple(sorted(env_args.items())) if env_args is not None else None
+            group_key = (
+                target["model"],
+                target["num_examples"],
+                target["rollouts_per_example"],
+                env_args_key,
+                target.get("timeout_minutes"),
+                target.get("allow_sandbox_access", False),
+                target.get("allow_instances_access", False),
+                target.get("eval_name"),
+            )
+            if group_key not in grouped_targets:
+                grouped_targets[group_key] = {
+                    "target": target,
+                    "targets": [],
+                    "platform_slugs": [],
+                    "environment_ids": [],
+                }
+                target_order.append(group_key)
+            grouped_targets[group_key]["targets"].append(target)
 
         try:
-            result = _create_hosted_evaluations(hosted_config, environment_ids=environment_ids)
+            for group_key in target_order:
+                group = grouped_targets[group_key]
+                for grouped_target in group["targets"]:
+                    platform_slug, environment_id = _resolve_hosted_environment(
+                        grouped_target["env_id"],
+                        env_dir_path=grouped_target["env_dir_path"],
+                        env_path=env_path,
+                    )
+                    group["platform_slugs"].append(platform_slug)
+                    group["environment_ids"].append(environment_id)
+        except APIError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1) from exc
+
+        all_platform_slugs: list[str] = []
+        all_evaluation_ids: list[str] = []
+        try:
+            for group_key in target_order:
+                group = grouped_targets[group_key]
+                target = group["target"]
+                hosted_config = HostedEvalConfig(
+                    environment_id=group["environment_ids"][0],
+                    inference_model=target["model"],
+                    num_examples=target["num_examples"],
+                    rollouts_per_example=target["rollouts_per_example"],
+                    env_args=target.get("env_args"),
+                    name=target.get("eval_name"),
+                    timeout_minutes=target.get("timeout_minutes"),
+                    allow_sandbox_access=target.get("allow_sandbox_access", False),
+                    allow_instances_access=target.get("allow_instances_access", False),
+                    custom_secrets=parsed_custom_secrets,
+                )
+                result = _create_hosted_evaluations(
+                    hosted_config,
+                    environment_ids=group["environment_ids"],
+                )
+                all_platform_slugs.extend(group["platform_slugs"])
+                all_evaluation_ids.extend(result.get("evaluation_ids") or [result["evaluation_id"]])
         except APIError as exc:
             console.print(f"[red]Hosted evaluation failed:[/red] {exc}")
             raise typer.Exit(1) from exc
 
-        evaluation_ids = result.get("evaluation_ids") or [result["evaluation_id"]]
-
         if follow:
             console.print("[green]✓ Hosted evaluation started[/green]")
-            console.print(f"[cyan]Environment:[/cyan] {platform_slugs[0]}")
-            console.print(f"[cyan]Evaluation ID:[/cyan] {evaluation_ids[0]}")
+            console.print(f"[cyan]Environment:[/cyan] {all_platform_slugs[0]}")
+            console.print(f"[cyan]Evaluation ID:[/cyan] {all_evaluation_ids[0]}")
             console.print()
             _display_logs(
-                evaluation_ids[0],
+                all_evaluation_ids[0],
                 tail=HOSTED_LOGS_DEFAULT_TAIL_LINES,
                 follow=True,
                 poll_interval=poll_interval,
@@ -1355,15 +1375,17 @@ def run_eval_cmd(
             return
 
         console.print("[green]✓ Hosted evaluation started[/green]")
-        if len(platform_slugs) == 1:
-            console.print(f"[cyan]Environment:[/cyan] {platform_slugs[0]}")
-            console.print(f"[cyan]Evaluation ID:[/cyan] {evaluation_ids[0]}")
-            console.print(f"[green]View results:[/green] {get_eval_viewer_url(evaluation_ids[0])}")
-            console.print("[dim]View logs:[/dim] prime eval logs " + evaluation_ids[0] + " -f")
+        if len(all_platform_slugs) == 1:
+            console.print(f"[cyan]Environment:[/cyan] {all_platform_slugs[0]}")
+            console.print(f"[cyan]Evaluation ID:[/cyan] {all_evaluation_ids[0]}")
+            console.print(
+                f"[green]View results:[/green] {get_eval_viewer_url(all_evaluation_ids[0])}"
+            )
+            console.print("[dim]View logs:[/dim] prime eval logs " + all_evaluation_ids[0] + " -f")
             return
 
-        console.print(f"[cyan]Environments:[/cyan] {', '.join(platform_slugs)}")
-        console.print(f"[cyan]Evaluation IDs:[/cyan] {', '.join(evaluation_ids)}")
+        console.print(f"[cyan]Environments:[/cyan] {', '.join(all_platform_slugs)}")
+        console.print(f"[cyan]Evaluation IDs:[/cyan] {', '.join(all_evaluation_ids)}")
         console.print("[dim]View logs:[/dim] prime eval logs <evaluation-id> -f")
         return
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from prime_cli.client import APIError
 from prime_cli.main import app
 from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
@@ -337,6 +339,105 @@ env_id = "gsm8k"
     assert result.exit_code == 1
     assert "does not support" in result.output
     assert "`resume`" in result.output
+
+
+def test_eval_run_hosted_toml_preserves_cli_env_dir_path(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        captured["environment"] = environment
+        captured["env_dir_path"] = env_dir_path
+        captured["env_path"] = env_path
+        return ("primeintellect/gsm8k", "env-123")
+
+    def fake_run_hosted_evaluation(config):
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            str(config_path),
+            "--hosted",
+            "--env-dir-path",
+            "/tmp/custom-envs",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "env_dir_path": "/tmp/custom-envs",
+        "env_path": None,
+    }
+
+
+def test_eval_run_hosted_endpoint_id_uses_default_endpoints_path_from_cwd(monkeypatch, tmp_path):
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    config_path = config_dir / "eval.toml"
+    config_path.write_text(
+        """
+endpoint_id = "test-endpoint"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    captured = {}
+
+    def fake_resolve_endpoints_file(path):
+        captured["endpoints_path"] = path
+        return Path(path)
+
+    def fake_load_endpoints(path):
+        return {
+            "test-endpoint": [
+                {
+                    "model": "openai/gpt-4.1-mini",
+                    "url": "https://api.example.com/v1",
+                    "key": "PRIME_API_KEY",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
+        fake_resolve_endpoints_file,
+    )
+    monkeypatch.setattr("verifiers.utils.eval_utils.load_endpoints", fake_load_endpoints)
+
+    from prime_cli.commands.evals import _load_hosted_eval_config
+
+    loaded = _load_hosted_eval_config(str(config_path))
+
+    assert loaded["model"] == "openai/gpt-4.1-mini"
+    assert captured["endpoints_path"] == "./configs/endpoints.toml"
 
 
 def test_eval_run_rejects_hosted_only_flags_without_hosted():

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -440,6 +440,41 @@ env_id = "gsm8k"
     assert captured["endpoints_path"] == "./configs/endpoints.toml"
 
 
+def test_eval_run_local_toml_passthrough(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+model = "openai/gpt-4.1-mini"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    def fake_run_eval_passthrough(environment, passthrough_args, skip_upload, env_path):
+        captured["environment"] = environment
+        captured["passthrough_args"] = passthrough_args
+        captured["skip_upload"] = skip_upload
+        captured["env_path"] = env_path
+
+    monkeypatch.setattr("prime_cli.commands.evals.run_eval_passthrough", fake_run_eval_passthrough)
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--skip-upload"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": str(config_path),
+        "passthrough_args": [],
+        "skip_upload": True,
+        "env_path": None,
+    }
+
+
 def test_eval_run_rejects_hosted_only_flags_without_hosted():
     result = runner.invoke(
         app,

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -167,6 +167,32 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
     assert captured["json"]["team_id"] == "team-123"
 
 
+def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            return {"evaluation_ids": ["eval-123", "eval-456"]}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    result = _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+        ),
+        environment_ids=["env-123", "env-456"],
+    )
+
+    assert result["evaluation_ids"] == ["eval-123", "eval-456"]
+
+
 def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     captured = {}
 
@@ -427,7 +453,8 @@ env_id = "math500"
     assert "eval-123, eval-456" in result.output
 
 
-def test_eval_run_hosted_rejects_multi_eval_toml_with_different_shared_settings(tmp_path):
+def test_eval_run_hosted_supports_multi_eval_toml_with_different_settings(monkeypatch, tmp_path):
+    captured_calls = []
     config_path = tmp_path / "eval.toml"
     config_path.write_text(
         """
@@ -441,13 +468,52 @@ num_examples = 10
 """.strip()
     )
 
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        return (f"primeintellect/{environment}", f"env-{environment}")
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured_calls.append(
+            {
+                "environment_id": config.environment_id,
+                "environment_ids": environment_ids,
+                "num_examples": config.num_examples,
+                "rollouts_per_example": config.rollouts_per_example,
+            }
+        )
+        return {
+            "evaluation_id": f"eval-{len(captured_calls)}",
+            "evaluation_ids": [f"eval-{len(captured_calls)}"],
+        }
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
     result = runner.invoke(
         app,
         ["eval", "run", str(config_path), "--hosted"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
-    assert result.exit_code == 1
-    assert "must share the same" in result.output
+
+    assert result.exit_code == 0, result.output
+    assert captured_calls == [
+        {
+            "environment_id": "env-gsm8k",
+            "environment_ids": ["env-gsm8k"],
+            "num_examples": 5,
+            "rollouts_per_example": 3,
+        },
+        {
+            "environment_id": "env-math500",
+            "environment_ids": ["env-math500"],
+            "num_examples": 10,
+            "rollouts_per_example": 3,
+        },
+    ]
+    assert "Evaluation IDs:" in result.output
+    assert "eval-1, eval-2" in result.output
 
 
 def test_eval_run_hosted_rejects_invalid_supported_toml_field_types(tmp_path):

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -709,6 +709,38 @@ model = "anthropic/claude-sonnet-4"
     assert loaded["model"] == "anthropic/claude-sonnet-4"
 
 
+def test_hosted_eval_config_endpoint_id_reports_missing_verifiers(monkeypatch, tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+endpoint_id = "test-endpoint"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def raise_import_error(name, *args, **kwargs):
+        if name == "verifiers.utils.eval_utils":
+            raise ImportError("missing verifiers")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", raise_import_error)
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "verifiers is required to resolve `endpoint_id`" in result.output
+
+
 def test_eval_run_local_toml_passthrough(monkeypatch, tmp_path):
     captured = {}
     config_path = tmp_path / "eval.toml"

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -645,6 +645,70 @@ env_id = "gsm8k"
     assert captured["endpoints_path"] == "./configs/endpoints.toml"
 
 
+def test_hosted_eval_config_allows_eval_endpoint_id_to_override_top_level_model(
+    monkeypatch, tmp_path
+):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+model = "openai/gpt-4.1-mini"
+
+[[eval]]
+env_id = "gsm8k"
+endpoint_id = "test-endpoint"
+""".strip()
+    )
+
+    monkeypatch.setattr(
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
+        lambda path: Path(path),
+    )
+    monkeypatch.setattr(
+        "verifiers.utils.eval_utils.load_endpoints",
+        lambda path: {
+            "test-endpoint": [
+                {
+                    "model": "anthropic/claude-sonnet-4",
+                    "url": "https://api.example.com/v1",
+                    "key": "PRIME_API_KEY",
+                }
+            ]
+        },
+    )
+
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
+
+    assert loaded["model"] == "anthropic/claude-sonnet-4"
+
+
+def test_hosted_eval_config_allows_eval_model_to_override_top_level_endpoint_id(
+    monkeypatch, tmp_path
+):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+endpoint_id = "test-endpoint"
+
+[[eval]]
+env_id = "gsm8k"
+model = "anthropic/claude-sonnet-4"
+""".strip()
+    )
+
+    monkeypatch.setattr(
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
+        lambda path: (_ for _ in ()).throw(AssertionError("should not resolve endpoint_id")),
+    )
+    monkeypatch.setattr(
+        "verifiers.utils.eval_utils.load_endpoints",
+        lambda path: (_ for _ in ()).throw(AssertionError("should not load endpoints")),
+    )
+
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
+
+    assert loaded["model"] == "anthropic/claude-sonnet-4"
+
+
 def test_eval_run_local_toml_passthrough(monkeypatch, tmp_path):
     captured = {}
     config_path = tmp_path / "eval.toml"

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -97,27 +97,16 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
         ),
     )
 
-    def fake_run_hosted_evaluation(config):
+    def fake_run_hosted_evaluation(config, environment_ids=None):
         captured["environment_id"] = config.environment_id
+        captured["environment_ids"] = environment_ids
         captured["inference_model"] = config.inference_model
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
-
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=14,
-            avg_score=0.75,
-            min_score=0.5,
-            max_score=1.0,
-            error_message=None,
-            logs="done",
-        )
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 
@@ -129,6 +118,7 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["environment_id"] == "env-123"
+    assert captured["environment_ids"] == ["env-123"]
     assert captured["inference_model"] == "openai/gpt-4.1-mini"
     assert captured["num_examples"] == 5
     assert captured["rollouts_per_example"] == 3
@@ -153,10 +143,10 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
 
     monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
 
-    from prime_cli.commands.evals import _create_hosted_evaluation
+    from prime_cli.commands.evals import _create_hosted_evaluations
     from prime_cli.utils.hosted_eval import HostedEvalConfig
 
-    result = _create_hosted_evaluation(
+    result = _create_hosted_evaluations(
         HostedEvalConfig(
             environment_id="env-123",
             inference_model="openai/gpt-4.1-mini",
@@ -165,7 +155,7 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
         )
     )
 
-    assert result.evaluation_id == "eval-123"
+    assert result["evaluation_id"] == "eval-123"
     assert captured["endpoint"] == "/hosted-evaluations"
     assert captured["json"]["team_id"] == "team-123"
 
@@ -181,23 +171,14 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
         ),
     )
 
-    def fake_run_hosted_evaluation(config):
+    def fake_run_hosted_evaluation(config, environment_ids=None):
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
-
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=0,
-            avg_score=None,
-            min_score=None,
-            max_score=None,
-        )
+        captured["environment_ids"] = environment_ids
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 
@@ -228,6 +209,7 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["num_examples"] == 7
     assert captured["rollouts_per_example"] == 2
+    assert captured["environment_ids"] == ["env-123"]
     assert captured["display_eval_id"] == "eval-123"
     assert captured["display_tail"] == 1000
     assert captured["display_follow"] is True
@@ -242,6 +224,10 @@ def test_eval_run_hosted_supports_single_eval_toml(monkeypatch, tmp_path):
 model = "openai/gpt-4.1-mini"
 num_examples = 7
 rollouts_per_example = 2
+timeout_minutes = 180
+allow_sandbox_access = true
+allow_instances_access = true
+eval_name = "math500 smoke test"
 
 [[eval]]
 env_id = "gsm8k"
@@ -255,27 +241,22 @@ env_args = { split = "test" }
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    def fake_run_hosted_evaluation(config):
+    def fake_run_hosted_evaluation(config, environment_ids=None):
         captured["environment_id"] = config.environment_id
+        captured["environment_ids"] = environment_ids
         captured["inference_model"] = config.inference_model
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
         captured["env_args"] = config.env_args
-
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=0,
-            avg_score=None,
-            min_score=None,
-            max_score=None,
-        )
+        captured["timeout_minutes"] = config.timeout_minutes
+        captured["allow_sandbox_access"] = config.allow_sandbox_access
+        captured["allow_instances_access"] = config.allow_instances_access
+        captured["name"] = config.name
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 
@@ -291,22 +272,165 @@ env_args = { split = "test" }
         "env_dir_path": None,
         "env_path": None,
         "environment_id": "env-123",
+        "environment_ids": ["env-123"],
         "inference_model": "openai/gpt-4.1-mini",
         "num_examples": 7,
         "rollouts_per_example": 2,
         "env_args": {"split": "test"},
+        "timeout_minutes": 180,
+        "allow_sandbox_access": True,
+        "allow_instances_access": True,
+        "name": "math500 smoke test",
     }
 
 
-def test_eval_run_hosted_rejects_multi_eval_toml(tmp_path):
+def test_eval_run_hosted_cli_overrides_supported_toml_fields(monkeypatch, tmp_path):
+    captured = {}
     config_path = tmp_path / "eval.toml"
     config_path.write_text(
         """
+model = "openai/gpt-4.1-mini"
+num_examples = 7
+rollouts_per_example = 2
+timeout_minutes = 180
+allow_sandbox_access = true
+allow_instances_access = true
+eval_name = "from toml"
+
+[[eval]]
+env_id = "gsm8k"
+env_args = { split = "test" }
+""".strip()
+    )
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        return ("primeintellect/gsm8k", "env-123")
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["environment_ids"] = environment_ids
+        captured["inference_model"] = config.inference_model
+        captured["num_examples"] = config.num_examples
+        captured["rollouts_per_example"] = config.rollouts_per_example
+        captured["env_args"] = config.env_args
+        captured["timeout_minutes"] = config.timeout_minutes
+        captured["allow_sandbox_access"] = config.allow_sandbox_access
+        captured["allow_instances_access"] = config.allow_instances_access
+        captured["name"] = config.name
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            str(config_path),
+            "--hosted",
+            "-m",
+            "anthropic/claude-sonnet-4",
+            "-n",
+            "3",
+            "-r",
+            "4",
+            "--env-args",
+            '{"split":"validation"}',
+            "--timeout-minutes",
+            "240",
+            "--eval-name",
+            "from cli",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment_ids": ["env-123"],
+        "inference_model": "anthropic/claude-sonnet-4",
+        "num_examples": 3,
+        "rollouts_per_example": 4,
+        "env_args": {"split": "validation"},
+        "timeout_minutes": 240,
+        "allow_sandbox_access": True,
+        "allow_instances_access": True,
+        "name": "from cli",
+    }
+
+
+def test_eval_run_hosted_supports_multi_eval_toml_with_shared_config(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+model = "openai/gpt-4.1-mini"
+num_examples = 5
+rollouts_per_example = 3
+
 [[eval]]
 env_id = "gsm8k"
 
 [[eval]]
 env_id = "math500"
+""".strip()
+    )
+
+    resolved_calls = []
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        resolved_calls.append((environment, env_dir_path, env_path))
+        return (f"primeintellect/{environment}", f"env-{environment}")
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["environment_id"] = config.environment_id
+        captured["environment_ids"] = environment_ids
+        captured["inference_model"] = config.inference_model
+        captured["num_examples"] = config.num_examples
+        captured["rollouts_per_example"] = config.rollouts_per_example
+        return {"evaluation_id": "eval-123", "evaluation_ids": ["eval-123", "eval-456"]}
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert resolved_calls == [
+        ("gsm8k", None, None),
+        ("math500", None, None),
+    ]
+    assert captured == {
+        "environment_id": "env-gsm8k",
+        "environment_ids": ["env-gsm8k", "env-math500"],
+        "inference_model": "openai/gpt-4.1-mini",
+        "num_examples": 5,
+        "rollouts_per_example": 3,
+    }
+    assert "Evaluation IDs:" in result.output
+    assert "eval-123, eval-456" in result.output
+
+
+def test_eval_run_hosted_rejects_multi_eval_toml_with_different_shared_settings(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+[[eval]]
+env_id = "gsm8k"
+num_examples = 5
+
+[[eval]]
+env_id = "math500"
+num_examples = 10
 """.strip()
     )
 
@@ -316,8 +440,27 @@ env_id = "math500"
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
     assert result.exit_code == 1
-    assert "exactly one" in result.output
-    assert "eval" in result.output
+    assert "must share the same" in result.output
+
+
+def test_eval_run_hosted_rejects_invalid_supported_toml_field_types(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+timeout_minutes = "180"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "`timeout_minutes` must be an integer" in result.output
 
 
 def test_eval_run_hosted_rejects_unsupported_toml_fields(tmp_path):
@@ -357,21 +500,12 @@ env_id = "gsm8k"
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    def fake_run_hosted_evaluation(config):
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=0,
-            avg_score=None,
-            min_score=None,
-            max_score=None,
-        )
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 
@@ -432,9 +566,9 @@ env_id = "gsm8k"
     )
     monkeypatch.setattr("verifiers.utils.eval_utils.load_endpoints", fake_load_endpoints)
 
-    from prime_cli.commands.evals import _load_hosted_eval_config
+    from prime_cli.commands.evals import _load_hosted_eval_configs
 
-    loaded = _load_hosted_eval_config(str(config_path))
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
 
     assert loaded["model"] == "openai/gpt-4.1-mini"
     assert captured["endpoints_path"] == "./configs/endpoints.toml"
@@ -504,21 +638,12 @@ def test_eval_run_hosted_passes_env_dir_path_to_resolver(monkeypatch):
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    def fake_run_hosted_evaluation(config):
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=0,
-            avg_score=None,
-            min_score=None,
-            max_score=None,
-        )
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 
@@ -552,21 +677,12 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
         captured["env_path"] = env_path
         return ("primeintellect/gsm8k", "env-123")
 
-    def fake_run_hosted_evaluation(config):
-        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
-
-        return HostedEvalResult(
-            evaluation_id="eval-123",
-            status=EvalStatus.PENDING,
-            total_samples=0,
-            avg_score=None,
-            min_score=None,
-            max_score=None,
-        )
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
     monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluation",
+        "prime_cli.commands.evals._create_hosted_evaluations",
         fake_run_hosted_evaluation,
     )
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -232,14 +232,111 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     assert captured["display_poll_interval"] == 10.0
 
 
-def test_eval_run_hosted_rejects_config_target():
+def test_eval_run_hosted_supports_single_eval_toml(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+model = "openai/gpt-4.1-mini"
+num_examples = 7
+rollouts_per_example = 2
+
+[[eval]]
+env_id = "gsm8k"
+env_args = { split = "test" }
+""".strip()
+    )
+
+    def fake_resolve(environment, env_dir_path=None, env_path=None):
+        captured["environment"] = environment
+        captured["env_dir_path"] = env_dir_path
+        captured["env_path"] = env_path
+        return ("primeintellect/gsm8k", "env-123")
+
+    def fake_run_hosted_evaluation(config):
+        captured["environment_id"] = config.environment_id
+        captured["inference_model"] = config.inference_model
+        captured["num_examples"] = config.num_examples
+        captured["rollouts_per_example"] = config.rollouts_per_example
+        captured["env_args"] = config.env_args
+
+        from prime_cli.utils.hosted_eval import EvalStatus, HostedEvalResult
+
+        return HostedEvalResult(
+            evaluation_id="eval-123",
+            status=EvalStatus.PENDING,
+            total_samples=0,
+            avg_score=None,
+            min_score=None,
+            max_score=None,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.evals._resolve_hosted_environment", fake_resolve)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluation",
+        fake_run_hosted_evaluation,
+    )
+
     result = runner.invoke(
         app,
-        ["eval", "run", "config.toml", "--hosted"],
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "env_dir_path": None,
+        "env_path": None,
+        "environment_id": "env-123",
+        "inference_model": "openai/gpt-4.1-mini",
+        "num_examples": 7,
+        "rollouts_per_example": 2,
+        "env_args": {"split": "test"},
+    }
+
+
+def test_eval_run_hosted_rejects_multi_eval_toml(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+[[eval]]
+env_id = "gsm8k"
+
+[[eval]]
+env_id = "math500"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
     assert result.exit_code == 1
-    assert "single environment" in result.output
+    assert "exactly one" in result.output
+    assert "eval" in result.output
+
+
+def test_eval_run_hosted_rejects_unsupported_toml_fields(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+resume = true
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "does not support" in result.output
+    assert "`resume`" in result.output
 
 
 def test_eval_run_rejects_hosted_only_flags_without_hosted():

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
 from prime_cli.client import APIError
+from prime_cli.commands.evals import (
+    _create_hosted_evaluations,
+    _load_hosted_eval_configs,
+    _print_eval_status,
+)
 from prime_cli.main import app
-from prime_cli.utils.hosted_eval import clean_logs, filter_progress_bars, strip_ansi
+from prime_cli.utils.hosted_eval import (
+    HostedEvalConfig,
+    clean_logs,
+    filter_progress_bars,
+    strip_ansi,
+)
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -142,9 +152,6 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
             return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
-
-    from prime_cli.commands.evals import _create_hosted_evaluations
-    from prime_cli.utils.hosted_eval import HostedEvalConfig
 
     result = _create_hosted_evaluations(
         HostedEvalConfig(
@@ -566,8 +573,6 @@ env_id = "gsm8k"
     )
     monkeypatch.setattr("verifiers.utils.eval_utils.load_endpoints", fake_load_endpoints)
 
-    from prime_cli.commands.evals import _load_hosted_eval_configs
-
     loaded = _load_hosted_eval_configs(str(config_path))[0]
 
     assert loaded["model"] == "openai/gpt-4.1-mini"
@@ -747,8 +752,6 @@ def test_eval_stop_command_calls_cancel_endpoint(monkeypatch):
 
 
 def test_print_eval_status_prefers_returned_viewer_url(monkeypatch, capsys):
-    from prime_cli.commands.evals import _print_eval_status
-
     called = {"used": False}
 
     monkeypatch.setattr(
@@ -771,8 +774,6 @@ def test_print_eval_status_prefers_returned_viewer_url(monkeypatch, capsys):
 
 
 def test_print_eval_status_falls_back_to_eval_id_when_viewer_url_missing(monkeypatch, capsys):
-    from prime_cli.commands.evals import _print_eval_status
-
     monkeypatch.setattr(
         "prime_cli.commands.evals.get_eval_viewer_url",
         lambda eval_id: f"fallback/{eval_id}",


### PR DESCRIPTION
## Summary
- add hosted `prime eval run <config.toml> --hosted` support for single-eval TOML configs
- validate hosted TOML constraints and reject unsupported local-only fields like `resume`
- add tests for single-eval hosted TOML success and invalid hosted TOML configs

## Testing
- pytest -q packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_eval_help.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends `prime eval run --hosted` to accept and validate TOML-driven multi-target runs and changes hosted-eval creation to handle multiple environment IDs/returned IDs, which could affect how hosted jobs are scheduled and displayed.
> 
> **Overview**
> Enables `prime eval run <config>.toml --hosted` by adding a TOML loader/validator for hosted-eval configs (including strict allowed fields, type checks, and env/model resolution via `model` or `endpoint_id`).
> 
> Updates hosted run execution to support multiple `[[eval]]` entries: CLI flags override TOML per target, targets with identical settings are grouped into a single API call with multiple `environment_ids`, `--follow` is restricted to single-target runs, and output/log instructions now handle multiple evaluation IDs.
> 
> Refactors hosted-eval creation to `_create_hosted_evaluations` returning the raw API response and accepting both `evaluation_id` and `evaluation_ids`; adds comprehensive tests covering TOML success/error cases, overrides, multi-eval grouping, and `endpoint_id` resolution behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c4c13b649dc0834a40e15b261a1c4d24308260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->