### PR TITLE
release: cli 0.5.51

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.50"
+__version__ = "0.5.51"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI version to 0.5.51.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only bump with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the Prime CLI package `__version__` from `0.5.50` to `0.5.51` for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19199c8faae52329a9c3f7375bdce8aa0b0a1380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->