### PR TITLE
Relax eval inference preflight timeouts

### DIFF
--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -16,13 +16,6 @@ class InferencePaymentRequiredError(InferenceAPIError):
     pass
 
 
-class InferenceTimeoutError(InferenceAPIError):
-    pass
-
-
-RequestTimeout = float | httpx.Timeout | None
-
-
 def _extract_error_message(response: httpx.Response) -> str:
     text = response.text.strip()
     return text or response.reason_phrase or "Unknown error"
@@ -48,6 +41,7 @@ class InferenceClient:
         api_key: Optional[str] = None,
         team_id: Optional[str] = None,
         inference_url: Optional[str] = None,
+        timeout: Optional[float | httpx.Timeout] = None,
     ) -> None:
         # Load config
         self.config = Config()
@@ -71,17 +65,14 @@ class InferenceClient:
 
         self._client = httpx.Client(
             headers=headers,
-            timeout=httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0),
+            timeout=timeout or httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0),
         )
 
-    def list_models(self, timeout: RequestTimeout = None) -> Dict[str, Any]:
+    def list_models(self) -> Dict[str, Any]:
         url = f"{self.inference_url}/models"
-        request_kwargs = {"timeout": timeout} if timeout is not None else {}
+        resp = self._client.get(url)
         try:
-            resp = self._client.get(url, **request_kwargs)
             resp.raise_for_status()
-        except httpx.TimeoutException as e:
-            raise InferenceTimeoutError(f"GET {url} timed out") from e
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             message = _extract_error_message(e.response)
@@ -92,14 +83,11 @@ class InferenceClient:
             raise InferenceAPIError(f"GET {url} failed: {status} {message}") from e
         return resp.json()
 
-    def retrieve_model(self, model_id: str, timeout: RequestTimeout = None) -> Dict[str, Any]:
+    def retrieve_model(self, model_id: str) -> Dict[str, Any]:
         url = f"{self.inference_url}/models/{model_id}"
-        request_kwargs = {"timeout": timeout} if timeout is not None else {}
+        resp = self._client.get(url)
         try:
-            resp = self._client.get(url, **request_kwargs)
             resp.raise_for_status()
-        except httpx.TimeoutException as e:
-            raise InferenceTimeoutError(f"GET {url} timed out") from e
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             message = _extract_error_message(e.response)
@@ -116,20 +104,14 @@ class InferenceClient:
         return resp.json()
 
     def chat_completion(
-        self,
-        payload: Dict[str, Any],
-        stream: bool = False,
-        timeout: RequestTimeout = None,
+        self, payload: Dict[str, Any], stream: bool = False
     ) -> Dict[str, Any] | Iterable[Dict[str, Any]]:
         url = f"{self.inference_url}/chat/completions"
-        request_kwargs = {"timeout": timeout} if timeout is not None else {}
 
         if not stream:
+            resp = self._client.post(url, json=payload)
             try:
-                resp = self._client.post(url, json=payload, **request_kwargs)
                 resp.raise_for_status()
-            except httpx.TimeoutException as e:
-                raise InferenceTimeoutError(f"POST {url} timed out") from e
             except httpx.HTTPStatusError as e:
                 status = e.response.status_code
                 message = _extract_error_message(e.response)
@@ -142,39 +124,36 @@ class InferenceClient:
 
         # Streamed (SSE-style: lines prefixed with 'data: ')
         def _stream() -> Iterator[Dict[str, Any]]:
