### PR TITLE
Fix Windows CLI startup when tunnel imports fail

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -12,7 +12,6 @@ from prime_tunnel.exceptions import (
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
-from prime_tunnel.tunnel import Tunnel
 
 __all__ = [
     "__version__",
@@ -31,3 +30,11 @@ __all__ = [
     "TunnelConnectionError",
     "TunnelTimeoutError",
 ]
+
+
+def __getattr__(name: str):
+    if name == "Tunnel":
+        from prime_tunnel.tunnel import Tunnel
+
+        return Tunnel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -1,5 +1,4 @@
 import asyncio
-import fcntl
 import os
 import re
 import subprocess
@@ -18,6 +17,11 @@ from prime_tunnel.exceptions import (
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
+
+if os.name == "posix":
+    import fcntl
+else:
+    fcntl = None
 
 # timestamp + level + caller prefix + message
 _LOG_RE = re.compile(

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -3,7 +3,6 @@ import signal
 from typing import List, Optional
 
 import typer
-from prime_tunnel import Tunnel
 from prime_tunnel.core.client import TunnelClient
 from prime_tunnel.exceptions import (
     TunnelConnectionError,
@@ -30,6 +29,8 @@ def start_tunnel(
     """Start a tunnel to expose a local port."""
 
     async def run_tunnel():
+        from prime_tunnel import Tunnel
+
         tunnel = Tunnel(local_port=port, name=name, team_id=team_id)
 
         shutdown_event = asyncio.Event()

--- a/packages/prime/tests/test_windows_cli.py
+++ b/packages/prime/tests/test_windows_cli.py
@@ -59,3 +59,60 @@ sys.stdout.write("ok\\n")
 
     assert result.returncode == 0, stderr or stdout
     assert stdout.strip() == "ok"
+
+
+def test_help_does_not_import_tunnel_module() -> None:
+    project_root = Path(__file__).resolve().parents[3]
+    pythonpath = os.pathsep.join(
+        [
+            str(project_root / "packages" / "prime" / "src"),
+            str(project_root / "packages" / "prime-tunnel" / "src"),
+            str(project_root / "packages" / "prime-evals" / "src"),
+            str(project_root / "packages" / "prime-sandboxes" / "src"),
+        ]
+    )
+    env = {
+        **os.environ,
+        "PRIME_DISABLE_VERSION_CHECK": "1",
+        "PYTHONPATH": pythonpath,
+        "PYTHONIOENCODING": "utf-8",
+    }
+    script = """
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "prime_tunnel.tunnel":
+        raise RuntimeError("prime_tunnel.tunnel imported during CLI startup")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = fake_import
+
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+result = CliRunner().invoke(app, ["--help"], env={"PRIME_DISABLE_VERSION_CHECK": "1"})
+if result.exit_code != 0:
+    sys.stderr.write(result.output)
+    raise SystemExit(result.exit_code)
+if "Prime Intellect CLI" not in result.output:
+    sys.stderr.write("missing help banner\\n")
+    raise SystemExit(1)
+sys.stdout.write("ok\\n")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=False,
+        env=env,
+        check=False,
+    )
+
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr or stdout
+    assert stdout.strip() == "ok"

--- a/packages/prime/tests/test_windows_cli.py
+++ b/packages/prime/tests/test_windows_cli.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_works_without_fcntl() -> None:
+    project_root = Path(__file__).resolve().parents[3]
+    pythonpath = os.pathsep.join(
+        [
+            str(project_root / "packages" / "prime" / "src"),
+            str(project_root / "packages" / "prime-tunnel" / "src"),
+            str(project_root / "packages" / "prime-evals" / "src"),
+            str(project_root / "packages" / "prime-sandboxes" / "src"),
+        ]
+    )
+    env = {
+        **os.environ,
+        "PRIME_DISABLE_VERSION_CHECK": "1",
+        "PYTHONPATH": pythonpath,
+        "PYTHONIOENCODING": "utf-8",
+    }
+    script = """
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "fcntl":
+        raise ModuleNotFoundError("No module named 'fcntl'")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = fake_import
+
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+result = CliRunner().invoke(app, ["--help"], env={"PRIME_DISABLE_VERSION_CHECK": "1"})
+if result.exit_code != 0:
+    sys.stderr.write(result.output)
+    raise SystemExit(result.exit_code)
+if "Prime Intellect CLI" not in result.output:
+    sys.stderr.write("missing help banner\\n")
+    raise SystemExit(1)
+sys.stdout.write("ok\\n")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=False,
+        env=env,
+        check=False,
+    )
+
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+
+    assert result.returncode == 0, stderr or stdout
+    assert stdout.strip() == "ok"


### PR DESCRIPTION
What changed
- Stop re-exporting `Tunnel` eagerly from `prime_tunnel.__init__`.
- Lazy-load `Tunnel` only when `prime tunnel start` executes, so unrelated commands do not import `prime_tunnel.tunnel` at CLI startup.
- Guard the `fcntl` import in `prime_tunnel.tunnel` so the module can be imported on non-POSIX platforms.
- Add regression tests covering both the missing-`fcntl` path and the requirement that `prime --help` not import `prime_tunnel.tunnel`.
- This patch is scoped to import-time compatibility and CLI startup behavior, not full tunnel support on Windows.

Why
- On Windows, any invocation of `prime` could fail with `ModuleNotFoundError: No module named 'fcntl'` before command dispatch.
- The CLI imported the tunnel command eagerly in `prime_cli.main`, which imported `prime_tunnel`, which imported Unix-only `fcntl` at module import time.
- That prevented Windows users from using unrelated commands such as `pods`, `availability`, or even `--help`.

Impact
- Windows users can now use the CLI for non-tunnel commands.
- Tunnel code is only imported when `prime tunnel start` is invoked, instead of breaking the entire CLI at startup.
- This does not add or guarantee native Windows support for tunnel functionality itself. A fuller Windows-compatible tunnel design and implementation would still be needed.

Validation
- `uv run pytest packages/prime/tests/test_windows_cli.py packages/prime-tunnel/tests/test_tunnel.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk import-time compatibility change; main risk is accidentally breaking `Tunnel` exports or tunnel startup due to the new lazy-import path.
> 
> **Overview**
> Fixes Windows CLI startup by **removing eager tunnel imports**: `prime_tunnel.Tunnel` is now lazy-exported via `__getattr__`, and the `prime tunnel start` command imports `Tunnel` only when invoked.
> 
> Makes `prime_tunnel.tunnel` importable on non-POSIX platforms by guarding the `fcntl` import, and adds regression tests ensuring `prime --help` works when `fcntl` is unavailable and that CLI help does not import `prime_tunnel.tunnel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958e7d8a23ddac4e1f488962a78877f9da22305e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->