### PR TITLE
Release: Bump prime cli to 0.5.48.

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.47"
+__version__ = "0.5.48"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version string with no functional code changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.47` to `0.5.48` in `prime_cli/__init__.py` for a new release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b15f0dd41c2feb77d091b167c37a57c86a7217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->