### PR TITLE
release: cli 0.5.54

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.53"
+__version__ = "0.5.54"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI version to 0.5.54.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple version string bump with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the Prime CLI package version in `prime_cli/__init__.py` from `0.5.53` to `0.5.54` for the release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fd0ac99f157ee5dd4d300c463182f782f60aec4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->