-            try:
-                with self._client.stream("POST", url, json=payload, **request_kwargs) as r:
-                    try:
-                        r.raise_for_status()
-                    except httpx.HTTPStatusError as e:
-                        e.response.read()
-                        status = e.response.status_code
-                        message = _extract_error_message(e.response)
-                        if status == 402:
-                            raise InferencePaymentRequiredError(
-                                f"Payment required. {_extract_payment_error_message(e.response)}"
-                            ) from e
-                        raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
-                    for line in r.iter_lines():
-                        if not line:
-                            continue
-                        if line.startswith("data: "):
-                            data = line[6:].strip()
-                        else:
-                            # Some servers don't prefix; try parsing anyway
-                            data = line.strip()
+            with self._client.stream("POST", url, json=payload) as r:
+                try:
+                    r.raise_for_status()
+                except httpx.HTTPStatusError as e:
+                    e.response.read()
+                    status = e.response.status_code
+                    message = _extract_error_message(e.response)
+                    if status == 402:
+                        raise InferencePaymentRequiredError(
+                            f"Payment required. {_extract_payment_error_message(e.response)}"
+                        ) from e
+                    raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
+                for line in r.iter_lines():
+                    if not line:
+                        continue
+                    if line.startswith("data: "):
+                        data = line[6:].strip()
+                    else:
+                        # Some servers don't prefix; try parsing anyway
+                        data = line.strip()
 
-                        if not data or data == "[DONE]":
-                            if data == "[DONE]":
-                                return
-                            continue
-                        try:
-                            chunk = json.loads(data)
-                            yield chunk
-                        except json.JSONDecodeError:
-                            # Skip unparsable lines quietly
-                            continue
-            except httpx.TimeoutException as e:
-                raise InferenceTimeoutError(f"POST {url} timed out") from e
+                    if not data or data == "[DONE]":
+                        if data == "[DONE]":
+                            return
+                        continue
+                    try:
+                        chunk = json.loads(data)
+                        yield chunk
+                    except json.JSONDecodeError:
+                        # Skip unparsable lines quietly
+                        continue
 
         return _stream()

--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -16,6 +16,13 @@ class InferencePaymentRequiredError(InferenceAPIError):
     pass
 
 
+class InferenceTimeoutError(InferenceAPIError):
+    pass
+
+
+RequestTimeout = float | httpx.Timeout | None
+
+
 def _extract_error_message(response: httpx.Response) -> str:
     text = response.text.strip()
     return text or response.reason_phrase or "Unknown error"
@@ -67,11 +74,14 @@ class InferenceClient:
             timeout=httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0),
         )
 
-    def list_models(self) -> Dict[str, Any]:
+    def list_models(self, timeout: RequestTimeout = None) -> Dict[str, Any]:
         url = f"{self.inference_url}/models"
-        resp = self._client.get(url)
+        request_kwargs = {"timeout": timeout} if timeout is not None else {}
         try:
+            resp = self._client.get(url, **request_kwargs)
             resp.raise_for_status()
+        except httpx.TimeoutException as e:
+            raise InferenceTimeoutError(f"GET {url} timed out") from e
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             message = _extract_error_message(e.response)
@@ -82,11 +92,14 @@ class InferenceClient:
             raise InferenceAPIError(f"GET {url} failed: {status} {message}") from e
         return resp.json()
 
-    def retrieve_model(self, model_id: str) -> Dict[str, Any]:
+    def retrieve_model(self, model_id: str, timeout: RequestTimeout = None) -> Dict[str, Any]:
         url = f"{self.inference_url}/models/{model_id}"
-        resp = self._client.get(url)
+        request_kwargs = {"timeout": timeout} if timeout is not None else {}
         try:
+            resp = self._client.get(url, **request_kwargs)
             resp.raise_for_status()
+        except httpx.TimeoutException as e:
+            raise InferenceTimeoutError(f"GET {url} timed out") from e
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             message = _extract_error_message(e.response)
@@ -103,14 +116,20 @@ class InferenceClient:
         return resp.json()
 
     def chat_completion(
-        self, payload: Dict[str, Any], stream: bool = False
+        self,
+        payload: Dict[str, Any],
+        stream: bool = False,
+        timeout: RequestTimeout = None,
     ) -> Dict[str, Any] | Iterable[Dict[str, Any]]:
         url = f"{self.inference_url}/chat/completions"
+        request_kwargs = {"timeout": timeout} if timeout is not None else {}
 
         if not stream:
