### PR TITLE
Release prime CLI 0.5.60

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.59"
+__version__ = "0.5.60"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- bump prime CLI version to 0.5.60
- includes the merged eval preflight timeout fix for slow thinking models

## Notes
- release workflow tags and publishes from the version in packages/prime/src/prime_cli/__init__.py after this PR merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the published package version string and does not change runtime behavior.
> 
> **Overview**
> **Release bump only.** Updates `prime_cli.__version__` from `0.5.59` to `0.5.60` to drive the release/tagging workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92420d7e432ca40644a372f7c24544fd96da421c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->