### PR TITLE
fix: prevent API key leak to untrusted download URLs

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1633,7 +1633,7 @@ def pull(
                 try:
                     if is_valid_url(download_url):
                         headers = {}
-                        if client.api_key:
+                        if client.api_key and _is_trusted_url(download_url, client.base_url):
                             headers["Authorization"] = f"Bearer {client.api_key}"
                         with httpx.stream(
                             "GET", download_url, headers=headers, timeout=60.0
@@ -1753,6 +1753,16 @@ def is_valid_url(url: str) -> bool:
     try:
         result = urlparse(url)
         return all([result.scheme in ("http", "https"), result.netloc])
+    except Exception:
+        return False
+
+
+def _is_trusted_url(url: str, base_url: str) -> bool:
+    """Check if a URL belongs to the same host as the trusted API base URL."""
+    try:
+        url_host = urlparse(url).netloc.lower()
+        base_host = urlparse(base_url).netloc.lower()
+        return url_host == base_host
     except Exception:
         return False
 
@@ -2790,7 +2800,7 @@ def _pull_and_build_private_env(
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             temp_file_path = tmp.name
             headers = {}
-            if client.api_key:
+            if client.api_key and _is_trusted_url(download_url, client.base_url):
                 headers["Authorization"] = f"Bearer {client.api_key}"
 
             with httpx.stream("GET", download_url, headers=headers, timeout=60.0) as resp:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1654,8 +1654,8 @@ def pull(
 
                 try:
                     with tarfile.open(tmp.name, "r:gz") as tar:
-                        tar.extractall(target_dir)
-                except tarfile.TarError as e:
+                        _safe_tar_extract(tar, target_dir)
+                except (tarfile.TarError, ValueError) as e:
                     console.print(f"[red]Failed to extract archive: {e}[/red]")
                     raise typer.Exit(1)
                 except IOError as e:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1758,11 +1758,13 @@ def is_valid_url(url: str) -> bool:
 
 
 def _is_trusted_url(url: str, base_url: str) -> bool:
-    """Check if a URL belongs to the same host as the trusted API base URL."""
+    """Check if a URL belongs to the same host as the trusted API base URL over HTTPS."""
     try:
-        url_host = urlparse(url).netloc.lower()
-        base_host = urlparse(base_url).netloc.lower()
-        return url_host == base_host
+        parsed_url = urlparse(url)
+        parsed_base = urlparse(base_url)
+        if parsed_url.scheme != "https":
+            return False
+        return parsed_url.netloc.lower() == parsed_base.netloc.lower()
     except Exception:
         return False
 


### PR DESCRIPTION
Prevents sending the Authorization header when downloading env packages from URLs that don't match the trusted API host.

- Added _is_trusted_url helper to verify download URL host matches API base URL
- Applied check in both pull command and _download_and_build_private_env

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authentication header handling in environment downloads, which can affect access to private env artifacts if download URLs are not HTTPS or don’t match the configured API host. Also changes tar extraction behavior to fail on additional validation errors.
> 
> **Overview**
> Prevents leaking credentials during `prime env pull` and private env downloads by only attaching the `Authorization` header when the `download_url` is **HTTPS** and matches the configured API host (`_is_trusted_url`).
> 
> Switches archive extraction in `pull` to use `_safe_tar_extract` and treats validation failures (`ValueError`) as extraction errors, improving protection against malicious tar contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8118f3f75edc4ea5bc40c2891052a03c7f4b749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->