### PR TITLE
fix: prevent API key exfiltration via custom base URL

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -1,6 +1,7 @@
 import os
 import re
 from typing import Optional
+from urllib.parse import urlparse
 
 import typer
 from rich.table import Table
@@ -134,13 +135,21 @@ def set_api_key(
         # Try to fetch user id like in login flow
         try:
             client = APIClient(api_key=api_key)
-            whoami_resp = client.get("/user/whoami")
-            data = whoami_resp.get("data") if isinstance(whoami_resp, dict) else None
-            if isinstance(data, dict):
-                user_id = data.get("id")
-                if user_id:
-                    config.set_user_id(user_id)
-                    config.update_current_environment_file()
+            # Only send API key to known Prime Intellect domains
+            parsed = urlparse(client.base_url)
+            hostname = parsed.hostname or ""
+            if hostname.endswith(".primeintellect.ai") or hostname == "primeintellect.ai":
+                whoami_resp = client.get("/user/whoami")
+                data = whoami_resp.get("data") if isinstance(whoami_resp, dict) else None
+                if isinstance(data, dict):
+                    user_id = data.get("id")
+                    if user_id:
+                        config.set_user_id(user_id)
+                        config.update_current_environment_file()
+            else:
+                console.print(
+                    "[yellow]Skipping user verification: custom base URL detected[/yellow]"
+                )
         except (APIError, Exception):
             pass
 


### PR DESCRIPTION
Validates that the base URL points to a trusted primeintellect.ai domain before sending the API key during set-api-key whoami verification. Prevents a poisoned PRIME_API_BASE_URL env var from redirecting the key to an attacker-controlled server.

- Added urlparse check on base URL hostname before whoami call
- Shows warning when custom base URL is detected and verification is skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API key handling during `prime config set-api-key`, preventing accidental credential exfiltration when a custom `PRIME_API_BASE_URL` is set. Low scope but security-sensitive behavior change and could skip auto user-id population for non-standard domains.
> 
> **Overview**
> Prevents API key exfiltration during `prime config set-api-key` by validating the `APIClient.base_url` hostname before making the `/user/whoami` verification request.
> 
> If a custom/non-`primeintellect.ai` base URL is detected, the CLI now **skips user verification** (and thus won’t auto-populate `user_id`) and prints a warning instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ff1b905b22d881f316f5a39610fa5feffb8963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->