### PR TITLE
fix: skip symlinks in env push source archives

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -404,6 +404,10 @@ def should_include_file_in_archive(file_path: Path, base_path: Path) -> bool:
     if not file_path.is_file():
         return False
 
+    # Skip symlinks - they cause extraction failures in _safe_tar_extract
+    if file_path.is_symlink():
+        return False
+
     # Skip hidden files
     if file_path.name.startswith("."):
         return False


### PR DESCRIPTION
## Summary
- Skips symlinks when building source tarballs during `prime env push`
- Fixes private env installs failing with `Refusing to extract symlink: wandb/debug-internal.log` because `_safe_tar_extract` blocks symlinks on the install side but the push side was including them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small filtering change that only alters which files are included in `prime env push` source tarballs, reducing install failures without affecting network/auth flows.
> 
> **Overview**
> Prevents `prime env push` from including symlinked files in generated source tarballs by updating `should_include_file_in_archive` to explicitly skip symlinks.
> 
> This aligns archive creation with the install-side `_safe_tar_extract` behavior (which rejects symlinks), avoiding extraction failures for environments containing symlinked artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74f8ff3c4507f1e7b61562d5d663efb7447c6105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->