### PR TITLE
release: cli 0.5.52

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.51"
+__version__ = "0.5.52"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI version to 0.5.52.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the exported `__version__` string with no functional code changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.51` to `0.5.52` in `prime_cli/__init__.py` for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae9265a7b0ffa4606236638836d82032bbc7596. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->