### PR TITLE
Release: Bump prime CLI to 0.5.49

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.48"
+__version__ = "0.5.49"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump prime CLI version to 0.5.49
- Includes symlink fix from #451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version metadata change only; no functional code paths are modified.
> 
> **Overview**
> Updates `prime_cli.__version__` to `0.5.49` (from `0.5.48`) for the Prime CLI release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9319d8398f02421feeaeb3b5f4b8f7483bfd1abb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->