### PR TITLE
release: cli 0.5.55

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.54"
+__version__ = "0.5.55"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump CLI version to 0.5.55.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change that updates a version constant with no functional code modifications.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.54` to `0.5.55` in `packages/prime/src/prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fafbc6f7222733825b2bb7d09680bb2c4001b7e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->