### PR TITLE
VM Sandboxes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -168,10 +168,11 @@ prime sandbox list [--team_id TEAM] [--status STATUS] [--page N] [--per_page N]
 # Create sandbox
 prime sandbox create IMAGE [OPTIONS]
 
-# Create GPU sandbox
-prime sandbox create --gpu-count 1 --gpu-type H100_80GB
+# Create VM sandbox with GPUs
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
 
-# Note: DOCKER_IMAGE is not supported for GPU sandboxes
+# Create CPU-only VM sandbox
+prime sandbox create user-1/vm-image:latest --vm
 
 # With environment variables and secrets:
 prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -40,6 +40,7 @@ class Sandbox(BaseModel):
     disk_mount_path: str = Field(..., alias="diskMountPath")
     gpu_count: int = Field(..., alias="gpuCount")
     gpu_type: Optional[str] = Field(None, alias="gpuType")
+    vm: bool = False
     network_access: bool = Field(True, alias="networkAccess")
     status: str
     timeout_minutes: int = Field(..., alias="timeoutMinutes")
@@ -85,6 +86,7 @@ class CreateSandboxRequest(BaseModel):
     disk_size_gb: float = 5.0
     gpu_count: int = 0
     gpu_type: Optional[str] = None
+    vm: bool = False
     network_access: bool = True
     timeout_minutes: int = 60
     environment_vars: Optional[Dict[str, str]] = None
@@ -98,6 +100,10 @@ class CreateSandboxRequest(BaseModel):
     def validate_gpu_fields(self) -> "CreateSandboxRequest":
         if self.gpu_count > 0 and not self.gpu_type:
             raise ValueError("gpu_type is required when gpu_count is greater than 0")
+        if self.gpu_count > 0 and not self.vm:
+            raise ValueError("gpu_count is only supported when vm is true")
+        if self.gpu_count == 0 and self.gpu_type is not None:
+            raise ValueError("gpu_type requires gpu_count greater than 0")
         return self
 
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -302,37 +302,37 @@ class SandboxAuthCache:
         await self._save_cache_async()
         return dict(response)
 