-            resp = self._client.post(url, json=payload)
             try:
+                resp = self._client.post(url, json=payload, **request_kwargs)
                 resp.raise_for_status()
+            except httpx.TimeoutException as e:
+                raise InferenceTimeoutError(f"POST {url} timed out") from e
             except httpx.HTTPStatusError as e:
                 status = e.response.status_code
                 message = _extract_error_message(e.response)
@@ -123,36 +142,39 @@ class InferenceClient:
 
         # Streamed (SSE-style: lines prefixed with 'data: ')
         def _stream() -> Iterator[Dict[str, Any]]:
-            with self._client.stream("POST", url, json=payload) as r:
-                try:
-                    r.raise_for_status()
-                except httpx.HTTPStatusError as e:
-                    e.response.read()
-                    status = e.response.status_code
-                    message = _extract_error_message(e.response)
-                    if status == 402:
-                        raise InferencePaymentRequiredError(
-                            f"Payment required. {_extract_payment_error_message(e.response)}"
-                        ) from e
-                    raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
-                for line in r.iter_lines():
-                    if not line:
-                        continue
-                    if line.startswith("data: "):
-                        data = line[6:].strip()
-                    else:
-                        # Some servers don't prefix; try parsing anyway
-                        data = line.strip()
-
-                    if not data or data == "[DONE]":
-                        if data == "[DONE]":
-                            return
-                        continue
+            try:
+                with self._client.stream("POST", url, json=payload, **request_kwargs) as r:
                     try:
-                        chunk = json.loads(data)
-                        yield chunk
-                    except json.JSONDecodeError:
-                        # Skip unparsable lines quietly
-                        continue
+                        r.raise_for_status()
+                    except httpx.HTTPStatusError as e:
+                        e.response.read()
+                        status = e.response.status_code
+                        message = _extract_error_message(e.response)
+                        if status == 402:
+                            raise InferencePaymentRequiredError(
+                                f"Payment required. {_extract_payment_error_message(e.response)}"
+                            ) from e
+                        raise InferenceAPIError(f"POST {url} failed: {status} {message}") from e
+                    for line in r.iter_lines():
+                        if not line:
+                            continue
+                        if line.startswith("data: "):
+                            data = line[6:].strip()
+                        else:
+                            # Some servers don't prefix; try parsing anyway
+                            data = line.strip()
+
+                        if not data or data == "[DONE]":
+                            if data == "[DONE]":
+                                return
+                            continue
+                        try:
+                            chunk = json.loads(data)
+                            yield chunk
+                        except json.JSONDecodeError:
+                            # Skip unparsable lines quietly
+                            continue
+            except httpx.TimeoutException as e:
+                raise InferenceTimeoutError(f"POST {url} timed out") from e
 
         return _stream()

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -12,12 +12,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+import httpx
 import toml
 import typer
 
 from prime_cli.core import Config
 
-from .api.inference import InferenceAPIError, InferenceClient, InferencePaymentRequiredError
+from .api.inference import (
+    InferenceAPIError,
+    InferenceClient,
+    InferencePaymentRequiredError,
+    InferenceTimeoutError,
+)
 from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
 from .utils.eval_push import push_eval_results_to_hub
@@ -30,6 +36,7 @@ DEFAULT_MODEL = "openai/gpt-4.1-mini"
 DEFAULT_ENV_DIR_PATH = "./environments"
 PRIME_SLUG = "primeintellect"
 INTERNAL_ENV_DISPLAY_HEADER = "X-Prime-Eval-Env-Display"
