### PR TITLE
Add run_config passthrough for orchestrator settings

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -143,6 +143,7 @@ class RLClient:
         checkpoint_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
         infrastructure_config: Optional[Dict[str, Any]] = None,
+        run_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -234,6 +235,9 @@ class RLClient:
             if infrastructure_config:
                 if "compute_size" in infrastructure_config:
                     payload["compute_size"] = infrastructure_config["compute_size"]
+
+            if run_config:
+                payload["run_config"] = run_config
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -498,6 +498,7 @@ class RLConfig(BaseModel):
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
+    run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
 
@@ -709,6 +710,8 @@ def create_run(
             console.print(f"  Oversampling Factor: {cfg.oversampling_factor}")
         if cfg.max_async_level is not None:
             console.print(f"  Max Async Level:     {cfg.max_async_level}")
+        if cfg.run_config:
+            console.print(f"  Run Config:          {cfg.run_config}")
 
         # Sampling
         has_sampling = (
@@ -860,6 +863,7 @@ def create_run(
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
+            run_config=cfg.run_config if cfg.run_config else None,
         )
 
         if output == "json":


### PR DESCRIPTION
## Summary
- Expose `[run_config]` TOML section for passing arbitrary orchestrator CLI args to hosted training
- The backend already supports `runConfig` as a freeform dict converted to CLI args — this just wires it up in the CLI
- Enables settings like `use_token_client`, `max_concurrent`, `filters`, `advantage`, etc. that aren't first-class CLI fields

## Usage
```toml
model = "Qwen/Qwen3-4B-Thinking-2507"
batch_size = 256

[run_config]
use_token_client = false
max_concurrent = 512
```

## Test plan
- [ ] `prime rl run` with `[run_config]` section parses without error
- [ ] Verify `runConfig` appears in API payload
- [ ] Verify orchestrator receives the extra CLI args

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a freeform `run_config` dict to the RL run config and forwards it to the `/rft/runs` payload, which can change orchestrator behavior and potentially cause unexpected run failures if misconfigured.
> 
> **Overview**
> **Adds support for a freeform `run_config` section in `prime rl run` configs.** The CLI now parses `run_config`, prints it in the training config preview, and passes it through to `RLClient.create_run` so it is included as `run_config` in the `/rft/runs` request payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d3de4e80869b7d3eac1e97e2172168a5f06445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->