### PR TITLE
feature: CLI queue support

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -49,6 +49,9 @@ class RLRun(BaseModel):
     wandb_project: Optional[str] = Field(None, alias="wandbProject")
     wandb_run_name: Optional[str] = Field(None, alias="wandbRunName")
 
+    # Queue info
+    runs_ahead: Optional[int] = Field(None, alias="runsAhead")
+
     # Timestamps
     started_at: Optional[datetime] = Field(None, alias="startedAt")
     completed_at: Optional[datetime] = Field(None, alias="completedAt")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -869,7 +869,7 @@ def create_run(
         if run.status == "QUEUED":
             queue_msg = "✓ Run created and queued"
             if run.runs_ahead is not None:
-                queue_msg += f" (#{run.runs_ahead + 1} in queue)"
+                queue_msg += f" (~{run.runs_ahead} runs ahead)"
             console.print(f"[yellow]{queue_msg}[/yellow]")
             console.print("[dim]The run will start automatically when capacity is available.[/dim]")
         else:
@@ -1063,7 +1063,7 @@ def get_run(
         console.print(f"[bold]Run {run_id}[/bold]\n")
         status_text = run.status
         if run.status == "QUEUED" and run.runs_ahead is not None:
-            status_text += f" (#{run.runs_ahead + 1} in queue)"
+            status_text += f" (~{run.runs_ahead} runs ahead)"
         console.print(f"  Status: [{status_color}]{status_text}[/{status_color}]")
         console.print(f"  Model: [magenta]{run.base_model}[/magenta]")
         console.print(f"  Environments: [green]{formatted['environments']}[/green]")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1234,13 +1234,13 @@ def get_logs(
 
                             last_lines = formatted_lines
                 except APIError as e:
-                    consecutive_errors += 1
                     if "404" in str(e) and (
                         "queued" in str(e).lower() or "pending" in str(e).lower()
                     ):
                         console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
                         time.sleep(10)
                         continue
+                    consecutive_errors += 1
                     if "429" in str(e):
                         if consecutive_errors >= 3:
                             console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -554,6 +554,7 @@ def load_config(path: str) -> RLConfig:
 
 # Status color mapping
 RUN_STATUS_COLORS = {
+    "QUEUED": "white",
     "PENDING": "yellow",
     "RUNNING": "green",
     "COMPLETED": "cyan",
@@ -865,14 +866,22 @@ def create_run(
             output_data_as_json({"run": run.model_dump()}, console)
             return
 
-        console.print("[green]✓ Run created successfully![/green]")
+        if run.status == "QUEUED":
+            queue_msg = "✓ Run created and queued"
+            if run.runs_ahead is not None:
+                queue_msg += f" (#{run.runs_ahead + 1} in queue)"
+            console.print(f"[yellow]{queue_msg}[/yellow]")
+            console.print("[dim]The run will start automatically when capacity is available.[/dim]")
+        else:
+            console.print("[green]✓ Run created successfully![/green]")
 
         dashboard_url = f"{app_config.frontend_url}/dashboard/training/{run.id}"
         console.print("\n[cyan]Monitor run at:[/cyan]")
         console.print(f"  [link={dashboard_url}]{dashboard_url}[/link]")
 
-        console.print("\n[dim]View logs with:[/dim]")
-        console.print(f"  prime rl logs {run.id} -f")
+        if run.status != "QUEUED":
+            console.print("\n[dim]View logs with:[/dim]")
+            console.print(f"  prime rl logs {run.id} -f")
 
     except ValidationError as e:
         console.print("[red]Configuration Error:[/red]")
@@ -1052,7 +1061,10 @@ def get_run(
         status_color = _get_status_color(run.status)
 
         console.print(f"[bold]Run {run_id}[/bold]\n")
-        console.print(f"  Status: [{status_color}]{run.status}[/{status_color}]")
+        status_text = run.status
+        if run.status == "QUEUED" and run.runs_ahead is not None:
+            status_text += f" (#{run.runs_ahead + 1} in queue)"
+        console.print(f"  Status: [{status_color}]{status_text}[/{status_color}]")
         console.print(f"  Model: [magenta]{run.base_model}[/magenta]")
         console.print(f"  Environments: [green]{formatted['environments']}[/green]")
         console.print(f"  Max Steps: {run.max_steps}")
@@ -1223,6 +1235,12 @@ def get_logs(
                             last_lines = formatted_lines
                 except APIError as e:
                     consecutive_errors += 1
+                    if "404" in str(e) and (
+                        "queued" in str(e).lower() or "pending" in str(e).lower()
+                    ):
+                        console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
+                        time.sleep(10)
+                        continue
                     if "429" in str(e):
                         if consecutive_errors >= 3:
                             console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
@@ -1251,6 +1269,11 @@ def get_logs(
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped watching logs.[/dim]")
     except APIError as e:
+        err_str = str(e).lower()
+        if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
+            msg = "Run has not started yet. Logs will be available once running."
+            console.print(f"[yellow]{msg}[/yellow]")
+            raise typer.Exit(0)
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 


### PR DESCRIPTION
Add queue awareness to the CLI for the new run queue system.

- Show queue position when a run is created as QUEUED
- Show queue position in rl get output
- Add QUEUED status color
- Handle 404 gracefully in rl logs for queued/pending runs
- Wait and retry in follow mode when run is queued

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CLI-only changes to display queued runs and handle missing logs more gracefully; no auth, data writes, or protocol changes beyond accepting an extra API field.
> 
> **Overview**
> Adds queue awareness to `prime rl` by accepting `runsAhead` on `RLRun` and treating `QUEUED` as a first-class status.
> 
> When creating or fetching a run, the CLI now shows queued state with an estimated queue position and avoids suggesting `prime rl logs` until the run starts. The `rl logs` command now handles queued/pending runs that return 404 by either exiting with a friendly message (non-follow) or waiting/retrying in follow mode, and `QUEUED` is included in the status color map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf91d27345eadd582162c647a0299b2ea3b5dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->