+EVAL_PREFLIGHT_TIMEOUT = httpx.Timeout(connect=10.0, read=1800.0, write=60.0, pool=60.0)
 MODULE_TO_PRIME_COMMAND = {
     "verifiers.cli.commands.eval": "prime eval run",
     "verifiers.cli.commands.gepa": "prime gepa run",
@@ -785,7 +792,13 @@ def _validate_model(model: str, inference_base_url: str, configured_base_url: st
         return
     client = InferenceClient()
     try:
-        client.retrieve_model(model)
+        client.retrieve_model(model, timeout=EVAL_PREFLIGHT_TIMEOUT)
+    except InferenceTimeoutError:
+        console.print(
+            f"[yellow]Timed out validating model '{model}' during eval preflight.[/yellow] "
+            "Continuing anyway because some thinking models take longer to warm up."
+        )
+        return
     except InferenceAPIError as exc:
         console.print(
             f"[red]Invalid model:[/red] {exc} \n\n"
@@ -806,8 +819,15 @@ def _preflight_inference_billing(
             {
                 "model": model,
                 "messages": [{"role": "user", "content": "Reply with OK."}],
-            }
+            },
+            timeout=EVAL_PREFLIGHT_TIMEOUT,
         )
+    except InferenceTimeoutError:
+        console.print(
+            f"[yellow]Timed out running the inference preflight probe for '{model}'.[/yellow] "
+            "Continuing anyway because some thinking models take longer to warm up."
+        )
+        return
     except InferencePaymentRequiredError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1) from exc

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -18,12 +18,7 @@ import typer
 
 from prime_cli.core import Config
 
-from .api.inference import (
-    InferenceAPIError,
-    InferenceClient,
-    InferencePaymentRequiredError,
-    InferenceTimeoutError,
-)
+from .api.inference import InferenceAPIError, InferenceClient, InferencePaymentRequiredError
 from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
 from .utils.eval_push import push_eval_results_to_hub
@@ -790,10 +785,10 @@ def _add_default_inference_and_key_args(
 def _validate_model(model: str, inference_base_url: str, configured_base_url: str) -> None:
     if inference_base_url != configured_base_url:
         return
-    client = InferenceClient()
+    client = InferenceClient(timeout=EVAL_PREFLIGHT_TIMEOUT)
     try:
-        client.retrieve_model(model, timeout=EVAL_PREFLIGHT_TIMEOUT)
-    except InferenceTimeoutError:
+        client.retrieve_model(model)
+    except httpx.TimeoutException:
         console.print(
             f"[yellow]Timed out validating model '{model}' during eval preflight.[/yellow] "
             "Continuing anyway because some thinking models take longer to warm up."
@@ -813,16 +808,15 @@ def _preflight_inference_billing(
     if inference_base_url != configured_base_url:
         return
 
-    client = InferenceClient()
+    client = InferenceClient(timeout=EVAL_PREFLIGHT_TIMEOUT)
     try:
         client.chat_completion(
             {
                 "model": model,
                 "messages": [{"role": "user", "content": "Reply with OK."}],
-            },
-            timeout=EVAL_PREFLIGHT_TIMEOUT,
+            }
         )
-    except InferenceTimeoutError:
+    except httpx.TimeoutException:
         console.print(
             f"[yellow]Timed out running the inference preflight probe for '{model}'.[/yellow] "
             "Continuing anyway because some thinking models take longer to warm up."

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -36,7 +36,7 @@ DEFAULT_MODEL = "openai/gpt-4.1-mini"
 DEFAULT_ENV_DIR_PATH = "./environments"
 PRIME_SLUG = "primeintellect"
 INTERNAL_ENV_DISPLAY_HEADER = "X-Prime-Eval-Env-Display"
-EVAL_PREFLIGHT_TIMEOUT = httpx.Timeout(connect=10.0, read=1800.0, write=60.0, pool=60.0)
+EVAL_PREFLIGHT_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=60.0)
 MODULE_TO_PRIME_COMMAND = {
     "verifiers.cli.commands.eval": "prime eval run",
     "verifiers.cli.commands.gepa": "prime gepa run",

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -140,7 +140,7 @@ def test_eval_preflight_omits_max_tokens(monkeypatch):
         }
     ]
     assert len(seen_timeouts) == 1
-    assert seen_timeouts[0].read == 1800.0
+    assert seen_timeouts[0].read == 300.0
 
 
 def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
@@ -178,7 +178,7 @@ def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
 
     assert exc_info.value.exit_code == 0
     assert len(seen_model_timeouts) == 1
-    assert seen_model_timeouts[0].read == 1800.0
+    assert seen_model_timeouts[0].read == 300.0
 
 
 def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
@@ -218,7 +218,7 @@ def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
 
     assert exc_info.value.exit_code == 0
     assert len(seen_billing_timeouts) == 1
-    assert seen_billing_timeouts[0].read == 1800.0
+    assert seen_billing_timeouts[0].read == 300.0
 
 
 def test_inference_client_maps_timeout_to_inference_timeout_error():

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -5,6 +5,7 @@ from prime_cli.api.inference import (
     InferenceAPIError,
     InferenceClient,
     InferencePaymentRequiredError,
+    InferenceTimeoutError,
 )
 from prime_cli.verifiers_bridge import run_eval_passthrough
 
@@ -74,10 +75,10 @@ def test_eval_run_blocks_when_inference_billing_is_missing(monkeypatch, error_me
     monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        lambda self, model: {"id": model},
+        lambda self, model, timeout=None: {"id": model},
     )
 
-    def fake_chat_completion(self, payload, stream=False):
+    def fake_chat_completion(self, payload, stream=False, timeout=None):
         raise InferencePaymentRequiredError(error_message)
 
     monkeypatch.setattr(
@@ -103,13 +104,15 @@ def test_eval_preflight_omits_max_tokens(monkeypatch):
     monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        lambda self, model: {"id": model},
+        lambda self, model, timeout=None: {"id": model},
     )
 
     seen_payloads = []
+    seen_timeouts = []
 
-    def fake_chat_completion(self, payload, stream=False):
+    def fake_chat_completion(self, payload, stream=False, timeout=None):
         seen_payloads.append(payload)
+        seen_timeouts.append(timeout)
         return {"id": "cmpl-123", "choices": []}
 
     monkeypatch.setattr(
@@ -136,6 +139,100 @@ def test_eval_preflight_omits_max_tokens(monkeypatch):
             "messages": [{"role": "user", "content": "Reply with OK."}],
         }
     ]
+    assert len(seen_timeouts) == 1
+    assert seen_timeouts[0].read == 1800.0
+
+
+def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+
+    seen_model_timeouts = []
+
+    def fake_retrieve_model(self, model, timeout=None):
+        seen_model_timeouts.append(timeout)
+        raise InferenceTimeoutError("GET https://api.pinference.ai/api/v1/models/foo timed out")
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
+        fake_retrieve_model,
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
+        lambda self, payload, stream=False, timeout=None: {"id": "cmpl-123", "choices": []},
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="single_turn_math",
+            passthrough_args=["-m", "moonshotai/kimi-k2.5"],
+            skip_upload=False,
+            env_path=None,
+        )
+
+    assert exc_info.value.exit_code == 0
+    assert len(seen_model_timeouts) == 1
+    assert seen_model_timeouts[0].read == 1800.0
+
+
+def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
+        lambda self, model, timeout=None: {"id": model},
+    )
+
+    seen_billing_timeouts = []
+
+    def fake_chat_completion(self, payload, stream=False, timeout=None):
+        seen_billing_timeouts.append(timeout)
+        raise InferenceTimeoutError(
+            "POST https://api.pinference.ai/api/v1/chat/completions timed out"
+        )
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
+        fake_chat_completion,
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        run_eval_passthrough(
+            environment="single_turn_math",
+            passthrough_args=["-m", "moonshotai/kimi-k2.5"],
+            skip_upload=False,
+            env_path=None,
+        )
+
+    assert exc_info.value.exit_code == 0
+    assert len(seen_billing_timeouts) == 1
+    assert seen_billing_timeouts[0].read == 1800.0
+
+
+def test_inference_client_maps_timeout_to_inference_timeout_error():
+    client = InferenceClient.__new__(InferenceClient)
+    client.inference_url = "https://api.pinference.ai/api/v1"
+
+    class DummyHTTPClient:
+        def get(self, url, **kwargs):
+            raise httpx.ReadTimeout("timed out")
+
+    client._client = DummyHTTPClient()
+
+    with pytest.raises(InferenceTimeoutError, match="GET .* timed out"):
+        client.retrieve_model("moonshotai/kimi-k2.5")
 
 
 def test_streaming_error_reads_response_before_formatting(monkeypatch):

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -5,7 +5,6 @@ from prime_cli.api.inference import (
     InferenceAPIError,
     InferenceClient,
     InferencePaymentRequiredError,
-    InferenceTimeoutError,
 )
 from prime_cli.verifiers_bridge import run_eval_passthrough
 
