### PR TITLE
ENG-3201 Fix eval auto-upload for metadata-linked environments

### DIFF
--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -1,5 +1,10 @@
+import time
+
+import pytest
+
 from prime_sandboxes import (
     APIClient,
+    APIError,
     CreateSandboxRequest,
     SandboxClient,
 )
@@ -30,9 +35,23 @@ def test_command_timeout():
 
         print("\nExecuting command...")
         command = "sleep 100 && echo 'done'"
-        result = sandbox_client.execute_command(
-            sandbox_id=sandbox.id, command=command, timeout=60 * 2
-        )
+
+        last_error = None
+        for attempt in range(3):
+            try:
+                result = sandbox_client.execute_command(
+                    sandbox_id=sandbox.id, command=command, timeout=60 * 2
+                )
+                break
+            except APIError as exc:
+                last_error = exc
+                if "HTTP 502 POST" not in str(exc) or attempt == 2:
+                    raise
+                print(f"Retrying after transient gateway failure (attempt {attempt + 1}/3)...")
+                time.sleep(2)
+        else:
+            pytest.fail(f"Command execution did not succeed: {last_error}")
+
         print(f"✓ Executed command: {command} with result: {result}")
 
         assert result.exit_code == 0

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -33,6 +33,7 @@ from ..utils import (
     validate_output_format,
 )
 from ..utils.env_metadata import find_environment_metadata
+from ..utils.environment_versions import extract_env_version_summary
 from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
