### PR TITLE
tunnel retries on connection loss + better cleanup

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -1,5 +1,5 @@
-import atexit
 import asyncio
+import atexit
 import fcntl
 import os
 import re

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -1,3 +1,4 @@
+import atexit
 import asyncio
 import fcntl
 import os
@@ -186,6 +187,7 @@ class Tunnel:
             raise TunnelConnectionError(message=f"Failed to start pipe drain: {e}") from e
 
         self._started = True
+        atexit.register(self.sync_stop)
 
         return self.url
 
@@ -194,6 +196,7 @@ class Tunnel:
         if not self._started:
             return
 
+        atexit.unregister(self.sync_stop)
         await self._cleanup()
         self._started = False
 
@@ -201,6 +204,8 @@ class Tunnel:
         """Stop the tunnel synchronously. Safe for signal handlers and atexit."""
         if not self._started:
             return
+
+        atexit.unregister(self.sync_stop)
 
         if self._process is not None:
             try:
@@ -347,6 +352,9 @@ auth.token = "{self._tunnel_info.frp_token}"
 
 # Per-tunnel binding secret
 metadatas.binding_secret = "{self._tunnel_info.binding_secret}"
+
+# Keep retrying if connection to frps is lost instead of exiting
+loginFailExit = false
 
 # Transport settings
 transport.tcpMux = true

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -196,8 +196,8 @@ class Tunnel:
         if not self._started:
             return
 
-        atexit.unregister(self.sync_stop)
         await self._cleanup()
+        atexit.unregister(self.sync_stop)
         self._started = False
 
     def sync_stop(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes tunnel lifecycle/cleanup behavior via `atexit` hooks and alters frpc reconnection behavior, which could impact process teardown or long-running tunnel stability.
> 
> **Overview**
> Improves tunnel robustness by configuring frpc to **keep retrying after losing the server connection** (`loginFailExit = false`) instead of exiting.
> 
> Adds an `atexit` hook to automatically call `Tunnel.sync_stop()` after a successful start, and ensures the hook is unregistered on both async `stop()` and `sync_stop()` to avoid double-cleanup or lingering handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b03b4fbc5fa8c0c0c25c837f377dd9c49d7579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->