@@ -73,18 +72,18 @@ def test_eval_run_blocks_when_inference_billing_is_missing(monkeypatch, error_me
         "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
     )
     monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        lambda self, model, timeout=None: {"id": model},
-    )
 
-    def fake_chat_completion(self, payload, stream=False, timeout=None):
-        raise InferencePaymentRequiredError(error_message)
+    class DummyInferenceClient:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
 
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
-        fake_chat_completion,
-    )
+        def retrieve_model(self, model):
+            return {"id": model}
+
+        def chat_completion(self, payload, stream=False):
+            raise InferencePaymentRequiredError(error_message)
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge.InferenceClient", DummyInferenceClient)
 
     with pytest.raises(typer.Exit) as exc_info:
         run_eval_passthrough(
@@ -102,23 +101,21 @@ def test_eval_preflight_omits_max_tokens(monkeypatch):
         "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
     )
     monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        lambda self, model, timeout=None: {"id": model},
-    )
-
     seen_payloads = []
     seen_timeouts = []
 
-    def fake_chat_completion(self, payload, stream=False, timeout=None):
-        seen_payloads.append(payload)
-        seen_timeouts.append(timeout)
-        return {"id": "cmpl-123", "choices": []}
+    class DummyInferenceClient:
+        def __init__(self, timeout=None):
+            seen_timeouts.append(timeout)
 
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
-        fake_chat_completion,
-    )
+        def retrieve_model(self, model):
+            return {"id": model}
+
+        def chat_completion(self, payload, stream=False):
+            seen_payloads.append(payload)
+            return {"id": "cmpl-123", "choices": []}
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge.InferenceClient", DummyInferenceClient)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
         lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
