### PR TITLE
Add sampling_args support for hosted evals

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -65,6 +65,7 @@ HOSTED_EVAL_CONFIG_ALLOWED_FIELDS = {
     "timeout_minutes",
     "allow_sandbox_access",
     "allow_instances_access",
+    "sampling_args",
     "eval_name",
 }
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
@@ -137,7 +138,7 @@ def format_output(data: dict, output: str) -> None:
         console.print(syntax)
 
 
-def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[str, str]]:
+def _parse_json_object_option(raw: Optional[str], option_name: str) -> Optional[dict[str, Any]]:
     if raw is None:
         return None
     try:
@@ -150,6 +151,14 @@ def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[st
         console.print(f"[red]Error:[/red] {option_name} must be a JSON object")
         raise typer.Exit(1)
 
+    return parsed
+
+
+def _parse_string_map_option(raw: Optional[str], option_name: str) -> Optional[dict[str, str]]:
+    parsed = _parse_json_object_option(raw, option_name)
+    if parsed is None:
+        return None
+
     for key, value in parsed.items():
         if type(key) is not str or type(value) is not str:
             console.print(
@@ -158,6 +167,37 @@ def _parse_json_option(raw: Optional[str], option_name: str) -> Optional[dict[st
             raise typer.Exit(1)
 
     return parsed
+
+
+def _validate_string_map_field(merged: dict[str, Any], field_name: str) -> None:
+    field_value = merged.get(field_name)
+    if field_value is None:
+        return
+    if not isinstance(field_value, dict) or any(
+        type(key) is not str or type(value) is not str for key, value in field_value.items()
+    ):
+        console.print(
+            "[red]Error:[/red] hosted eval config "
+            f"`{field_name}` must contain only string keys and values"
+        )
+        raise typer.Exit(1)
+
+
+def _validate_json_object_field(merged: dict[str, Any], field_name: str) -> None:
+    field_value = merged.get(field_name)
+    if field_value is None:
+        return
+    if not isinstance(field_value, dict):
+        console.print(f"[red]Error:[/red] hosted eval config `{field_name}` must be a TOML table")
+        raise typer.Exit(1)
+
+
+def _freeze_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(sorted((key, _freeze_json_value(nested)) for key, nested in value.items()))
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
 
 
 def _validate_hosted_config_field(
@@ -257,17 +297,8 @@ def _validate_single_hosted_eval_config(
         console.print("[red]Error:[/red] hosted eval config requires a non-empty `env_id`")
         raise typer.Exit(1)
 
-    env_args = merged.get("env_args")
-    if env_args is None:
-        merged["env_args"] = None
-    elif not isinstance(env_args, dict) or any(
-        type(key) is not str or type(value) is not str for key, value in env_args.items()
-    ):
-        console.print(
-            "[red]Error:[/red] hosted eval config `env_args` must contain only "
-            "string keys and values"
-        )
-        raise typer.Exit(1)
+    _validate_string_map_field(merged, "env_args")
+    _validate_json_object_field(merged, "sampling_args")
 
     for field_name, (expected_type, description) in HOSTED_EVAL_CONFIG_FIELD_TYPES.items():
         _validate_hosted_config_field(merged, field_name, expected_type, description)
@@ -337,6 +368,8 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         eval_config["timeout_minutes"] = config.timeout_minutes
     if config.custom_secrets:
         eval_config["custom_secrets"] = config.custom_secrets
+    if config.sampling_args:
+        eval_config["sampling_args"] = config.sampling_args
 
     payload: dict[str, Any] = {
         "environment_ids": [config.environment_id],
@@ -1159,6 +1192,14 @@ def run_eval_cmd(
         "--custom-secrets",
         help='Custom secrets for hosted eval as JSON (e.g. \'{"API_KEY":"xxx"}\')',
     ),
+    sampling_args: Optional[str] = typer.Option(
+        None,
+        "--sampling-args",
+        help=(
+            "Sampling args for hosted eval as JSON. "
+            "Example: {'temperature': 0.7, 'extra_body': {'provider': {'order': ['azure']}}}"
+        ),
+    ),
     eval_name: Optional[str] = typer.Option(
         None,
         "--eval-name",
@@ -1195,6 +1236,7 @@ def run_eval_cmd(
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
             "--custom-secrets": custom_secrets is not None,
+            "--sampling-args": sampling_args is not None,
             "--eval-name": eval_name is not None,
         }
         used_hosted_only_args = [flag for flag, used in hosted_only_args.items() if used]
@@ -1221,6 +1263,7 @@ def run_eval_cmd(
                     "timeout_minutes": None,
                     "allow_sandbox_access": False,
                     "allow_instances_access": False,
+                    "sampling_args": None,
                     "eval_name": None,
                 }
             ]
@@ -1234,9 +1277,12 @@ def run_eval_cmd(
         )
         raw_env_args = _parse_value_option(passthrough_args, "--env-args", "")
         parsed_cli_env_args = (
-            _parse_json_option(raw_env_args, "--env-args") if raw_env_args is not None else None
+            _parse_string_map_option(raw_env_args, "--env-args")
+            if raw_env_args is not None
+            else None
         )
-        parsed_custom_secrets = _parse_json_option(custom_secrets, "--custom-secrets")
+        parsed_custom_secrets = _parse_string_map_option(custom_secrets, "--custom-secrets")
+        parsed_sampling_args = _parse_json_object_option(sampling_args, "--sampling-args")
 
         effective_targets: list[dict[str, Any]] = []
         for target_config in hosted_target_configs:
@@ -1296,6 +1342,12 @@ def run_eval_cmd(
                         if allow_instances_access
                         else target_config.get("allow_instances_access", False)
                     ),
+                    "custom_secrets": parsed_custom_secrets,
+                    "sampling_args": (
+                        parsed_sampling_args
+                        if parsed_sampling_args is not None
+                        else target_config.get("sampling_args")
+                    ),
                     "eval_name": eval_name or target_config.get("eval_name"),
                 }
             )
@@ -1309,16 +1361,15 @@ def run_eval_cmd(
         grouped_targets: dict[tuple[Any, ...], dict[str, Any]] = {}
         target_order: list[tuple[Any, ...]] = []
         for target in effective_targets:
-            env_args = target.get("env_args")
-            env_args_key = tuple(sorted(env_args.items())) if env_args is not None else None
             group_key = (
                 target["model"],
                 target["num_examples"],
                 target["rollouts_per_example"],
-                env_args_key,
+                _freeze_json_value(target.get("env_args")),
                 target.get("timeout_minutes"),
                 target.get("allow_sandbox_access", False),
                 target.get("allow_instances_access", False),
+                _freeze_json_value(target.get("sampling_args")),
                 target.get("eval_name"),
             )
             if group_key not in grouped_targets:
@@ -1362,7 +1413,8 @@ def run_eval_cmd(
                     timeout_minutes=target.get("timeout_minutes"),
                     allow_sandbox_access=target.get("allow_sandbox_access", False),
                     allow_instances_access=target.get("allow_instances_access", False),
-                    custom_secrets=parsed_custom_secrets,
+                    custom_secrets=target.get("custom_secrets"),
+                    sampling_args=target.get("sampling_args"),
                 )
                 result = _create_hosted_evaluations(
                     hosted_config,

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -191,6 +191,15 @@ def _validate_json_object_field(merged: dict[str, Any], field_name: str) -> None
         console.print(f"[red]Error:[/red] hosted eval config `{field_name}` must be a TOML table")
         raise typer.Exit(1)
 
+    try:
+        json.dumps(field_value)
+    except (TypeError, ValueError) as exc:
+        console.print(
+            "[red]Error:[/red] hosted eval config "
+            f"`{field_name}` must contain only JSON-serializable values"
+        )
+        raise typer.Exit(1) from exc
+
 
 def _freeze_json_value(value: Any) -> Any:
     if isinstance(value, dict):
@@ -1197,7 +1206,7 @@ def run_eval_cmd(
         "--sampling-args",
         help=(
             "Sampling args for hosted eval as JSON. "
-            "Example: {'temperature': 0.7, 'extra_body': {'provider': {'order': ['azure']}}}"
+            'Example: {"temperature": 0.7, "extra_body": {"provider": {"order": ["azure"]}}}'
         ),
     ),
     eval_name: Optional[str] = typer.Option(

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from .formatters import strip_ansi
 
@@ -45,6 +45,7 @@ class HostedEvalConfig:
     allow_sandbox_access: bool = False
     allow_instances_access: bool = False
     custom_secrets: Optional[dict[str, str]] = None
+    sampling_args: Optional[dict[str, Any]] = None
 
 
 @dataclass

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -167,6 +167,55 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
     assert captured["json"]["team_id"] == "team-123"
 
 
+def test_create_hosted_evaluation_includes_sampling_args_in_payload(monkeypatch):
+    captured = {}
+
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+            sampling_args={
+                "temperature": 0.2,
+                "extra_body": {
+                    "provider": {
+                        "order": ["azure"],
+                        "allow_fallbacks": False,
+                        "require_parameters": True,
+                    }
+                },
+            },
+        )
+    )
+
+    assert captured["endpoint"] == "/hosted-evaluations"
+    assert captured["json"]["eval_config"]["sampling_args"] == {
+        "temperature": 0.2,
+        "extra_body": {
+            "provider": {
+                "order": ["azure"],
+                "allow_fallbacks": False,
+                "require_parameters": True,
+            }
+        },
+    }
+
+
 def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
     class DummyConfig:
         team_id = None
@@ -253,7 +302,8 @@ def test_eval_run_hosted_supports_single_eval_toml(monkeypatch, tmp_path):
     captured = {}
     config_path = tmp_path / "eval.toml"
     config_path.write_text(
-        """
+        (
+            """
 model = "openai/gpt-4.1-mini"
 num_examples = 7
 rollouts_per_example = 2
@@ -261,11 +311,14 @@ timeout_minutes = 180
 allow_sandbox_access = true
 allow_instances_access = true
 eval_name = "math500 smoke test"
-
-[[eval]]
-env_id = "gsm8k"
-env_args = { split = "test" }
-""".strip()
+"""
+            + "sampling_args = { "
+            + 'extra_body = { provider = { order = ["azure"], '
+            + "allow_fallbacks = false, require_parameters = true } } }\n\n"
+            + "[[eval]]\n"
+            + 'env_id = "gsm8k"\n'
+            + 'env_args = { split = "test" }'
+        )
     )
 
     def fake_resolve(environment, env_dir_path=None, env_path=None):
@@ -284,6 +337,7 @@ env_args = { split = "test" }
         captured["timeout_minutes"] = config.timeout_minutes
         captured["allow_sandbox_access"] = config.allow_sandbox_access
         captured["allow_instances_access"] = config.allow_instances_access
+        captured["sampling_args"] = config.sampling_args
         captured["name"] = config.name
         return {"evaluation_id": "eval-123"}
 
@@ -313,6 +367,15 @@ env_args = { split = "test" }
         "timeout_minutes": 180,
         "allow_sandbox_access": True,
         "allow_instances_access": True,
+        "sampling_args": {
+            "extra_body": {
+                "provider": {
+                    "order": ["azure"],
+                    "allow_fallbacks": False,
+                    "require_parameters": True,
+                }
+            }
+        },
         "name": "math500 smoke test",
     }
 
@@ -348,6 +411,7 @@ env_args = { split = "test" }
         captured["timeout_minutes"] = config.timeout_minutes
         captured["allow_sandbox_access"] = config.allow_sandbox_access
         captured["allow_instances_access"] = config.allow_instances_access
+        captured["sampling_args"] = config.sampling_args
         captured["name"] = config.name
         return {"evaluation_id": "eval-123"}
 
@@ -374,6 +438,8 @@ env_args = { split = "test" }
             '{"split":"validation"}',
             "--timeout-minutes",
             "240",
+            "--sampling-args",
+            '{"temperature":0.2,"extra_body":{"provider":{"order":["azure"],"allow_fallbacks":false,"require_parameters":true}}}',
             "--eval-name",
             "from cli",
         ],
@@ -390,6 +456,16 @@ env_args = { split = "test" }
         "timeout_minutes": 240,
         "allow_sandbox_access": True,
         "allow_instances_access": True,
+        "sampling_args": {
+            "temperature": 0.2,
+            "extra_body": {
+                "provider": {
+                    "order": ["azure"],
+                    "allow_fallbacks": False,
+                    "require_parameters": True,
+                }
+            },
+        },
         "name": "from cli",
     }
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -612,6 +612,28 @@ env_id = "gsm8k"
     assert "`timeout_minutes` must be an integer" in result.output
 
 
+def test_eval_run_hosted_rejects_non_json_serializable_sampling_args_in_toml(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+sampling_args = { until = 1979-05-27T07:32:00Z }
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "`sampling_args`" in result.output
+    assert "JSON-serializable" in result.output
+
+
 def test_eval_run_hosted_rejects_unsupported_toml_fields(tmp_path):
     config_path = tmp_path / "eval.toml"
     config_path.write_text(


### PR DESCRIPTION
## Summary
- add CLI and TOML support for hosted eval sampling_args
- pass sampling_args through hosted eval payload construction
- add tests covering payloads, TOML configs, and CLI overrides

## Notes
- This PR is ready from the prime-cli side, but end-to-end behavior still depends on platform support.
- The platform hosted eval backend currently drops sampling_args before the runner executes, so this should wait to merge until platform support lands.

## Validation
- uv run pytest packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_eval_help.py packages/prime/tests/test_eval_push.py -q
- python -m compileall packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/utils/hosted_eval.py packages/prime/tests/test_hosted_eval.py
- manual hosted eval E2E launch using hosted eval TOML with sampling_args

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new hosted-eval configuration surface (`sampling_args`) that is parsed from CLI/TOML and affects request payloads and grouping logic; mis-parsing or grouping changes could alter how multi-target hosted runs are batched.
> 
> **Overview**
> Adds support for passing `sampling_args` through hosted eval runs, via a new `--sampling-args` CLI option and a `sampling_args` TOML field, and includes it in the hosted evaluation payload under `eval_config`.
> 
> Refactors JSON option parsing/validation to distinguish *string maps* (`env_args`, `custom_secrets`) from arbitrary JSON objects (`sampling_args`), and updates hosted-target grouping to hash nested JSON values deterministically. Updates `HostedEvalConfig` and extends tests to cover payload construction, TOML loading, and CLI override behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43efa74ef63c86e4127c91d9a842dde885fdab3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->