### PR TITLE
Allow local eval sampling args passthrough

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1217,7 +1217,7 @@ def run_eval_cmd(
         None,
         "--sampling-args",
         help=(
-            "Sampling args for hosted eval as JSON. "
+            "Sampling args as JSON for local or hosted evals. "
             'Example: {"temperature": 0.7, "extra_body": {"provider": {"order": ["azure"]}}}'
         ),
     ),
@@ -1248,6 +1248,9 @@ def run_eval_cmd(
     poll_interval_was_provided = (
         ctx.get_parameter_source("poll_interval") == ParameterSource.COMMANDLINE
     )
+    local_passthrough_args = list(passthrough_args)
+    if sampling_args is not None:
+        local_passthrough_args.extend(["--sampling-args", sampling_args])
 
     if not hosted:
         hosted_only_args = {
@@ -1257,7 +1260,6 @@ def run_eval_cmd(
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
             "--custom-secrets": custom_secrets is not None,
-            "--sampling-args": sampling_args is not None,
             "--eval-name": eval_name is not None,
         }
         used_hosted_only_args = [flag for flag, used in hosted_only_args.items() if used]
@@ -1477,7 +1479,7 @@ def run_eval_cmd(
 
     run_eval_passthrough(
         environment=environment,
-        passthrough_args=passthrough_args,
+        passthrough_args=local_passthrough_args,
         skip_upload=skip_upload,
         env_path=env_path,
     )

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -874,6 +874,32 @@ env_id = "gsm8k"
     }
 
 
+def test_eval_run_local_sampling_args_passthrough(monkeypatch):
+    captured = {}
+
+    def fake_run_eval_passthrough(environment, passthrough_args, skip_upload, env_path):
+        captured["environment"] = environment
+        captured["passthrough_args"] = passthrough_args
+        captured["skip_upload"] = skip_upload
+        captured["env_path"] = env_path
+
+    monkeypatch.setattr("prime_cli.commands.evals.run_eval_passthrough", fake_run_eval_passthrough)
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--sampling-args", '{"temperature":0.2}'],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "passthrough_args": ["--sampling-args", '{"temperature":0.2}'],
+        "skip_upload": False,
+        "env_path": None,
+    }
+
+
 def test_eval_run_rejects_hosted_only_flags_without_hosted():
     result = runner.invoke(
         app,


### PR DESCRIPTION
## Summary
- allow `prime eval run` to forward `--sampling-args` for local runs instead of treating it as hosted-only
- update the CLI help text to reflect local and hosted support
- add a regression test for local sampling-args passthrough

## Testing
- `.venv/bin/pytest packages/prime/tests/test_hosted_eval.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to CLI argument passthrough for local `prime eval run` and is covered by a new regression test; main risk is minor behavior change in how `--sampling-args` is forwarded locally.
> 
> **Overview**
> Allows `prime eval run` to accept `--sampling-args` for **local** evaluations by appending it to the `run_eval_passthrough` argument list instead of treating it as hosted-only.
> 
> Updates the `--sampling-args` help text to reflect local+hosted support and adds a regression test asserting the local passthrough behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cf097ebe4455f8f7287f2d00be28da0dfa5b34c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->