-    def is_gpu(self, sandbox_id: str) -> bool:
-        """Return True if sandbox is GPU-backed, cached alongside auth token data."""
+    def is_vm(self, sandbox_id: str) -> bool:
+        """Return True if sandbox is VM-backed, cached alongside auth token data."""
         cached_auth = self._check_cached_auth(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        if cached_auth and isinstance(cached_auth.get("is_vm"), bool):
+            return bool(cached_auth["is_vm"])
 
         sandbox_data = self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
-        is_gpu = sandbox.gpu_count > 0
+        is_vm = sandbox.vm
 
         if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+            self._auth_cache[sandbox_id]["is_vm"] = is_vm
             self._save_cache()
 
-        return is_gpu
+        return is_vm
 
-    async def is_gpu_async(self, sandbox_id: str) -> bool:
-        """Return True if sandbox is GPU-backed, cached alongside auth token data."""
+    async def is_vm_async(self, sandbox_id: str) -> bool:
+        """Return True if sandbox is VM-backed, cached alongside auth token data."""
         cached_auth = await self._check_cached_auth_async(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        if cached_auth and isinstance(cached_auth.get("is_vm"), bool):
+            return bool(cached_auth["is_vm"])
 
         sandbox_data = await self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
-        is_gpu = sandbox.gpu_count > 0
+        is_vm = sandbox.vm
 
         if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+            self._auth_cache[sandbox_id]["is_vm"] = is_vm
             await self._save_cache_async()
 
-        return is_gpu
+        return is_vm
 
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         """Cache auth info"""
@@ -540,7 +540,7 @@ class SandboxClient:
         """Execute command directly via gateway."""
         auth = self._auth_cache.get_or_refresh(sandbox_id)
 
-        if self._auth_cache.is_gpu(sandbox_id):
+        if self._auth_cache.is_vm(sandbox_id):
             return self._execute_command_connect_rpc(
                 sandbox_id=sandbox_id,
                 command=command,
@@ -1300,7 +1300,7 @@ class AsyncSandboxClient:
         """Execute command directly via gateway (async)."""
         auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
 
-        if await self._auth_cache.is_gpu_async(sandbox_id):
+        if await self._auth_cache.is_vm_async(sandbox_id):
             return await self._execute_command_connect_rpc(
                 sandbox_id=sandbox_id,
                 command=command,

--- a/packages/prime-sandboxes/tests/test_command_transport_selection.py
+++ b/packages/prime-sandboxes/tests/test_command_transport_selection.py
@@ -1,4 +1,4 @@
-"""Tests for CPU/GPU command transport selection."""
+"""Tests for container/VM command transport selection."""
 
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
@@ -24,30 +24,30 @@ def _auth_payload():
 
 
 class _FakeCache:
-    def __init__(self, is_gpu: bool):
-        self._is_gpu = is_gpu
+    def __init__(self, is_vm: bool):
+        self._is_vm = is_vm
 
     def get_or_refresh(self, _sandbox_id: str):
         return _auth_payload()
 
-    def is_gpu(self, _sandbox_id: str) -> bool:
-        return self._is_gpu
+    def is_vm(self, _sandbox_id: str) -> bool:
+        return self._is_vm
 
 
 class _AsyncFakeCache:
-    def __init__(self, is_gpu: bool):
-        self._is_gpu = is_gpu
+    def __init__(self, is_vm: bool):
+        self._is_vm = is_vm
 
     async def get_or_refresh_async(self, _sandbox_id: str):
         return _auth_payload()
 
-    async def is_gpu_async(self, _sandbox_id: str) -> bool:
-        return self._is_gpu
+    async def is_vm_async(self, _sandbox_id: str) -> bool:
+        return self._is_vm
 
 
-def test_sync_execute_command_uses_connect_for_gpu():
+def test_sync_execute_command_uses_connect_for_vm():
     client = SandboxClient(APIClient(api_key="test-key"))
-    cast(Any, client)._auth_cache = _FakeCache(is_gpu=True)
+    cast(Any, client)._auth_cache = _FakeCache(is_vm=True)
 
     called = {"connect": False}
 
@@ -56,7 +56,7 @@ def test_sync_execute_command_uses_connect_for_gpu():
         return CommandResponse(stdout="ok", stderr="", exit_code=0)
 
     def _rest(*_args, **_kwargs):
-        raise AssertionError("REST path should not be used for GPU sandboxes")
+        raise AssertionError("REST path should not be used for VM sandboxes")
 
     client_any = cast(Any, client)
     client_any._execute_command_connect_rpc = _connect
@@ -70,7 +70,7 @@ def test_sync_execute_command_uses_connect_for_gpu():
 
 def test_sync_execute_command_uses_rest_for_cpu():
     client = SandboxClient(APIClient(api_key="test-key"))
-    cast(Any, client)._auth_cache = _FakeCache(is_gpu=False)
+    cast(Any, client)._auth_cache = _FakeCache(is_vm=False)
 
     called = {"rest": False}
 
@@ -92,9 +92,9 @@ def test_sync_execute_command_uses_rest_for_cpu():
 
 
 @pytest.mark.asyncio
-async def test_async_execute_command_uses_connect_for_gpu():
+async def test_async_execute_command_uses_connect_for_vm():
     client = AsyncSandboxClient(api_key="test-key")
-    cast(Any, client)._auth_cache = _AsyncFakeCache(is_gpu=True)
+    cast(Any, client)._auth_cache = _AsyncFakeCache(is_vm=True)
 
     called = {"connect": False}
 
@@ -103,7 +103,7 @@ async def test_async_execute_command_uses_connect_for_gpu():
         return CommandResponse(stdout="ok", stderr="", exit_code=0)
 
     async def _rest(*_args, **_kwargs):
-        raise AssertionError("REST path should not be used for GPU sandboxes")
+        raise AssertionError("REST path should not be used for VM sandboxes")
 
     client_any = cast(Any, client)
     client_any._execute_command_connect_rpc = _connect
@@ -121,7 +121,7 @@ async def test_async_execute_command_uses_connect_for_gpu():
 @pytest.mark.asyncio
 async def test_async_execute_command_uses_rest_for_cpu():
     client = AsyncSandboxClient(api_key="test-key")
-    cast(Any, client)._auth_cache = _AsyncFakeCache(is_gpu=False)
+    cast(Any, client)._auth_cache = _AsyncFakeCache(is_vm=False)
 
     called = {"rest": False}
 
@@ -145,7 +145,7 @@ async def test_async_execute_command_uses_rest_for_cpu():
         await client.aclose()
 
 
-def test_auth_cache_stores_gpu_flag_for_reuse(tmp_path):
+def test_auth_cache_stores_vm_flag_for_reuse(tmp_path):
     class _FakeAPIClient:
         def __init__(self):
             self.calls = 0
@@ -155,15 +155,16 @@ def test_auth_cache_stores_gpu_flag_for_reuse(tmp_path):
                 self.calls += 1
                 return {
                     "id": "sbx-1",
-                    "name": "gpu-box",
+                    "name": "vm-box",
                     "dockerImage": "img",
                     "startCommand": None,
                     "cpuCores": 1.0,
                     "memoryGB": 2.0,
                     "diskSizeGB": 10.0,
                     "diskMountPath": "/sandbox-workspace",
-                    "gpuCount": 1,
-                    "gpuType": "RTX_PRO_6000",
+                    "gpuCount": 0,
+                    "gpuType": None,
+                    "vm": True,
                     "networkAccess": True,
                     "status": "RUNNING",
                     "timeoutMinutes": 60,
@@ -188,8 +189,8 @@ def test_auth_cache_stores_gpu_flag_for_reuse(tmp_path):
     cache = SandboxAuthCache(tmp_path / "auth_cache.json", _FakeAPIClient())
     cache.set("sbx-1", _auth_payload())
 
-    assert cache.is_gpu("sbx-1")
-    assert cache.is_gpu("sbx-1")
+    assert cache.is_vm("sbx-1")
+    assert cache.is_vm("sbx-1")
     assert cache.client.calls == 1
 
 

--- a/packages/prime-sandboxes/tests/test_gateway_error_mapping.py
+++ b/packages/prime-sandboxes/tests/test_gateway_error_mapping.py
@@ -18,7 +18,7 @@ class _DummyAuthCache:
             "token": "tok",
         }
 
-    def is_gpu(self, _sandbox_id: str) -> bool:
+    def is_vm(self, _sandbox_id: str) -> bool:
         return False
 
 
@@ -31,7 +31,7 @@ class _AsyncDummyAuthCache:
             "token": "tok",
         }
 
-    async def is_gpu_async(self, _sandbox_id: str) -> bool:
+    async def is_vm_async(self, _sandbox_id: str) -> bool:
         return False
 
 

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -24,6 +24,7 @@ def test_create_sandbox_request_defaults():
     assert request.disk_size_gb == 5
     assert request.gpu_count == 0
     assert request.gpu_type is None
+    assert request.vm is False
     assert request.timeout_minutes == 60
     assert request.labels == []
 
@@ -45,10 +46,34 @@ def test_create_sandbox_request_accepts_gpu_type_for_gpu_count():
         docker_image="python:3.11-slim",
         gpu_count=1,
         gpu_type="H100_80GB",
+        vm=True,
     )
 
     assert request.gpu_count == 1
     assert request.gpu_type == "H100_80GB"
+    assert request.vm is True
+
+
+def test_create_sandbox_request_requires_vm_for_gpu_count():
+    """Test vm is required when gpu_count > 0"""
+    with pytest.raises(ValidationError):
+        CreateSandboxRequest(
+            name="gpu-sandbox",
+            docker_image="python:3.11-slim",
+            gpu_count=1,
+            gpu_type="H100_80GB",
+        )
+
+
+def test_create_sandbox_request_rejects_gpu_type_without_gpu_count():
+    """Test gpu_type is rejected when gpu_count is zero"""
+    with pytest.raises(ValidationError):
+        CreateSandboxRequest(
+            name="cpu-sandbox",
+            docker_image="python:3.11-slim",
+            gpu_type="H100_80GB",
+            vm=True,
+        )
 
 
 def test_create_sandbox_request_gpu_type_none_matches_default():
@@ -86,6 +111,7 @@ def test_sandbox_model_with_alias():
         "diskMountPath": "/workspace",
         "gpuCount": 1,
         "gpuType": "H100_80GB",
+        "vm": True,
         "status": "RUNNING",
         "timeoutMinutes": 120,
         "labels": ["test"],
@@ -101,3 +127,4 @@ def test_sandbox_model_with_alias():
     assert sandbox.memory_gb == 4
     assert sandbox.status == "RUNNING"
     assert sandbox.gpu_type == "H100_80GB"
+    assert sandbox.vm is True

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -147,10 +147,11 @@ Isolated environments for running code remotely:
 # Create a sandbox
 prime sandbox create python:3.11
 
-# Create a GPU sandbox
-prime sandbox create --gpu-count 1 --gpu-type H100_80GB
+# Create a VM sandbox with GPUs
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
 
-# Note: DOCKER_IMAGE is not supported for GPU sandboxes
+# Create a CPU-only VM sandbox
+prime sandbox create user-1/vm-image:latest --vm
 
 # List sandboxes
 prime sandbox list

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -71,6 +71,7 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
     data: Dict[str, Any] = {
         "id": sandbox.id,
         "name": sandbox.name,
+        "type": "VM" if sandbox.vm else "Container",
         "docker_image": sandbox.docker_image,
         "start_command": sandbox.start_command,
         "status": sandbox.status,
@@ -264,6 +265,7 @@ def get(
 
             table.add_row("ID", sandbox_data["id"])
             table.add_row("Name", sandbox_data["name"])
+            table.add_row("Type", sandbox_data["type"])
             table.add_row("Docker Image", sandbox_data["docker_image"])
             table.add_row("Start Command", sandbox_data["start_command"] or "N/A")
 

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -49,16 +49,14 @@ console = Console()
 
 
 config = Config()
-GPU_SANDBOX_INTERNAL_DOCKER_IMAGE = "gpu-managed-runtime"
 
 
 def _format_sandbox_for_list(sandbox: Sandbox) -> Dict[str, Any]:
     """Format sandbox data for list display (both table and JSON)"""
-    image_display = "Platform GPU runtime" if sandbox.gpu_count > 0 else sandbox.docker_image
     return {
         "id": sandbox.id,
         "name": sandbox.name,
-        "image": image_display,
+        "image": sandbox.docker_image,
         "status": sandbox.status,
         "resources": format_resources(sandbox.cpu_cores, sandbox.memory_gb, sandbox.gpu_count),
         "labels": ", ".join(sandbox.labels) if sandbox.labels else "-",  # For table output
@@ -70,13 +68,10 @@ def _format_sandbox_for_list(sandbox: Sandbox) -> Dict[str, Any]:
 
 def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
     """Format sandbox data for details display (both table and JSON)"""
-    docker_image_display = (
-        "N/A (platform GPU runtime)" if sandbox.gpu_count > 0 else sandbox.docker_image
-    )
     data: Dict[str, Any] = {
         "id": sandbox.id,
         "name": sandbox.name,
-        "docker_image": docker_image_display,
+        "docker_image": sandbox.docker_image,
         "start_command": sandbox.start_command,
         "status": sandbox.status,
         "cpu_cores": sandbox.cpu_cores,
@@ -342,7 +337,7 @@ def get(
 def create(
     docker_image: Optional[str] = typer.Argument(
         None,
-        help="Docker image to run for CPU sandboxes (not yet supported for GPU sandboxes)",
+        help="Image to run. For GPU sandboxes, provide the VM image reference.",
     ),
     name: Optional[str] = typer.Option(
         None, help="Name for the sandbox (auto-generated if not provided)"
@@ -393,8 +388,6 @@ def create(
     try:
         base_client = APIClient()
         sandbox_client = SandboxClient(base_client)
-        docker_image_was_provided = docker_image is not None
-
         # Parse environment variables
         env_vars = {}
         if env:
@@ -428,18 +421,9 @@ def create(
             )
             raise typer.Exit(1)
 
-        if gpu_count > 0:
-            if docker_image_was_provided:
-                console.print(
-                    "[red]Docker image is not supported for GPU sandboxes.[/red] "
-                    "Do not provide a DOCKER_IMAGE positional argument."
-                )
-                raise typer.Exit(1)
-            docker_image = GPU_SANDBOX_INTERNAL_DOCKER_IMAGE
-        elif not docker_image:
+        if not docker_image:
             console.print(
-                "[red]Docker image is required for CPU sandboxes.[/red] "
-                "Provide a DOCKER_IMAGE positional argument."
+                "[red]Docker image is required.[/red] Provide a DOCKER_IMAGE positional argument."
             )
             raise typer.Exit(1)
 
@@ -479,12 +463,7 @@ def create(
         # Show configuration summary
         console.print("\n[bold]Sandbox Configuration:[/bold]")
         console.print(f"Name: {name}")
-        if gpu_count > 0:
-            console.print("Docker Image: Not supported (platform GPU runtime)")
-        elif docker_image_was_provided:
-            console.print(f"Docker Image: {docker_image}")
-        else:
-            console.print("Docker Image: N/A")
+        console.print(f"Docker Image: {docker_image}")
         console.print(f"Start Command: {start_command or 'N/A'}")
         console.print(f"Resources: {cpu_cores} CPU, {memory_gb}GB RAM, {disk_size_gb}GB disk")
         if gpu_count > 0:

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -80,6 +80,7 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
         "disk_mount_path": sandbox.disk_mount_path,
         "gpu_count": sandbox.gpu_count,
         "gpu_type": getattr(sandbox, "gpu_type", None),
+        "vm": sandbox.vm,
         "network_access": sandbox.network_access,
         "timeout_minutes": sandbox.timeout_minutes,
         "labels": sandbox.labels,
@@ -105,9 +106,9 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
     return data
 
 
-def _guard_gpu_unsupported(sandbox: Sandbox, feature_name: str) -> None:
-    if sandbox.gpu_count > 0:
-        console.print(f"[red]Error:[/red] {feature_name} is not yet supported for GPU sandboxes.")
+def _guard_vm_unsupported(sandbox: Sandbox, feature_name: str) -> None:
+    if sandbox.vm:
+        console.print(f"[red]Error:[/red] {feature_name} is not yet supported for VM sandboxes.")
         raise typer.Exit(1)
 
 
@@ -337,7 +338,7 @@ def get(
 def create(
     docker_image: Optional[str] = typer.Argument(
         None,
-        help="Image to run. For GPU sandboxes, provide the VM image reference.",
+        help="Image to run. When using --vm, provide the VM image reference.",
     ),
     name: Optional[str] = typer.Option(
         None, help="Name for the sandbox (auto-generated if not provided)"
@@ -353,6 +354,11 @@ def create(
         None,
         "--gpu-type",
         help="GPU type/model (e.g. H100_80GB, A100_80GB). Required when --gpu-count > 0",
+    ),
+    vm: bool = typer.Option(
+        False,
+        "--vm",
+        help="Create a VM-backed sandbox on the VM sandbox infra. Required when requesting GPUs.",
     ),
     network_access: bool = typer.Option(
         True,
@@ -414,6 +420,12 @@ def create(
             )
             raise typer.Exit(1)
 
+        if gpu_count > 0 and not vm:
+            console.print(
+                "[red]GPUs require VM sandboxes.[/red] Pass --vm whenever using --gpu-count."
+            )
+            raise typer.Exit(1)
+
         if gpu_count == 0 and gpu_type:
             console.print(
                 "[red]GPU type provided without GPUs.[/red] "
@@ -432,6 +444,12 @@ def create(
             if gpu_count > 0 and gpu_type:
                 gpu_slug = "".join(c if c.isalnum() or c == "-" else "-" for c in gpu_type.lower())
                 base_name = f"gpu-{'-'.join(filter(None, gpu_slug.split('-')))}"
+            elif vm:
+                image_parts = docker_image.split("/")[-1].split(":")[0]
+                image_slug = "".join(
+                    c if c.isalnum() or c == "-" else "-" for c in image_parts.lower()
+                )
+                base_name = f"vm-{'-'.join(filter(None, image_slug.split('-')))}"
             else:
                 image_parts = docker_image.split("/")[-1].split(":")[0]
                 base_name = "".join(
@@ -451,6 +469,7 @@ def create(
             disk_size_gb=disk_size_gb,
             gpu_count=gpu_count,
             gpu_type=gpu_type,
+            vm=vm,
             network_access=network_access,
             timeout_minutes=timeout_minutes,
             environment_vars=env_vars if env_vars else None,
@@ -466,6 +485,7 @@ def create(
         console.print(f"Docker Image: {docker_image}")
         console.print(f"Start Command: {start_command or 'N/A'}")
         console.print(f"Resources: {cpu_cores} CPU, {memory_gb}GB RAM, {disk_size_gb}GB disk")
+        console.print(f"VM: {'Enabled' if vm else 'Disabled'}")
         if gpu_count > 0:
             console.print(f"GPUs: {gpu_type} x{gpu_count}")
         network_status = "[green]Enabled[/green]" if network_access else "[yellow]Disabled[/yellow]"
@@ -1028,7 +1048,7 @@ def expose_port(
 
         with console.status("[bold blue]Checking sandbox status...", spinner="dots"):
             sandbox = sandbox_client.get(sandbox_id)
-        _guard_gpu_unsupported(sandbox, "Port exposure")
+        _guard_vm_unsupported(sandbox, "Port exposure")
 
         with console.status("[bold blue]Exposing port...", spinner="dots"):
             exposed = sandbox_client.expose(sandbox_id, port, name, protocol)
@@ -1085,7 +1105,7 @@ def unexpose_port(
 
         with console.status("[bold blue]Checking sandbox status...", spinner="dots"):
             sandbox = sandbox_client.get(sandbox_id)
-        _guard_gpu_unsupported(sandbox, "Port unexpose")
+        _guard_vm_unsupported(sandbox, "Port unexpose")
 
         with console.status("[bold blue]Unexposing port...", spinner="dots"):
             sandbox_client.unexpose(sandbox_id, exposure_id)
@@ -1121,7 +1141,7 @@ def list_ports(
             # List ports for a specific sandbox
             with console.status("[bold blue]Checking sandbox status...", spinner="dots"):
                 sandbox = sandbox_client.get(sandbox_id)
-            _guard_gpu_unsupported(sandbox, "Port listing")
+            _guard_vm_unsupported(sandbox, "Port listing")
 
             with console.status("[bold blue]Fetching exposed ports...", spinner="dots"):
                 response = sandbox_client.list_exposed_ports(sandbox_id)
@@ -1265,7 +1285,7 @@ def ssh_connect(
         with console.status("[bold blue]Checking sandbox status...", spinner="dots"):
             sandbox = sandbox_client.get(sandbox_id)
 
-        _guard_gpu_unsupported(sandbox, "SSH")
+        _guard_vm_unsupported(sandbox, "SSH")
 
         if sandbox.status != "RUNNING":
             console.print(f"[red]Error:[/red] Sandbox is not running (status: {sandbox.status})")

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -26,6 +26,7 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
         [
             "sandbox",
             "create",
+            "team-1/gpu-runtime:v1",
             "--gpu-count",
             "1",
             "--gpu-type",
@@ -38,8 +39,8 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Successfully created sandbox sbx-gpu-123" in output
     assert "GPUs: H100_80GB x1" in output
-    assert "Docker Image: Not supported (platform GPU runtime)" in output
-    assert captured["request"].docker_image == "gpu-managed-runtime"
+    assert "Docker Image: team-1/gpu-runtime:v1" in output
+    assert captured["request"].docker_image == "team-1/gpu-runtime:v1"
     assert captured["request"].gpu_count == 1
     assert captured["request"].gpu_type == "H100_80GB"
 
@@ -70,24 +71,21 @@ def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch
     )
 
     output = strip_ansi(result.output)
-    assert result.exit_code == 0, f"Failed: {result.output}"
-    assert "Successfully created sandbox sbx-gpu-default-image" in output
-    assert "Docker Image: Not supported (platform GPU runtime)" in output
-    assert captured["request"].docker_image == "gpu-managed-runtime"
-    assert captured["request"].gpu_count == 1
-    assert captured["request"].gpu_type == "RTX_PRO_6000"
+    assert result.exit_code == 1
+    assert "Docker image is required." in output
+    assert "Successfully created sandbox" not in output
+    assert "request" not in captured
 
 
-def test_sandbox_create_rejects_docker_image_for_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sandbox_create_accepts_docker_image_for_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
 
-    called = False
+    captured: dict[str, Any] = {}
 
     def mock_create(self: Any, request: Any) -> Any:
-        nonlocal called
-        called = True
-        return SimpleNamespace(id="sbx-should-not-create")
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-gpu-with-image")
 
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
 
@@ -106,9 +104,11 @@ def test_sandbox_create_rejects_docker_image_for_gpu(monkeypatch: pytest.MonkeyP
     )
 
     output = strip_ansi(result.output)
-    assert result.exit_code == 1
-    assert "Docker image is not supported for GPU sandboxes." in output
-    assert called is False
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Successfully created sandbox sbx-gpu-with-image" in output
+    assert captured["request"].docker_image == "python:3.11-slim"
+    assert captured["request"].gpu_count == 1
+    assert captured["request"].gpu_type == "H100_80GB"
 
 
 def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -176,5 +176,5 @@ def test_sandbox_create_requires_docker_image_for_cpu(monkeypatch: pytest.Monkey
 
     output = strip_ansi(result.output)
     assert result.exit_code == 1
-    assert "Docker image is required for CPU sandboxes." in output
+    assert "Docker image is required." in output
     assert called is False

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -27,6 +27,7 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
             "sandbox",
             "create",
             "team-1/gpu-runtime:v1",
+            "--vm",
             "--gpu-count",
             "1",
             "--gpu-type",
@@ -38,11 +39,13 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Successfully created sandbox sbx-gpu-123" in output
+    assert "VM: Enabled" in output
     assert "GPUs: H100_80GB x1" in output
     assert "Docker Image: team-1/gpu-runtime:v1" in output
     assert captured["request"].docker_image == "team-1/gpu-runtime:v1"
     assert captured["request"].gpu_count == 1
     assert captured["request"].gpu_type == "H100_80GB"
+    assert captured["request"].vm is True
 
 
 def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -72,7 +75,7 @@ def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch
 
     output = strip_ansi(result.output)
     assert result.exit_code == 1
-    assert "Docker image is required." in output
+    assert "GPUs require VM sandboxes." in output
     assert "Successfully created sandbox" not in output
     assert "request" not in captured
 
@@ -95,6 +98,7 @@ def test_sandbox_create_accepts_docker_image_for_gpu(monkeypatch: pytest.MonkeyP
             "sandbox",
             "create",
             "python:3.11-slim",
+            "--vm",
             "--gpu-count",
             "1",
             "--gpu-type",
@@ -109,6 +113,7 @@ def test_sandbox_create_accepts_docker_image_for_gpu(monkeypatch: pytest.MonkeyP
     assert captured["request"].docker_image == "python:3.11-slim"
     assert captured["request"].gpu_count == 1
     assert captured["request"].gpu_type == "H100_80GB"
+    assert captured["request"].vm is True
 
 
 def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,6 +137,39 @@ def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> No
     output = strip_ansi(result.output)
     assert result.exit_code == 1
     assert "GPU type is required when requesting GPUs." in output
+    assert called is False
+
+
+def test_sandbox_create_requires_vm_for_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    called = False
+
+    def mock_create(self: Any, request: Any) -> Any:
+        nonlocal called
+        called = True
+        return SimpleNamespace(id="sbx-should-not-create")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.11-slim",
+            "--gpu-count",
+            "1",
+            "--gpu-type",
+            "H100_80GB",
+            "--yes",
+        ],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "GPUs require VM sandboxes." in output
     assert called is False
 
 
@@ -178,3 +216,27 @@ def test_sandbox_create_requires_docker_image_for_cpu(monkeypatch: pytest.Monkey
     assert result.exit_code == 1
     assert "Docker image is required." in output
     assert called is False
+
+
+def test_sandbox_create_vm_without_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-vm-123")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "user-1/vm-image:latest", "--vm", "--yes"],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Successfully created sandbox sbx-vm-123" in output
+    assert captured["request"].vm is True
+    assert captured["request"].gpu_count == 0


### PR DESCRIPTION
Pass a `--vm` flag which forwards to the platform to signal and create a VM based sandbox

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes sandbox creation validation and switches command transport selection from GPU-based to VM-based, which can affect how commands are executed for existing sandboxes if the `vm` flag is mis-set or missing from API responses.
> 
> **Overview**
> Adds first-class **VM-backed sandboxes** across the CLI and `prime-sandboxes` SDK via a new `vm` boolean field.
> 
> CLI `prime sandbox create` now accepts `--vm`, requires `--vm` when requesting GPUs, and always requires an explicit image (removing the prior implicit “platform GPU runtime” image behavior). Sandbox details output now includes the sandbox *type* (VM vs container) and VM sandboxes are explicitly blocked from port exposure/listing and SSH.
> 
> SDK models and auth caching are updated to carry the `vm` flag, and command execution transport selection is changed to use Connect RPC for VM sandboxes (instead of GPU-count-based detection), with tests/docs updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec7d21e410c0e00b20ff429283fb78f225dfeb52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->