### PR TITLE
Fix images list showing team images in personal context

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -223,20 +223,15 @@ def push_image(
 @app.command("list", epilog=LIST_IMAGES_JSON_HELP)
 def list_images(
     output: str = typer.Option("table", "--output", "-o", help="Output format (table or json)"),
-    all_images: bool = typer.Option(
-        False, "--all", "-a", help="Show all accessible images (personal + team)"
-    ),
 ):
     """
     List all images you've pushed to Prime Intellect registry.
 
-    By default, shows images in the current context (personal or team).
-    Use --all to show all accessible images including team images.
+    Shows personal images by default, or team images when a team is configured.
 
     \b
     Examples:
         prime images list
-        prime images list --all
         prime images list --output json
     """
     validate_output_format(output, console)
@@ -245,10 +240,8 @@ def list_images(
 
         # Build query params
         params = {}
-        if config.team_id and not all_images:
+        if config.team_id:
             params["teamId"] = config.team_id
-        elif not config.team_id and not all_images:
-            params["scope"] = "personal"
 
         response = client.request("GET", "/images", params=params if params else None)
         images = response.get("data", [])
@@ -263,10 +256,8 @@ def list_images(
             return
 
         # Table output
-        if config.team_id and not all_images:
+        if config.team_id:
             title = f"Team Docker Images (team: {config.team_id})"
-        elif all_images:
-            title = "All Accessible Docker Images"
         else:
             title = "Personal Docker Images"
 

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -247,6 +247,8 @@ def list_images(
         params = {}
         if config.team_id and not all_images:
             params["teamId"] = config.team_id
+        elif not config.team_id and not all_images:
+            params["scope"] = "personal"
 
         response = client.request("GET", "/images", params=params if params else None)
         images = response.get("data", [])
@@ -261,11 +263,12 @@ def list_images(
             return
 
         # Table output
-        title = "Your Docker Images"
         if config.team_id and not all_images:
             title = f"Team Docker Images (team: {config.team_id})"
         elif all_images:
             title = "All Accessible Docker Images"
+        else:
+            title = "Personal Docker Images"
 
         # Group images by (owner, imageName, imageTag) to deduplicate rows.
         grouped: dict[str, list] = {}

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -223,6 +223,9 @@ def push_image(
 @app.command("list", epilog=LIST_IMAGES_JSON_HELP)
 def list_images(
     output: str = typer.Option("table", "--output", "-o", help="Output format (table or json)"),
+    all_images: bool = typer.Option(
+        False, "--all", "-a", help="[Deprecated] Show all accessible images (personal + team)"
+    ),
 ):
     """
     List all images you've pushed to Prime Intellect registry.
@@ -234,6 +237,13 @@ def list_images(
         prime images list
         prime images list --output json
     """
+    if all_images:
+        console.print(
+            "[yellow]Warning: --all flag is deprecated and will be removed in a future release. "
+            "Images are now scoped to your current context (personal or team).[/yellow]"
+        )
+        console.print()
+
     validate_output_format(output, console)
     try:
         client = APIClient()

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -237,14 +237,14 @@ def list_images(
         prime images list
         prime images list --output json
     """
-    if all_images:
+    validate_output_format(output, console)
+
+    if all_images and output != "json":
         console.print(
             "[yellow]Warning: --all flag is deprecated and will be removed in a future release. "
             "Images are now scoped to your current context (personal or team).[/yellow]"
         )
         console.print()
-
-    validate_output_format(output, console)
     try:
         client = APIClient()
 


### PR DESCRIPTION
## Summary


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI behavior change limited to `prime images list`, though it may surprise users who relied on `--all` to see cross-context results.
> 
> **Overview**
> `prime images list` now always scopes results to the current context: personal by default, or the configured team via `teamId` when `config.team_id` is set (instead of conditionally depending on `--all`).
> 
> The `--all` flag is marked *deprecated* and prints a warning (for non-JSON output), and the table title/help text were updated to reflect the new context-scoped behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83da1483789f6ea6af6c9b59343dde3794000aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->