### PR TITLE
feat: run_background_job() on SandboxClient + AsyncSandboxClient

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -920,8 +920,6 @@ class SandboxClient:
         Raises:
             TimeoutError: If command doesn't complete within timeout
         """
-        import time
-
         job = self.start_background_job(
             sandbox_id, command, working_dir=working_dir, env=env
         )
@@ -1781,16 +1779,15 @@ class AsyncSandboxClient:
         Raises:
             TimeoutError: If command doesn't complete within timeout
         """
-        import asyncio as _asyncio
-
         job = await self.start_background_job(
             sandbox_id, command, working_dir=working_dir, env=env
         )
-        for _elapsed in range(0, timeout + poll_interval, poll_interval):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             status = await self.get_background_job(sandbox_id, job)
             if status.completed:
                 return status
-            await _asyncio.sleep(poll_interval)
+            await asyncio.sleep(poll_interval)
         raise TimeoutError(
             f"Background job {job.job_id} timed out after {timeout}s"
         )

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -891,6 +891,50 @@ class SandboxClient:
             stderr=read_or_cat(job.stderr_log_file),
         )
 
+    def run_background_job(
+        self,
+        sandbox_id: str,
+        command: str,
+        timeout: int = 900,
+        working_dir: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        poll_interval: int = 3,
+    ) -> BackgroundJobStatus:
+        """Run a command in the background and wait for completion.
+
+        Combines start_background_job() + polling into a single call.
+        Use this for long-running commands that would exceed HTTP timeouts
+        with execute_command().
+
+        Args:
+            sandbox_id: The sandbox ID
+            command: Command to execute
+            timeout: Maximum seconds to wait for completion
+            working_dir: Working directory for command execution
+            env: Environment variables
+            poll_interval: Seconds between status polls
+
+        Returns:
+            BackgroundJobStatus with exit_code, stdout, stderr
+
+        Raises:
+            TimeoutError: If command doesn't complete within timeout
+        """
+        import time
+
+        job = self.start_background_job(
+            sandbox_id, command, working_dir=working_dir, env=env
+        )
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status = self.get_background_job(sandbox_id, job)
+            if status.completed:
+                return status
+            time.sleep(poll_interval)
+        raise TimeoutError(
+            f"Background job {job.job_id} timed out after {timeout}s"
+        )
+
     def wait_for_creation(
         self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
     ) -> None:
@@ -1706,6 +1750,49 @@ class AsyncSandboxClient:
             exit_code=exit_code,
             stdout=await read_or_cat(job.stdout_log_file),
             stderr=await read_or_cat(job.stderr_log_file),
+        )
+
+    async def run_background_job(
+        self,
+        sandbox_id: str,
+        command: str,
+        timeout: int = 900,
+        working_dir: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        poll_interval: int = 3,
+    ) -> BackgroundJobStatus:
+        """Run a command in the background and wait for completion (async).
+
+        Combines start_background_job() + polling into a single call.
+        Use this for long-running commands that would exceed HTTP timeouts
+        with execute_command().
+
+        Args:
+            sandbox_id: The sandbox ID
+            command: Command to execute
+            timeout: Maximum seconds to wait for completion
+            working_dir: Working directory for command execution
+            env: Environment variables
+            poll_interval: Seconds between status polls
+
+        Returns:
+            BackgroundJobStatus with exit_code, stdout, stderr
+
+        Raises:
+            TimeoutError: If command doesn't complete within timeout
+        """
+        import asyncio as _asyncio
+
+        job = await self.start_background_job(
+            sandbox_id, command, working_dir=working_dir, env=env
+        )
+        for _elapsed in range(0, timeout + poll_interval, poll_interval):
+            status = await self.get_background_job(sandbox_id, job)
+            if status.completed:
+                return status
+            await _asyncio.sleep(poll_interval)
+        raise TimeoutError(
+            f"Background job {job.job_id} timed out after {timeout}s"
         )
 
     async def wait_for_creation(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -918,7 +918,7 @@ class SandboxClient:
             BackgroundJobStatus with exit_code, stdout, stderr
 
         Raises:
-            TimeoutError: If command doesn't complete within timeout
+            CommandTimeoutError: If command doesn't complete within timeout
         """
         job = self.start_background_job(
             sandbox_id, command, working_dir=working_dir, env=env
@@ -929,9 +929,7 @@ class SandboxClient:
             if status.completed:
                 return status
             time.sleep(poll_interval)
-        raise TimeoutError(
-            f"Background job {job.job_id} timed out after {timeout}s"
-        )
+        raise CommandTimeoutError(sandbox_id, command, timeout)
 
     def wait_for_creation(
         self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
@@ -1777,7 +1775,7 @@ class AsyncSandboxClient:
             BackgroundJobStatus with exit_code, stdout, stderr
 
         Raises:
-            TimeoutError: If command doesn't complete within timeout
+            CommandTimeoutError: If command doesn't complete within timeout
         """
         job = await self.start_background_job(
             sandbox_id, command, working_dir=working_dir, env=env
@@ -1788,9 +1786,7 @@ class AsyncSandboxClient:
             if status.completed:
                 return status
             await asyncio.sleep(poll_interval)
-        raise TimeoutError(
-            f"Background job {job.job_id} timed out after {timeout}s"
-        )
+        raise CommandTimeoutError(sandbox_id, command, timeout)
 
     async def wait_for_creation(
         self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1


### PR DESCRIPTION
## Summary

Adds `run_background_job()` to both `SandboxClient` and `AsyncSandboxClient` — a convenience method that combines `start_background_job()` + polling into a single call.

### Problem

Long-running sandbox commands (e.g. running test suites for 10+ minutes) can't use `execute_command()` because the HTTP connection times out. Users currently have to manually implement `start_background_job()` + poll `get_background_job()` in a loop. This pattern is duplicated across multiple TaskSpec implementations and validation code.

### Solution

```python
# Before: manual poll loop (repeated everywhere)
job = await client.start_background_job(sandbox_id, command)
while True:
    status = await client.get_background_job(sandbox_id, job)
    if status.completed:
        break
    await asyncio.sleep(3)

# After: one call
result = await client.run_background_job(sandbox_id, command, timeout=900)
```

### API

```python
# Async
result = await client.run_background_job(
    sandbox_id, command,
    timeout=900,            # max seconds to wait
    working_dir="/testbed", # optional
    env={"FOO": "bar"},     # optional
    poll_interval=3,        # seconds between polls
)
# result.completed, result.exit_code, result.stdout, result.stderr

# Sync (same signature, blocking)
result = client.run_background_job(sandbox_id, command, timeout=900)
```

Raises `TimeoutError` if the command doesn't complete within the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that introduces a new helper method; main concern is callers relying on default polling/timeout behavior for long-running commands.
> 
> **Overview**
> Adds `run_background_job()` to both `SandboxClient` and `AsyncSandboxClient`, providing a single call that starts a background job, polls `get_background_job()` until completion, and returns the final `BackgroundJobStatus`.
> 
> The helper supports `timeout`, `working_dir`, `env`, and `poll_interval`, and raises `CommandTimeoutError` when the deadline is exceeded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a73c7add1ca0ae30ae2dadd5f393442011c625e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->