### PR TITLE
Support hosted eval API base URLs

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -95,6 +95,8 @@ HOSTED_EVAL_CONFIG_ALLOWED_FIELDS = {
     "allow_sandbox_access",
     "allow_instances_access",
     "sampling_args",
+    "api_base_url",
+    "api_key_var",
     "eval_name",
 }
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
@@ -104,6 +106,8 @@ HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "timeout_minutes": (int, "an integer"),
     "allow_sandbox_access": (bool, "a boolean"),
     "allow_instances_access": (bool, "a boolean"),
+    "api_base_url": (str, "a non-empty string"),
+    "api_key_var": (str, "a non-empty string"),
     "eval_name": (str, "a non-empty string"),
 }
 
@@ -391,6 +395,10 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         eval_config["custom_secrets"] = config.custom_secrets
     if config.sampling_args:
         eval_config["sampling_args"] = config.sampling_args
+    if config.api_base_url:
+        eval_config["api_base_url"] = config.api_base_url
+    if config.api_key_var:
+        eval_config["api_key_var"] = config.api_key_var
 
     payload: dict[str, Any] = {
         "environment_ids": [config.environment_id],
@@ -1287,6 +1295,8 @@ def run_eval_cmd(
                     "allow_sandbox_access": False,
                     "allow_instances_access": False,
                     "sampling_args": None,
+                    "api_base_url": None,
+                    "api_key_var": None,
                     "eval_name": None,
                 }
             ]
@@ -1299,6 +1309,8 @@ def run_eval_cmd(
             "-r",
         )
         raw_env_args = _parse_value_option(passthrough_args, "--env-args", "")
+        raw_api_base_url = _parse_value_option(passthrough_args, "--api-base-url", "-b")
+        raw_api_key_var = _parse_value_option(passthrough_args, "--api-key-var", "-k")
         parsed_cli_env_args = (
             _parse_string_map_option(raw_env_args, "--env-args")
             if raw_env_args is not None
@@ -1371,6 +1383,8 @@ def run_eval_cmd(
                         if parsed_sampling_args is not None
                         else target_config.get("sampling_args")
                     ),
+                    "api_base_url": raw_api_base_url or target_config.get("api_base_url"),
+                    "api_key_var": raw_api_key_var or target_config.get("api_key_var"),
                     "eval_name": eval_name or target_config.get("eval_name"),
                 }
             )
@@ -1393,6 +1407,8 @@ def run_eval_cmd(
                 target.get("allow_sandbox_access", False),
                 target.get("allow_instances_access", False),
                 _freeze_json_value(target.get("sampling_args")),
+                target.get("api_base_url"),
+                target.get("api_key_var"),
                 target.get("eval_name"),
             )
             if group_key not in grouped_targets:
@@ -1438,6 +1454,8 @@ def run_eval_cmd(
                     allow_instances_access=target.get("allow_instances_access", False),
                     custom_secrets=target.get("custom_secrets"),
                     sampling_args=target.get("sampling_args"),
+                    api_base_url=target.get("api_base_url"),
+                    api_key_var=target.get("api_key_var"),
                 )
                 result = _create_hosted_evaluations(
                     hosted_config,

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -46,6 +46,8 @@ class HostedEvalConfig:
     allow_instances_access: bool = False
     custom_secrets: Optional[dict[str, str]] = None
     sampling_args: Optional[dict[str, Any]] = None
+    api_base_url: Optional[str] = None
+    api_key_var: Optional[str] = None
 
 
 @dataclass

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -136,6 +136,49 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
     assert "prime eval logs eval-123 -f" in result.output
 
 
+def test_eval_run_hosted_passes_api_base_url_and_key_var(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["api_base_url"] = config.api_base_url
+        captured["api_key_var"] = config.api_key_var
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "primeintellect/gsm8k",
+            "--hosted",
+            "-m",
+            "openai/gpt-4.1-mini",
+            "-b",
+            "https://api.openai.com/v1",
+            "-k",
+            "OPENAI_API_KEY",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["api_base_url"] == "https://api.openai.com/v1"
+    assert captured["api_key_var"] == "OPENAI_API_KEY"
+
+
 def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
     captured = {}
 
@@ -214,6 +257,39 @@ def test_create_hosted_evaluation_includes_sampling_args_in_payload(monkeypatch)
             }
         },
     }
+
+
+def test_create_hosted_evaluation_includes_api_base_url_and_key_var_in_payload(monkeypatch):
+    captured = {}
+
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+            api_base_url="https://api.openai.com/v1",
+            api_key_var="OPENAI_API_KEY",
+        )
+    )
+
+    assert captured["endpoint"] == "/hosted-evaluations"
+    assert captured["json"]["eval_config"]["api_base_url"] == "https://api.openai.com/v1"
+    assert captured["json"]["eval_config"]["api_key_var"] == "OPENAI_API_KEY"
 
 
 def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):


### PR DESCRIPTION
Add hosted eval support for --api-base-url and --api-key-var so third-party OpenAI-compatible endpoints can be forwarded through the hosted eval API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies hosted evaluation CLI argument parsing and request payloads, which could break hosted eval runs if the new fields are mis-specified or the backend rejects them. No direct secret values are handled, but it changes how endpoint configuration is forwarded.
> 
> **Overview**
> Adds support for passing OpenAI-compatible endpoint settings through hosted eval runs by introducing `api_base_url` and `api_key_var` in hosted eval TOML validation, CLI parsing (`--api-base-url`/`--api-key-var`), grouping logic, and the hosted evaluation creation payload.
> 
> Extends `HostedEvalConfig` with these fields and adds tests to ensure they propagate from `prime eval run --hosted` into `_create_hosted_evaluations` and are included under `eval_config` in the `/hosted-evaluations` POST body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3eb47d4886533af45bcb1aab6d708447af9bc999. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->