### PR TITLE
fix: use safe tar extraction in env pull to prevent path traversal

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1654,8 +1654,8 @@ def pull(
 
                 try:
                     with tarfile.open(tmp.name, "r:gz") as tar:
-                        tar.extractall(target_dir)
-                except tarfile.TarError as e:
+                        _safe_tar_extract(tar, target_dir)
+                except (tarfile.TarError, ValueError) as e:
                     console.print(f"[red]Failed to extract archive: {e}[/red]")
                     raise typer.Exit(1)
                 except IOError as e:


### PR DESCRIPTION
Replace unsafe `tar.extractall()` in env pull with the existing `_safe_tar_extract` helper that validates archive members against path traversal, symlink, and absolute path attacks.

- Use `_safe_tar_extract` instead of raw `extractall` in the pull command
- Catch `ValueError` from validation alongside `TarError`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches archive extraction in the CLI download path, which is security-sensitive; behavior changes are small but could cause pulls to fail if archives contain previously-accepted unsafe entries.
> 
> **Overview**
> **Security hardening for `prime env pull`.** Replaces direct `tar.extractall()` with `_safe_tar_extract()` so pulled environment archives are validated against path traversal, absolute paths, and link entries before extraction.
> 
> Extraction now also treats validation failures (`ValueError`) as user-facing extraction errors alongside `tarfile.TarError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a6c28e794d8247b43e215f4182dd5ab660f9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->