### PR TITLE
fix read_file in get_background_job

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -16,6 +16,7 @@ from .core import (
 from .exceptions import (
     CommandTimeoutError,
     DownloadTimeoutError,
+    SandboxFileNotFoundError,
     SandboxImagePullError,
     SandboxNotRunningError,
     SandboxOOMError,
@@ -87,6 +88,7 @@ __all__ = [
     "APIError",
     "UnauthorizedError",
     "PaymentRequiredError",
+    "SandboxFileNotFoundError",
     "APITimeoutError",
     "TimeoutError",  # Deprecated alias
     "SandboxOOMError",

--- a/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
@@ -1,5 +1,13 @@
 """Custom exceptions for Prime Sandboxes SDK."""
 
+from .core.client import APIError
+
+
+class SandboxFileNotFoundError(APIError):
+    """Raised when a file is not found in the sandbox (404)."""
+
+    pass
+
 
 class SandboxNotRunningError(RuntimeError):
     """Raised when an operation requires a RUNNING sandbox but it is not running."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -866,15 +866,13 @@ class SandboxClient:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
 
-        def read_or_cat(path: str, timeout: int = 60) -> str:
+        def read_or_empty(path: str) -> str:
             try:
                 return self.read_file(sandbox_id, path).content
             except APIError:
-                return self.execute_command(
-                    sandbox_id, f"cat {shlex.quote(path)} 2>/dev/null", timeout=timeout
-                ).stdout
+                return ""
 
-        exit_content = read_or_cat(job.exit_file, timeout=30)
+        exit_content = read_or_empty(job.exit_file)
         if not exit_content.strip():
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
@@ -887,8 +885,8 @@ class SandboxClient:
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=read_or_cat(job.stdout_log_file),
-            stderr=read_or_cat(job.stderr_log_file),
+            stdout=read_or_empty(job.stdout_log_file),
+            stderr=read_or_empty(job.stderr_log_file),
         )
 
     def run_background_job(
@@ -920,9 +918,7 @@ class SandboxClient:
         Raises:
             CommandTimeoutError: If command doesn't complete within timeout
         """
-        job = self.start_background_job(
-            sandbox_id, command, working_dir=working_dir, env=env
-        )
+        job = self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             status = self.get_background_job(sandbox_id, job)
@@ -1719,19 +1715,13 @@ class AsyncSandboxClient:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
         """
 
-        async def read_or_cat(path: str, timeout: int = 60) -> str:
+        async def read_or_empty(path: str) -> str:
             try:
                 return (await self.read_file(sandbox_id, path)).content
             except APIError:
-                return (
-                    await self.execute_command(
-                        sandbox_id,
-                        f"cat {shlex.quote(path)} 2>/dev/null",
-                        timeout=timeout,
-                    )
-                ).stdout
+                return ""
 
-        exit_content = await read_or_cat(job.exit_file, timeout=30)
+        exit_content = await read_or_empty(job.exit_file)
         if not exit_content.strip():
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
@@ -1744,8 +1734,8 @@ class AsyncSandboxClient:
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=await read_or_cat(job.stdout_log_file),
-            stderr=await read_or_cat(job.stderr_log_file),
+            stdout=await read_or_empty(job.stdout_log_file),
+            stderr=await read_or_empty(job.stderr_log_file),
         )
 
     async def run_background_job(
@@ -1777,9 +1767,7 @@ class AsyncSandboxClient:
         Raises:
             CommandTimeoutError: If command doesn't complete within timeout
         """
-        job = await self.start_background_job(
-            sandbox_id, command, working_dir=working_dir, env=env
-        )
+        job = await self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             status = await self.get_background_job(sandbox_id, job)

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -29,6 +29,7 @@ from .core import APIClient, APIError, AsyncAPIClient
 from .exceptions import (
     CommandTimeoutError,
     DownloadTimeoutError,
+    SandboxFileNotFoundError,
     SandboxImagePullError,
     SandboxNotRunningError,
     SandboxOOMError,
@@ -869,7 +870,7 @@ class SandboxClient:
         def read_or_empty(path: str) -> str:
             try:
                 return self.read_file(sandbox_id, path).content
-            except APIError:
+            except SandboxFileNotFoundError:
                 return ""
 
         exit_content = read_or_empty(job.exit_file)
@@ -1198,6 +1199,8 @@ class SandboxClient:
                     f"Read file timed out after {effective_timeout}s: {file_path}"
                 ) from e
             except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    raise SandboxFileNotFoundError(f"File not found: {file_path}") from e
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
@@ -1718,7 +1721,7 @@ class AsyncSandboxClient:
         async def read_or_empty(path: str) -> str:
             try:
                 return (await self.read_file(sandbox_id, path)).content
-            except APIError:
+            except SandboxFileNotFoundError:
                 return ""
 
         exit_content = await read_or_empty(job.exit_file)
@@ -2063,6 +2066,8 @@ class AsyncSandboxClient:
                     f"Read file timed out after {effective_timeout}s: {file_path}"
                 ) from e
             except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    raise SandboxFileNotFoundError(f"File not found: {file_path}") from e
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error-handling behavior for `read_file` and background job log/exit retrieval, which could affect callers that previously relied on generic `APIError` or the `cat` fallback path. Risk is moderate and localized to file-read/background-job codepaths.
> 
> **Overview**
> Fixes background job polling to rely on `read_file` instead of falling back to `execute_command(cat ...)`, and treats missing job files as *not yet available* by returning empty content.
> 
> Adds a dedicated `SandboxFileNotFoundError` for `read_file` 404s (sync + async) and exports it from the package so callers can distinguish missing remote files from other gateway errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feafd1293ec24dee027b032c5763ff27d0cef2e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->