### PR TITLE
fix: typo in sanboxes async read_file

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1974,7 +1974,7 @@ class AsyncSandboxClient:
         timeout: Optional[int] = None,
     ) -> ReadFileResponse:
         """Read a file from a sandbox via gateway (async)"""
-        auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/read-file"


### PR DESCRIPTION
AsyncSandboxAuthCache has no get_or_refresh_async method; every other call site uses get_or_refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fixes a broken method call in `AsyncSandboxClient.read_file` by using the existing `AsyncSandboxAuthCache.get_or_refresh`, with no behavior change beyond preventing runtime attribute errors.
> 
> **Overview**
> Fixes `AsyncSandboxClient.read_file` to call `AsyncSandboxAuthCache.get_or_refresh` instead of a non-existent `get_or_refresh_async`, preventing async file reads from failing at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2dc5645fbf2d86a0e22c4155a2037dd74cc49ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->