### PR TITLE
Release prime 0.5.57

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.56"
+__version__ = "0.5.57"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- bump the `packages/prime` version from `0.5.56` to `0.5.57`
- keep the release diff scoped to the single package version source

## Validation
- confirmed `packages/prime/src/prime_cli/__init__.py` now reports `0.5.57`
- pre-commit hooks passed during commit

## Release
Merging this PR will trigger `.github/workflows/release-prime.yml` on `main`, which tags `v0.5.57`, builds `packages/prime`, publishes the GitHub release, uploads to PyPI, and pushes the Docker images.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple version string bump with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.56` to `0.5.57` by updating `__version__` in `packages/prime/src/prime_cli/__init__.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c06dc8f23d063510172ed38e2e81b2c0188591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->