### PR TITLE
AsyncSandboxAuthCache

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -329,7 +329,7 @@ class SandboxAuthCache:
             response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
             with self._lock:
                 self._auth_cache[sandbox_id] = response
-                self._save_cache()
+            self._save_cache()
             return dict(response)
         finally:
             with self._lock:
@@ -352,7 +352,7 @@ class SandboxAuthCache:
         with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                self._save_cache()
+        self._save_cache()
 
         return is_gpu
 
@@ -361,7 +361,7 @@ class SandboxAuthCache:
         with self._lock:
             self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
-            self._save_cache()
+        self._save_cache()
 
     def clear(self) -> None:
         """Clear all cached auth tokens."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -247,11 +247,9 @@ class SandboxAuthCache:
         self._inflight: Dict[str, threading.Event] = {}
         self._auth_cache, needs_save = _load_auth_cache(self._cache_file)
         if needs_save:
-            self._save_cache()
+            self._save_cache(dict(self._auth_cache))
 
-    def _save_cache(self, data: Optional[Dict[str, Any]] = None) -> None:
-        if data is None:
-            data = self._auth_cache
+    def _save_cache(self, data: Dict[str, Any]) -> None:
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
@@ -352,13 +350,13 @@ class AsyncSandboxAuthCache:
         self._auth_cache, needs_save = await asyncio.to_thread(_load_auth_cache, self._cache_file)
         self._loaded = True
         if needs_save:
-            await self._save_cache(dict(self._auth_cache))
+            await self._save_cache(json.dumps(self._auth_cache))
 
-    async def _save_cache(self, data: Dict[str, Any]) -> None:
+    async def _save_cache(self, data: str) -> None:
         def _write() -> None:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
-                json.dump(data, f)
+                f.write(data)
 
         try:
             await asyncio.to_thread(_write)
@@ -396,8 +394,8 @@ class AsyncSandboxAuthCache:
                 response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
                 async with self._lock:
                     self._auth_cache[sandbox_id] = response
-                    snapshot = dict(self._auth_cache)
-                await self._save_cache(snapshot)
+                    serialized = json.dumps(self._auth_cache)
+                await self._save_cache(serialized)
                 return dict(response)
             finally:
                 async with self._lock:
@@ -420,11 +418,11 @@ class AsyncSandboxAuthCache:
         async with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                snapshot = dict(self._auth_cache)
+                serialized = json.dumps(self._auth_cache)
             else:
-                snapshot = None
-        if snapshot is not None:
-            await self._save_cache(snapshot)
+                serialized = None
+        if serialized is not None:
+            await self._save_cache(serialized)
 
         return is_gpu
 
@@ -432,8 +430,8 @@ class AsyncSandboxAuthCache:
         async with self._lock:
             await self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
-            snapshot = dict(self._auth_cache)
-        await self._save_cache(snapshot)
+            serialized = json.dumps(self._auth_cache)
+        await self._save_cache(serialized)
 
     async def clear(self) -> None:
         async with self._lock:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -373,6 +373,16 @@ class SandboxAuthCache:
 
         return is_gpu
 
+    async def clear_async(self) -> None:
+        """Clear all cached auth tokens (async)."""
+        async with self._get_async_lock():
+            self._auth_cache = {}
+            try:
+                if self._cache_file.exists():
+                    self._cache_file.unlink()
+            except Exception:
+                pass
+
 
 def _check_sandbox_statuses(
     sandboxes: List[Sandbox], target_ids: set
@@ -1243,9 +1253,9 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    def clear_auth_cache(self) -> None:
+    async def clear_auth_cache(self) -> None:
         """Clear all cached auth tokens"""
-        self._auth_cache.clear()
+        await self._auth_cache.clear_async()
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:
         """Create a new sandbox"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -247,13 +247,14 @@ class SandboxAuthCache:
         self._inflight: Dict[str, threading.Event] = {}
         self._auth_cache, needs_save = _load_auth_cache(self._cache_file)
         if needs_save:
-            self._save_cache(dict(self._auth_cache))
+            self._save_cache()
 
-    def _save_cache(self, data: Dict[str, Any]) -> None:
+    def _save_cache(self) -> None:
+        """Write current in-memory cache to disk. Must be called under self._lock."""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
-                json.dump(data, f)
+                json.dump(self._auth_cache, f)
         except Exception:
             pass
 
@@ -287,8 +288,7 @@ class SandboxAuthCache:
                 response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
                 with self._lock:
                     self._auth_cache[sandbox_id] = response
-                    snapshot = dict(self._auth_cache)
-                self._save_cache(snapshot)
+                    self._save_cache()
                 return dict(response)
             finally:
                 with self._lock:
@@ -310,27 +310,19 @@ class SandboxAuthCache:
         with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                snapshot = dict(self._auth_cache)
-            else:
-                snapshot = None
-        if snapshot is not None:
-            self._save_cache(snapshot)
+                self._save_cache()
 
         return is_gpu
 
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         with self._lock:
             self._auth_cache[sandbox_id] = auth_info
-            snapshot = dict(self._auth_cache)
-        self._save_cache(snapshot)
+            self._save_cache()
 
     def clear(self) -> None:
         with self._lock:
             self._auth_cache = {}
-        try:
-            self._cache_file.unlink(missing_ok=True)
-        except Exception:
-            pass
+            self._save_cache()
 
 
 class AsyncSandboxAuthCache:
@@ -350,9 +342,12 @@ class AsyncSandboxAuthCache:
         self._auth_cache, needs_save = await asyncio.to_thread(_load_auth_cache, self._cache_file)
         self._loaded = True
         if needs_save:
-            await self._save_cache(json.dumps(self._auth_cache))
+            await self._save_cache()
 
-    async def _save_cache(self, data: str) -> None:
+    async def _save_cache(self) -> None:
+        """Write current in-memory cache to disk. Must be called under self._lock."""
+        data = json.dumps(self._auth_cache)
+
         def _write() -> None:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
@@ -394,8 +389,7 @@ class AsyncSandboxAuthCache:
                 response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
                 async with self._lock:
                     self._auth_cache[sandbox_id] = response
-                    serialized = json.dumps(self._auth_cache)
-                await self._save_cache(serialized)
+                    await self._save_cache()
                 return dict(response)
             finally:
                 async with self._lock:
