### PR TITLE
bump oversampling defaults

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -182,8 +182,8 @@ batch_size = 128
 rollouts_per_example = 8
 # learning_rate = 1e-6
 # lora_alpha = 16
-# oversampling_factor = 1.0
-# max_async_level = 4
+# oversampling_factor = 1.5
+# max_async_level = 2
 
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
@@ -485,8 +485,8 @@ class RLConfig(BaseModel):
     rollouts_per_example: int = 8
     learning_rate: float | None = None
     lora_alpha: int | None = None
-    oversampling_factor: float | None = None
-    max_async_level: int | None = None
+    oversampling_factor: float | None = 1.5
+    max_async_level: int | None = 2
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
     env: List[EnvConfig] = Field(default_factory=list)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -486,7 +486,7 @@ class RLConfig(BaseModel):
     learning_rate: float | None = None
     lora_alpha: int | None = None
     oversampling_factor: float | None = 1.5
-    max_async_level: int | None = 2
+    max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
     env: List[EnvConfig] = Field(default_factory=list)


### PR DESCRIPTION
Higher oversampling default should make the averange run more efficient as it schedules more concurrent requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RL run behavior by enabling oversampling (`oversampling_factor=1.5`) when not explicitly configured, which can increase compute usage and alter training dynamics. Also updates the generated config template’s recommended `max_async_level`, affecting throughput expectations.
> 
> **Overview**
> Makes `oversampling_factor` default to `1.5` in `RLConfig`, so runs oversample unless users explicitly disable/override it.
> 
> Updates the `prime rl init` TOML template comments to reflect the new oversampling default and a lower recommended `max_async_level` (`2` vs `4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48e7ee9554a4223b25c89b7fc3071ae7c955754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->