### PR TITLE
fix: validate tunnel server response fields

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -19,7 +19,7 @@ from prime_tunnel.exceptions import (
 )
 from prime_tunnel.models import TunnelInfo
 
-_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}\Z")
 
 
 def _validate_tunnel_field(value: str, field_name: str, allow_empty: bool = False) -> str:
@@ -367,13 +367,13 @@ class Tunnel:
 
         # Generate config content
         config = f"""# Prime Tunnel frpc configuration
-# Tunnel ID: {self._tunnel_info.tunnel_id}
+# Tunnel ID: {tunnel_id}
 
 serverAddr = "{server_host}"
 serverPort = {server_port}
 
 # Authentication
-user = "{self._tunnel_info.tunnel_id}"
+user = "{tunnel_id}"
 auth.method = "token"
 auth.token = "{self._tunnel_info.frp_token}"
 
@@ -392,11 +392,11 @@ log.level = "{self.log_level}"
 
 # HTTP proxy configuration
 [[proxies]]
-name = "{self._tunnel_info.tunnel_id}"
+name = "{tunnel_id}"
 type = "http"
 localIP = "{self.local_addr}"
 localPort = {self.local_port}
-subdomain = "{self._tunnel_info.tunnel_id}"
+subdomain = "{tunnel_id}"
 """
 
         # Write to config directory

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -19,6 +19,28 @@ from prime_tunnel.exceptions import (
 )
 from prime_tunnel.models import TunnelInfo
 
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
+
+
+def _validate_tunnel_field(value: str, field_name: str) -> str:
+    """Validate a server-provided field is safe for use in file paths and TOML config."""
+    if not isinstance(value, str) or not value:
+        raise TunnelError(f"Invalid {field_name}: must be a non-empty string")
+    if "\n" in value or "\r" in value or '"' in value or "\\" in value:
+        raise TunnelError(f"Invalid {field_name}: contains unsafe characters")
+    return value
+
+
+def _validate_tunnel_id(value: str) -> str:
+    """Validate tunnel_id is safe for use as a filename and TOML value."""
+    if not isinstance(value, str) or not _SAFE_ID_RE.match(value):
+        raise TunnelError(
+            f"Invalid tunnel_id '{value}': must be alphanumeric"
+            " with optional dots, hyphens, underscores"
+        )
+    return value
+
+
 # timestamp + level + caller prefix + message
 _LOG_RE = re.compile(
     r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}\s"
@@ -330,6 +352,12 @@ class Tunnel:
         if self._tunnel_info is None:
             raise TunnelError("Tunnel not registered")
 
+        # Validate server-provided values before using in file path and config
+        tunnel_id = _validate_tunnel_id(self._tunnel_info.tunnel_id)
+        _validate_tunnel_field(self._tunnel_info.frp_token, "frp_token")
+        _validate_tunnel_field(self._tunnel_info.binding_secret, "binding_secret")
+        _validate_tunnel_field(self._tunnel_info.server_host, "server_host")
+
         server_host = self._tunnel_info.server_host
         server_port = self._tunnel_info.server_port
 
@@ -371,7 +399,7 @@ subdomain = "{self._tunnel_info.tunnel_id}"
         config_dir = Path.home() / ".prime" / "tunnels"
         config_dir.mkdir(parents=True, exist_ok=True)
         config_dir.chmod(0o700)
