### PR TITLE
feat: add teacher config/sft loss for hosted training SFT

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -205,6 +205,8 @@ class RLClient:
         enable_thinking: Optional[bool] = None,
         reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
         run_config: Optional[Dict[str, Any]] = None,
+        loss: Literal["rl", "sft"] = "rl",
+        teacher: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -219,6 +221,7 @@ class RLClient:
                 "rollouts_per_example": rollouts_per_example,
                 "max_steps": max_steps,
                 "batch_size": batch_size,
+                "loss": loss,
                 "secrets": secrets_list,
             }
 
@@ -308,6 +311,9 @@ class RLClient:
 
             if run_config:
                 payload["run_config"] = run_config
+
+            if teacher:
+                payload["teacher"] = teacher
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -203,7 +203,7 @@ class RLClient:
         infrastructure_config: Optional[Dict[str, Any]] = None,
         tailscale_config: Optional[Dict[str, Any]] = None,
         enable_thinking: Optional[bool] = None,
-        reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
+        reasoning_effort: Optional[str] = None,
         run_config: Optional[Dict[str, Any]] = None,
         loss: Literal["rl", "sft"] = "rl",
         teacher: Optional[Dict[str, Any]] = None,
@@ -260,8 +260,24 @@ class RLClient:
             if temp_scheduler is not None:
                 payload["temp_scheduler"] = temp_scheduler
 
-            if extra_body is not None:
-                payload["extra_body"] = extra_body
+            extra_body_payload = dict(extra_body) if extra_body is not None else None
+            if enable_thinking is not None or reasoning_effort is not None:
+                if extra_body_payload is None:
+                    extra_body_payload = {}
+                chat_template_kwargs = extra_body_payload.get("chat_template_kwargs")
+                if chat_template_kwargs is not None and not isinstance(chat_template_kwargs, dict):
+                    raise ValueError("extra_body.chat_template_kwargs must be an object")
+                merged_chat_template_kwargs = (
+                    dict(chat_template_kwargs) if isinstance(chat_template_kwargs, dict) else {}
+                )
+                if enable_thinking is not None:
+                    merged_chat_template_kwargs["enable_thinking"] = enable_thinking
+                if reasoning_effort is not None:
+                    merged_chat_template_kwargs["reasoning_effort"] = reasoning_effort
+                extra_body_payload["chat_template_kwargs"] = merged_chat_template_kwargs
+
+            if extra_body_payload is not None:
+                payload["extra_body"] = extra_body_payload
 
             if eval_config:
                 payload["eval"] = eval_config
@@ -302,12 +318,6 @@ class RLClient:
 
             if tailscale_config:
                 payload["tailscale"] = tailscale_config
-
-            if enable_thinking is not None:
-                payload["enable_thinking"] = enable_thinking
-
-            if reasoning_effort is not None:
-                payload["reasoning_effort"] = reasoning_effort
 
             if run_config:
                 payload["run_config"] = run_config

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -184,7 +184,6 @@ def generate_rl_config_template(environment: str | None = None) -> str:
 
     return f'''\
 model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
-loss = "rl"
 max_steps = 100
 
 # env_files = ["secrets.env"] # optional file(s) for secrets
@@ -197,6 +196,9 @@ rollouts_per_example = 8
 # oversampling_factor = 1.0
 # max_async_level = 4
 
+# Optional: warm-start from an existing checkpoint
+# checkpoint_id = "..."
+
 # Optional: SFT hard distillation
 # loss = "sft"
 # [teacher]
@@ -206,9 +208,6 @@ rollouts_per_example = 8
 # [teacher.sampling]
 # max_tokens = 2048
 # reasoning_effort = "medium"
-
-# Optional: warm-start from an existing checkpoint
-# checkpoint_id = "..."
 
 [sampling]
 max_tokens = 2048

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -184,6 +184,7 @@ def generate_rl_config_template(environment: str | None = None) -> str:
 
     return f'''\
 model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+loss = "rl"
 max_steps = 100
 
 # env_files = ["secrets.env"] # optional file(s) for secrets
@@ -195,6 +196,16 @@ rollouts_per_example = 8
 # lora_alpha = 16
 # oversampling_factor = 1.0
 # max_async_level = 4
