### PR TITLE
Release: Bump prime CLI to 0.5.49

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.48"
+__version__ = "0.5.49"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump prime CLI version to 0.5.49
- Includes symlink fix from #451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the `prime_cli` package version string with no functional code changes.
> 
> **Overview**
> Bumps the Prime CLI version in `prime_cli/__init__.py` from `0.5.48` to `0.5.49`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17029a051f2b46542e42b8da89c89e29c0d73dd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->