### PR TITLE
Fix wheel upload timeout for large environments

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1214,6 +1214,7 @@ def push(
                             wheel_upload_url,
                             content=f.read(),
                             headers={"Content-Type": "application/octet-stream"},
+                            timeout=300.0,
                         )
                         upload_response.raise_for_status()
                 except httpx.RequestError as e:


### PR DESCRIPTION
- Wheel upload via prime env push was missing a timeout on the httpx.put() call to R2
- httpx defaults to 5s write timeout, which causes failures for large wheels (e.g. 26MB+)
- Source package upload already had timeout=300.0, wheel upload was missing it
- This was causing 'The write operation timed out' for users pushing large envs (e.g. surge-ai/hle-stem-env)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CLI upload behavior; it only adjusts the HTTP timeout to reduce failures when uploading large wheel files.
> 
> **Overview**
> Fixes `prime env push` wheel uploads timing out on large environments by adding an explicit `timeout=300.0` to the `httpx.put()` call used for wheel uploads (matching the existing source-archive upload timeout).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e1c8f83075b6e54e55cede0b0d2aa9472d0d82b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->