### PR TITLE
BulkDeleteSandboxRequest only_mine

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -168,6 +168,7 @@ class BulkDeleteSandboxRequest(BaseModel):
 
     sandbox_ids: Optional[List[str]] = None
     labels: Optional[List[str]] = None
+    only_mine: bool = True
 
 
 class BulkDeleteSandboxResponse(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -169,6 +169,7 @@ class BulkDeleteSandboxRequest(BaseModel):
     sandbox_ids: Optional[List[str]] = None
     labels: Optional[List[str]] = None
     only_mine: bool = True
+    team_id: Optional[str] = None
 
 
 class BulkDeleteSandboxResponse(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1449,9 +1449,12 @@ class AsyncSandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        only_mine: bool = True,
     ) -> BulkDeleteSandboxResponse:
         """Bulk delete multiple sandboxes by IDs or labels"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        request = BulkDeleteSandboxRequest(
+            sandbox_ids=sandbox_ids, labels=labels, only_mine=only_mine
+        )
         response = await self.client.request(
             "DELETE",
             "/sandbox",

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -595,9 +595,12 @@ class SandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        only_mine: bool = True,
     ) -> BulkDeleteSandboxResponse:
         """Bulk delete multiple sandboxes by IDs or labels (must specify one, not both)"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        request = BulkDeleteSandboxRequest(
+            sandbox_ids=sandbox_ids, labels=labels, only_mine=only_mine
+        )
         response = self.client.request(
             "DELETE",
             "/sandbox",

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -596,10 +596,17 @@ class SandboxClient:
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
         only_mine: bool = True,
+        team_id: Optional[str] = None,
     ) -> BulkDeleteSandboxResponse:
         """Bulk delete multiple sandboxes by IDs or labels (must specify one, not both)"""
+        # Auto-populate team_id from config if not specified
+        if team_id is None:
+            team_id = self.client.config.team_id
         request = BulkDeleteSandboxRequest(
-            sandbox_ids=sandbox_ids, labels=labels, only_mine=only_mine
+            sandbox_ids=sandbox_ids,
+            labels=labels,
+            only_mine=only_mine,
+            team_id=team_id,
         )
         response = self.client.request(
             "DELETE",
@@ -1450,10 +1457,17 @@ class AsyncSandboxClient:
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
         only_mine: bool = True,
+        team_id: Optional[str] = None,
     ) -> BulkDeleteSandboxResponse:
         """Bulk delete multiple sandboxes by IDs or labels"""
