### PR TITLE
release: cli 0.5.53

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.52"
+__version__ = "0.5.53"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI version to 0.5.53.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only bump with no behavioral or API changes beyond updating the reported package version string.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.52` to `0.5.53` by updating `__version__` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71df8864b32bb7daf99febbfc113b23ddf54cb08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->