### PR TITLE
fix: preserve auth cache clear semantics across async paths

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -225,11 +225,19 @@ class SandboxAuthCache:
 
     async def _ensure_loaded_async(self) -> None:
         if not self._loaded:
-            self._auth_cache = await asyncio.to_thread(self._load_cache)
-            self._loaded = True
+            loaded_cache, dirty = await asyncio.to_thread(self._read_cache_file)
+            cache_to_persist: Optional[Dict[str, Any]] = None
+            with self._lock:
+                if not self._loaded:
+                    self._auth_cache = loaded_cache
+                    self._loaded = True
+                    if dirty:
+                        cache_to_persist = dict(self._auth_cache)
+            if cache_to_persist is not None:
+                await self._save_cache_data_async(cache_to_persist)
 
-    def _load_cache(self) -> Dict[str, Any]:
-        """Load auth cache from file and clean expired entries"""
+    def _read_cache_file(self) -> tuple[Dict[str, Any], bool]:
+        """Read auth cache from disk and return cleaned contents plus a dirty flag."""
         try:
             if self._cache_file.exists():
                 with open(self._cache_file, "r") as f:
@@ -247,14 +255,18 @@ class SandboxAuthCache:
                     except Exception:
                         pass
 
-                if len(cleaned_cache) != len(cache):
-                    self._auth_cache = cleaned_cache
-                    self._save_cache()
-
-                return cleaned_cache
+                return cleaned_cache, len(cleaned_cache) != len(cache)
         except Exception:
             pass
-        return {}
+        return {}, False
+
+    def _load_cache(self) -> Dict[str, Any]:
+        """Load auth cache from file and clean expired entries"""
+        cleaned_cache, dirty = self._read_cache_file()
+        if dirty:
+            self._auth_cache = cleaned_cache
+            self._save_cache()
+        return cleaned_cache
 
     def _save_cache(self) -> None:
         """Save auth cache to file"""
@@ -267,15 +279,26 @@ class SandboxAuthCache:
 
     async def _save_cache_async(self) -> None:
         """Save auth cache to file (async version)"""
+        await self._save_cache_data_async(dict(self._auth_cache))
+
+    async def _save_cache_data_async(self, cache_data: Dict[str, Any]) -> None:
+        """Persist a cache snapshot only if it still matches the current shared state."""
+        await asyncio.to_thread(self._save_cache_data_if_current, cache_data)
+
+    def _save_cache_data_if_current(self, cache_data: Dict[str, Any]) -> None:
+        """Save cache data when no sync operation has changed the cache since snapshot."""
         try:
-            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            async with aiofiles.open(self._cache_file, "w") as f:
-                await f.write(json.dumps(self._auth_cache))
+            with self._lock:
+                if self._auth_cache != cache_data:
+                    return
+                self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+                with open(self._cache_file, "w") as f:
+                    json.dump(cache_data, f)
         except Exception:
             pass
 
