### PR TITLE
Add Tunnel.check_registered() for server-side liveness

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -115,6 +115,20 @@ class Tunnel:
             return False
         return self._process.poll() is None
 
+    async def check_registered(self) -> bool:
+        """Check if the tunnel is still registered server-side.
+
+        Calls get_tunnel() on the backend API. Returns True if the
+        registration exists, False if it returns 404 (gone).
+
+        Raises TunnelError/TunnelTimeoutError on transient API failures
+        so the caller can distinguish "tunnel gone" from "API unreachable".
+        """
+        if self._tunnel_info is None:
+            return False
+        info = await self._client.get_tunnel(self._tunnel_info.tunnel_id)
+        return info is not None
+
     async def start(self) -> str:
         """
         Start the tunnel.

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from prime_tunnel import Config, Tunnel, TunnelClient
+from prime_tunnel.exceptions import TunnelTimeoutError
 from prime_tunnel.models import TunnelInfo
 
 
@@ -124,3 +127,38 @@ def test_sync_stop_survives_delete_failure():
 
     assert tunnel._started is False
     assert tunnel._tunnel_info is None
+
+
+# -- check_registered tests --
+
+
+@pytest.mark.asyncio
+async def test_check_registered_returns_true():
+    tunnel = _make_started_tunnel()
+    tunnel._client = AsyncMock()
+    tunnel._client.get_tunnel.return_value = tunnel._tunnel_info
+    assert await tunnel.check_registered() is True
+    tunnel._client.get_tunnel.assert_awaited_once_with("t-test123")
+
+
+@pytest.mark.asyncio
+async def test_check_registered_returns_false_on_404():
+    tunnel = _make_started_tunnel()
+    tunnel._client = AsyncMock()
+    tunnel._client.get_tunnel.return_value = None
+    assert await tunnel.check_registered() is False
+
+
+@pytest.mark.asyncio
+async def test_check_registered_returns_false_when_no_tunnel_info():
+    tunnel = Tunnel(local_port=8080)
+    assert await tunnel.check_registered() is False
+
+
+@pytest.mark.asyncio
+async def test_check_registered_propagates_api_errors():
+    tunnel = _make_started_tunnel()
+    tunnel._client = AsyncMock()
+    tunnel._client.get_tunnel.side_effect = TunnelTimeoutError("timeout")
+    with pytest.raises(TunnelTimeoutError):
+        await tunnel.check_registered()


### PR DESCRIPTION
## Summary
- Adds `Tunnel.check_registered()` async method that queries the backend API to verify the tunnel registration still exists
- Returns `False` when the registration is gone (404), `True` if it exists
- Lets transient API errors (timeouts, connection issues) propagate so callers can distinguish "tunnel gone" from "API unreachable"
- 4 unit tests covering all paths

## Context
During a training run, the Prime tunnel died server-side (registration expired) while the frpc process stayed alive. The existing `is_running` property only checks process liveness, so it couldn't detect this. Every rollout got `404 - Tunnel Not Found` for 30+ hours.

This method enables callers (e.g. verifiers `CliAgentEnv`) to detect dead tunnels and recreate them. See companion PR: https://github.com/PrimeIntellect-ai/verifiers/pull/new/daniel/tunnel-death-detection

## Test plan
- [x] `test_check_registered_returns_true` — mock get_tunnel returning TunnelInfo
- [x] `test_check_registered_returns_false_on_404` — mock get_tunnel returning None
- [x] `test_check_registered_returns_false_when_no_tunnel_info` — no _tunnel_info set
- [x] `test_check_registered_propagates_api_errors` — mock raising TunnelTimeoutError
- [x] All 25 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small read-only API check and accompanying unit tests without changing tunnel startup/teardown behavior or data handling.
> 
> **Overview**
> Adds `Tunnel.check_registered()` to query the backend via `TunnelClient.get_tunnel()` and report whether the current tunnel registration still exists (*True* when found, *False* when missing or when no local `_tunnel_info` is set), while allowing API exceptions to propagate.
> 
> Extends unit coverage with new async tests for the success, missing/404, unstarted, and error-propagation paths using `AsyncMock`/`pytest.mark.asyncio`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058a3fd941a9fdd53f5b7df041d02edd06156566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->