### PR TITLE
fix personal image list

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -253,7 +253,8 @@ def list_images(
 
         # When in personal context (no team selected), filter to personal images only
         if not config.team_id and not all_images:
-            images = [img for img in images if img.get("ownerType") == "personal"]
+            images = [img for img in images if img.get("ownerType", "personal") == "personal"]
+            response["data"] = images
 
         if not images:
             console.print("[yellow]No images or builds found.[/yellow]")
@@ -261,7 +262,7 @@ def list_images(
             return
 
         if output == "json":
-            console.print(json.dumps({"data": images}, indent=2))
+            console.print(json.dumps(response, indent=2))
             return
 
         # Table output

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -251,13 +251,17 @@ def list_images(
         response = client.request("GET", "/images", params=params if params else None)
         images = response.get("data", [])
 
+        # When in personal context (no team selected), filter to personal images only
+        if not config.team_id and not all_images:
+            images = [img for img in images if img.get("ownerType") == "personal"]
+
         if not images:
             console.print("[yellow]No images or builds found.[/yellow]")
             console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
             return
 
         if output == "json":
-            console.print(json.dumps(response, indent=2))
+            console.print(json.dumps({"data": images}, indent=2))
             return
 
         # Table output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small CLI-only change that post-filters the `/images` response when no team is selected, affecting only listing behavior.
> 
> **Overview**
> Fixes `prime images list` so that in *personal context* (no `team_id` and without `--all`) it shows only personal images by filtering the API response to `ownerType == "personal"` before rendering JSON or table output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 003f9e09afa578b490f1c1367bd8874209ea8cff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->