@@ -801,11 +802,12 @@ def status_cmd(
             # Latest Version section
             console.print("\n[bold]Latest Version:[/bold]")
             latest_version = data.get("latest_version")
-            if latest_version:
-                content_hash = latest_version.get("content_hash") or ""
-                version_str = latest_version.get("semantic_version") or content_hash[:8]
+            if isinstance(latest_version, dict):
+                latest_summary = extract_env_version_summary(latest_version)
+                content_hash = latest_summary.get("content_hash", "")
+                version_str = latest_summary.get("semantic_version") or content_hash[:8]
                 console.print(f"  Version: {version_str}")
-                console.print(f"  Hash: {(latest_version.get('content_hash') or '-')[:12]}")
+                console.print(f"  Hash: {content_hash[:12] if content_hash else '-'}")
                 created_at = latest_version.get("created_at")
                 console.print(f"  Created: {format_time_ago(created_at)}")
             else:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -802,13 +802,13 @@ def status_cmd(
             # Latest Version section
             console.print("\n[bold]Latest Version:[/bold]")
             latest_version = data.get("latest_version")
-            if isinstance(latest_version, dict):
-                latest_summary = extract_env_version_summary(latest_version)
+            latest_summary = extract_env_version_summary(latest_version)
+            if latest_summary:
                 content_hash = latest_summary.get("content_hash", "")
                 version_str = latest_summary.get("semantic_version") or content_hash[:8]
                 console.print(f"  Version: {version_str}")
                 console.print(f"  Hash: {content_hash[:12] if content_hash else '-'}")
-                created_at = latest_version.get("created_at")
+                created_at = latest_version.get("created_at") if latest_version else None
                 console.print(f"  Created: {format_time_ago(created_at)}")
             else:
                 console.print("  [dim]No versions found[/dim]")

--- a/packages/prime/src/prime_cli/utils/environment_versions.py
+++ b/packages/prime/src/prime_cli/utils/environment_versions.py
@@ -5,7 +5,10 @@ from typing import Mapping, Optional
 from ..client import APIClient, APIError
 
 
-def extract_env_version_summary(version_data: Mapping[str, object]) -> dict[str, str]:
+def extract_env_version_summary(version_data: Mapping[str, object] | None) -> dict[str, str]:
+    if version_data is None:
+        return {}
+
     version_label = version_data.get("semantic_version") or version_data.get("version")
     semantic_version = (
         version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""

--- a/packages/prime/src/prime_cli/utils/environment_versions.py
+++ b/packages/prime/src/prime_cli/utils/environment_versions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional, cast
+from typing import Mapping, Optional
 
 from ..client import APIClient, APIError
 
@@ -9,17 +9,11 @@ def extract_env_version_summary(version_data: Mapping[str, object] | None) -> di
     if version_data is None:
         return {}
 
-    # TODO: remove these fallback aliases once the platform /versions response
-    # exposes semantic_version/content_hash directly alongside version/sha256.
-    version_label = version_data.get("semantic_version") or version_data.get("version")
-    semantic_version = (
-        version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""
-    )
-
-    content_hash = version_data.get("content_hash") or version_data.get("sha256")
+    semantic_version = version_data.get("semantic_version")
+    content_hash = version_data.get("content_hash")
 
     summary: dict[str, str] = {}
-    if semantic_version:
+    if isinstance(semantic_version, str) and semantic_version:
         summary["semantic_version"] = semantic_version
     if isinstance(content_hash, str) and content_hash:
         summary["content_hash"] = content_hash
@@ -33,9 +27,11 @@ def fetch_latest_env_version_summary(
 ) -> Optional[dict[str, str]]:
     try:
         response = client.get(f"/environmentshub/{owner_slug}/{env_name}/versions")
-        versions = response["data"]["versions"]
-        latest_version = cast(Mapping[str, object], versions[0])
+        latest_version = response["data"]["versions"][0]
     except (APIError, KeyError, IndexError, TypeError):
+        return None
+
+    if not isinstance(latest_version, Mapping):
         return None
 
     summary = extract_env_version_summary(latest_version)

--- a/packages/prime/src/prime_cli/utils/environment_versions.py
+++ b/packages/prime/src/prime_cli/utils/environment_versions.py
@@ -9,6 +9,8 @@ def extract_env_version_summary(version_data: Mapping[str, object] | None) -> di
     if version_data is None:
         return {}
 
+    # TODO: remove these fallback aliases once the platform /versions response
+    # exposes semantic_version/content_hash directly alongside version/sha256.
     version_label = version_data.get("semantic_version") or version_data.get("version")
     semantic_version = (
         version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""

--- a/packages/prime/src/prime_cli/utils/environment_versions.py
+++ b/packages/prime/src/prime_cli/utils/environment_versions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+from ..client import APIClient, APIError
+
+
+def extract_env_version_summary(version_data: Mapping[str, object]) -> dict[str, str]:
+    version_label = version_data.get("semantic_version") or version_data.get("version")
+    semantic_version = (
+        version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""
+    )
+
+    content_hash = version_data.get("content_hash") or version_data.get("sha256")
+
+    summary: dict[str, str] = {}
+    if semantic_version:
+        summary["semantic_version"] = semantic_version
+    if isinstance(content_hash, str) and content_hash:
+        summary["content_hash"] = content_hash
+    return summary
+
+
+def fetch_latest_env_version_summary(
+    client: APIClient,
+    owner_slug: str,
+    env_name: str,
+) -> Optional[dict[str, str]]:
+    try:
+        response = client.get(f"/environmentshub/{owner_slug}/{env_name}/versions")
+    except APIError:
+        return None
+
+    versions_data = response.get("data", response)
+    if not isinstance(versions_data, dict):
+        return None
+
+    versions = versions_data.get("versions")
+    if not isinstance(versions, list) or not versions:
+        return None
+
+    latest_version = versions[0]
+    if not isinstance(latest_version, Mapping):
+        return None
+
+    summary = extract_env_version_summary(latest_version)
+    return summary or None

--- a/packages/prime/src/prime_cli/utils/environment_versions.py
+++ b/packages/prime/src/prime_cli/utils/environment_versions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional
+from typing import Mapping, Optional, cast
 
 from ..client import APIClient, APIError
 
@@ -31,19 +31,9 @@ def fetch_latest_env_version_summary(
 ) -> Optional[dict[str, str]]:
     try:
         response = client.get(f"/environmentshub/{owner_slug}/{env_name}/versions")
-    except APIError:
-        return None
-
-    versions_data = response.get("data", response)
-    if not isinstance(versions_data, dict):
-        return None
-
-    versions = versions_data.get("versions")
-    if not isinstance(versions, list) or not versions:
-        return None
-
-    latest_version = versions[0]
-    if not isinstance(latest_version, Mapping):
+        versions = response["data"]["versions"]
+        latest_version = cast(Mapping[str, object], versions[0])
+    except (APIError, KeyError, IndexError, TypeError):
         return None
 
     summary = extract_env_version_summary(latest_version)

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Mapping, Optional
+from typing import Optional
 
 import toml
 import typer
@@ -20,6 +20,10 @@ from prime_cli.core import Config
 from .api.inference import InferenceAPIError, InferenceClient, InferencePaymentRequiredError
 from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
+from .utils.environment_versions import (
+    extract_env_version_summary,
+    fetch_latest_env_version_summary,
+)
 from .utils.eval_push import push_eval_results_to_hub
 from .utils.plain import get_console
 from .verifiers_plugin import PrimeVerifiersPlugin, load_verifiers_prime_plugin
@@ -343,41 +347,6 @@ def _fetch_active_team_slug(client: APIClient, active_team_id: Optional[str]) ->
     return None
 
 
-def _extract_version_summary(version_data: Mapping[str, object]) -> dict[str, str]:
-    version_label = version_data.get("semantic_version") or version_data.get("version")
-    semantic_version = (
-        version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""
-    )
-
-    content_hash = version_data.get("content_hash") or version_data.get("sha256")
-
-    summary: dict[str, str] = {}
-    if semantic_version:
-        summary["semantic_version"] = semantic_version
-    if isinstance(content_hash, str) and content_hash:
-        summary["content_hash"] = content_hash
-    return summary
-
-
-def _fetch_latest_version_summary(
-    client: APIClient,
-    owner_slug: str,
-    env_name: str,
-) -> Optional[dict[str, str]]:
-    try:
-        response = client.get(f"/environmentshub/{owner_slug}/{env_name}/versions")
-    except APIError:
-        return None
-
-    versions_data = response.get("data", response)
-    versions = versions_data.get("versions")
-    if not versions:
-        return None
-
-    latest_version = _extract_version_summary(versions[0])
-    return latest_version or None
-
-
 def _fetch_remote_env_details(
     client: APIClient, owner_slug: str, env_name: str, version: str = "latest"
 ) -> Optional[dict]:
@@ -390,17 +359,15 @@ def _fetch_remote_env_details(
     if not isinstance(details, dict) or version != "latest":
         return details if isinstance(details, dict) else {}
 
-    # The @latest endpoint currently returns an artifact sha256, not the source content hash
-    # used by `prime env push`. The /versions endpoint exposes the content hash we need for
-    # local-vs-remote sync detection, so enrich latest_version from there when needed.
+    # Enrich latest_version from /versions when @latest does not include the source content hash.
     latest_version = details.get("latest_version")
     latest_summary = (
-        _extract_version_summary(latest_version) if isinstance(latest_version, Mapping) else {}
+        extract_env_version_summary(latest_version) if isinstance(latest_version, dict) else {}
     )
     if latest_summary.get("content_hash"):
         return details
 
-    fallback_latest_version = _fetch_latest_version_summary(client, owner_slug, env_name)
+    fallback_latest_version = fetch_latest_env_version_summary(client, owner_slug, env_name)
     if not fallback_latest_version:
         return details
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -10,7 +10,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 import toml
 import typer
@@ -343,20 +343,74 @@ def _fetch_active_team_slug(client: APIClient, active_team_id: Optional[str]) ->
     return None
 
 
+def _extract_version_summary(version_data: Mapping[str, object]) -> dict[str, str]:
+    version_label = version_data.get("semantic_version") or version_data.get("version")
+    semantic_version = (
+        version_label.removesuffix(" (latest)") if isinstance(version_label, str) else ""
+    )
+
+    content_hash = version_data.get("content_hash") or version_data.get("sha256")
+
+    summary: dict[str, str] = {}
+    if semantic_version:
+        summary["semantic_version"] = semantic_version
+    if isinstance(content_hash, str) and content_hash:
+        summary["content_hash"] = content_hash
+    return summary
+
+
+def _fetch_latest_version_summary(
+    client: APIClient,
+    owner_slug: str,
+    env_name: str,
+) -> Optional[dict[str, str]]:
+    try:
+        response = client.get(f"/environmentshub/{owner_slug}/{env_name}/versions")
+    except APIError:
+        return None
+
+    versions_data = response.get("data", response)
+    versions = versions_data.get("versions")
+    if not versions:
+        return None
+
+    latest_version = _extract_version_summary(versions[0])
+    return latest_version or None
+
+
 def _fetch_remote_env_details(
     client: APIClient, owner_slug: str, env_name: str, version: str = "latest"
 ) -> Optional[dict]:
     try:
         response = client.get(f"/environmentshub/{owner_slug}/{env_name}/@{version}")
-        details = response.get("data", response) if isinstance(response, dict) else None
-        if isinstance(details, dict):
-            return details
-        return {}
-    except APIError as exc:
-        message = str(exc).lower()
-        if "404" in message or "not found" in message:
-            return None
+    except APIError:
         return None
+
+    details = response.get("data", response)
+    if not isinstance(details, dict) or version != "latest":
+        return details if isinstance(details, dict) else {}
+
+    # The @latest endpoint currently returns an artifact sha256, not the source content hash
+    # used by `prime env push`. The /versions endpoint exposes the content hash we need for
+    # local-vs-remote sync detection, so enrich latest_version from there when needed.
+    latest_version = details.get("latest_version")
+    latest_summary = (
+        _extract_version_summary(latest_version) if isinstance(latest_version, Mapping) else {}
+    )
+    if latest_summary.get("content_hash"):
+        return details
+
+    fallback_latest_version = _fetch_latest_version_summary(client, owner_slug, env_name)
+    if not fallback_latest_version:
+        return details
+
+    return {
+        **details,
+        "latest_version": {
+            **latest_summary,
+            **fallback_latest_version,
+        },
+    }
 
 
 def _extract_remote_version_details(details: Optional[dict]) -> tuple[Optional[str], Optional[str]]:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -856,6 +856,53 @@ def _print_environment_source_footer(resolved: Optional[ResolvedEnvironment]) ->
         )
 
 
+def _ensure_published_environment_for_eval(
+    resolved: ResolvedEnvironment,
+    env_dir_path: str,
+) -> ResolvedEnvironment:
+    console.print(
+        "[red]Cannot push evaluation results:[/red] the local environment differs from the "
+        "published upstream."
+    )
+    console.print(
+        "[yellow]Pushed evaluations must match a published environment version to remain "
+        "reproducible.[/yellow]"
+    )
+    console.print(
+        f"[dim]Publish the current local version with:[/dim] {_format_push_command(resolved)}"
+    )
+
+    if not sys.stdin.isatty():
+        raise typer.Exit(1)
+
+    if not typer.confirm("Publish the current local environment now?", default=True):
+        raise typer.Exit(1)
+
+    from .commands.env import push as env_push
+
+    owner = None
+    name = None
+    if resolved.platform_slug:
+        parts = _split_owner_and_name(resolved.platform_slug)
+        if parts is not None:
+            owner, name = parts
+
+    env_push(
+        path=str(resolved.local_env_path) if resolved.local_env_path is not None else None,
+        owner=owner,
+        name=name,
+    )
+
+    refreshed = _resolve_environment_reference(resolved.env_name, env_dir_path)
+    if refreshed.recommend_push:
+        console.print(
+            "[red]Failed to publish a reproducible environment version for this evaluation.[/red]"
+        )
+        raise typer.Exit(1)
+
+    return refreshed
+
+
 def run_eval_passthrough(
     environment: str,
     passthrough_args: list[str],
@@ -923,13 +970,10 @@ def run_eval_passthrough(
         )
         return
 
-    if (
-        resolved_env is not None
-        and resolved_env.recommend_push
-        and resolved_env.platform_slug is not None
-        and upstream_slug is None
-    ):
-        upstream_slug = resolved_env.platform_slug
+    if resolved_env is not None and resolved_env.recommend_push:
+        resolved_env = _ensure_published_environment_for_eval(resolved_env, env_dir_path)
+        upstream_slug = resolved_env.upstream_slug or resolved_env.platform_slug
+        env_name_for_upload = resolved_env.env_name
 
     upload_env_name = env_name_for_upload or environment
     if upstream_slug is None:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -878,13 +878,17 @@ def run_eval_passthrough(
         )
         return
 
-    if resolved_env is not None and resolved_env.recommend_push:
+    if (
+        resolved_env is not None
+        and resolved_env.recommend_push
+        and resolved_env.platform_slug is not None
+    ):
         _print_environment_source_footer(resolved_env)
         console.print(
             "[yellow]Warning:[/yellow] Local environment differs from the current "
             "platform version. Uploading evaluation results to the tracked upstream anyway."
         )
-        if upstream_slug is None and resolved_env.platform_slug is not None:
+        if upstream_slug is None:
             upstream_slug = resolved_env.platform_slug
 
     upload_env_name = env_name_for_upload or environment
@@ -907,7 +911,7 @@ def run_eval_passthrough(
             "correct environment path."
         )
         console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
-        raise typer.Exit(1)
+        return
 
     if resolved_env is not None and resolved_env.platform_url:
         console.print(f"[dim]Environment URL: {resolved_env.platform_url}[/dim]")

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -289,59 +289,16 @@ def _is_valid_hash(value: object) -> bool:
     )
 
 
-def _should_skip_directory(name: str) -> bool:
-    if name.startswith("."):
-        return True
-    if name in {"dist", "__pycache__", "build", "outputs"}:
-        return True
-    if name.endswith(".egg-info"):
-        return True
-    return False
-
-
 def _compute_local_content_hash(env_path: Path) -> Optional[str]:
-    import hashlib
-
     if not env_path.exists() or not env_path.is_dir():
         return None
 
-    hasher = hashlib.sha256()
-    items_to_hash: list[tuple[str, Path]] = []
+    from .commands.env import compute_content_hash
 
-    for pattern in ("pyproject.toml", "*.py", "README.md"):
-        for file_path in env_path.glob(pattern):
-            if file_path.is_file():
-                items_to_hash.append(("file", file_path))
-
-    for subdir in sorted(env_path.iterdir(), key=lambda p: p.name):
-        if not subdir.is_dir() or _should_skip_directory(subdir.name):
-            continue
-        items_to_hash.append(("dir", subdir))
-        for file_path in sorted(subdir.rglob("*")):
-            if not file_path.is_file():
-                continue
-            rel_parts = file_path.relative_to(env_path).parts
-            if any(_should_skip_directory(part) for part in rel_parts[:-1]):
-                continue
-            if file_path.name.startswith("."):
-                continue
-            items_to_hash.append(("file", file_path))
-
-    items_to_hash.sort(key=lambda item: item[1].relative_to(env_path).as_posix().lower())
-
-    for item_type, path in items_to_hash:
-        rel = path.relative_to(env_path).as_posix()
-        if item_type == "dir":
-            hasher.update(f"dir:{rel}".encode("utf-8"))
-            continue
-        hasher.update(f"file:{rel}".encode("utf-8"))
-        try:
-            with open(path, "rb") as f:
-                hasher.update(f.read())
-        except OSError:
-            return None
-
-    return hasher.hexdigest()
+    try:
+        return compute_content_hash(env_path)
+    except OSError:
+        return None
 
 
 def _fetch_user_slug(client: APIClient) -> Optional[str]:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -838,6 +838,7 @@ def run_eval_passthrough(
     upstream_slug: Optional[str] = None
     env_name_for_upload: Optional[str] = None
     resolved_env: Optional[ResolvedEnvironment] = None
+    printed_environment_footer = False
 
     if _is_config_target(environment):
         for env_ref, ref_env_dir in _collect_eval_config_envs(Path(environment), env_dir_path):
@@ -884,6 +885,7 @@ def run_eval_passthrough(
         and resolved_env.platform_slug is not None
     ):
         _print_environment_source_footer(resolved_env)
+        printed_environment_footer = True
         console.print(
             "[yellow]Warning:[/yellow] Local environment differs from the current "
             "platform version. Uploading evaluation results to the tracked upstream anyway."
@@ -913,7 +915,7 @@ def run_eval_passthrough(
         console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
         return
 
-    if resolved_env is not None and resolved_env.platform_url:
+    if resolved_env is not None and resolved_env.platform_url and not printed_environment_footer:
         console.print(f"[dim]Environment URL: {resolved_env.platform_url}[/dim]")
 
     try:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -824,10 +824,11 @@ def _print_environment_source_footer(resolved: Optional[ResolvedEnvironment]) ->
 
 
 def _fail_unpublished_environment_for_eval(resolved: ResolvedEnvironment) -> None:
-    console.print(
-        "[red]Cannot push evaluation results:[/red] the local environment differs from the "
-        "published upstream."
-    )
+    message = "the local environment differs from the published upstream."
+    if resolved.push_reason == "local_only":
+        message = "the local environment is not published yet."
+
+    console.print(f"[red]Cannot push evaluation results:[/red] {message}")
     console.print(
         "[yellow]Pushed evaluations must match a published environment version to remain "
         "reproducible.[/yellow]"

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -823,25 +823,7 @@ def _print_environment_source_footer(resolved: Optional[ResolvedEnvironment]) ->
         )
 
 
-def _publish_environment_for_eval(resolved: ResolvedEnvironment) -> None:
-    command = [sys.executable, "-m", "prime_cli.main", "env", "push"]
-
-    if resolved.local_env_path is not None:
-        command.extend(["--path", str(resolved.local_env_path)])
-
-    if resolved.platform_slug:
-        parts = _split_owner_and_name(resolved.platform_slug)
-        if parts is not None:
-            owner, name = parts
-            command.extend(["--owner", owner, "--name", name])
-
-    _run_command(command)
-
-
-def _ensure_published_environment_for_eval(
-    resolved: ResolvedEnvironment,
-    env_dir_path: str,
-) -> ResolvedEnvironment:
+def _fail_unpublished_environment_for_eval(resolved: ResolvedEnvironment) -> None:
     console.print(
         "[red]Cannot push evaluation results:[/red] the local environment differs from the "
         "published upstream."
@@ -853,23 +835,7 @@ def _ensure_published_environment_for_eval(
     console.print(
         f"[dim]Publish the current local version with:[/dim] {_format_push_command(resolved)}"
     )
-
-    if not sys.stdin.isatty():
-        raise typer.Exit(1)
-
-    if not typer.confirm("Publish the current local environment now?"):
-        raise typer.Exit(1)
-
-    _publish_environment_for_eval(resolved)
-
-    refreshed = _resolve_environment_reference(resolved.env_name, env_dir_path)
-    if refreshed.recommend_push:
-        console.print(
-            "[red]Failed to publish a reproducible environment version for this evaluation.[/red]"
-        )
-        raise typer.Exit(1)
-
-    return refreshed
+    raise typer.Exit(1)
 
 
 def run_eval_passthrough(
@@ -940,9 +906,7 @@ def run_eval_passthrough(
         return
 
     if resolved_env is not None and resolved_env.recommend_push:
-        resolved_env = _ensure_published_environment_for_eval(resolved_env, env_dir_path)
-        upstream_slug = resolved_env.upstream_slug or resolved_env.platform_slug
-        env_name_for_upload = resolved_env.env_name
+        _fail_unpublished_environment_for_eval(resolved_env)
 
     upload_env_name = env_name_for_upload or environment
     if upstream_slug is None:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -849,17 +849,8 @@ def _print_environment_source_footer(resolved: Optional[ResolvedEnvironment]) ->
         return
     if resolved.platform_url:
         console.print(f"[dim]Environment URL: {resolved.platform_url}[/dim]")
-    if resolved.recommend_push:
-        if resolved.push_reason == "ahead" and resolved.platform_slug:
-            console.print(
-                f"[yellow]Local environment is ahead of {resolved.platform_slug}.[/yellow]"
-            )
-        elif resolved.push_reason == "local_only":
-            console.print("[yellow]Local environment is not linked to an upstream.[/yellow]")
-        else:
-            console.print(
-                "[yellow]Local environment differs from the current platform version.[/yellow]"
-            )
+    if resolved.push_reason == "local_only":
+        console.print("[yellow]Local environment is not linked to an upstream.[/yellow]")
         console.print(
             f"[dim]Publish the current local version with:[/dim] {_format_push_command(resolved)}"
         )
@@ -892,7 +883,6 @@ def run_eval_passthrough(
     upstream_slug: Optional[str] = None
     env_name_for_upload: Optional[str] = None
     resolved_env: Optional[ResolvedEnvironment] = None
-    printed_environment_footer = False
 
     if _is_config_target(environment):
         for env_ref, ref_env_dir in _collect_eval_config_envs(Path(environment), env_dir_path):
@@ -937,15 +927,9 @@ def run_eval_passthrough(
         resolved_env is not None
         and resolved_env.recommend_push
         and resolved_env.platform_slug is not None
+        and upstream_slug is None
     ):
-        _print_environment_source_footer(resolved_env)
-        printed_environment_footer = True
-        console.print(
-            "[yellow]Warning:[/yellow] Local environment differs from the current "
-            "platform version. Uploading evaluation results to the tracked upstream anyway."
-        )
-        if upstream_slug is None:
-            upstream_slug = resolved_env.platform_slug
+        upstream_slug = resolved_env.platform_slug
 
     upload_env_name = env_name_for_upload or environment
     if upstream_slug is None:
@@ -969,7 +953,7 @@ def run_eval_passthrough(
         console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
         return
 
-    if resolved_env is not None and resolved_env.platform_url and not printed_environment_footer:
+    if resolved_env is not None and resolved_env.platform_url:
         console.print(f"[dim]Environment URL: {resolved_env.platform_url}[/dim]")
 
     try:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -823,6 +823,21 @@ def _print_environment_source_footer(resolved: Optional[ResolvedEnvironment]) ->
         )
 
 
+def _publish_environment_for_eval(resolved: ResolvedEnvironment) -> None:
+    command = [sys.executable, "-m", "prime_cli.main", "env", "push"]
+
+    if resolved.local_env_path is not None:
+        command.extend(["--path", str(resolved.local_env_path)])
+
+    if resolved.platform_slug:
+        parts = _split_owner_and_name(resolved.platform_slug)
+        if parts is not None:
+            owner, name = parts
+            command.extend(["--owner", owner, "--name", name])
+
+    _run_command(command)
+
+
 def _ensure_published_environment_for_eval(
     resolved: ResolvedEnvironment,
     env_dir_path: str,
@@ -842,23 +857,10 @@ def _ensure_published_environment_for_eval(
     if not sys.stdin.isatty():
         raise typer.Exit(1)
 
-    if not typer.confirm("Publish the current local environment now?", default=True):
+    if not typer.confirm("Publish the current local environment now?"):
         raise typer.Exit(1)
 
-    from .commands.env import push as env_push
-
-    owner = None
-    name = None
-    if resolved.platform_slug:
-        parts = _split_owner_and_name(resolved.platform_slug)
-        if parts is not None:
-            owner, name = parts
-
-    env_push(
-        path=str(resolved.local_env_path) if resolved.local_env_path is not None else None,
-        owner=owner,
-        name=name,
-    )
+    _publish_environment_for_eval(resolved)
 
     refreshed = _resolve_environment_reference(resolved.env_name, env_dir_path)
     if refreshed.recommend_push:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -881,10 +881,11 @@ def run_eval_passthrough(
     if resolved_env is not None and resolved_env.recommend_push:
         _print_environment_source_footer(resolved_env)
         console.print(
-            "[yellow]Evaluation completed. Automatic upload is skipped until the local "
-            "environment is published.[/yellow]"
+            "[yellow]Warning:[/yellow] Local environment differs from the current "
+            "platform version. Uploading evaluation results to the tracked upstream anyway."
         )
-        return
+        if upstream_slug is None and resolved_env.platform_slug is not None:
+            upstream_slug = resolved_env.platform_slug
 
     upload_env_name = env_name_for_upload or environment
     if upstream_slug is None:
@@ -901,12 +902,12 @@ def run_eval_passthrough(
     if upstream_slug is None:
         _print_environment_source_footer(resolved_env)
         console.print(
-            "[dim]No upstream environment found. "
-            "Skipped uploading evaluation results to platform.\n"
+            "[red]Failed to push results to hub:[/red] no upstream environment found. "
             "Use `prime env push` to set an upstream, or use `--env-path` to specify the "
-            "correct environment path.[/dim]"
+            "correct environment path."
         )
-        return
+        console.print("[yellow]Evaluation completed but results were not pushed.[/yellow]")
+        raise typer.Exit(1)
 
     if resolved_env is not None and resolved_env.platform_url:
         console.print(f"[dim]Environment URL: {resolved_env.platform_url}[/dim]")

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -128,6 +128,7 @@ def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
 
     output = capsys.readouterr().out
     assert "tracked upstream anyway" in output
+    assert output.count("Environment URL:") == 1
 
 
 def test_run_eval_warns_when_upload_is_required_but_no_upstream_exists(monkeypatch, capsys):

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -147,10 +147,13 @@ def test_run_eval_requires_publish_before_upload_when_local_env_is_ahead(monkeyp
 
     push_calls = []
 
-    def fake_env_push(**kwargs):
-        push_calls.append(kwargs)
+    def fake_publish_environment_for_eval(resolved):
+        push_calls.append(resolved.platform_slug)
 
-    monkeypatch.setattr("prime_cli.commands.env.push", fake_env_push)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._publish_environment_for_eval",
+        fake_publish_environment_for_eval,
+    )
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._resolve_environment_reference",
         lambda env_name, env_dir_path: ResolvedEnvironment(
@@ -183,7 +186,7 @@ def test_run_eval_requires_publish_before_upload_when_local_env_is_ahead(monkeyp
         env_path=None,
     )
 
-    assert push_calls == [{"path": None, "owner": "alice", "name": "simpleqa"}]
+    assert push_calls == ["alice/simpleqa"]
     assert captured["env_name"] == "simpleqa"
     assert captured["model"] == "openai/gpt-4.1-mini"
     assert captured["job_id"] == "job-123"

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -142,6 +142,14 @@ def test_run_eval_fails_when_local_env_is_ahead(monkeypatch, capsys):
             local_env_path=None,
         ),
     )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.push_eval_results_to_hub",
+        lambda **kwargs: pytest.fail("eval upload should not run for unpublished environments"),
+    )
+    monkeypatch.setattr(
+        "typer.confirm",
+        lambda *args, **kwargs: pytest.fail("eval upload should not prompt to publish"),
+    )
 
     with pytest.raises(typer.Exit) as exc_info:
         run_eval_passthrough(
@@ -154,6 +162,7 @@ def test_run_eval_fails_when_local_env_is_ahead(monkeypatch, capsys):
     assert cast(typer.Exit, exc_info.value).exit_code == 1
     output = capsys.readouterr().out
     assert "Cannot push evaluation results:" in output
+    assert "differs from the published" in output
     assert "reproducible" in output
     assert "Publish the current local version with:" in output
 
@@ -183,5 +192,6 @@ def test_run_eval_fails_when_local_env_diverges_in_non_interactive_mode(monkeypa
     assert cast(typer.Exit, exc_info.value).exit_code == 1
     output = capsys.readouterr().out
     assert "Cannot push evaluation results:" in output
+    assert "the local environment is not published yet" in output
     assert "reproducible" in output
     assert "Publish the current local version with:" in output

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -126,7 +126,7 @@ def _setup_eval_passthrough(monkeypatch):
     monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", lambda *args, **kwargs: None)
 
 
-def test_run_eval_requires_publish_before_upload_when_local_env_is_ahead(monkeypatch, capsys):
+def test_run_eval_fails_when_local_env_is_ahead(monkeypatch, capsys):
     _setup_eval_passthrough(monkeypatch)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
@@ -142,60 +142,20 @@ def test_run_eval_requires_publish_before_upload_when_local_env_is_ahead(monkeyp
             local_env_path=None,
         ),
     )
-    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    monkeypatch.setattr("typer.confirm", lambda *args, **kwargs: True)
 
-    push_calls = []
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="simpleqa",
+            passthrough_args=[],
+            skip_upload=False,
+            env_path=None,
+        )
 
-    def fake_publish_environment_for_eval(resolved):
-        push_calls.append(resolved.platform_slug)
-
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge._publish_environment_for_eval",
-        fake_publish_environment_for_eval,
-    )
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge._resolve_environment_reference",
-        lambda env_name, env_dir_path: ResolvedEnvironment(
-            original=env_name,
-            env_name=env_name,
-            install_mode="local",
-            env_display_id="alice/simpleqa",
-            upstream_slug="alice/simpleqa",
-            platform_slug="alice/simpleqa",
-            platform_url="https://app.primeintellect.ai/dashboard/environments/alice/simpleqa",
-            recommend_push=False,
-            local_env_path=None,
-        ),
-    )
-
-    captured = {}
-
-    def fake_push_eval_results_to_hub(**kwargs):
-        captured.update(kwargs)
-
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.push_eval_results_to_hub",
-        fake_push_eval_results_to_hub,
-    )
-
-    run_eval_passthrough(
-        environment="simpleqa",
-        passthrough_args=[],
-        skip_upload=False,
-        env_path=None,
-    )
-
-    assert push_calls == ["alice/simpleqa"]
-    assert captured["env_name"] == "simpleqa"
-    assert captured["model"] == "openai/gpt-4.1-mini"
-    assert captured["job_id"] == "job-123"
-    assert captured["upstream_slug"] == "alice/simpleqa"
-
+    assert cast(typer.Exit, exc_info.value).exit_code == 1
     output = capsys.readouterr().out
     assert "Cannot push evaluation results:" in output
     assert "reproducible" in output
-    assert output.count("Environment URL:") == 1
+    assert "Publish the current local version with:" in output
 
 
 def test_run_eval_fails_when_local_env_diverges_in_non_interactive_mode(monkeypatch, capsys):
@@ -212,8 +172,6 @@ def test_run_eval_fails_when_local_env_diverges_in_non_interactive_mode(monkeypa
             local_env_path=None,
         ),
     )
-    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-
     with pytest.raises(typer.Exit) as exc_info:
         run_eval_passthrough(
             environment="simpleqa",

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -46,8 +46,8 @@ def test_fetch_remote_env_details_uses_versions_endpoint_for_content_hash():
                     "data": {
                         "versions": [
                             {
-                                "version": "0.1.4 (latest)",
-                                "sha256": "a" * 64,
+                                "semantic_version": "0.1.4",
+                                "content_hash": "a" * 64,
                             }
                         ]
                     }

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -4,6 +4,7 @@ from prime_cli.commands.env import compute_content_hash
 from prime_cli.verifiers_bridge import (
     ResolvedEnvironment,
     _compute_local_content_hash,
+    _fetch_remote_env_details,
     _resolve_local_env_display,
     run_eval_passthrough,
 )
@@ -24,6 +25,39 @@ def test_compute_local_content_hash_matches_env_push_hash(tmp_path):
     _create_env(env_dir)
 
     assert _compute_local_content_hash(env_dir) == compute_content_hash(env_dir)
+
+
+def test_fetch_remote_env_details_uses_versions_endpoint_for_content_hash():
+    class DummyClient:
+        def get(self, endpoint):
+            if endpoint == "/environmentshub/alice/simpleqa/@latest":
+                return {
+                    "data": {
+                        "name": "simpleqa",
+                        "sha256": "artifact-sha-not-source-hash",
+                    }
+                }
+            if endpoint == "/environmentshub/alice/simpleqa/versions":
+                return {
+                    "data": {
+                        "versions": [
+                            {
+                                "version": "0.1.4 (latest)",
+                                "sha256": "a" * 64,
+                            }
+                        ]
+                    }
+                }
+            raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    details = _fetch_remote_env_details(DummyClient(), "alice", "simpleqa")
+
+    assert details is not None
+    assert details["sha256"] == "artifact-sha-not-source-hash"
+    assert details["latest_version"] == {
+        "semantic_version": "0.1.4",
+        "content_hash": "a" * 64,
+    }
 
 
 def test_resolve_local_env_display_recognizes_in_sync_metadata_connected_env(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -1,6 +1,10 @@
 import json
+from typing import Any, cast
 
+import pytest
+import typer
 from prime_cli.commands.env import compute_content_hash
+from prime_cli.core import APIClient
 from prime_cli.verifiers_bridge import (
     ResolvedEnvironment,
     _compute_local_content_hash,
@@ -50,7 +54,7 @@ def test_fetch_remote_env_details_uses_versions_endpoint_for_content_hash():
                 }
             raise AssertionError(f"Unexpected endpoint: {endpoint}")
 
-    details = _fetch_remote_env_details(DummyClient(), "alice", "simpleqa")
+    details = _fetch_remote_env_details(cast(Any, DummyClient()), "alice", "simpleqa")
 
     assert details is not None
     assert details["sha256"] == "artifact-sha-not-source-hash"
@@ -79,7 +83,7 @@ def test_resolve_local_env_display_recognizes_in_sync_metadata_connected_env(tmp
     )
 
     env_display_id, platform_slug, platform_url, recommend_push, push_reason = (
-        _resolve_local_env_display("simpleqa", env_dir, object())
+        _resolve_local_env_display("simpleqa", env_dir, APIClient(api_key="test-key"))
     )
 
     assert env_display_id == "alice/simpleqa"
@@ -122,7 +126,7 @@ def _setup_eval_passthrough(monkeypatch):
     monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", lambda *args, **kwargs: None)
 
 
-def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
+def test_run_eval_requires_publish_before_upload_when_local_env_is_ahead(monkeypatch, capsys):
     _setup_eval_passthrough(monkeypatch)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
@@ -135,6 +139,30 @@ def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
             platform_url="https://app.primeintellect.ai/dashboard/environments/alice/simpleqa",
             recommend_push=True,
             push_reason="ahead",
+            local_env_path=None,
+        ),
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("typer.confirm", lambda *args, **kwargs: True)
+
+    push_calls = []
+
+    def fake_env_push(**kwargs):
+        push_calls.append(kwargs)
+
+    monkeypatch.setattr("prime_cli.commands.env.push", fake_env_push)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._resolve_environment_reference",
+        lambda env_name, env_dir_path: ResolvedEnvironment(
+            original=env_name,
+            env_name=env_name,
+            install_mode="local",
+            env_display_id="alice/simpleqa",
+            upstream_slug="alice/simpleqa",
+            platform_slug="alice/simpleqa",
+            platform_url="https://app.primeintellect.ai/dashboard/environments/alice/simpleqa",
+            recommend_push=False,
+            local_env_path=None,
         ),
     )
 
@@ -155,18 +183,19 @@ def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
         env_path=None,
     )
 
+    assert push_calls == [{"path": None, "owner": "alice", "name": "simpleqa"}]
     assert captured["env_name"] == "simpleqa"
     assert captured["model"] == "openai/gpt-4.1-mini"
     assert captured["job_id"] == "job-123"
     assert captured["upstream_slug"] == "alice/simpleqa"
 
     output = capsys.readouterr().out
-    assert "tracked upstream anyway" not in output
-    assert "Local environment is ahead" not in output
+    assert "Cannot push evaluation results:" in output
+    assert "reproducible" in output
     assert output.count("Environment URL:") == 1
 
 
-def test_run_eval_warns_when_upload_is_required_but_no_upstream_exists(monkeypatch, capsys):
+def test_run_eval_fails_when_local_env_diverges_in_non_interactive_mode(monkeypatch, capsys):
     _setup_eval_passthrough(monkeypatch)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
@@ -177,21 +206,21 @@ def test_run_eval_warns_when_upload_is_required_but_no_upstream_exists(monkeypat
             env_display_id="simpleqa (local only)",
             recommend_push=True,
             push_reason="local_only",
+            local_env_path=None,
         ),
     )
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.find_environment_metadata", lambda **kwargs: None
-    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
-    run_eval_passthrough(
-        environment="simpleqa",
-        passthrough_args=[],
-        skip_upload=False,
-        env_path=None,
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="simpleqa",
+            passthrough_args=[],
+            skip_upload=False,
+            env_path=None,
+        )
 
+    assert cast(typer.Exit, exc_info.value).exit_code == 1
     output = capsys.readouterr().out
-    assert "Failed to push results to hub:" in output
-    assert "no upstream environment found" in output
-    assert "Evaluation completed but results were not pushed." in output
-    assert "tracked upstream anyway" not in output
+    assert "Cannot push evaluation results:" in output
+    assert "reproducible" in output
+    assert "Publish the current local version with:" in output

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -1,7 +1,14 @@
 import json
 
+import pytest
+import typer
 from prime_cli.commands.env import compute_content_hash
-from prime_cli.verifiers_bridge import _compute_local_content_hash, _resolve_local_env_display
+from prime_cli.verifiers_bridge import (
+    ResolvedEnvironment,
+    _compute_local_content_hash,
+    _resolve_local_env_display,
+    run_eval_passthrough,
+)
 
 
 def _create_env(env_dir):
@@ -48,3 +55,109 @@ def test_resolve_local_env_display_recognizes_in_sync_metadata_connected_env(tmp
     assert platform_url is not None
     assert recommend_push is False
     assert push_reason is None
+
+
+class DummyConfig:
+    api_key = "test-api-key"
+    inference_url = None
+    team_id = None
+
+
+class DummyPlugin:
+    eval_module = "verifiers.cli.commands.eval"
+
+    def build_module_command(self, module: str, args: list[str]) -> list[str]:
+        return [module, *args]
+
+
+def _setup_eval_passthrough(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._add_default_inference_and_key_args",
+        lambda args, config: (list(args), {}, "openai/gpt-4.1-mini", None),
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge._validate_model", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._preflight_inference_billing",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._build_job_id", lambda *args, **kwargs: "job-123"
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", lambda *args, **kwargs: None)
+
+
+def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
+    _setup_eval_passthrough(monkeypatch)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        lambda *args, **kwargs: ResolvedEnvironment(
+            original="simpleqa",
+            env_name="simpleqa",
+            install_mode="local",
+            env_display_id="simpleqa (local - ahead of alice/simpleqa)",
+            platform_slug="alice/simpleqa",
+            platform_url="https://app.primeintellect.ai/dashboard/environments/alice/simpleqa",
+            recommend_push=True,
+            push_reason="ahead",
+        ),
+    )
+
+    captured = {}
+
+    def fake_push_eval_results_to_hub(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.push_eval_results_to_hub",
+        fake_push_eval_results_to_hub,
+    )
+
+    run_eval_passthrough(
+        environment="simpleqa",
+        passthrough_args=[],
+        skip_upload=False,
+        env_path=None,
+    )
+
+    assert captured["env_name"] == "simpleqa"
+    assert captured["model"] == "openai/gpt-4.1-mini"
+    assert captured["job_id"] == "job-123"
+    assert captured["upstream_slug"] == "alice/simpleqa"
+
+    output = capsys.readouterr().out
+    assert "tracked upstream anyway" in output
+
+
+def test_run_eval_errors_when_upload_is_required_but_no_upstream_exists(monkeypatch, capsys):
+    _setup_eval_passthrough(monkeypatch)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        lambda *args, **kwargs: ResolvedEnvironment(
+            original="simpleqa",
+            env_name="simpleqa",
+            install_mode="local",
+            env_display_id="simpleqa (local only)",
+            recommend_push=True,
+            push_reason="local_only",
+        ),
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.find_environment_metadata", lambda **kwargs: None
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="simpleqa",
+            passthrough_args=[],
+            skip_upload=False,
+            env_path=None,
+        )
+
+    assert exc_info.value.exit_code == 1
+    output = capsys.readouterr().out
+    assert "Failed to push results to hub:" in output
+    assert "no upstream environment found" in output

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -161,7 +161,8 @@ def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
     assert captured["upstream_slug"] == "alice/simpleqa"
 
     output = capsys.readouterr().out
-    assert "tracked upstream anyway" in output
+    assert "tracked upstream anyway" not in output
+    assert "Local environment is ahead" not in output
     assert output.count("Environment URL:") == 1
 
 

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -1,7 +1,5 @@
 import json
 
-import pytest
-import typer
 from prime_cli.commands.env import compute_content_hash
 from prime_cli.verifiers_bridge import (
     ResolvedEnvironment,
@@ -132,7 +130,7 @@ def test_run_eval_uploads_even_when_local_env_is_ahead(monkeypatch, capsys):
     assert "tracked upstream anyway" in output
 
 
-def test_run_eval_errors_when_upload_is_required_but_no_upstream_exists(monkeypatch, capsys):
+def test_run_eval_warns_when_upload_is_required_but_no_upstream_exists(monkeypatch, capsys):
     _setup_eval_passthrough(monkeypatch)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
@@ -149,15 +147,15 @@ def test_run_eval_errors_when_upload_is_required_but_no_upstream_exists(monkeypa
         "prime_cli.verifiers_bridge.find_environment_metadata", lambda **kwargs: None
     )
 
-    with pytest.raises(typer.Exit) as exc_info:
-        run_eval_passthrough(
-            environment="simpleqa",
-            passthrough_args=[],
-            skip_upload=False,
-            env_path=None,
-        )
+    run_eval_passthrough(
+        environment="simpleqa",
+        passthrough_args=[],
+        skip_upload=False,
+        env_path=None,
+    )
 
-    assert exc_info.value.exit_code == 1
     output = capsys.readouterr().out
     assert "Failed to push results to hub:" in output
     assert "no upstream environment found" in output
+    assert "Evaluation completed but results were not pushed." in output
+    assert "tracked upstream anyway" not in output

--- a/packages/prime/tests/test_verifiers_bridge.py
+++ b/packages/prime/tests/test_verifiers_bridge.py
@@ -1,0 +1,50 @@
+import json
+
+from prime_cli.commands.env import compute_content_hash
+from prime_cli.verifiers_bridge import _compute_local_content_hash, _resolve_local_env_display
+
+
+def _create_env(env_dir):
+    env_dir.mkdir(parents=True)
+    (env_dir / "pyproject.toml").write_text('[project]\nname = "simpleqa"\nversion = "0.1.0"\n')
+    (env_dir / "README.md").write_text("# simpleqa\n")
+    (env_dir / "simpleqa.py").write_text("def load_environment():\n    return None\n")
+    package_dir = env_dir / "prompts"
+    package_dir.mkdir()
+    (package_dir / "system.txt").write_text("answer carefully\n")
+
+
+def test_compute_local_content_hash_matches_env_push_hash(tmp_path):
+    env_dir = tmp_path / "simpleqa"
+    _create_env(env_dir)
+
+    assert _compute_local_content_hash(env_dir) == compute_content_hash(env_dir)
+
+
+def test_resolve_local_env_display_recognizes_in_sync_metadata_connected_env(tmp_path, monkeypatch):
+    env_dir = tmp_path / "simpleqa"
+    _create_env(env_dir)
+
+    prime_dir = env_dir / ".prime"
+    prime_dir.mkdir()
+    (prime_dir / ".env-metadata.json").write_text(
+        json.dumps({"owner": "alice", "name": "simpleqa", "environment_id": "env-123"})
+    )
+
+    remote_hash = compute_content_hash(env_dir)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._fetch_remote_env_details",
+        lambda client, owner_slug, env_name, version="latest": {
+            "latest_version": {"content_hash": remote_hash}
+        },
+    )
+
+    env_display_id, platform_slug, platform_url, recommend_push, push_reason = (
+        _resolve_local_env_display("simpleqa", env_dir, object())
+    )
+
+    assert env_display_id == "alice/simpleqa"
+    assert platform_slug == "alice/simpleqa"
+    assert platform_url is not None
+    assert recommend_push is False
+    assert push_reason is None


### PR DESCRIPTION
## Summary
- reuse the env push content hash implementation when comparing local envs against the platform
- stop falsely marking metadata-linked local environments as ahead when their content matches the upstream
- add regression coverage for hash parity and in-sync metadata-linked env resolution

## Testing
- pytest packages/prime/tests/test_verifiers_bridge.py packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_eval_billing.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment version/hash resolution and makes `prime eval` auto-upload fail fast when the local environment isn’t published or can’t be linked, which can alter user workflows. Risk is moderate due to reliance on API response shapes and new error/exit paths.
> 
> **Overview**
> Fixes environment/version handling so metadata-linked local environments are no longer incorrectly marked as “ahead” when their content matches the hub, by reusing `prime env push`’s `compute_content_hash` and enriching `@latest` env details with `content_hash` from the `/versions` endpoint when missing.
> 
> Updates `prime env status` to display latest version/hash via a shared `extract_env_version_summary` helper, and changes `prime eval` passthrough to **refuse** pushing results when the local env diverges/unpublished (and improves messaging when no upstream is found). Adds regression tests for hash parity, remote detail enrichment, in-sync resolution, and new eval failure behavior, plus a retry loop in the sandbox command timeout test for transient 502s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e061e5720045c95563daf59e3169885d820402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->