+
+# Optional: SFT hard distillation
+# loss = "sft"
+# [teacher]
+# model = "openai/gpt-oss-120b"
+# save = false
+#
+# [teacher.sampling]
+# max_tokens = 2048
+# reasoning_effort = "medium"
 
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
@@ -484,18 +495,6 @@ class AdaptersConfig(BaseModel):
         return result if result else None
 
 
-class InfrastructureConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    compute_size: str | None = None
-
-    def to_api_dict(self) -> Dict[str, Any] | None:
-        d: Dict[str, Any] = {}
-        if self.compute_size is not None:
-            d["compute_size"] = self.compute_size
-        return d if d else None
-
-
 class TailscaleConfig(BaseModel):
     """Optional per-run tailscale sidecar (enterprise-only feature).
 
@@ -570,11 +569,62 @@ class TailscaleConfig(BaseModel):
         }
 
 
+class InfrastructureConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    compute_size: str | None = None
+
+    def to_api_dict(self) -> Dict[str, Any] | None:
+        d: Dict[str, Any] = {}
+        if self.compute_size is not None:
+            d["compute_size"] = self.compute_size
+        return d if d else None
+
+
+class TeacherSamplingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    max_tokens: int | None = None
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
+
+    def to_api_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        if self.max_tokens is not None:
+            result["max_tokens"] = self.max_tokens
+        if self.reasoning_effort is not None:
+            result["reasoning_effort"] = self.reasoning_effort
+        return result
+
+
+class TeacherConfig(BaseModel):
+    """Teacher model for SFT distillation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    save: bool = False
+    sampling: TeacherSamplingConfig = Field(default_factory=TeacherSamplingConfig)
+
+    @model_validator(mode="after")
+    def reject_teacher_save(self) -> "TeacherConfig":
+        if self.save:
+            raise ValueError("teacher.save=true is not supported")
+        return self
+
+    def to_api_dict(self) -> Dict[str, Any]:
+        return {
+            "model": self.model,
+            "save": self.save,
+            "sampling": self.sampling.to_api_dict(),
+        }
+
+
 class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
     model: str
+    loss: Literal["rl", "sft"] = "rl"
     max_steps: int = 100
     batch_size: int = 128
     rollouts_per_example: int = 8
@@ -584,6 +634,7 @@ class RLConfig(BaseModel):
     max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