+        # Auto-populate team_id from config if not specified
+        if team_id is None:
+            team_id = self.client.config.team_id
         request = BulkDeleteSandboxRequest(
-            sandbox_ids=sandbox_ids, labels=labels, only_mine=only_mine
+            sandbox_ids=sandbox_ids,
+            labels=labels,
+            only_mine=only_mine,
+            team_id=team_id,
         )
         response = await self.client.request(
             "DELETE",

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -619,6 +619,10 @@ def delete(
                     seen.add(id)
             sandbox_ids = cleaned_ids
 
+            if not sandbox_ids and not labels:
+                console.print("[red]Error:[/red] No valid sandbox IDs provided")
+                raise typer.Exit(1)
+
         if sandbox_ids and len(sandbox_ids) == 1:
             sandbox_id = sandbox_ids[0]
             if not confirm_or_skip(f"Are you sure you want to delete sandbox {sandbox_id}?", yes):
@@ -652,11 +656,15 @@ def delete(
                 console.print("Delete cancelled")
                 return
 
+            # only_mine applies to --all and --label
+            # explicit IDs use standard team-membership ownership checks
+            effective_only_mine = only_mine if (all or labels) else False
+
             with console.status("[bold blue]Deleting sandboxes...", spinner="dots"):
                 result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(
                     sandbox_ids=sandbox_ids if sandbox_ids else None,
                     labels=labels if labels else None,
-                    only_mine=only_mine,
+                    only_mine=effective_only_mine,
                 )
 
             console.print(f"\n[green]{result.message}[/green]")

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -648,6 +648,7 @@ def delete(
                     f"This action cannot be undone."
                 )
             else:
+                assert sandbox_ids
                 confirmation_msg = (
                     f"Are you sure you want to delete {len(sandbox_ids)} sandbox(es)?"
                 )

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -657,15 +657,11 @@ def delete(
                 console.print("Delete cancelled")
                 return
 
-            # only_mine applies to --all and --label
-            # explicit IDs use standard team-membership ownership checks
-            effective_only_mine = only_mine if (all or labels) else False
-
             with console.status("[bold blue]Deleting sandboxes...", spinner="dots"):
                 result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(
                     sandbox_ids=sandbox_ids if sandbox_ids else None,
                     labels=labels if labels else None,
-                    only_mine=effective_only_mine,
+                    only_mine=only_mine,
                 )
 
             console.print(f"\n[green]{result.message}[/green]")

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -578,13 +578,14 @@ def delete(
         True,
         "--only-mine/--all-users",
         "-m/-A",
-        help="Restrict '--all' deletes to only your sandboxes",
+        help="Restrict '--all' and '--label' deletes to only your sandboxes",
         show_default=True,
     ),
 ) -> None:
     """Delete one or more sandboxes by ID, by label, or all sandboxes with --all
 
-    --only-mine controls whether '--all' will restrict to your sandboxes or delete for all users.
+    --only-mine (default) restricts '--all' and '--label' to your sandboxes only.
+    Use --all-users to include sandboxes from all team members.
     """
     try:
         base_client = APIClient()
@@ -602,42 +603,7 @@ def delete(
             )
             raise typer.Exit(1)
 
-        if all:
-            with console.status("[bold blue]Fetching all sandboxes...", spinner="dots"):
-                all_sandboxes = []
-                page = 1
-                while True:
-                    list_response = sandbox_client.list(
-                        per_page=100, page=page, exclude_terminated=True
-                    )
-                    all_sandboxes.extend(list_response.sandboxes)
-                    if not list_response.has_next:
-                        break
-                    page += 1
-
-                if only_mine:
-                    current_user_id = config.user_id
-                    if not current_user_id:
-                        console.print(
-                            "[red]Error:[/red] Cannot filter by user - no user_id configured. "
-                            "Use --all-users to delete all sandboxes, or configure your user_id."
-                        )
-                        raise typer.Exit(1)
-                    sandboxes_to_delete = [s for s in all_sandboxes if s.user_id == current_user_id]
-                else:
-                    sandboxes_to_delete = all_sandboxes
-
-                sandbox_ids = [s.id for s in sandboxes_to_delete]
-
-                if not sandbox_ids:
-                    console.print("[yellow]No sandboxes to delete[/yellow]")
-                    if only_mine and all_sandboxes:
-                        console.print(
-                            "\n[dim]Note: --all only deletes your own sandboxes by default. "
-                            "Use --all-users to delete sandboxes from all team members.[/dim]"
-                        )
-                    return
-        else:
+        if not all:
             parsed_ids = []
             for id_string in sandbox_ids or []:
                 if "," in id_string:
@@ -653,29 +619,7 @@ def delete(
                     seen.add(id)
             sandbox_ids = cleaned_ids
 
-        if labels:
-            labels_str = ", ".join(labels)
-            confirmation_msg = (
-                f"Are you sure you want to delete ALL sandboxes with labels: {labels_str}? "
-                f"This action cannot be undone."
-            )
-
-            if not confirm_or_skip(confirmation_msg, yes):
-                console.print("Delete cancelled")
-                return
-
-            with console.status("[bold blue]Deleting sandboxes by labels...", spinner="dots"):
-                result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(labels=labels)
-
-            console.print(f"\n[green]{result.message}[/green]")
-            if result.succeeded:
-                console.print(
-                    f"\n[bold green]Deleted {len(result.succeeded)} sandbox(es):[/bold green]"
-                )
-                for sandbox_id in result.succeeded:
-                    console.print(f"  ✓ {sandbox_id}")
-
-        elif len(sandbox_ids) == 1 and not all:
+        if sandbox_ids and len(sandbox_ids) == 1:
             sandbox_id = sandbox_ids[0]
             if not confirm_or_skip(f"Are you sure you want to delete sandbox {sandbox_id}?", yes):
                 console.print("Delete cancelled")
@@ -687,63 +631,46 @@ def delete(
             console.print(f"[green]Successfully deleted sandbox {sandbox_id}[/green]")
 
         else:
+            scope = "your" if only_mine else "ALL users'"
             if all:
                 confirmation_msg = (
-                    f"Are you sure you want to delete ALL {len(sandbox_ids)} "
-                    f"sandbox(es)? This action cannot be undone."
+                    f"Are you sure you want to delete {scope} sandboxes? "
+                    f"This action cannot be undone."
                 )
-                cancel_msg = "Delete all cancelled"
+            elif labels:
+                labels_str = ", ".join(labels)
+                confirmation_msg = (
+                    f"Are you sure you want to delete {scope} sandboxes with labels: {labels_str}? "
+                    f"This action cannot be undone."
+                )
             else:
                 confirmation_msg = (
                     f"Are you sure you want to delete {len(sandbox_ids)} sandbox(es)?"
                 )
-                cancel_msg = "Bulk delete cancelled"
 
             if not confirm_or_skip(confirmation_msg, yes):
-                console.print(cancel_msg)
+                console.print("Delete cancelled")
                 return
 
-            batch_size = 100
-            all_succeeded = []
-            all_failed = []
-
             with console.status("[bold blue]Deleting sandboxes...", spinner="dots"):
-                for i in range(0, len(sandbox_ids), batch_size):
-                    batch = sandbox_ids[i : i + batch_size]
-                    batch_num = (i // batch_size) + 1
-                    total_batches = (len(sandbox_ids) + batch_size - 1) // batch_size
-
-                    console.print(
-                        f"[dim]Processing batch {batch_num}/{total_batches} "
-                        f"({len(batch)} sandboxes)...[/dim]"
-                    )
-
-                    result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(
-                        sandbox_ids=batch
-                    )
-
-                    if result.succeeded:
-                        all_succeeded.extend(result.succeeded)
-                    if result.failed:
-                        all_failed.extend(result.failed)
-
-            # Display combined results
-            total_processed = len(all_succeeded) + len(all_failed)
-            console.print(f"\n[green]Processed {total_processed} sandbox(es)[/green]")
-
-            if all_succeeded:
-                console.print(
-                    f"\n[bold green]Successfully deleted {len(all_succeeded)} "
-                    f"sandbox(es):[/bold green]"
+                result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(
+                    sandbox_ids=sandbox_ids if sandbox_ids else None,
+                    labels=labels if labels else None,
+                    only_mine=only_mine,
                 )
-                for sandbox_id in all_succeeded:
+
+            console.print(f"\n[green]{result.message}[/green]")
+            if result.succeeded:
+                console.print(
+                    f"\n[bold green]Deleted {len(result.succeeded)} sandbox(es):[/bold green]"
+                )
+                for sandbox_id in result.succeeded:
                     console.print(f"  ✓ {sandbox_id}")
-
-            if all_failed:
+            if result.failed:
                 console.print(
-                    f"\n[bold red]Failed to delete {len(all_failed)} sandbox(es):[/bold red]"
+                    f"\n[bold red]Failed to delete {len(result.failed)} sandbox(es):[/bold red]"
                 )
-                for failure in all_failed:
+                for failure in result.failed:
                     sandbox_id = failure.get("sandbox_id", "unknown")
                     error = failure.get("error", "unknown error")
                     console.print(f"  ✗ {sandbox_id}: {error}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes bulk deletion semantics and moves filtering/batching from the CLI to the API request, which could impact which sandboxes get deleted if server-side handling differs from prior client-side logic.
> 
> **Overview**
> Adds `only_mine` (default `True`) and optional `team_id` to `BulkDeleteSandboxRequest`, and updates both sync/async `SandboxClient.bulk_delete` to auto-fill `team_id` from config and send these fields to the backend.
> 
> Updates `prime sandbox delete` so `--only-mine/--all-users` also applies to `--label` deletes, and simplifies deletion by calling `bulk_delete` once (no pre-fetch of all sandboxes and no client-side batching), with updated confirmation messaging to reflect the selected scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330a29d4d604c52bafd77bd6d05a28e91004a2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->