### PR TITLE
release: cli 0.5.54

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.53"
+__version__ = "0.5.54"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump CLI version to 0.5.54.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package `__version__` string with no functional or behavioral code changes.
> 
> **Overview**
> Updates the Prime CLI package version from `0.5.53` to `0.5.54` in `prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52687ba022fd67b237833f91eae0f79cb9040212. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->