@@ -418,11 +412,7 @@ class AsyncSandboxAuthCache:
         async with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                serialized = json.dumps(self._auth_cache)
-            else:
-                serialized = None
-        if serialized is not None:
-            await self._save_cache(serialized)
+                await self._save_cache()
 
         return is_gpu
 
@@ -430,17 +420,13 @@ class AsyncSandboxAuthCache:
         async with self._lock:
             await self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
-            serialized = json.dumps(self._auth_cache)
-        await self._save_cache(serialized)
+            await self._save_cache()
 
     async def clear(self) -> None:
         async with self._lock:
             self._auth_cache = {}
             self._loaded = True
-        try:
-            await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
-        except Exception:
-            pass
+            await self._save_cache()
 
 
 def _check_sandbox_statuses(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,6 +6,7 @@ import os
 import re
 import shlex
 import sys
+import threading
 import time
 import uuid
 from datetime import datetime, timezone
@@ -200,10 +201,32 @@ def _raise_not_running_error(
 class SandboxAuthCache:
     """Shared auth cache management for sandbox clients"""
 
-    def __init__(self, cache_file_path: Any, client: Any) -> None:
+    def __init__(self, cache_file_path: Any, client: Any, *, lazy: bool = False) -> None:
         self._cache_file = cache_file_path
-        self._auth_cache = self._load_cache()
         self.client = client
+        self._lock = threading.Lock()
+        self._async_lock: Optional[asyncio.Lock] = None
+        if lazy:
+            self._auth_cache: Dict[str, Any] = {}
+            self._loaded = False
+        else:
+            self._auth_cache = self._load_cache()
+            self._loaded = True
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        if self._async_lock is None:
+            self._async_lock = asyncio.Lock()
+        return self._async_lock
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self._auth_cache = self._load_cache()
+            self._loaded = True
+
+    async def _ensure_loaded_async(self) -> None:
+        if not self._loaded:
+            self._auth_cache = await asyncio.to_thread(self._load_cache)
+            self._loaded = True
 
     def _load_cache(self) -> Dict[str, Any]:
         """Load auth cache from file and clean expired entries"""
@@ -212,13 +235,13 @@ class SandboxAuthCache:
                 with open(self._cache_file, "r") as f:
                     cache = json.load(f)
                 cleaned_cache = {}
+                now = datetime.now(timezone.utc)
                 for sandbox_id, auth_info in cache.items():
                     try:
                         expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
                         expires_at = datetime.fromisoformat(expires_at_str)
                         if expires_at.tzinfo is None:
                             expires_at = expires_at.replace(tzinfo=timezone.utc)
-                        now = datetime.now(timezone.utc)
                         if now < expires_at:
                             cleaned_cache[sandbox_id] = auth_info
                     except Exception:
@@ -243,7 +266,7 @@ class SandboxAuthCache:
             pass
 
     async def _save_cache_async(self) -> None:
-        """Save auth cache to file (async version)"""
+        """Save auth cache to file without blocking the event loop."""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             async with aiofiles.open(self._cache_file, "w") as f:
@@ -252,7 +275,7 @@ class SandboxAuthCache:
             pass
 
     def _check_cached_auth(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Check if cached auth info exists and is valid"""
+        """Return a copy of cached auth if still valid, else evict and return None."""
         if sandbox_id in self._auth_cache:
             auth_info = self._auth_cache[sandbox_id]
             expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
@@ -261,92 +284,92 @@ class SandboxAuthCache:
                 expires_at = expires_at.replace(tzinfo=timezone.utc)
             if datetime.now(timezone.utc) < expires_at:
                 return dict(auth_info)
-            else:
-                del self._auth_cache[sandbox_id]
-                self._save_cache()
-        return None
-
-    async def _check_cached_auth_async(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Check if cached auth info exists and is valid (async version)"""
-        if sandbox_id in self._auth_cache:
-            auth_info = self._auth_cache[sandbox_id]
-            expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
-            expires_at = datetime.fromisoformat(expires_at_str)
-            if expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) < expires_at:
-                return dict(auth_info)
-            else:
-                del self._auth_cache[sandbox_id]
-                await self._save_cache_async()
+            del self._auth_cache[sandbox_id]
         return None
 
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing"""
-        cached_auth = self._check_cached_auth(sandbox_id)
-        if cached_auth:
-            return cached_auth
+        """Get cached auth info or fetch new token if expired/missing."""
+        with self._lock:
+            self._ensure_loaded()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth:
+                return cached_auth
 
         response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-        self.set(sandbox_id, response)
-        self._save_cache()
-        return dict(response)
 
-    async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing (async)"""
-        cached_auth = await self._check_cached_auth_async(sandbox_id)
-        if cached_auth:
-            return cached_auth
-        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-        self._auth_cache[sandbox_id] = response
-        await self._save_cache_async()
+        with self._lock:
+            self._auth_cache[sandbox_id] = response
+            self._save_cache()
         return dict(response)
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
-        cached_auth = self._check_cached_auth(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        with self._lock:
+            self._ensure_loaded()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
+                return bool(cached_auth["is_gpu"])
 
         sandbox_data = self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
         is_gpu = sandbox.gpu_count > 0
 
-        if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-            self._save_cache()
+        with self._lock:
+            if sandbox_id in self._auth_cache:
+                self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+                self._save_cache()
 
         return is_gpu
 
+    def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
+        """Cache auth info."""
+        with self._lock:
+            self._auth_cache[sandbox_id] = auth_info
+            self._save_cache()
+
+    def clear(self) -> None:
+        """Clear all cached auth tokens."""
+        with self._lock:
+            self._auth_cache = {}
+            try:
+                if self._cache_file.exists():
+                    self._cache_file.unlink()
+            except Exception:
+                pass
+
+    async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
+        """Get cached auth info or fetch new token if expired/missing (async)."""
+        async with self._get_async_lock():
+            await self._ensure_loaded_async()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth:
+                return cached_auth
+
+        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+
+        async with self._get_async_lock():
+            self._auth_cache[sandbox_id] = response
+            await self._save_cache_async()
+        return dict(response)
+
     async def is_gpu_async(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
-        cached_auth = await self._check_cached_auth_async(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        async with self._get_async_lock():
+            await self._ensure_loaded_async()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
+                return bool(cached_auth["is_gpu"])
 
         sandbox_data = await self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
         is_gpu = sandbox.gpu_count > 0
 
-        if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-            await self._save_cache_async()
+        async with self._get_async_lock():
+            if sandbox_id in self._auth_cache:
+                self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+                await self._save_cache_async()
 
         return is_gpu
-
-    def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
-        """Cache auth info"""
-        self._auth_cache[sandbox_id] = auth_info
-        self._save_cache()
-
-    def clear(self) -> None:
-        """Clear all cached auth tokens"""
-        self._auth_cache = {}
-        try:
-            if self._cache_file.exists():
-                self._cache_file.unlink()
-        except Exception:
-            pass
 
 
 def _check_sandbox_statuses(
@@ -1119,6 +1142,7 @@ class AsyncSandboxClient:
         self._auth_cache = SandboxAuthCache(
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
+            lazy=True,
         )
         # Connection pool configuration
         self._max_connections = max_connections

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1254,8 +1254,12 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    async def clear_auth_cache(self) -> None:
-        """Clear all cached auth tokens"""
+    def clear_auth_cache(self) -> None:
+        """Clear cached auth tokens synchronously for backward compatibility."""
+        self._auth_cache.clear()
+
+    async def clear_auth_cache_async(self) -> None:
+        """Clear cached auth tokens without blocking other async cache users."""
         await self._auth_cache.clear_async()
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -205,6 +205,7 @@ class SandboxAuthCache:
         self._cache_file = cache_file_path
         self.client = client
         self._lock = threading.Lock()
+        self._async_lock_init = threading.Lock()
         self._async_lock: Optional[asyncio.Lock] = None
         if lazy:
             self._auth_cache: Dict[str, Any] = {}
@@ -217,7 +218,9 @@ class SandboxAuthCache:
 
     def _get_async_lock(self) -> asyncio.Lock:
         if self._async_lock is None:
-            self._async_lock = asyncio.Lock()
+            with self._async_lock_init:
+                if self._async_lock is None:
+                    self._async_lock = asyncio.Lock()
         return self._async_lock
 
     def _ensure_loaded(self) -> None:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,6 +6,7 @@ import os
 import re
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -253,8 +254,14 @@ class SandboxAuthCache:
         """Write current in-memory cache to disk. Must be called under self._lock."""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._cache_file, "w") as f:
-                json.dump(self._auth_cache, f)
+            fd, tmp = tempfile.mkstemp(dir=self._cache_file.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(self._auth_cache, f)
+                os.replace(tmp, self._cache_file)
+            except BaseException:
+                os.unlink(tmp)
+                raise
         except Exception:
             pass
 
@@ -350,8 +357,14 @@ class AsyncSandboxAuthCache:
 
         def _write() -> None:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._cache_file, "w") as f:
-                f.write(data)
+            fd, tmp = tempfile.mkstemp(dir=self._cache_file.parent, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w") as f:
+                    f.write(data)
+                os.replace(tmp, self._cache_file)
+            except BaseException:
+                os.unlink(tmp)
+                raise
 
         try:
             await asyncio.to_thread(_write)

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -351,13 +351,13 @@ class AsyncSandboxAuthCache:
         self._auth_cache, needs_save = await asyncio.to_thread(_load_auth_cache, self._cache_file)
         self._loaded = True
         if needs_save:
-            await self._save_cache()
+            await self._save_cache(dict(self._auth_cache))
 
-    async def _save_cache(self) -> None:
+    async def _save_cache(self, data: Dict[str, Any]) -> None:
         try:
             await asyncio.to_thread(self._cache_file.parent.mkdir, parents=True, exist_ok=True)
             async with aiofiles.open(self._cache_file, "w") as f:
-                await f.write(json.dumps(self._auth_cache))
+                await f.write(json.dumps(data))
         except Exception:
             pass
 
@@ -391,10 +391,12 @@ class AsyncSandboxAuthCache:
             response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
             async with self._lock:
                 self._auth_cache[sandbox_id] = response
-            await self._save_cache()
+                snapshot = dict(self._auth_cache)
+            await self._save_cache(snapshot)
             return dict(response)
         finally:
-            ev = self._inflight.pop(sandbox_id, None)
+            async with self._lock:
+                ev = self._inflight.pop(sandbox_id, None)
             if ev is not None:
                 ev.set()
 
@@ -413,14 +415,19 @@ class AsyncSandboxAuthCache:
         async with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-        await self._save_cache()
+                snapshot = dict(self._auth_cache)
+            else:
+                snapshot = None
+        if snapshot is not None:
+            await self._save_cache(snapshot)
 
         return is_gpu
 
     async def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         async with self._lock:
             self._auth_cache[sandbox_id] = auth_info
-        await self._save_cache()
+            snapshot = dict(self._auth_cache)
+        await self._save_cache(snapshot)
 
     async def clear(self) -> None:
         async with self._lock:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,7 +6,6 @@ import os
 import re
 import shlex
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -254,14 +253,8 @@ class SandboxAuthCache:
         """Write current in-memory cache to disk. Must be called under self._lock."""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            fd, tmp = tempfile.mkstemp(dir=self._cache_file.parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w") as f:
-                    json.dump(self._auth_cache, f)
-                os.replace(tmp, self._cache_file)
-            except BaseException:
-                os.unlink(tmp)
-                raise
+            with open(self._cache_file, "w") as f:
+                json.dump(self._auth_cache, f)
         except Exception:
             pass
 
@@ -357,14 +350,8 @@ class AsyncSandboxAuthCache:
 
         def _write() -> None:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            fd, tmp = tempfile.mkstemp(dir=self._cache_file.parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w") as f:
-                    f.write(data)
-                os.replace(tmp, self._cache_file)
-            except BaseException:
-                os.unlink(tmp)
-                raise
+            with open(self._cache_file, "w") as f:
+                f.write(data)
 
         try:
             await asyncio.to_thread(_write)

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -341,7 +341,7 @@ class AsyncSandboxAuthCache:
         self._cache_file = cache_file_path
         self.client = client
         self._lock = asyncio.Lock()
-        self._inflight: Dict[str, asyncio.Future] = {}
+        self._inflight: Dict[str, asyncio.Event] = {}
         self._auth_cache: Dict[str, Any] = {}
         self._loaded = False
 
@@ -374,29 +374,29 @@ class AsyncSandboxAuthCache:
                 return cached
 
             if sandbox_id in self._inflight:
-                future = self._inflight[sandbox_id]
+                event = self._inflight[sandbox_id]
             else:
-                future = None
-                self._inflight[sandbox_id] = asyncio.get_running_loop().create_future()
+                event = None
+                self._inflight[sandbox_id] = asyncio.Event()
 
-        if future is not None:
-            return dict(await future)
+        if event is not None:
+            await event.wait()
+            async with self._lock:
+                cached = _check_cached_auth(self._auth_cache, sandbox_id)
+                if cached:
+                    return cached
+            return await self.get_or_refresh(sandbox_id)
 
         try:
             response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
             async with self._lock:
                 self._auth_cache[sandbox_id] = response
-                fut = self._inflight.pop(sandbox_id, None)
             await self._save_cache()
-            if fut is not None and not fut.done():
-                fut.set_result(response)
             return dict(response)
-        except BaseException as e:
-            async with self._lock:
-                fut = self._inflight.pop(sandbox_id, None)
-            if fut is not None and not fut.done():
-                fut.set_exception(e)
-            raise
+        finally:
+            ev = self._inflight.pop(sandbox_id, None)
+            if ev is not None:
+                ev.set()
 
     async def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -207,6 +207,10 @@ class SandboxAuthCache:
         self._lock = threading.Lock()
         self._async_lock_init = threading.Lock()
         self._async_lock: Optional[asyncio.Lock] = None
+        # Per-sandbox in-flight auth futures to coalesce concurrent requests
+        self._inflight_sync: Dict[str, threading.Event] = {}
+        self._inflight_sync_results: Dict[str, Dict[str, Any]] = {}
+        self._inflight_async: Dict[str, asyncio.Future] = {}
         if lazy:
             self._auth_cache: Dict[str, Any] = {}
             self._loaded = False
@@ -293,19 +297,45 @@ class SandboxAuthCache:
         return None
 
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing."""
+        """Get cached auth info or fetch new token if expired/missing.
+
+        Coalesces concurrent requests for the same sandbox_id so only one
+        auth POST is issued while others wait for the result.
+        """
         with self._lock:
             self._ensure_loaded()
             cached_auth = self._check_cached_auth(sandbox_id)
             if cached_auth:
                 return cached_auth
 
-        response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            # Check if another thread is already fetching auth for this sandbox
+            if sandbox_id in self._inflight_sync:
+                event = self._inflight_sync[sandbox_id]
+            else:
+                event = None
+                self._inflight_sync[sandbox_id] = threading.Event()
 
-        with self._lock:
-            self._auth_cache[sandbox_id] = response
-            self._save_cache()
-        return dict(response)
+        if event is not None:
+            # Wait for the in-flight request to complete
+            event.wait()
+            with self._lock:
+                cached_auth = self._check_cached_auth(sandbox_id)
+                if cached_auth:
+                    return cached_auth
+            # Fallback: if the in-flight request failed, fetch ourselves
+            return self.get_or_refresh(sandbox_id)
+
+        try:
+            response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            with self._lock:
+                self._auth_cache[sandbox_id] = response
+                self._save_cache()
+            return dict(response)
+        finally:
+            with self._lock:
+                event = self._inflight_sync.pop(sandbox_id, None)
+            if event is not None:
+                event.set()
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
@@ -345,19 +375,44 @@ class SandboxAuthCache:
                 pass
 
     async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing (async)."""
+        """Get cached auth info or fetch new token if expired/missing (async).
+
+        Coalesces concurrent requests for the same sandbox_id so only one
+        auth POST is issued while others await the result.
+        """
         async with self._get_async_lock():
             await self._ensure_loaded_async()
             cached_auth = self._check_cached_auth(sandbox_id)
             if cached_auth:
                 return cached_auth
 
-        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            # Check if another coroutine is already fetching auth for this sandbox
+            if sandbox_id in self._inflight_async:
+                future = self._inflight_async[sandbox_id]
+            else:
+                future = None
+                loop = asyncio.get_running_loop()
+                self._inflight_async[sandbox_id] = loop.create_future()
 
-        async with self._get_async_lock():
-            self._auth_cache[sandbox_id] = response
-            await self._save_cache_async()
-        return dict(response)
+        if future is not None:
+            # Wait for the in-flight request to complete
+            return dict(await future)
+
+        try:
+            response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            async with self._get_async_lock():
+                self._auth_cache[sandbox_id] = response
+                await self._save_cache_async()
+                fut = self._inflight_async.pop(sandbox_id, None)
+            if fut is not None and not fut.done():
+                fut.set_result(response)
+            return dict(response)
+        except BaseException as e:
+            async with self._get_async_lock():
+                fut = self._inflight_async.pop(sandbox_id, None)
+            if fut is not None and not fut.done():
+                fut.set_exception(e)
+            raise
 
     async def is_gpu_async(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -198,75 +198,58 @@ def _raise_not_running_error(
     raise exc
 
 
-class SandboxAuthCache:
-    """Shared auth cache management for sandbox clients"""
+def _load_auth_cache(cache_file: Any) -> tuple[Dict[str, Any], bool]:
+    """Load auth cache from file and clean expired entries."""
+    try:
+        if cache_file.exists():
+            with open(cache_file, "r") as f:
+                cache = json.load(f)
+            cleaned_cache = {}
+            now = datetime.now(timezone.utc)
+            for sandbox_id, auth_info in cache.items():
+                try:
+                    expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
+                    expires_at = datetime.fromisoformat(expires_at_str)
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=timezone.utc)
+                    if now < expires_at:
+                        cleaned_cache[sandbox_id] = auth_info
+                except Exception:
+                    pass
 
-    def __init__(self, cache_file_path: Any, client: Any, *, lazy: bool = False) -> None:
+            return cleaned_cache, len(cleaned_cache) != len(cache)
+    except Exception:
+        pass
+    return {}, False
+
+
+def _check_cached_auth(cache: Dict[str, Any], sandbox_id: str) -> Optional[Dict[str, Any]]:
+    """Return a copy of cached auth if still valid, else evict and return None."""
+    if sandbox_id in cache:
+        auth_info = cache[sandbox_id]
+        expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
+        expires_at = datetime.fromisoformat(expires_at_str)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) < expires_at:
+            return dict(auth_info)
+        del cache[sandbox_id]
+    return None
+
+
+class SandboxAuthCache:
+    """Thread-safe auth cache for sync SandboxClient."""
+
+    def __init__(self, cache_file_path: Any, client: Any) -> None:
         self._cache_file = cache_file_path
         self.client = client
         self._lock = threading.Lock()
-        self._async_lock_init = threading.Lock()
-        self._async_lock: Optional[asyncio.Lock] = None
-        # Per-sandbox in-flight auth futures to coalesce concurrent requests
-        self._inflight_sync: Dict[str, threading.Event] = {}
-        self._inflight_sync_results: Dict[str, Dict[str, Any]] = {}
-        self._inflight_async: Dict[str, asyncio.Future] = {}
-        if lazy:
-            self._auth_cache: Dict[str, Any] = {}
-            self._loaded = False
-        else:
-            self._auth_cache, needs_save = self._load_cache()
-            self._loaded = True
-            if needs_save:
-                self._save_cache()
-
-    def _get_async_lock(self) -> asyncio.Lock:
-        if self._async_lock is None:
-            with self._async_lock_init:
-                if self._async_lock is None:
-                    self._async_lock = asyncio.Lock()
-        return self._async_lock
-
-    def _ensure_loaded(self) -> None:
-        if not self._loaded:
-            self._auth_cache, needs_save = self._load_cache()
-            self._loaded = True
-            if needs_save:
-                self._save_cache()
-
-    async def _ensure_loaded_async(self) -> None:
-        if not self._loaded:
-            self._auth_cache, needs_save = await asyncio.to_thread(self._load_cache)
-            self._loaded = True
-            if needs_save:
-                await self._save_cache_async()
-
-    def _load_cache(self) -> tuple[Dict[str, Any], bool]:
-        """Load auth cache from file and clean expired entries"""
-        try:
-            if self._cache_file.exists():
-                with open(self._cache_file, "r") as f:
-                    cache = json.load(f)
-                cleaned_cache = {}
-                now = datetime.now(timezone.utc)
-                for sandbox_id, auth_info in cache.items():
-                    try:
-                        expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
-                        expires_at = datetime.fromisoformat(expires_at_str)
-                        if expires_at.tzinfo is None:
-                            expires_at = expires_at.replace(tzinfo=timezone.utc)
-                        if now < expires_at:
-                            cleaned_cache[sandbox_id] = auth_info
-                    except Exception:
-                        pass
-
-                return cleaned_cache, len(cleaned_cache) != len(cache)
-        except Exception:
-            pass
-        return {}, False
+        self._inflight: Dict[str, threading.Event] = {}
+        self._auth_cache, needs_save = _load_auth_cache(self._cache_file)
+        if needs_save:
+            self._save_cache()
 
     def _save_cache(self) -> None:
-        """Save auth cache to file"""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
@@ -274,57 +257,29 @@ class SandboxAuthCache:
         except Exception:
             pass
 
-    async def _save_cache_async(self) -> None:
-        """Save auth cache to file (async version)"""
-        try:
-            await asyncio.to_thread(
-                self._cache_file.parent.mkdir, parents=True, exist_ok=True
-            )
-            async with aiofiles.open(self._cache_file, "w") as f:
-                await f.write(json.dumps(self._auth_cache))
-        except Exception:
-            pass
-
-    def _check_cached_auth(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Return a copy of cached auth if still valid, else evict and return None."""
-        if sandbox_id in self._auth_cache:
-            auth_info = self._auth_cache[sandbox_id]
-            expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
-            expires_at = datetime.fromisoformat(expires_at_str)
-            if expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) < expires_at:
-                return dict(auth_info)
-            del self._auth_cache[sandbox_id]
-        return None
-
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing.
+        """Get cached auth or fetch a new token.
 
         Coalesces concurrent requests for the same sandbox_id so only one
         auth POST is issued while others wait for the result.
         """
         with self._lock:
-            self._ensure_loaded()
-            cached_auth = self._check_cached_auth(sandbox_id)
-            if cached_auth:
-                return cached_auth
+            cached = _check_cached_auth(self._auth_cache, sandbox_id)
+            if cached:
+                return cached
 
-            # Check if another thread is already fetching auth for this sandbox
-            if sandbox_id in self._inflight_sync:
-                event = self._inflight_sync[sandbox_id]
+            if sandbox_id in self._inflight:
+                event = self._inflight[sandbox_id]
             else:
                 event = None
-                self._inflight_sync[sandbox_id] = threading.Event()
+                self._inflight[sandbox_id] = threading.Event()
 
         if event is not None:
-            # Wait for the in-flight request to complete
             event.wait()
             with self._lock:
-                cached_auth = self._check_cached_auth(sandbox_id)
-                if cached_auth:
-                    return cached_auth
-            # Fallback: if the in-flight request failed, fetch ourselves
+                cached = _check_cached_auth(self._auth_cache, sandbox_id)
+                if cached:
+                    return cached
             return self.get_or_refresh(sandbox_id)
 
         try:
@@ -335,17 +290,16 @@ class SandboxAuthCache:
             return dict(response)
         finally:
             with self._lock:
-                event = self._inflight_sync.pop(sandbox_id, None)
-            if event is not None:
-                event.set()
+                ev = self._inflight.pop(sandbox_id, None)
+            if ev is not None:
+                ev.set()
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
         with self._lock:
-            self._ensure_loaded()
-            cached_auth = self._check_cached_auth(sandbox_id)
-            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-                return bool(cached_auth["is_gpu"])
+            cached = _check_cached_auth(self._auth_cache, sandbox_id)
+            if cached and isinstance(cached.get("is_gpu"), bool):
+                return bool(cached["is_gpu"])
 
         sandbox_data = self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
@@ -359,91 +313,115 @@ class SandboxAuthCache:
         return is_gpu
 
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
-        """Cache auth info."""
         with self._lock:
-            self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
         self._save_cache()
 
     def clear(self) -> None:
-        """Clear all cached auth tokens."""
         with self._lock:
             self._auth_cache = {}
-            self._loaded = True
-            try:
-                if self._cache_file.exists():
-                    self._cache_file.unlink()
-            except Exception:
-                pass
+        try:
+            self._cache_file.unlink(missing_ok=True)
+        except Exception:
+            pass
 
-    async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing (async).
+
+class AsyncSandboxAuthCache:
+    """Async auth cache for AsyncSandboxClient."""
+
+    def __init__(self, cache_file_path: Any, client: Any) -> None:
+        self._cache_file = cache_file_path
+        self.client = client
+        self._lock = asyncio.Lock()
+        self._inflight: Dict[str, asyncio.Future] = {}
+        self._auth_cache: Dict[str, Any] = {}
+        self._loaded = False
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._auth_cache, needs_save = await asyncio.to_thread(_load_auth_cache, self._cache_file)
+        self._loaded = True
+        if needs_save:
+            await self._save_cache()
+
+    async def _save_cache(self) -> None:
+        try:
+            await asyncio.to_thread(self._cache_file.parent.mkdir, parents=True, exist_ok=True)
+            async with aiofiles.open(self._cache_file, "w") as f:
+                await f.write(json.dumps(self._auth_cache))
+        except Exception:
+            pass
+
+    async def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
+        """Get cached auth or fetch a new token.
 
         Coalesces concurrent requests for the same sandbox_id so only one
         auth POST is issued while others await the result.
         """
-        async with self._get_async_lock():
-            await self._ensure_loaded_async()
-            cached_auth = self._check_cached_auth(sandbox_id)
-            if cached_auth:
-                return cached_auth
+        async with self._lock:
+            await self._ensure_loaded()
+            cached = _check_cached_auth(self._auth_cache, sandbox_id)
+            if cached:
+                return cached
 
-            # Check if another coroutine is already fetching auth for this sandbox
-            if sandbox_id in self._inflight_async:
-                future = self._inflight_async[sandbox_id]
+            if sandbox_id in self._inflight:
+                future = self._inflight[sandbox_id]
             else:
                 future = None
-                loop = asyncio.get_running_loop()
-                self._inflight_async[sandbox_id] = loop.create_future()
+                self._inflight[sandbox_id] = asyncio.get_running_loop().create_future()
 
         if future is not None:
-            # Wait for the in-flight request to complete
             return dict(await future)
 
         try:
             response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-            async with self._get_async_lock():
+            async with self._lock:
                 self._auth_cache[sandbox_id] = response
-                await self._save_cache_async()
-                fut = self._inflight_async.pop(sandbox_id, None)
+                fut = self._inflight.pop(sandbox_id, None)
+            await self._save_cache()
             if fut is not None and not fut.done():
                 fut.set_result(response)
             return dict(response)
         except BaseException as e:
-            async with self._get_async_lock():
-                fut = self._inflight_async.pop(sandbox_id, None)
+            async with self._lock:
+                fut = self._inflight.pop(sandbox_id, None)
             if fut is not None and not fut.done():
                 fut.set_exception(e)
             raise
 
-    async def is_gpu_async(self, sandbox_id: str) -> bool:
+    async def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
-        async with self._get_async_lock():
-            await self._ensure_loaded_async()
-            cached_auth = self._check_cached_auth(sandbox_id)
-            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-                return bool(cached_auth["is_gpu"])
+        async with self._lock:
+            await self._ensure_loaded()
+            cached = _check_cached_auth(self._auth_cache, sandbox_id)
+            if cached and isinstance(cached.get("is_gpu"), bool):
+                return bool(cached["is_gpu"])
 
         sandbox_data = await self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
         is_gpu = sandbox.gpu_count > 0
 
-        async with self._get_async_lock():
+        async with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                await self._save_cache_async()
+        await self._save_cache()
 
         return is_gpu
 
-    async def clear_async(self) -> None:
-        """Clear all cached auth tokens (async)."""
-        async with self._get_async_lock():
+    async def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
+        async with self._lock:
+            self._auth_cache[sandbox_id] = auth_info
+        await self._save_cache()
+
+    async def clear(self) -> None:
+        async with self._lock:
             self._auth_cache = {}
             self._loaded = True
-            try:
-                await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
-            except Exception:
-                pass
+        try:
+            await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
+        except Exception:
+            pass
 
 
 def _check_sandbox_statuses(
@@ -1213,10 +1191,9 @@ class AsyncSandboxClient:
             max_keepalive_connections: Maximum keep-alive connections (default: 200)
         """
         self.client = AsyncAPIClient(api_key=api_key, user_agent=_build_user_agent())
-        self._auth_cache = SandboxAuthCache(
+        self._auth_cache = AsyncSandboxAuthCache(
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
-            lazy=True,
         )
         # Connection pool configuration
         self._max_connections = max_connections
@@ -1315,13 +1292,9 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    def clear_auth_cache(self) -> None:
-        """Clear cached auth tokens synchronously for backward compatibility."""
-        self._auth_cache.clear()
-
-    async def clear_auth_cache_async(self) -> None:
-        """Clear cached auth tokens without blocking other async cache users."""
-        await self._auth_cache.clear_async()
+    async def clear_auth_cache(self) -> None:
+        """Clear all cached auth tokens."""
+        await self._auth_cache.clear()
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:
         """Create a new sandbox"""
@@ -1400,9 +1373,9 @@ class AsyncSandboxClient:
         timeout: Optional[int] = None,
     ) -> CommandResponse:
         """Execute command directly via gateway (async)."""
-        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
-        if await self._auth_cache.is_gpu_async(sandbox_id):
+        if await self._auth_cache.is_gpu(sandbox_id):
             return await self._execute_command_connect_rpc(
                 sandbox_id=sandbox_id,
                 command=command,
@@ -1789,7 +1762,7 @@ class AsyncSandboxClient:
         if not await asyncio.to_thread(os.path.exists, local_file_path):
             raise FileNotFoundError(f"Local file not found: {local_file_path}")
 
-        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/upload"
@@ -1848,7 +1821,7 @@ class AsyncSandboxClient:
             filename: Name for the file (used in multipart form)
             timeout: Optional timeout in seconds
         """
-        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/upload"
@@ -1886,7 +1859,7 @@ class AsyncSandboxClient:
         timeout: Optional[int] = None,
     ) -> None:
         """Download a file from a sandbox via gateway (async)"""
-        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/download"

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -249,11 +249,13 @@ class SandboxAuthCache:
         if needs_save:
             self._save_cache()
 
-    def _save_cache(self) -> None:
+    def _save_cache(self, data: Optional[Dict[str, Any]] = None) -> None:
+        if data is None:
+            data = self._auth_cache
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
-                json.dump(self._auth_cache, f)
+                json.dump(data, f)
         except Exception:
             pass
 
@@ -286,7 +288,8 @@ class SandboxAuthCache:
             response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
             with self._lock:
                 self._auth_cache[sandbox_id] = response
-            self._save_cache()
+                snapshot = dict(self._auth_cache)
+            self._save_cache(snapshot)
             return dict(response)
         finally:
             with self._lock:
@@ -308,14 +311,19 @@ class SandboxAuthCache:
         with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-        self._save_cache()
+                snapshot = dict(self._auth_cache)
+            else:
+                snapshot = None
+        if snapshot is not None:
+            self._save_cache(snapshot)
 
         return is_gpu
 
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         with self._lock:
             self._auth_cache[sandbox_id] = auth_info
-        self._save_cache()
+            snapshot = dict(self._auth_cache)
+        self._save_cache(snapshot)
 
     def clear(self) -> None:
         with self._lock:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -265,37 +265,38 @@ class SandboxAuthCache:
         Coalesces concurrent requests for the same sandbox_id so only one
         auth POST is issued while others wait for the result.
         """
-        with self._lock:
-            cached = _check_cached_auth(self._auth_cache, sandbox_id)
-            if cached:
-                return cached
-
-            if sandbox_id in self._inflight:
-                event = self._inflight[sandbox_id]
-            else:
-                event = None
-                self._inflight[sandbox_id] = threading.Event()
-
-        if event is not None:
-            event.wait()
+        while True:
             with self._lock:
                 cached = _check_cached_auth(self._auth_cache, sandbox_id)
                 if cached:
                     return cached
-            return self.get_or_refresh(sandbox_id)
 
-        try:
-            response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-            with self._lock:
-                self._auth_cache[sandbox_id] = response
-                snapshot = dict(self._auth_cache)
-            self._save_cache(snapshot)
-            return dict(response)
-        finally:
-            with self._lock:
-                ev = self._inflight.pop(sandbox_id, None)
-            if ev is not None:
-                ev.set()
+                if sandbox_id in self._inflight:
+                    event = self._inflight[sandbox_id]
+                else:
+                    event = None
+                    self._inflight[sandbox_id] = threading.Event()
+
+            if event is not None:
+                event.wait()
+                with self._lock:
+                    cached = _check_cached_auth(self._auth_cache, sandbox_id)
+                    if cached:
+                        return cached
+                continue
+
+            try:
+                response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+                with self._lock:
+                    self._auth_cache[sandbox_id] = response
+                    snapshot = dict(self._auth_cache)
+                self._save_cache(snapshot)
+                return dict(response)
+            finally:
+                with self._lock:
+                    ev = self._inflight.pop(sandbox_id, None)
+                if ev is not None:
+                    ev.set()
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
@@ -370,38 +371,39 @@ class AsyncSandboxAuthCache:
         Coalesces concurrent requests for the same sandbox_id so only one
         auth POST is issued while others await the result.
         """
-        async with self._lock:
-            await self._ensure_loaded()
-            cached = _check_cached_auth(self._auth_cache, sandbox_id)
-            if cached:
-                return cached
-
-            if sandbox_id in self._inflight:
-                event = self._inflight[sandbox_id]
-            else:
-                event = None
-                self._inflight[sandbox_id] = asyncio.Event()
-
-        if event is not None:
-            await event.wait()
+        while True:
             async with self._lock:
+                await self._ensure_loaded()
                 cached = _check_cached_auth(self._auth_cache, sandbox_id)
                 if cached:
                     return cached
-            return await self.get_or_refresh(sandbox_id)
 
-        try:
-            response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-            async with self._lock:
-                self._auth_cache[sandbox_id] = response
-                snapshot = dict(self._auth_cache)
-            await self._save_cache(snapshot)
-            return dict(response)
-        finally:
-            async with self._lock:
-                ev = self._inflight.pop(sandbox_id, None)
-            if ev is not None:
-                ev.set()
+                if sandbox_id in self._inflight:
+                    event = self._inflight[sandbox_id]
+                else:
+                    event = None
+                    self._inflight[sandbox_id] = asyncio.Event()
+
+            if event is not None:
+                await event.wait()
+                async with self._lock:
+                    cached = _check_cached_auth(self._auth_cache, sandbox_id)
+                    if cached:
+                        return cached
+                continue
+
+            try:
+                response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+                async with self._lock:
+                    self._auth_cache[sandbox_id] = response
+                    snapshot = dict(self._auth_cache)
+                await self._save_cache(snapshot)
+                return dict(response)
+            finally:
+                async with self._lock:
+                    ev = self._inflight.pop(sandbox_id, None)
+                if ev is not None:
+                    ev.set()
 
     async def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -210,8 +210,10 @@ class SandboxAuthCache:
             self._auth_cache: Dict[str, Any] = {}
             self._loaded = False
         else:
-            self._auth_cache = self._load_cache()
+            self._auth_cache, needs_save = self._load_cache()
             self._loaded = True
+            if needs_save:
+                self._save_cache()
 
     def _get_async_lock(self) -> asyncio.Lock:
         if self._async_lock is None:
@@ -220,15 +222,19 @@ class SandboxAuthCache:
 
     def _ensure_loaded(self) -> None:
         if not self._loaded:
-            self._auth_cache = self._load_cache()
+            self._auth_cache, needs_save = self._load_cache()
             self._loaded = True
+            if needs_save:
+                self._save_cache()
 
     async def _ensure_loaded_async(self) -> None:
         if not self._loaded:
-            self._auth_cache = await asyncio.to_thread(self._load_cache)
+            self._auth_cache, needs_save = await asyncio.to_thread(self._load_cache)
             self._loaded = True
+            if needs_save:
+                await self._save_cache_async()
 
-    def _load_cache(self) -> Dict[str, Any]:
+    def _load_cache(self) -> tuple[Dict[str, Any], bool]:
         """Load auth cache from file and clean expired entries"""
         try:
             if self._cache_file.exists():
@@ -247,14 +253,10 @@ class SandboxAuthCache:
                     except Exception:
                         pass
 
-                if len(cleaned_cache) != len(cache):
-                    self._auth_cache = cleaned_cache
-                    self._save_cache()
-
-                return cleaned_cache
+                return cleaned_cache, len(cleaned_cache) != len(cache)
         except Exception:
             pass
-        return {}
+        return {}, False
 
     def _save_cache(self) -> None:
         """Save auth cache to file"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -354,10 +354,13 @@ class AsyncSandboxAuthCache:
             await self._save_cache(dict(self._auth_cache))
 
     async def _save_cache(self, data: Dict[str, Any]) -> None:
+        def _write() -> None:
+            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._cache_file, "w") as f:
+                json.dump(data, f)
+
         try:
-            await asyncio.to_thread(self._cache_file.parent.mkdir, parents=True, exist_ok=True)
-            async with aiofiles.open(self._cache_file, "w") as f:
-                await f.write(json.dumps(data))
+            await asyncio.to_thread(_write)
         except Exception:
             pass
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -425,6 +425,7 @@ class AsyncSandboxAuthCache:
 
     async def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         async with self._lock:
+            await self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
             snapshot = dict(self._auth_cache)
         await self._save_cache(snapshot)

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -379,8 +379,7 @@ class SandboxAuthCache:
             self._auth_cache = {}
             self._loaded = True
             try:
-                if self._cache_file.exists():
-                    self._cache_file.unlink()
+                await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
             except Exception:
                 pass
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -277,7 +277,9 @@ class SandboxAuthCache:
     async def _save_cache_async(self) -> None:
         """Save auth cache to file (async version)"""
         try:
-            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(
+                self._cache_file.parent.mkdir, parents=True, exist_ok=True
+            )
             async with aiofiles.open(self._cache_file, "w") as f:
                 await f.write(json.dumps(self._auth_cache))
         except Exception:
@@ -1784,7 +1786,7 @@ class AsyncSandboxClient:
             local_file_path: Local file path to upload
             timeout: Optional timeout in seconds
         """
-        if not os.path.exists(local_file_path):
+        if not await asyncio.to_thread(os.path.exists, local_file_path):
             raise FileNotFoundError(f"Local file not found: {local_file_path}")
 
         auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
@@ -1903,7 +1905,7 @@ class AsyncSandboxClient:
 
                 dir_path = os.path.dirname(local_file_path)
                 if dir_path:
-                    os.makedirs(dir_path, exist_ok=True)
+                    await asyncio.to_thread(os.makedirs, dir_path, exist_ok=True)
 
                 # Write file asynchronously (non-blocking I/O)
                 async with aiofiles.open(local_file_path, "wb") as f:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -324,6 +324,7 @@ class SandboxAuthCache:
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         """Cache auth info."""
         with self._lock:
+            self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
             self._save_cache()
 
@@ -331,6 +332,7 @@ class SandboxAuthCache:
         """Clear all cached auth tokens."""
         with self._lock:
             self._auth_cache = {}
+            self._loaded = True
             try:
                 if self._cache_file.exists():
                     self._cache_file.unlink()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -377,6 +377,7 @@ class SandboxAuthCache:
         """Clear all cached auth tokens (async)."""
         async with self._get_async_lock():
             self._auth_cache = {}
+            self._loaded = True
             try:
                 if self._cache_file.exists():
                     self._cache_file.unlink()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -266,7 +266,7 @@ class SandboxAuthCache:
             pass
 
     async def _save_cache_async(self) -> None:
-        """Save auth cache to file without blocking the event loop."""
+        """Save auth cache to file (async version)"""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             async with aiofiles.open(self._cache_file, "w") as f:

--- a/packages/prime-sandboxes/tests/test_command_transport_selection.py
+++ b/packages/prime-sandboxes/tests/test_command_transport_selection.py
@@ -38,10 +38,10 @@ class _AsyncFakeCache:
     def __init__(self, is_gpu: bool):
         self._is_gpu = is_gpu
 
-    async def get_or_refresh_async(self, _sandbox_id: str):
+    async def get_or_refresh(self, _sandbox_id: str):
         return _auth_payload()
 
-    async def is_gpu_async(self, _sandbox_id: str) -> bool:
+    async def is_gpu(self, _sandbox_id: str) -> bool:
         return self._is_gpu
 
 

--- a/packages/prime-sandboxes/tests/test_gateway_error_mapping.py
+++ b/packages/prime-sandboxes/tests/test_gateway_error_mapping.py
@@ -23,7 +23,7 @@ class _DummyAuthCache:
 
 
 class _AsyncDummyAuthCache:
-    async def get_or_refresh_async(self, _sandbox_id: str):
+    async def get_or_refresh(self, _sandbox_id: str):
         return {
             "gateway_url": "https://gateway.example.com",
             "user_ns": "ns",
@@ -31,7 +31,7 @@ class _AsyncDummyAuthCache:
             "token": "tok",
         }
 
-    async def is_gpu_async(self, _sandbox_id: str) -> bool:
+    async def is_gpu(self, _sandbox_id: str) -> bool:
         return False
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches auth-token caching and refresh behavior for both sync and async sandbox clients, including new locking/inflight coordination and file I/O changes; bugs here can cause extra auth calls or stale/incorrect tokens under concurrency.
> 
> **Overview**
> Adds a new `AsyncSandboxAuthCache` for `AsyncSandboxClient`, with async locking, lazy disk-load, async-safe disk writes via `to_thread`, and *inflight* request coalescing so concurrent token refreshes for the same sandbox only issue one `/auth` call.
> 
> Refactors the sync `SandboxAuthCache` to be thread-safe (lock + inflight event coalescing) and factors shared cache load/expiry cleanup into `_load_auth_cache`/`_check_cached_auth` helpers.
> 
> Updates async client call sites and tests to use the new cache API (`get_or_refresh`/`is_gpu`) and makes async file helpers avoid blocking the event loop by moving `os.path.exists`/`os.makedirs` to `asyncio.to_thread`; `AsyncSandboxClient.clear_auth_cache` is now async.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 313fd53ce26f3f1b98bff88df3830f8a2808405e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->