### PR TITLE
Release prime CLI 0.5.61

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.60"
+__version__ = "0.5.61"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
includes passing through all `prime-rl` configs to `prime` training CLI via `run_config` config.
for users with correct permissions only.
https://github.com/PrimeIntellect-ai/prime/pull/497