@@ -139,8 +136,8 @@ def test_eval_preflight_omits_max_tokens(monkeypatch):
             "messages": [{"role": "user", "content": "Reply with OK."}],
         }
     ]
-    assert len(seen_timeouts) == 1
-    assert seen_timeouts[0].read == 300.0
+    assert len(seen_timeouts) == 2
+    assert all(timeout.read == 300.0 for timeout in seen_timeouts)
 
 
 def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
@@ -151,18 +148,17 @@ def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
 
     seen_model_timeouts = []
 
-    def fake_retrieve_model(self, model, timeout=None):
-        seen_model_timeouts.append(timeout)
-        raise InferenceTimeoutError("GET https://api.pinference.ai/api/v1/models/foo timed out")
+    class DummyInferenceClient:
+        def __init__(self, timeout=None):
+            seen_model_timeouts.append(timeout)
 
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        fake_retrieve_model,
-    )
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
-        lambda self, payload, stream=False, timeout=None: {"id": "cmpl-123", "choices": []},
-    )
+        def retrieve_model(self, model):
+            raise httpx.ReadTimeout("timed out")
+
+        def chat_completion(self, payload, stream=False):
+            return {"id": "cmpl-123", "choices": []}
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge.InferenceClient", DummyInferenceClient)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
         lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
@@ -177,7 +173,7 @@ def test_eval_run_continues_when_model_validation_times_out(monkeypatch):
         )
 
     assert exc_info.value.exit_code == 0