-    def _check_cached_auth(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Return a copy of cached auth if still valid, else evict and return None."""
+    def _check_cached_auth(self, sandbox_id: str) -> tuple[Optional[Dict[str, Any]], bool]:
+        """Return cached auth plus whether an expired entry was evicted."""
         if sandbox_id in self._auth_cache:
             auth_info = self._auth_cache[sandbox_id]
             expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
@@ -283,15 +306,18 @@ class SandboxAuthCache:
             if expires_at.tzinfo is None:
                 expires_at = expires_at.replace(tzinfo=timezone.utc)
             if datetime.now(timezone.utc) < expires_at:
-                return dict(auth_info)
+                return dict(auth_info), False
             del self._auth_cache[sandbox_id]
-        return None
+            return None, True
+        return None, False
 
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
         """Get cached auth info or fetch new token if expired/missing."""
         with self._lock:
             self._ensure_loaded()
-            cached_auth = self._check_cached_auth(sandbox_id)
+            cached_auth, evicted = self._check_cached_auth(sandbox_id)
+            if evicted:
+                self._save_cache()
             if cached_auth:
                 return cached_auth
 
@@ -306,7 +332,9 @@ class SandboxAuthCache:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
         with self._lock:
             self._ensure_loaded()
-            cached_auth = self._check_cached_auth(sandbox_id)
+            cached_auth, evicted = self._check_cached_auth(sandbox_id)
+            if evicted:
+                self._save_cache()
             if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
                 return bool(cached_auth["is_gpu"])
 
@@ -343,22 +371,36 @@ class SandboxAuthCache:
         """Get cached auth info or fetch new token if expired/missing (async)."""
         async with self._get_async_lock():
             await self._ensure_loaded_async()
-            cached_auth = self._check_cached_auth(sandbox_id)
+            cache_to_persist: Optional[Dict[str, Any]] = None
+            with self._lock:
+                cached_auth, evicted = self._check_cached_auth(sandbox_id)
+                if evicted:
+                    cache_to_persist = dict(self._auth_cache)
+            if cache_to_persist is not None:
+                await self._save_cache_data_async(cache_to_persist)
             if cached_auth:
                 return cached_auth
 
         response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
 
         async with self._get_async_lock():
-            self._auth_cache[sandbox_id] = response
-            await self._save_cache_async()
+            with self._lock:
+                self._auth_cache[sandbox_id] = response
+                cache_to_persist = dict(self._auth_cache)
+            await self._save_cache_data_async(cache_to_persist)
         return dict(response)
 
     async def is_gpu_async(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
         async with self._get_async_lock():
             await self._ensure_loaded_async()
-            cached_auth = self._check_cached_auth(sandbox_id)
+            cache_to_persist: Optional[Dict[str, Any]] = None
+            with self._lock:
+                cached_auth, evicted = self._check_cached_auth(sandbox_id)
+                if evicted:
+                    cache_to_persist = dict(self._auth_cache)
+            if cache_to_persist is not None:
+                await self._save_cache_data_async(cache_to_persist)
             if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
                 return bool(cached_auth["is_gpu"])
 
@@ -367,21 +409,20 @@ class SandboxAuthCache:
         is_gpu = sandbox.gpu_count > 0
 
         async with self._get_async_lock():
-            if sandbox_id in self._auth_cache:
-                self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                await self._save_cache_async()
+            cache_to_persist: Optional[Dict[str, Any]] = None
+            with self._lock:
+                if sandbox_id in self._auth_cache:
+                    self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+                    cache_to_persist = dict(self._auth_cache)
+            if cache_to_persist is not None:
+                await self._save_cache_data_async(cache_to_persist)
 
         return is_gpu
 
     async def clear_async(self) -> None:
         """Clear all cached auth tokens (async)."""
         async with self._get_async_lock():
-            self._auth_cache = {}
-            self._loaded = True
-            try:
-                await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
-            except Exception:
-                pass
+            await asyncio.to_thread(self.clear)
 
 
 def _check_sandbox_statuses(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -277,10 +277,6 @@ class SandboxAuthCache:
         except Exception:
             pass
 
-    async def _save_cache_async(self) -> None:
-        """Save auth cache to file (async version)"""
-        await self._save_cache_data_async(dict(self._auth_cache))
-
     async def _save_cache_data_async(self, cache_data: Dict[str, Any]) -> None:
         """Persist a cache snapshot only if it still matches the current shared state."""
         await asyncio.to_thread(self._save_cache_data_if_current, cache_data)

--- a/packages/prime-sandboxes/tests/test_command_transport_selection.py
+++ b/packages/prime-sandboxes/tests/test_command_transport_selection.py
@@ -1,5 +1,8 @@
 """Tests for CPU/GPU command transport selection."""
 
+import asyncio
+import json
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
@@ -191,6 +194,83 @@ def test_auth_cache_stores_gpu_flag_for_reuse(tmp_path):
     assert cache.is_gpu("sbx-1")
     assert cache.is_gpu("sbx-1")
     assert cache.client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_clear_wins_over_inflight_lazy_load(tmp_path, monkeypatch):
+    stale_auth = _auth_payload() | {"token": "stale"}
+    cache_file = tmp_path / "auth_cache.json"
+    cache_file.write_text(json.dumps({"sbx-stale": stale_auth}))
+
+    class _FakeAsyncAPIClient:
+        async def request(self, method: str, path: str):
+            assert method == "POST"
+            assert path == "/sandbox/sbx-new/auth"
+            return _auth_payload() | {"token": "fresh"}
+
+    cache = SandboxAuthCache(tmp_path / "auth_cache.json", _FakeAsyncAPIClient(), lazy=True)
+
+    started = threading.Event()
+    allow_finish = threading.Event()
+
+    def _blocked_read_cache_file() -> tuple[dict[str, Any], bool]:
+        started.set()
+        allow_finish.wait(timeout=5)
+        return {"sbx-stale": stale_auth}, False
+
+    monkeypatch.setattr(cache, "_read_cache_file", _blocked_read_cache_file)
+
+    task = asyncio.create_task(cache.get_or_refresh_async("sbx-new"))
+    await asyncio.to_thread(started.wait, 5)
+
+    cache.clear()
+    allow_finish.set()
+
+    fresh_auth = await task
+
+    assert fresh_auth["token"] == "fresh"
+    assert cache._loaded is True
+    assert cache._auth_cache == {"sbx-new": fresh_auth}
+
+    persisted = json.loads(cache_file.read_text())
+    assert persisted == {"sbx-new": fresh_auth}
+
+
+@pytest.mark.asyncio
+async def test_sync_clear_wins_over_inflight_async_save(tmp_path, monkeypatch):
+    cache_file = tmp_path / "auth_cache.json"
+
+    class _FakeAsyncAPIClient:
+        async def request(self, method: str, path: str):
+            assert method == "POST"
+            assert path == "/sandbox/sbx-new/auth"
+            return _auth_payload() | {"token": "fresh"}
+
+    cache = SandboxAuthCache(cache_file, _FakeAsyncAPIClient(), lazy=True)
+
+    started = threading.Event()
+    allow_finish = threading.Event()
+    original_write = cache._save_cache_data_if_current
+
+    def _blocked_save_cache_data_if_current(cache_data: dict[str, Any]) -> None:
+        started.set()
+        allow_finish.wait(timeout=5)
+        original_write(cache_data)
+
+    monkeypatch.setattr(cache, "_save_cache_data_if_current", _blocked_save_cache_data_if_current)
+
+    task = asyncio.create_task(cache.get_or_refresh_async("sbx-new"))
+    await asyncio.to_thread(started.wait, 5)
+
+    cache.clear()
+    allow_finish.set()
+
+    fresh_auth = await task
+
+    assert fresh_auth["token"] == "fresh"
+    assert cache._loaded is True
+    assert cache._auth_cache == {}
+    assert not cache_file.exists()
 
 
 def test_sync_connect_execution_collects_stdout_stderr(monkeypatch):


### PR DESCRIPTION
## Summary
- keep lazy async cache loads from rehydrating cleared file contents
- make async cache writes conditional on current shared state so sync clears cannot rewrite stale snapshots
- route clear_async through the sync clear path and add regressions for the lazy-load and async-save races

## Verification
- uv run ruff check packages/prime-sandboxes/src/prime_sandboxes/sandbox.py packages/prime-sandboxes/tests/test_command_transport_selection.py
- uv run pytest packages/prime-sandboxes/tests/test_command_transport_selection.py -k 'auth_cache or async_clear_wins_over_inflight_lazy_load or sync_clear_wins_over_inflight_async_save'
- uv run pytest packages/prime-sandboxes/tests -k 'not cmd_timeout and not command_execution and not file_operations and not sandbox_operations'

## Notes
- the full prime-sandboxes suite still includes live API/sandbox tests that require PRIME_API_KEY and external network access, so those were not treated as local blockers for this follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared auth token caching and persistence across sync/async code paths; incorrect locking/snapshot logic could lead to stale tokens being re-persisted or cache state divergence under concurrency.
> 
> **Overview**
> Fixes `SandboxAuthCache` concurrency around lazy async loading and persistence so a `clear()` cannot be overwritten by an in-flight async read/write.
> 
> Async paths now **load cache contents outside the lock but commit them only if still unloaded**, and async writes persist a *snapshot* only if it still matches current shared state (preventing stale rewrites). Expired-entry eviction now reports when it removed data so callers can persist the eviction, and `clear_async()` is routed through `clear()`.
> 
> Adds regression tests covering (1) sync clear vs in-flight async lazy load and (2) sync clear vs in-flight async save.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ead2ad66b2953f2780d56a0be637d86e87a6d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->