+    teacher: TeacherConfig | None = None
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
@@ -597,6 +648,22 @@ class RLConfig(BaseModel):
     run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_sft_rollout_default(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("loss", "rl") == "sft":
+            if "rollouts_per_example" not in data:
+                data = {**data, "rollouts_per_example": 1}
+        return data
+
+    @model_validator(mode="after")
+    def validate_loss_teacher(self) -> "RLConfig":
+        if self.loss == "sft" and self.teacher is None:
+            raise ValueError("loss='sft' requires a [teacher] config")
+        if self.loss == "rl" and self.teacher is not None:
+            raise ValueError("[teacher] can only be set when loss='sft'")
+        return self
 
 
 def _format_validation_errors(errors: list[Any]) -> list[str]:
@@ -874,6 +941,7 @@ def create_run(
 
         # Training
         console.print("\n[cyan]Training[/cyan]")
+        console.print(f"  Loss:                {cfg.loss}")
         console.print(f"  Max Steps:           {cfg.max_steps}")
         console.print(f"  Batch Size:          {cfg.batch_size}")
         console.print(f"  Rollouts per Example: {cfg.rollouts_per_example}")
@@ -885,8 +953,24 @@ def create_run(
             console.print(f"  Oversampling Factor: {cfg.oversampling_factor}")
         if cfg.max_async_level is not None:
             console.print(f"  Max Async Level:     {cfg.max_async_level}")
+
+        # Teacher
+        if cfg.teacher:
+            console.print("\n[cyan]Teacher[/cyan]")
+            console.print(f"  Model:            {cfg.teacher.model}")
+            console.print(f"  Save:             {cfg.teacher.save}")
+            teacher_sampling = cfg.teacher.sampling
+            if teacher_sampling.max_tokens is not None or teacher_sampling.reasoning_effort:
+                console.print("  Sampling:")
+                if teacher_sampling.max_tokens is not None:
+                    console.print(f"    Max Tokens:       {teacher_sampling.max_tokens}")
+                if teacher_sampling.reasoning_effort:
+                    console.print(f"    Reasoning Effort: {teacher_sampling.reasoning_effort}")
+
+        # Run config
         if cfg.run_config:
-            console.print(f"  Run Config:          {cfg.run_config}")
+            console.print("\n[cyan]Run Config[/cyan]")
+            console.print(f"  Values: {cfg.run_config}")
 
         # Sampling
         has_sampling = (
@@ -1084,6 +1168,8 @@ def create_run(
             enable_thinking=cfg.sampling.enable_thinking,
             reasoning_effort=cfg.sampling.reasoning_effort,
             run_config=cfg.run_config if cfg.run_config else None,
+            loss=cfg.loss,
+            teacher=cfg.teacher.to_api_dict() if cfg.teacher else None,
         )
 
         if output == "json":

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -35,6 +35,7 @@ from ..utils.formatters import (
     strip_ansi,
 )
 from ..utils.prompt import confirm_or_skip
+from ..utils.sampling import SamplingArgsConfig
 from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
 console = get_console()
@@ -207,6 +208,7 @@ rollouts_per_example = 8
 #
 # [teacher.sampling]
 # max_tokens = 2048
+# enable_thinking = false
 # reasoning_effort = "medium"
 
 [sampling]
@@ -216,9 +218,9 @@ max_tokens = 2048
 # min_tokens = 0
 # seed = 42
 
-# Optional: hosted RL reasoning controls (mutually exclusive)
-# enable_thinking = false    # supported models: Qwen3.5, Nemotron
-# reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
+# Optional: chat template kwargs forwarded through extra_body.chat_template_kwargs
+# enable_thinking = false
+# reasoning_effort = "high"
 
 # Optional: temperature scheduling (use instead of temperature)
 # [sampling.temp_scheduler]
@@ -361,24 +363,10 @@ class TemperatureSchedulerConfig(BaseModel):
     total_steps: int | None = None
 
 
-class SamplingConfig(BaseModel):
+class SamplingConfig(SamplingArgsConfig):
     model_config = ConfigDict(extra="forbid")
 
-    max_tokens: int | None = None
-    temperature: float | None = None
-    repetition_penalty: float | None = None
-    min_tokens: int | None = None
-    seed: int | None = None
     temp_scheduler: TemperatureSchedulerConfig | None = None
-    extra_body: Dict[str, Any] | None = None
-    enable_thinking: bool | None = None
-    reasoning_effort: Literal["low", "medium", "high"] | None = None
-
-    @model_validator(mode="after")
-    def _reasoning_controls_mutually_exclusive(self) -> "SamplingConfig":
-        if self.enable_thinking is not None and self.reasoning_effort is not None:
-            raise ValueError("enable_thinking and reasoning_effort cannot both be set")
-        return self
 
 
 class EvalConfig(BaseModel):
@@ -580,29 +568,14 @@ class InfrastructureConfig(BaseModel):
         return d if d else None
 
 
-class TeacherSamplingConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    max_tokens: int | None = None
-    reasoning_effort: Literal["low", "medium", "high"] | None = None
-
-    def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {}
-        if self.max_tokens is not None:
-            result["max_tokens"] = self.max_tokens
-        if self.reasoning_effort is not None:
-            result["reasoning_effort"] = self.reasoning_effort
-        return result
-
-
 class TeacherConfig(BaseModel):
     """Teacher model for SFT distillation."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     model: str
     save: bool = False
-    sampling: TeacherSamplingConfig = Field(default_factory=TeacherSamplingConfig)
+    sampling: SamplingArgsConfig = Field(default_factory=SamplingArgsConfig)
 
     @model_validator(mode="after")
     def reject_teacher_save(self) -> "TeacherConfig":
@@ -611,11 +584,9 @@ class TeacherConfig(BaseModel):
         return self
 
     def to_api_dict(self) -> Dict[str, Any]:
-        return {
-            "model": self.model,
-            "save": self.save,
-            "sampling": self.sampling.to_api_dict(),
-        }
+        result = self.model_dump(exclude_none=True)
+        result["sampling"] = self.sampling.to_api_dict()
+        return result
 
 
 class RLConfig(BaseModel):
@@ -959,12 +930,21 @@ def create_run(
             console.print(f"  Model:            {cfg.teacher.model}")
             console.print(f"  Save:             {cfg.teacher.save}")
             teacher_sampling = cfg.teacher.sampling
-            if teacher_sampling.max_tokens is not None or teacher_sampling.reasoning_effort:
+            if (
+                teacher_sampling.max_tokens is not None
+                or teacher_sampling.enable_thinking is not None
+                or teacher_sampling.reasoning_effort
+                or teacher_sampling.extra_body is not None
+            ):
                 console.print("  Sampling:")
                 if teacher_sampling.max_tokens is not None:
                     console.print(f"    Max Tokens:       {teacher_sampling.max_tokens}")
+                if teacher_sampling.enable_thinking is not None:
+                    console.print(f"    Enable Thinking:  {teacher_sampling.enable_thinking}")
                 if teacher_sampling.reasoning_effort:
                     console.print(f"    Reasoning Effort: {teacher_sampling.reasoning_effort}")
+                if teacher_sampling.extra_body is not None:
+                    console.print(f"    Extra Body:       {teacher_sampling.extra_body}")
 
         # Run config
         if cfg.run_config:
@@ -1143,7 +1123,7 @@ def create_run(
             temp_scheduler=cfg.sampling.temp_scheduler.model_dump(exclude_none=True)
             if cfg.sampling.temp_scheduler
             else None,
-            extra_body=cfg.sampling.extra_body,
+            extra_body=cfg.sampling.extra_body_to_api_dict(),
             batch_size=cfg.batch_size,
             name=cfg.name,
             wandb_entity=cfg.wandb.entity,
@@ -1164,8 +1144,6 @@ def create_run(
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
             tailscale_config=cfg.tailscale.to_api_dict(),
-            enable_thinking=cfg.sampling.enable_thinking,
-            reasoning_effort=cfg.sampling.reasoning_effort,
             run_config=cfg.run_config if cfg.run_config else None,
             loss=cfg.loss,
             teacher=cfg.teacher.to_api_dict() if cfg.teacher else None,

--- a/packages/prime/src/prime_cli/utils/sampling.py
+++ b/packages/prime/src/prime_cli/utils/sampling.py
@@ -1,0 +1,58 @@
+"""Shared sampling argument helpers."""
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class SamplingArgsConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    max_tokens: int | None = None
+    temperature: float | None = None
+    repetition_penalty: float | None = None
+    min_tokens: int | None = None
+    seed: int | None = None
+    extra_body: Dict[str, Any] | None = None
+    enable_thinking: bool | None = None
+    reasoning_effort: str | None = None
+
+    @model_validator(mode="after")
+    def validate_chat_template_kwargs(self) -> "SamplingArgsConfig":
+        if self.enable_thinking is None and self.reasoning_effort is None:
+            return self
+        if self.extra_body is None:
+            return self
+        chat_template_kwargs = self.extra_body.get("chat_template_kwargs")
+        if chat_template_kwargs is not None and not isinstance(chat_template_kwargs, dict):
+            raise ValueError("extra_body.chat_template_kwargs must be an object")
+        return self
+
+    def extra_body_to_api_dict(self) -> Dict[str, Any] | None:
+        extra_body = dict(self.extra_body) if self.extra_body is not None else None
+        if self.enable_thinking is None and self.reasoning_effort is None:
+            return extra_body
+
+        if extra_body is None:
+            extra_body = {}
+
+        existing_kwargs = extra_body.get("chat_template_kwargs")
+        chat_template_kwargs = dict(existing_kwargs) if isinstance(existing_kwargs, dict) else {}
+        if self.enable_thinking is not None:
+            chat_template_kwargs["enable_thinking"] = self.enable_thinking
+        if self.reasoning_effort is not None:
+            chat_template_kwargs["reasoning_effort"] = self.reasoning_effort
+        extra_body["chat_template_kwargs"] = chat_template_kwargs
+        return extra_body
+
+    def to_api_dict(self) -> Dict[str, Any]:
+        result = self.model_dump(
+            exclude_none=True,
+            exclude={"enable_thinking", "reasoning_effort"},
+        )
+        extra_body = self.extra_body_to_api_dict()
+        if extra_body is not None:
+            result["extra_body"] = extra_body
+        else:
+            result.pop("extra_body", None)
+        return result

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -69,6 +69,43 @@ def test_load_config_still_rejects_other_unknown_keys(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
+def test_load_config_rejects_legacy_sft_distill_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        'loss_type = "sft"\n'
+        "[teacher_rollout_model]\n"
+        'base_url = ["https://api.example.com/v1"]\n'
+        'api_key_var = "TEACHER_API_KEY"\n'
+        'name = "teacher-model"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+@pytest.mark.parametrize(
+    "config_body",
+    [
+        'loss_type = "sft"\n',
+        (
+            "[teacher_rollout_model]\n"
+            'base_url = ["https://api.example.com/v1"]\n'
+            'api_key_var = "TEACHER_API_KEY"\n'
+            'name = "teacher-model"\n'
+        ),
+    ],
+)
+def test_load_config_rejects_legacy_sft_distill_fields(
+    tmp_path: Path, config_body: str
+) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n' + config_body)
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
 def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> None:
     template = generate_rl_config_template()
 

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -1,13 +1,39 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 import typer
+from prime_cli.api.rl import RLClient
 from prime_cli.commands.rl import (
     RLConfig,
     _flatten_config_schema,
     generate_rl_config_template,
     load_config,
 )
+
+
+def _rl_run_payload() -> dict[str, Any]:
+    return {
+        "id": "rft_test",
+        "name": None,
+        "userId": "user_test",
+        "teamId": None,
+        "rftClusterId": None,
+        "status": "RUNNING",
+        "rolloutsPerExample": 1,
+        "seqLen": 2048,
+        "maxSteps": 100,
+        "maxTokens": None,
+        "batchSize": 128,
+        "baseModel": "openai/gpt-oss-20b",
+        "environments": [],
+        "runConfig": None,
+        "evalConfig": None,
+        "valConfig": None,
+        "bufferConfig": None,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+    }
 
 
 def test_load_config_warns_and_ignores_deprecated_trajectory_strategy(
@@ -109,6 +135,132 @@ def test_load_config_rejects_top_level_reasoning_effort(tmp_path: Path) -> None:
 
     with pytest.raises(typer.Exit):
         load_config(str(config_path))
+
+
+def test_load_config_accepts_sft_teacher_config_and_defaults_rollouts(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        "save = false\n"
+        "[teacher.sampling]\n"
+        "max_tokens = 2048\n"
+        'reasoning_effort = "medium"\n'
+        "[[env]]\n"
+        'id = "primeintellect/wordle"\n'
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.loss == "sft"
+    assert cfg.rollouts_per_example == 1
+    assert cfg.teacher is not None
+    assert cfg.teacher.to_api_dict() == {
+        "model": "openai/gpt-oss-120b",
+        "save": False,
+        "sampling": {
+            "max_tokens": 2048,
+            "reasoning_effort": "medium",
+        },
+    }
+
+
+def test_load_config_preserves_explicit_sft_rollouts(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "rollouts_per_example = 4\n"
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.rollouts_per_example == 4
+
+
+def test_load_config_rejects_sft_without_teacher(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "openai/gpt-oss-20b"\nloss = "sft"\n')
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_teacher_for_rl(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_teacher_save_true(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        "save = true\n"
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_private_teacher_endpoint_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        'base_url = ["https://api.openai.com/v1"]\n'
+        'api_key_var = "OPENAI_API_KEY"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_rl_client_create_run_forwards_loss_and_teacher_payload() -> None:
+    captured: dict[str, Any] = {}
+
+    class DummyClient:
+        def post(self, endpoint: str, json: dict[str, Any]) -> dict[str, Any]:
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"run": _rl_run_payload()}
+
+    teacher = {
+        "model": "openai/gpt-oss-120b",
+        "save": False,
+        "sampling": {
+            "max_tokens": 2048,
+            "reasoning_effort": "medium",
+        },
+    }
+
+    RLClient(DummyClient()).create_run(
+        model_name="openai/gpt-oss-20b",
+        environments=[{"id": "primeintellect/wordle"}],
+        rollouts_per_example=1,
+        loss="sft",
+        teacher=teacher,
+    )
+
+    assert captured["endpoint"] == "/rft/runs"
+    assert captured["json"]["loss"] == "sft"
+    assert captured["json"]["teacher"] == teacher
+    assert "teacher_rollout_model" not in captured["json"]
 
 
 def test_tailscale_config_disabled_by_default() -> None:

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -96,9 +96,7 @@ def test_load_config_rejects_legacy_sft_distill_config(tmp_path: Path) -> None:
         ),
     ],
 )
-def test_load_config_rejects_legacy_sft_distill_fields(
-    tmp_path: Path, config_body: str
-) -> None:
+def test_load_config_rejects_legacy_sft_distill_fields(tmp_path: Path, config_body: str) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text('model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n' + config_body)
 
@@ -111,6 +109,35 @@ def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> N
 
     assert "# easy_threshold = 1.0" in template
     assert "# hard_threshold = 0.0" in template
+
+
+def test_generate_rl_config_template_keeps_checkpoint_id_top_level_with_sft(
+    tmp_path: Path,
+) -> None:
+    template = generate_rl_config_template()
+    config_text = template
+    replacements = {
+        '# checkpoint_id = "..."': 'checkpoint_id = "ckpt_test"',
+        '# loss = "sft"': 'loss = "sft"',
+        "# [teacher]": "[teacher]",
+        '# model = "openai/gpt-oss-120b"': 'model = "openai/gpt-oss-120b"',
+        "# save = false": "save = false",
+        "# [teacher.sampling]": "[teacher.sampling]",
+        "# max_tokens = 2048": "max_tokens = 2048",
+        '# reasoning_effort = "medium"': 'reasoning_effort = "medium"',
+    }
+    for old, new in replacements.items():
+        config_text = config_text.replace(old, new, 1)
+
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(config_text)
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.checkpoint_id == "ckpt_test"
+    assert cfg.loss == "sft"
+    assert cfg.teacher is not None
+    assert cfg.teacher.sampling.max_tokens == 2048
 
 
 def test_flatten_config_schema_expands_optional_nested_models() -> None:
@@ -230,9 +257,7 @@ def test_load_config_rejects_sft_without_teacher(tmp_path: Path) -> None:
 def test_load_config_rejects_teacher_for_rl(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
-        'model = "openai/gpt-oss-20b"\n'
-        "[teacher]\n"
-        'model = "openai/gpt-oss-120b"\n'
+        'model = "openai/gpt-oss-20b"\n[teacher]\nmodel = "openai/gpt-oss-120b"\n'
     )
 
     with pytest.raises(typer.Exit):

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -124,6 +124,7 @@ def test_generate_rl_config_template_keeps_checkpoint_id_top_level_with_sft(
         "# save = false": "save = false",
         "# [teacher.sampling]": "[teacher.sampling]",
         "# max_tokens = 2048": "max_tokens = 2048",
+        "# enable_thinking = false": "enable_thinking = false",
         '# reasoning_effort = "medium"': 'reasoning_effort = "medium"',
     }
     for old, new in replacements.items():
@@ -138,6 +139,7 @@ def test_generate_rl_config_template_keeps_checkpoint_id_top_level_with_sft(
     assert cfg.loss == "sft"
     assert cfg.teacher is not None
     assert cfg.teacher.sampling.max_tokens == 2048
+    assert cfg.teacher.sampling.enable_thinking is False
 
 
 def test_flatten_config_schema_expands_optional_nested_models() -> None:
@@ -180,7 +182,7 @@ def test_load_config_accepts_sampling_enable_thinking(tmp_path: Path) -> None:
     assert cfg.sampling.reasoning_effort is None
 
 
-def test_load_config_rejects_both_reasoning_controls(tmp_path: Path) -> None:
+def test_load_config_passes_reasoning_controls_to_chat_template_kwargs(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\n'
@@ -189,8 +191,14 @@ def test_load_config_rejects_both_reasoning_controls(tmp_path: Path) -> None:
         'reasoning_effort = "low"\n'
     )
 
-    with pytest.raises(typer.Exit):
-        load_config(str(config_path))
+    cfg = load_config(str(config_path))
+
+    assert cfg.sampling.extra_body_to_api_dict() == {
+        "chat_template_kwargs": {
+            "enable_thinking": False,
+            "reasoning_effort": "low",
+        }
+    }
 
 
 def test_load_config_rejects_top_level_reasoning_effort(tmp_path: Path) -> None:
@@ -211,6 +219,7 @@ def test_load_config_accepts_sft_teacher_config_and_defaults_rollouts(tmp_path: 
         "save = false\n"
         "[teacher.sampling]\n"
         "max_tokens = 2048\n"
+        "enable_thinking = false\n"
         'reasoning_effort = "medium"\n'
         "[[env]]\n"
         'id = "primeintellect/wordle"\n'
@@ -226,7 +235,12 @@ def test_load_config_accepts_sft_teacher_config_and_defaults_rollouts(tmp_path: 
         "save": False,
         "sampling": {
             "max_tokens": 2048,
-            "reasoning_effort": "medium",
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                    "reasoning_effort": "medium",
+                }
+            },
         },
     }
 
@@ -278,7 +292,7 @@ def test_load_config_rejects_teacher_save_true(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
-def test_load_config_rejects_private_teacher_endpoint_fields(tmp_path: Path) -> None:
+def test_load_config_accepts_arbitrary_teacher_api_fields(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\n'
@@ -289,8 +303,11 @@ def test_load_config_rejects_private_teacher_endpoint_fields(tmp_path: Path) -> 
         'api_key_var = "OPENAI_API_KEY"\n'
     )
 
-    with pytest.raises(typer.Exit):
-        load_config(str(config_path))
+    cfg = load_config(str(config_path))
+
+    assert cfg.teacher is not None
+    assert cfg.teacher.to_api_dict()["base_url"] == ["https://api.openai.com/v1"]
+    assert cfg.teacher.to_api_dict()["api_key_var"] == "OPENAI_API_KEY"
 
 
 def test_rl_client_create_run_forwards_loss_and_teacher_payload() -> None:
@@ -307,7 +324,11 @@ def test_rl_client_create_run_forwards_loss_and_teacher_payload() -> None:
         "save": False,
         "sampling": {
             "max_tokens": 2048,
-            "reasoning_effort": "medium",
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "reasoning_effort": "medium",
+                }
+            },
         },
     }
 
@@ -323,6 +344,33 @@ def test_rl_client_create_run_forwards_loss_and_teacher_payload() -> None:
     assert captured["json"]["loss"] == "sft"
     assert captured["json"]["teacher"] == teacher
     assert "teacher_rollout_model" not in captured["json"]
+
+
+def test_rl_client_create_run_merges_reasoning_controls_into_extra_body() -> None:
+    captured: dict[str, Any] = {}
+
+    class DummyClient:
+        def post(self, endpoint: str, json: dict[str, Any]) -> dict[str, Any]:
+            captured["json"] = json
+            return {"run": _rl_run_payload()}
+
+    RLClient(DummyClient()).create_run(
+        model_name="openai/gpt-oss-20b",
+        environments=[{"id": "primeintellect/wordle"}],
+        extra_body={"provider": {"order": ["azure"]}},
+        enable_thinking=False,
+        reasoning_effort="medium",
+    )
+
+    assert captured["json"]["extra_body"] == {
+        "provider": {"order": ["azure"]},
+        "chat_template_kwargs": {
+            "enable_thinking": False,
+            "reasoning_effort": "medium",
+        },
+    }
+    assert "enable_thinking" not in captured["json"]
+    assert "reasoning_effort" not in captured["json"]
 
 
 def test_tailscale_config_disabled_by_default() -> None:

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -65,9 +65,7 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert Path("rl.toml").exists()
 
 
-def test_train_sft_config_forwards_teacher_payload_and_summary(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_train_sft_config_forwards_teacher_payload_and_summary(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "sft.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\n'
@@ -78,6 +76,7 @@ def test_train_sft_config_forwards_teacher_payload_and_summary(
         "save = false\n"
         "[teacher.sampling]\n"
         "max_tokens = 2048\n"
+        "enable_thinking = false\n"
         'reasoning_effort = "medium"\n'
         "[[env]]\n"
         'id = "primeintellect/wordle"\n'
@@ -124,12 +123,18 @@ def test_train_sft_config_forwards_teacher_payload_and_summary(
         "save": False,
         "sampling": {
             "max_tokens": 2048,
-            "reasoning_effort": "medium",
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                    "reasoning_effort": "medium",
+                }
+            },
         },
     }
     assert "Loss:                sft" in result.output
     assert "Teacher" in result.output
     assert "Model:            openai/gpt-oss-120b" in result.output
+    assert "Enable Thinking:  False" in result.output
     assert "Reasoning Effort: medium" in result.output
     assert "Run Config" in result.output
     assert "Values: {'note': 'cursor'}" in result.output

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 from prime_cli.main import app
 from typer.testing import CliRunner
@@ -61,3 +63,73 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert "Created rl.toml" in result.output
         assert "Run with: prime train rl.toml" in result.output
         assert Path("rl.toml").exists()
+
+
+def test_train_sft_config_forwards_teacher_payload_and_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "max_steps = 2\n"
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        "save = false\n"
+        "[teacher.sampling]\n"
+        "max_tokens = 2048\n"
+        'reasoning_effort = "medium"\n'
+        "[[env]]\n"
+        'id = "primeintellect/wordle"\n'
+        "[run_config]\n"
+        'note = "cursor"\n'
+    )
+    captured: dict[str, Any] = {}
+
+    class DummyRLClient:
+        def __init__(self, api_client: object) -> None:
+            pass
+
+        def list_models(self, team_id: str | None = None) -> list[Any]:
+            return []
+
+        def create_run(self, **kwargs: Any) -> SimpleNamespace:
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                id="rft_test",
+                status="RUNNING",
+                runs_ahead=None,
+                queue_reason=None,
+            )
+
+    class DummyConfig:
+        team_id = None
+        frontend_url = "https://app.primeintellect.ai"
+
+    monkeypatch.setattr("prime_cli.commands.rl.APIClient", lambda: object())
+    monkeypatch.setattr("prime_cli.commands.rl.Config", DummyConfig)
+    monkeypatch.setattr("prime_cli.commands.rl.RLClient", DummyRLClient)
+
+    result = runner.invoke(
+        app,
+        ["train", str(config_path), "--yes", "--skip-action-check"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["loss"] == "sft"
+    assert captured["kwargs"]["rollouts_per_example"] == 1
+    assert captured["kwargs"]["teacher"] == {
+        "model": "openai/gpt-oss-120b",
+        "save": False,
+        "sampling": {
+            "max_tokens": 2048,
+            "reasoning_effort": "medium",
+        },
+    }
+    assert "Loss:                sft" in result.output
+    assert "Teacher" in result.output
+    assert "Model:            openai/gpt-oss-120b" in result.output
+    assert "Reasoning Effort: medium" in result.output
+    assert "Run Config" in result.output
+    assert "Values: {'note': 'cursor'}" in result.output


### PR DESCRIPTION
## Summary

Implements APR-157 SFT distillation support through the existing `prime train` config path.

- Adds top-level `loss = "rl" | "sft"` with `[teacher]` and `[teacher.sampling]`.
- Builds teacher sampling on a general sampling-args config so provider/API-specific fields can pass through without adding new CLI schema for every parameter.
- Validates that SFT requires a teacher, RL rejects teacher config, and `teacher.save = true` is not supported.
- Defaults omitted SFT `rollouts_per_example` to `1` while preserving explicit overrides.
- Forwards the public platform payload shape as `loss` and `teacher`.
- Routes top-level `enable_thinking` and `reasoning_effort` sampling aliases into `extra_body.chat_template_kwargs`.
- Updates the confirmation summary so `Training`, `Teacher`, and `Run Config` render as separate sections.
- Keeps the generated template TOML-safe when SFT teacher config and `checkpoint_id` are uncommented together.

## Config Shape

```toml
model = "openai/gpt-oss-20b"
loss = "sft"

[teacher]
model = "openai/gpt-oss-120b"
save = false

[teacher.sampling]
max_tokens = 2048
enable_thinking = false
reasoning_effort = "medium"

[[env]]
id = "primeintellect/wordle"
```

## API Payload

```json
{
  "loss": "sft",
  "teacher": {
    "model": "openai/gpt-oss-120b",
    "save": false,
    "sampling": {
      "max_tokens": 2048,
      "extra_body": {
        "chat_template_kwargs": {
          "enable_thinking": false,
          "reasoning_effort": "medium"
        }
      }
    }
  }
}
```

## Tests

- `uv run pytest packages/prime/tests/test_rl_config.py packages/prime/tests/test_train_cli.py -q`
