### PR TITLE
fix: prevent dependency confusion in package install

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1971,7 +1971,7 @@ def info(
                 if target_version and target_version != "latest":
                     console.print(
                         f"  [green]$[/green] uv pip install {normalized_name}=={target_version} "
-                        f"--extra-index-url {simple_index_url}"
+                        f"--index-url {simple_index_url}"
                     )
                     console.print(
                         f"  [green]$[/green] uv add {normalized_name}=={target_version} "
@@ -1979,19 +1979,19 @@ def info(
                     )
                     console.print(
                         f"  [green]$[/green] pip install {normalized_name}=={target_version} "
-                        f"--extra-index-url {simple_index_url}"
+                        f"--index-url {simple_index_url}"
                     )
                 else:
                     console.print(
                         f"  [green]$[/green] uv pip install {normalized_name} "
-                        f"--extra-index-url {simple_index_url}"
+                        f"--index-url {simple_index_url}"
                     )
                     console.print(
                         f"  [green]$[/green] uv add {normalized_name} --index {simple_index_url}"
                     )
                     console.print(
                         f"  [green]$[/green] pip install {normalized_name} "
-                        f"--extra-index-url {simple_index_url}"
+                        f"--index-url {simple_index_url}"
                     )
             elif wheel_url:
                 console.print(f"  [green]$[/green] uv pip install {wheel_url}")
@@ -2939,7 +2939,7 @@ def _build_install_command(
             # Add URL dependencies as direct requirements (uv requires this)
             if url_dependencies:
                 cmd.extend(url_dependencies)
-            cmd.extend(["--extra-index-url", simple_index_url])
+            cmd.extend(["--index-url", simple_index_url])
             return cmd
         else:  # pip
             cmd = ["pip", "install"]
@@ -2952,7 +2952,7 @@ def _build_install_command(
             # Add URL dependencies for consistency
             if url_dependencies:
                 cmd.extend(url_dependencies)
-            cmd.extend(["--extra-index-url", simple_index_url])
+            cmd.extend(["--index-url", simple_index_url])
             return cmd
     elif wheel_url:
         try:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1971,7 +1971,7 @@ def info(
                 if target_version and target_version != "latest":
                     console.print(
                         f"  [green]$[/green] uv pip install {normalized_name}=={target_version} "
-                        f"--index-url {simple_index_url}"
+                        f"--index-url {simple_index_url} --extra-index-url https://pypi.org/simple/"
                     )
                     console.print(
                         f"  [green]$[/green] uv add {normalized_name}=={target_version} "
@@ -1979,19 +1979,19 @@ def info(
                     )
                     console.print(
                         f"  [green]$[/green] pip install {normalized_name}=={target_version} "
-                        f"--index-url {simple_index_url}"
+                        f"--index-url {simple_index_url} --extra-index-url https://pypi.org/simple/"
                     )
                 else:
                     console.print(
                         f"  [green]$[/green] uv pip install {normalized_name} "
-                        f"--index-url {simple_index_url}"
+                        f"--index-url {simple_index_url} --extra-index-url https://pypi.org/simple/"
                     )
                     console.print(
                         f"  [green]$[/green] uv add {normalized_name} --index {simple_index_url}"
                     )
                     console.print(
                         f"  [green]$[/green] pip install {normalized_name} "
-                        f"--index-url {simple_index_url}"
+                        f"--index-url {simple_index_url} --extra-index-url https://pypi.org/simple/"
                     )
             elif wheel_url:
                 console.print(f"  [green]$[/green] uv pip install {wheel_url}")
@@ -2939,7 +2939,9 @@ def _build_install_command(
             # Add URL dependencies as direct requirements (uv requires this)
             if url_dependencies:
                 cmd.extend(url_dependencies)
-            cmd.extend(["--index-url", simple_index_url])
+            cmd.extend(
+                ["--index-url", simple_index_url, "--extra-index-url", "https://pypi.org/simple/"]
+            )
             return cmd
         else:  # pip
             cmd = ["pip", "install"]
@@ -2952,7 +2954,9 @@ def _build_install_command(
             # Add URL dependencies for consistency
             if url_dependencies:
                 cmd.extend(url_dependencies)
-            cmd.extend(["--index-url", simple_index_url])
+            cmd.extend(
+                ["--index-url", simple_index_url, "--extra-index-url", "https://pypi.org/simple/"]
+            )
             return cmd
     elif wheel_url:
         try:


### PR DESCRIPTION
Replace --extra-index-url with --index-url when installing from the Prime package index.

- Prevents dependency confusion attacks where a same-name package on PyPI could be used instead of the intended private package
- Updates both the install command builder and the display hints shown to users
- uv add --index usage is unchanged (already correct)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package installation flags for `pip`/`uv pip` when using a `simple_index_url`, which can affect how dependencies are resolved and may break installs if the private index is incomplete. Touches install path security by making the private index authoritative and falling back to PyPI explicitly.
> 
> **Overview**
> Updates `prime env info` output and the internal install command builder to use `--index-url <prime_simple_index>` (with PyPI as an explicit `--extra-index-url`) instead of relying on `--extra-index-url` alone.
> 
> This makes Prime’s package index the primary source during `pip`/`uv pip` installs, reducing dependency confusion risk when a same-named package exists on PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0bbc50df3fe265101c0288195926ab15072dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->