### PR TITLE
feat: add `prime rl configs` command

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -488,6 +488,8 @@ class RLConfig(BaseModel):
     max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
+    env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
+    env_files: List[str] = Field(default_factory=list)
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
@@ -497,8 +499,6 @@ class RLConfig(BaseModel):
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
-    env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
-    env_files: List[str] = Field(default_factory=list)
 
 
 def _format_validation_errors(errors: list[Any]) -> list[str]:
@@ -930,6 +930,132 @@ def list_models(
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+
+def _flatten_config_schema(
+    schema: Dict[str, Any],
+    defs: Dict[str, Any],
+    prefix: str = "",
+) -> list[tuple[str, str, str]]:
+    """Walk a JSON schema and return (dotted_path, type, default) for each leaf field."""
+    leaf_rows: list[tuple[str, str, str]] = []
+    nested_rows: list[tuple[str, str, str]] = []
+    props = schema.get("properties", {})
+    for name, prop in props.items():
+        if name in ("model_config", "env_file"):
+            continue
+        path = f"{prefix}{name}" if not prefix else f"{prefix}.{name}"
+
+        # Resolve $ref or anyOf with a single non-null $ref (optional nested models)
+        resolved = prop
+        if "$ref" in prop:
+            ref_name = prop["$ref"].rsplit("/", 1)[-1]
+            resolved = defs.get(ref_name, prop)
+        elif "anyOf" in prop:
+            non_null = [v for v in prop["anyOf"] if v.get("type") != "null"]
+            if len(non_null) == 1 and "$ref" in non_null[0]:
+                ref_name = non_null[0]["$ref"].rsplit("/", 1)[-1]
+                resolved = defs.get(ref_name, prop)
+
+        # If it's an object with properties, recurse
+        if resolved.get("type") == "object" and "properties" in resolved:
+            nested_rows.extend(_flatten_config_schema(resolved, defs, path))
+            continue
+
+        # If it's an array of objects (like env), show as section hint
+        if resolved.get("type") == "array":
+            items = resolved.get("items", {})
+            if "$ref" in items:
+                ref_name = items["$ref"].rsplit("/", 1)[-1]
+                items = defs.get(ref_name, items)
+            if items.get("type") == "object" and "properties" in items:
+                nested_rows.extend(_flatten_config_schema(items, defs, f"{path}[]"))
+                continue
+
+        # Leaf field — extract type and default
+        type_str = _schema_type_str(resolved, defs)
+        default = str(prop.get("default", "")) if "default" in prop else ""
+        leaf_rows.append((path, type_str, default))
+
+    return leaf_rows + nested_rows
+
+
+def _schema_type_str(prop: Dict[str, Any], defs: Dict[str, Any]) -> str:
+    """Produce a human-readable type string from a JSON schema property."""
+    if "anyOf" in prop:
+        parts = []
+        for variant in prop["anyOf"]:
+            if variant.get("type") == "null":
+                continue
+            if "$ref" in variant:
+                ref_name = variant["$ref"].rsplit("/", 1)[-1]
+                parts.append(ref_name)
+            else:
+                parts.append(variant.get("type", "?"))
+        return " | ".join(parts) if parts else "any"
+    if "allOf" in prop and len(prop["allOf"]) == 1 and "$ref" in prop["allOf"][0]:
+        ref_name = prop["allOf"][0]["$ref"].rsplit("/", 1)[-1]
+        return ref_name
+    if prop.get("type") == "array":
+        items = prop.get("items", {})
+        inner = items.get("type", "any")
+        return f"list[{inner}]"
+    return prop.get("type", "any")
+
+
+RL_CONFIGS_JSON_HELP = json_output_help(
+    ".configs[] = {section, name, type, default}",
+)
+
+
+@app.command("configs", rich_help_panel="Commands", epilog=RL_CONFIGS_JSON_HELP)
+def list_configs(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List available configuration options for RL training."""
+    validate_output_format(output, console)
+
+    schema = RLConfig.model_json_schema()
+    defs = schema.get("$defs", {})
+    rows = _flatten_config_schema(schema, defs)
+    if output == "json":
+        output_data_as_json(
+            {
+                "configs": [
+                    {
+                        "section": r[0].rsplit(".", 1)[0] if "." in r[0] else "",
+                        "name": r[0].rsplit(".", 1)[-1],
+                        "type": r[1],
+                        "default": r[2],
+                    }
+                    for r in rows
+                ]
+            },
+            console,
+        )
+        return
+
+    table = Table(title="Prime RL — Config Options")
+    table.add_column("Section", style="magenta")
+    table.add_column("Config", style="cyan")
+    table.add_column("Type", style="green")
+    table.add_column("Default", style="yellow")
+
+    prev_section = None
+    for path, type_str, default in rows:
+        section = path.rsplit(".", 1)[0] if "." in path else ""
+        name = path.rsplit(".", 1)[-1]
+        if prev_section is not None and section != prev_section:
+            table.add_section()
+        display_section = section if section != prev_section else ""
+        prev_section = section
+        table.add_row(display_section, name, type_str, default)
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use these in your TOML config file. "
+        "See 'prime rl init' to generate a template.[/dim]"
+    )
 
 
 def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> None:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -946,6 +946,28 @@ def list_models(
         raise typer.Exit(1)
 
 
+def _unwrap_single_schema_variant(prop: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the concrete schema when a field is an optional/single wrapped variant."""
+    if "anyOf" in prop:
+        non_null = [variant for variant in prop["anyOf"] if variant.get("type") != "null"]
+        if len(non_null) == 1:
+            return _unwrap_single_schema_variant(non_null[0])
+
+    if "allOf" in prop and len(prop["allOf"]) == 1:
+        return _unwrap_single_schema_variant(prop["allOf"][0])
+
+    return prop
+
+
+def _resolve_schema_ref(prop: Dict[str, Any], defs: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a local JSON schema ref into its concrete schema when possible."""
+    if "$ref" not in prop:
+        return prop
+
+    ref_name = prop["$ref"].rsplit("/", 1)[-1]
+    return defs.get(ref_name, prop)
+
+
 def _flatten_config_schema(
     schema: Dict[str, Any],
     defs: Dict[str, Any],
@@ -959,35 +981,22 @@ def _flatten_config_schema(
         if name in ("model_config", "env_file"):
             continue
         path = f"{prefix}{name}" if not prefix else f"{prefix}.{name}"
+        resolved = _resolve_schema_ref(_unwrap_single_schema_variant(prop), defs)
 
-        # Resolve $ref or anyOf with a single non-null $ref (optional nested models)
-        resolved = prop
-        if "$ref" in prop:
-            ref_name = prop["$ref"].rsplit("/", 1)[-1]
-            resolved = defs.get(ref_name, prop)
-        elif "anyOf" in prop:
-            non_null = [v for v in prop["anyOf"] if v.get("type") != "null"]
-            if len(non_null) == 1 and "$ref" in non_null[0]:
-                ref_name = non_null[0]["$ref"].rsplit("/", 1)[-1]
-                resolved = defs.get(ref_name, prop)
-
-        # If it's an object with properties, recurse
         if resolved.get("type") == "object" and "properties" in resolved:
             nested_rows.extend(_flatten_config_schema(resolved, defs, path))
             continue
 
-        # If it's an array of objects (like env), show as section hint
         if resolved.get("type") == "array":
-            items = resolved.get("items", {})
-            if "$ref" in items:
-                ref_name = items["$ref"].rsplit("/", 1)[-1]
-                items = defs.get(ref_name, items)
+            items = _resolve_schema_ref(
+                _unwrap_single_schema_variant(resolved.get("items", {})),
+                defs,
+            )
             if items.get("type") == "object" and "properties" in items:
                 nested_rows.extend(_flatten_config_schema(items, defs, f"{path}[]"))
                 continue
 
-        # Leaf field — extract type and default
-        type_str = _schema_type_str(resolved, defs)
+        type_str = _schema_type_str(prop, defs)
         default = str(prop.get("default", "")) if "default" in prop else ""
         leaf_rows.append((path, type_str, default))
 
@@ -996,24 +1005,33 @@ def _flatten_config_schema(
 
 def _schema_type_str(prop: Dict[str, Any], defs: Dict[str, Any]) -> str:
     """Produce a human-readable type string from a JSON schema property."""
+    unwrapped = _unwrap_single_schema_variant(prop)
+    if unwrapped is not prop:
+        return _schema_type_str(unwrapped, defs)
+
+    if "$ref" in prop:
+        return prop["$ref"].rsplit("/", 1)[-1]
+
     if "anyOf" in prop:
-        parts = []
-        for variant in prop["anyOf"]:
-            if variant.get("type") == "null":
-                continue
-            if "$ref" in variant:
-                ref_name = variant["$ref"].rsplit("/", 1)[-1]
-                parts.append(ref_name)
-            else:
-                parts.append(variant.get("type", "?"))
+        parts = [
+            _schema_type_str(variant, defs)
+            for variant in prop["anyOf"]
+            if variant.get("type") != "null"
+        ]
         return " | ".join(parts) if parts else "any"
-    if "allOf" in prop and len(prop["allOf"]) == 1 and "$ref" in prop["allOf"][0]:
-        ref_name = prop["allOf"][0]["$ref"].rsplit("/", 1)[-1]
-        return ref_name
+
+    if "allOf" in prop:
+        parts = [_schema_type_str(variant, defs) for variant in prop["allOf"]]
+        return " & ".join(part for part in parts if part) or "any"
+
     if prop.get("type") == "array":
-        items = prop.get("items", {})
-        inner = items.get("type", "any")
+        inner = _schema_type_str(prop.get("items", {}), defs)
         return f"list[{inner}]"
+
+    resolved = _resolve_schema_ref(prop, defs)
+    if resolved is not prop:
+        return _schema_type_str(resolved, defs)
+
     return prop.get("type", "any")
 
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -489,8 +489,6 @@ class RLConfig(BaseModel):
     max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
-    env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
-    env_files: List[str] = Field(default_factory=list)
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 import typer
-from prime_cli.commands.rl import generate_rl_config_template, load_config
+from prime_cli.commands.rl import (
+    RLConfig,
+    _flatten_config_schema,
+    generate_rl_config_template,
+    load_config,
+)
 
 
 def test_load_config_warns_and_ignores_deprecated_trajectory_strategy(
@@ -43,3 +48,23 @@ def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> N
 
     assert "# easy_threshold = 1.0" in template
     assert "# hard_threshold = 0.0" in template
+
+
+def test_flatten_config_schema_expands_optional_nested_models() -> None:
+    schema = RLConfig.model_json_schema()
+    rows = _flatten_config_schema(schema, schema.get("$defs", {}))
+    paths = {path for path, _, _ in rows}
+
+    assert "sampling.temp_scheduler.type" in paths
+    assert "sampling.temp_scheduler.start_temperature" in paths
+    assert "sampling.temp_scheduler" not in paths
+
+
+def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
+    schema = RLConfig.model_json_schema()
+    rows = {
+        path: type_str
+        for path, type_str, _ in _flatten_config_schema(schema, schema.get("$defs", {}))
+    }
+
+    assert rows["buffer.env_ratios"] == "list[number]"


### PR DESCRIPTION
Did not use prime-rl type descriptions because would lead to missing descriptions for hosted configs that are not options in prime-rl.  Should either have a server endpoint that returns all the expected types or rewrite all descriptions here.  Not great that there is no single source of truth.  But not priority for this PR, just showing the options is good.

## Summary
- Adds `prime rl configs` command that lists all available hosted RL config options
- Table groups options by TOML section with horizontal separators
- Derives everything from existing Pydantic models — no manual maintenance
- Supports `--output json`

<img width="560" height="829" alt="image" src="https://github.com/user-attachments/assets/afecfe6e-254a-42cc-8d50-73a93115e1a1" />


## Test plan
- [x] `prime rl configs` renders grouped table
- [x] `prime rl configs --output json` returns structured JSON
- [x] `prime rl configs --help` shows help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only CLI command that introspects the existing `RLConfig` Pydantic schema to display config options; main risk is incorrect schema flattening/type rendering for some edge cases.
> 
> **Overview**
> Adds a new `prime rl configs` CLI command to enumerate available RL TOML configuration keys, grouped by section in table output and optionally emitted as structured JSON (`--output json`).
> 
> Implements JSON-schema traversal utilities (`_flatten_config_schema`, `_schema_type_str`, ref/optional unwrapping) to derive dotted config paths, human-readable types, and defaults from `RLConfig` without manual maintenance, and adds tests covering optional nested models and optional array item type rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669f8b3ef927d7f429eb259268f6b5b7dc19bb80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->