### PR TITLE
Add full sampling params support

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -116,6 +116,11 @@ class RLClient:
         max_steps: int = 100,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
+        repetition_penalty: Optional[float] = None,
+        min_tokens: Optional[int] = None,
+        seed: Optional[int] = None,
+        temp_scheduler: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
         batch_size: int = 128,
         name: Optional[str] = None,
         wandb_entity: Optional[str] = None,
@@ -174,6 +179,21 @@ class RLClient:
 
             if temperature is not None:
                 payload["temperature"] = temperature
+
+            if repetition_penalty is not None:
+                payload["repetition_penalty"] = repetition_penalty
+
+            if min_tokens is not None:
+                payload["min_tokens"] = min_tokens
+
+            if seed is not None:
+                payload["seed"] = seed
+
+            if temp_scheduler is not None:
+                payload["temp_scheduler"] = temp_scheduler
+
+            if extra_body is not None:
+                payload["extra_body"] = extra_body
 
             if eval_config:
                 payload["eval"] = eval_config

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -835,7 +835,7 @@ def create_run(
             repetition_penalty=cfg.sampling.repetition_penalty,
             min_tokens=cfg.sampling.min_tokens,
             seed=cfg.sampling.seed,
-            temp_scheduler=cfg.sampling.temp_scheduler.model_dump()
+            temp_scheduler=cfg.sampling.temp_scheduler.model_dump(exclude_none=True)
             if cfg.sampling.temp_scheduler
             else None,
             extra_body=cfg.sampling.extra_body,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -191,6 +191,17 @@ rollouts_per_example = 8
 [sampling]
 max_tokens = 2048
 # temperature = 0.7
+# repetition_penalty = 1.0
+# min_tokens = 0
+# seed = 42
+# extra_body = {{ }}
+
+# Optional: temperature scheduling (use instead of temperature)
+# [sampling.temp_scheduler]
+# type = "linear"               # "linear" or "cosine"
+# start_temperature = 1.5
+# end_temperature = 0.3
+# total_steps = 1000            # defaults to max_steps if not set
 
 [[env]]
 id = "{env_value}"
@@ -317,11 +328,25 @@ class EvalEnvConfig(BaseModel):
         return result
 
 
+class TemperatureSchedulerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = "linear"  # "linear" or "cosine"
+    start_temperature: float
+    end_temperature: float
+    total_steps: int | None = None
+
+
 class SamplingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     max_tokens: int | None = None
     temperature: float | None = None
+    repetition_penalty: float | None = None
+    min_tokens: int | None = None
+    seed: int | None = None
+    temp_scheduler: TemperatureSchedulerConfig | None = None
+    extra_body: Dict[str, Any] | None = None
 
 
 class EvalConfig(BaseModel):
@@ -684,12 +709,33 @@ def create_run(
             console.print(f"  Max Async Level:     {cfg.max_async_level}")
 
         # Sampling
-        if cfg.sampling.max_tokens or cfg.sampling.temperature is not None:
+        has_sampling = (
+            cfg.sampling.max_tokens
+            or cfg.sampling.temperature is not None
+            or cfg.sampling.repetition_penalty is not None
+            or cfg.sampling.min_tokens is not None
+            or cfg.sampling.seed is not None
+            or cfg.sampling.temp_scheduler is not None
+            or cfg.sampling.extra_body is not None
+        )
+        if has_sampling:
             console.print("\n[cyan]Sampling[/cyan]")
             if cfg.sampling.max_tokens:
-                console.print(f"  Max Tokens:  {cfg.sampling.max_tokens}")
+                console.print(f"  Max Tokens:          {cfg.sampling.max_tokens}")
             if cfg.sampling.temperature is not None:
-                console.print(f"  Temperature: {cfg.sampling.temperature}")
+                console.print(f"  Temperature:         {cfg.sampling.temperature}")
+            if cfg.sampling.repetition_penalty is not None:
+                console.print(f"  Repetition Penalty:  {cfg.sampling.repetition_penalty}")
+            if cfg.sampling.min_tokens is not None:
+                console.print(f"  Min Tokens:          {cfg.sampling.min_tokens}")
+            if cfg.sampling.seed is not None:
+                console.print(f"  Seed:                {cfg.sampling.seed}")
+            if cfg.sampling.temp_scheduler is not None:
+                ts = cfg.sampling.temp_scheduler
+                sched = f"{ts.type} ({ts.start_temperature} → {ts.end_temperature})"
+                console.print(f"  Temp Scheduler:      {sched}")
+            if cfg.sampling.extra_body is not None:
+                console.print(f"  Extra Body:          {cfg.sampling.extra_body}")
 
         # W&B
         if cfg.wandb.entity or cfg.wandb.project:
@@ -786,6 +832,13 @@ def create_run(
             max_steps=cfg.max_steps,
             max_tokens=cfg.sampling.max_tokens,
             temperature=cfg.sampling.temperature,
+            repetition_penalty=cfg.sampling.repetition_penalty,
+            min_tokens=cfg.sampling.min_tokens,
+            seed=cfg.sampling.seed,
+            temp_scheduler=cfg.sampling.temp_scheduler.model_dump()
+            if cfg.sampling.temp_scheduler
+            else None,
+            extra_body=cfg.sampling.extra_body,
             batch_size=cfg.batch_size,
             name=cfg.name,
             wandb_entity=cfg.wandb.entity,


### PR DESCRIPTION
- Adds repetition_penalty, min_tokens, seed, temp_scheduler, extra_body to SamplingConfig
- Updates API client to pass all new params to platform
- Updates TOML template with commented examples for all new params
- Updates config display to show all sampling params
- Companion to platform PR: https://github.com/PrimeIntellect-ai/platform/pull/990

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the payload sent to the RL platform when creating runs; incorrect field shapes (notably `temp_scheduler`/`extra_body`) could cause API validation failures or behavior changes.
> 
> **Overview**
> Adds full sampling-parameter support to `prime rl run`: `repetition_penalty`, `min_tokens`, `seed`, optional `temp_scheduler`, and arbitrary `extra_body`.
> 
> Updates the RL API client to include these fields in the `POST /rft/runs` payload when provided, expands the TOML template with commented examples, and enhances the CLI config preview to display the new sampling settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aebc3c87fe46cab391dd2c77b91e00bfeac9612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->