-        config_file = config_dir / f"{self._tunnel_info.tunnel_id}.toml"
+        config_file = config_dir / f"{tunnel_id}.toml"
 
         # Create file with 0600 permissions
         fd = os.open(str(config_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -39,8 +39,7 @@ def _validate_tunnel_id(value: str) -> str:
     """Validate tunnel_id is safe for use as a filename and TOML value."""
     if not isinstance(value, str) or not _SAFE_ID_RE.match(value):
         raise TunnelError(
-            f"Invalid tunnel_id '{value}': must be alphanumeric"
-            " with optional dots, hyphens, underscores"
+            "Invalid tunnel_id: must be alphanumeric with optional dots, hyphens, underscores"
         )
     return value
 
@@ -358,11 +357,11 @@ class Tunnel:
 
         # Validate server-provided values before using in file path and config
         tunnel_id = _validate_tunnel_id(self._tunnel_info.tunnel_id)
-        _validate_tunnel_field(self._tunnel_info.frp_token, "frp_token")
-        _validate_tunnel_field(self._tunnel_info.binding_secret, "binding_secret", allow_empty=True)
-        _validate_tunnel_field(self._tunnel_info.server_host, "server_host")
-
-        server_host = self._tunnel_info.server_host
+        frp_token = _validate_tunnel_field(self._tunnel_info.frp_token, "frp_token")
+        binding_secret = _validate_tunnel_field(
+            self._tunnel_info.binding_secret, "binding_secret", allow_empty=True
+        )
+        server_host = _validate_tunnel_field(self._tunnel_info.server_host, "server_host")
         server_port = self._tunnel_info.server_port
 
         # Generate config content
@@ -375,10 +374,10 @@ serverPort = {server_port}
 # Authentication
 user = "{tunnel_id}"
 auth.method = "token"
-auth.token = "{self._tunnel_info.frp_token}"
+auth.token = "{frp_token}"
 
 # Per-tunnel binding secret
-metadatas.binding_secret = "{self._tunnel_info.binding_secret}"
+metadatas.binding_secret = "{binding_secret}"
 
 # Transport settings
 transport.tcpMux = true

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -22,9 +22,13 @@ from prime_tunnel.models import TunnelInfo
 _SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$")
 
 
-def _validate_tunnel_field(value: str, field_name: str) -> str:
+def _validate_tunnel_field(value: str, field_name: str, allow_empty: bool = False) -> str:
     """Validate a server-provided field is safe for use in file paths and TOML config."""
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str):
+        raise TunnelError(f"Invalid {field_name}: must be a string")
+    if not value:
+        if allow_empty:
+            return value
         raise TunnelError(f"Invalid {field_name}: must be a non-empty string")
     if "\n" in value or "\r" in value or '"' in value or "\\" in value:
         raise TunnelError(f"Invalid {field_name}: contains unsafe characters")
@@ -355,7 +359,7 @@ class Tunnel:
         # Validate server-provided values before using in file path and config
         tunnel_id = _validate_tunnel_id(self._tunnel_info.tunnel_id)
         _validate_tunnel_field(self._tunnel_info.frp_token, "frp_token")
-        _validate_tunnel_field(self._tunnel_info.binding_secret, "binding_secret")
+        _validate_tunnel_field(self._tunnel_info.binding_secret, "binding_secret", allow_empty=True)
         _validate_tunnel_field(self._tunnel_info.server_host, "server_host")
 
         server_host = self._tunnel_info.server_host


### PR DESCRIPTION
Validates server-controlled values (tunnel_id, frp_token, binding_secret, server_host) before using them in file paths and TOML config to prevent path traversal and injection attacks.

- Added `_validate_tunnel_id` to reject IDs with path traversal chars
- Added `_validate_tunnel_field` to reject values with newlines, quotes, backslashes
- Validation runs in `_write_frpc_config` before any values are used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter validation on server-controlled values used in config generation, which can cause tunnel startup to fail for previously-accepted (but unsafe) values. Changes are localized to `Tunnel._write_frpc_config`, but affect the core connection path.
> 
> **Overview**
> Adds defensive validation for server-controlled `TunnelInfo` fields (`tunnel_id`, `frp_token`, `binding_secret`, `server_host`) before interpolating them into the generated frpc TOML or using them as the config filename.
> 
> Introduces `_validate_tunnel_id` (regex-based safe ID) and `_validate_tunnel_field` (rejects empty/non-string/unsafe characters), and wires these into `_write_frpc_config` so unsafe responses raise `TunnelError` early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66308b9bee4e6a132fe6f6c7e3b4f6fb01d4cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->