-    assert len(seen_model_timeouts) == 1
+    assert len(seen_model_timeouts) == 2
     assert seen_model_timeouts[0].read == 300.0
 
 
@@ -186,23 +182,20 @@ def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
         "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
     )
     monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.retrieve_model",
-        lambda self, model, timeout=None: {"id": model},
-    )
 
     seen_billing_timeouts = []
 
-    def fake_chat_completion(self, payload, stream=False, timeout=None):
-        seen_billing_timeouts.append(timeout)
-        raise InferenceTimeoutError(
-            "POST https://api.pinference.ai/api/v1/chat/completions timed out"
-        )
+    class DummyInferenceClient:
+        def __init__(self, timeout=None):
+            seen_billing_timeouts.append(timeout)
 
-    monkeypatch.setattr(
-        "prime_cli.verifiers_bridge.InferenceClient.chat_completion",
-        fake_chat_completion,
-    )
+        def retrieve_model(self, model):
+            return {"id": model}
+
+        def chat_completion(self, payload, stream=False):
+            raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge.InferenceClient", DummyInferenceClient)
     monkeypatch.setattr(
         "prime_cli.verifiers_bridge._prepare_single_environment",
         lambda *args, **kwargs: (_ for _ in ()).throw(typer.Exit(0)),
@@ -217,22 +210,16 @@ def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
         )
 
     assert exc_info.value.exit_code == 0
-    assert len(seen_billing_timeouts) == 1
-    assert seen_billing_timeouts[0].read == 300.0
+    assert len(seen_billing_timeouts) == 2
+    assert seen_billing_timeouts[1].read == 300.0
 
 
-def test_inference_client_maps_timeout_to_inference_timeout_error():
-    client = InferenceClient.__new__(InferenceClient)
-    client.inference_url = "https://api.pinference.ai/api/v1"
+def test_inference_client_uses_custom_timeout(monkeypatch):
+    monkeypatch.setattr("prime_cli.api.inference.Config", lambda: DummyConfig())
 
-    class DummyHTTPClient:
-        def get(self, url, **kwargs):
-            raise httpx.ReadTimeout("timed out")
+    client = InferenceClient(timeout=httpx.Timeout(connect=5.0, read=7.0, write=9.0, pool=11.0))
 
-    client._client = DummyHTTPClient()
-
-    with pytest.raises(InferenceTimeoutError, match="GET .* timed out"):
-        client.retrieve_model("moonshotai/kimi-k2.5")
+    assert client._client.timeout.read == 7.0
 
 
 def test_streaming_error_reads_response_before_formatting(monkeypatch):


### PR DESCRIPTION
## Summary
- add explicit inference timeout handling so eval preflight failures surface cleanly instead of crashing with a raw httpx timeout
- increase the Prime eval preflight timeout to 5 minutes and make timeouted model/billing probes warning-only so slow thinking models can still start
- add regression coverage for the longer preflight timeout and timeout fallback paths

## Testing
- pytest packages/prime/tests/test_eval_billing.py -q
- pytest packages/prime/tests/test_hosted_eval.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval preflight behavior by passing custom HTTP timeouts into `InferenceClient` and treating timeout failures as warnings, which could allow eval runs to proceed with an invalid/unwarmed model. Risk is limited to CLI UX/flow and is covered by added tests.
> 
> **Overview**
> Relaxes `prime eval` inference preflight by introducing a dedicated `EVAL_PREFLIGHT_TIMEOUT` and wiring it through to `InferenceClient`, rather than using the default client timeout.
> 
> Model validation and billing-probe preflights now catch `httpx.TimeoutException` and continue with a warning instead of crashing/failing the run.
> 
> Updates tests to stub `InferenceClient` construction, assert the preflight timeout is passed through, and adds regression coverage for the timeout-continue paths and custom client timeout support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d61392f834c9d8992d4830be5fb4e2cb220189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->