### PR TITLE
ENG-3310: Expose hosted training rollouts to coding agents via MCP

### DIFF
--- a/packages/prime-mcp-server/src/prime_mcp/__init__.py
+++ b/packages/prime-mcp-server/src/prime_mcp/__init__.py
@@ -1,6 +1,6 @@
 from prime_mcp.client import make_prime_request
 from prime_mcp.mcp import mcp
-from prime_mcp.tools import availability, pods, ssh
+from prime_mcp.tools import availability, pods, rl, ssh
 
 __version__ = "0.1.2"
 
@@ -9,5 +9,6 @@ __all__ = [
     "make_prime_request",
     "availability",
     "pods",
+    "rl",
     "ssh",
 ]

--- a/packages/prime-mcp-server/src/prime_mcp/mcp.py
+++ b/packages/prime-mcp-server/src/prime_mcp/mcp.py
@@ -1,6 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 
-from prime_mcp.tools import availability, pods, ssh
+from prime_mcp.tools import availability, pods, rl, ssh
 
 mcp = FastMCP("primeintellect")
 
@@ -251,6 +251,64 @@ async def manage_ssh_keys(
         SSH key operation result
     """
     return await ssh.manage_ssh_keys(action, key_name, public_key, key_id, offset, limit)
+
+
+@mcp.tool()
+async def list_rl_runs(team_id: str | None = None) -> dict:
+    """List hosted training runs available to the authenticated user.
+
+    This surfaces Prime hosted RL training runs to coding agents.
+    If team_id is omitted, the API returns personal runs plus runs from teams the user belongs to.
+
+    Args:
+        team_id: Optional team ID to limit the results to a single team context
+
+    Returns:
+        Hosted training runs with status, configuration, and metadata
+    """
+    return await rl.list_rl_runs(team_id)
+
+
+@mcp.tool()
+async def get_rl_run_progress(run_id: str) -> dict:
+    """Get progress metadata for a hosted training run.
+
+    Use this before fetching rollouts to discover:
+    - latestStep: newest training step seen by the backend
+    - stepsWithSamples: steps that currently have rollout samples available
+    - stepsWithDistributions: steps that currently have histogram data available
+
+    Args:
+        run_id: Unique identifier of the hosted training run
+
+    Returns:
+        Progress metadata for the run
+    """
+    return await rl.get_rl_run_progress(run_id)
+
+
+@mcp.tool()
+async def get_rl_run_rollouts(
+    run_id: str,
+    step: int,
+    page: int = 1,
+    limit: int = 100,
+) -> dict:
+    """Get rollout samples for a hosted training run step.
+
+    This exposes the same rollout samples shown for hosted training in the CLI/product so coding
+    agents can inspect concrete prompt/completion trajectories.
+
+    Args:
+        run_id: Unique identifier of the hosted training run
+        step: Training step to fetch rollouts for
+        page: Page number to fetch (1-indexed)
+        limit: Maximum number of rollout samples to return for the page
+
+    Returns:
+        Rollout samples and pagination metadata for the requested step
+    """
+    return await rl.get_rl_run_rollouts(run_id, step=step, page=page, limit=limit)
 
 
 if __name__ == "__main__":

--- a/packages/prime-mcp-server/src/prime_mcp/tools/rl.py
+++ b/packages/prime-mcp-server/src/prime_mcp/tools/rl.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from prime_mcp.client import make_prime_request
+
+
+async def list_rl_runs(team_id: str | None = None) -> dict[str, Any]:
+    """List hosted RL training runs for the authenticated user."""
+    params = {"team_id": team_id} if team_id else None
+    response_data = await make_prime_request("GET", "rft/runs", params=params)
+
+    if not response_data:
+        return {"error": "Unable to fetch RL runs"}
+
+    return response_data
+
+
+async def get_rl_run_progress(run_id: str) -> dict[str, Any]:
+    """Get rollout/distribution progress metadata for a hosted RL training run."""
+    response_data = await make_prime_request("GET", f"rft/runs/{run_id}/progress")
+
+    if not response_data:
+        return {"error": f"Unable to fetch progress for RL run: {run_id}"}
+
+    return response_data
+
+
+async def get_rl_run_rollouts(
+    run_id: str,
+    step: int,
+    page: int = 1,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Get rollout samples for a hosted RL training run step."""
+    if step < 0:
+        return {"error": "step must be greater than or equal to 0"}
+    if page < 1:
+        return {"error": "page must be greater than 0"}
+    if limit < 1:
+        return {"error": "limit must be greater than 0"}
+
+    response_data = await make_prime_request(
+        "GET",
+        f"rft/runs/{run_id}/samples",
+        params={"step": step, "page": page, "limit": limit},
+    )
+
+    if not response_data:
+        return {"error": f"Unable to fetch rollouts for RL run: {run_id}"}
+
+    return response_data

--- a/packages/prime-mcp-server/tests/test_mcp.py
+++ b/packages/prime-mcp-server/tests/test_mcp.py
@@ -82,6 +82,7 @@ async def test_create_pod_validation():
         cloud_id="test-cloud-id",
         gpu_type="A100_80GB",
         provider_type="runpod",
+        data_center_id="test-dc",
         gpu_count=0,  # Invalid
     )
 
@@ -96,6 +97,7 @@ async def test_create_pod_disk_size_validation():
         cloud_id="test-cloud-id",
         gpu_type="A100_80GB",
         provider_type="runpod",
+        data_center_id="test-dc",
         disk_size=0,  # Invalid
     )
 
@@ -110,6 +112,7 @@ async def test_create_pod_vcpus_validation():
         cloud_id="test-cloud-id",
         gpu_type="A100_80GB",
         provider_type="runpod",
+        data_center_id="test-dc",
         vcpus=0,  # Invalid
     )
 
@@ -124,6 +127,7 @@ async def test_create_pod_memory_validation():
         cloud_id="test-cloud-id",
         gpu_type="A100_80GB",
         provider_type="runpod",
+        data_center_id="test-dc",
         memory=0,  # Invalid
     )
 
@@ -180,10 +184,11 @@ async def test_manage_ssh_keys_invalid_action():
 
 def test_imports():
     """Test that all main modules can be imported"""
-    from prime_mcp import make_prime_request, mcp
+    from prime_mcp import make_prime_request, mcp, rl
 
     assert mcp is not None
     assert make_prime_request is not None
+    assert rl is not None
 
 
 if __name__ == "__main__":

--- a/packages/prime-mcp-server/tests/test_rl_tools.py
+++ b/packages/prime-mcp-server/tests/test_rl_tools.py
@@ -1,0 +1,141 @@
+import importlib
+
+import pytest
+
+from prime_mcp.tools import rl
+
+mcp_module = importlib.import_module("prime_mcp.mcp")
+
+
+@pytest.mark.asyncio
+async def test_list_rl_runs_passes_team_filter(monkeypatch):
+    captured = {}
+
+    async def fake_make_prime_request(method, endpoint, params=None, json_data=None):
+        captured.update(
+            {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params,
+                "json_data": json_data,
+            }
+        )
+        return {"runs": []}
+
+    monkeypatch.setattr(rl, "make_prime_request", fake_make_prime_request)
+
+    result = await rl.list_rl_runs(team_id="team-123")
+
+    assert result == {"runs": []}
+    assert captured == {
+        "method": "GET",
+        "endpoint": "rft/runs",
+        "params": {"team_id": "team-123"},
+        "json_data": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_rl_run_progress_uses_progress_endpoint(monkeypatch):
+    captured = {}
+    payload = {"latestStep": 42, "stepsWithSamples": [40, 41, 42]}
+
+    async def fake_make_prime_request(method, endpoint, params=None, json_data=None):
+        captured.update(
+            {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params,
+                "json_data": json_data,
+            }
+        )
+        return payload
+
+    monkeypatch.setattr(rl, "make_prime_request", fake_make_prime_request)
+
+    result = await rl.get_rl_run_progress("run-123")
+
+    assert result == payload
+    assert captured == {
+        "method": "GET",
+        "endpoint": "rft/runs/run-123/progress",
+        "params": None,
+        "json_data": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_rl_run_rollouts_passes_pagination(monkeypatch):
+    captured = {}
+    payload = {"samples": [{"prompt": "hi"}], "page": 2, "limit": 50}
+
+    async def fake_make_prime_request(method, endpoint, params=None, json_data=None):
+        captured.update(
+            {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params,
+                "json_data": json_data,
+            }
+        )
+        return payload
+
+    monkeypatch.setattr(rl, "make_prime_request", fake_make_prime_request)
+
+    result = await rl.get_rl_run_rollouts("run-123", step=7, page=2, limit=50)
+
+    assert result == payload
+    assert captured == {
+        "method": "GET",
+        "endpoint": "rft/runs/run-123/samples",
+        "params": {"step": 7, "page": 2, "limit": 50},
+        "json_data": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"step": -1}, "step must be greater than or equal to 0"),
+        ({"step": 1, "page": 0}, "page must be greater than 0"),
+        ({"step": 1, "limit": 0}, "limit must be greater than 0"),
+    ],
+)
+async def test_get_rl_run_rollouts_validates_pagination(monkeypatch, kwargs, message):
+    async def fail_make_prime_request(*args, **kwargs):
+        raise AssertionError("make_prime_request should not be called for invalid input")
+
+    monkeypatch.setattr(rl, "make_prime_request", fail_make_prime_request)
+
+    result = await rl.get_rl_run_rollouts("run-123", **kwargs)
+
+    assert result == {"error": message}
+
+
+@pytest.mark.asyncio
+async def test_mcp_rollout_tools_delegate_to_rl_module(monkeypatch):
+    async def fake_list(team_id):
+        return {"team_id": team_id, "runs": []}
+
+    async def fake_progress(run_id):
+        return {"run_id": run_id, "latestStep": 9}
+
+    async def fake_rollouts(run_id, step, page=1, limit=100):
+        return {"run_id": run_id, "step": step, "page": page, "limit": limit}
+
+    monkeypatch.setattr(mcp_module.rl, "list_rl_runs", fake_list)
+    monkeypatch.setattr(mcp_module.rl, "get_rl_run_progress", fake_progress)
+    monkeypatch.setattr(mcp_module.rl, "get_rl_run_rollouts", fake_rollouts)
+
+    assert await mcp_module.list_rl_runs("team-123") == {"team_id": "team-123", "runs": []}
+    assert await mcp_module.get_rl_run_progress("run-123") == {
+        "run_id": "run-123",
+        "latestStep": 9,
+    }
+    assert await mcp_module.get_rl_run_rollouts("run-123", step=3, page=2, limit=25) == {
+        "run_id": "run-123",
+        "step": 3,
+        "page": 2,
+        "limit": 25,
+    }


### PR DESCRIPTION
## Summary
- expose hosted RL runs, progress, and rollout samples through the MCP server
- add focused tests for the new MCP tool surface and fix existing pod validation tests

## Testing
- uv run pytest packages/prime-mcp-server/tests/test_mcp.py packages/prime-mcp-server/tests/test_rl_tools.py -q
- uv run ruff check packages/prime-mcp-server/src/prime_mcp packages/prime-mcp-server/tests

Closes ENG-3310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MCP tool surface that fetches hosted training metadata and rollout samples from backend APIs, increasing reliance on new endpoints and potentially exposing larger/variable payloads. Changes are otherwise additive with basic input validation and test coverage.
> 
> **Overview**
> Adds new MCP tools to surface hosted RL training data to coding agents: `list_rl_runs`, `get_rl_run_progress`, and `get_rl_run_rollouts`.
> 
> Implements a new `prime_mcp.tools.rl` module that calls Prime API endpoints (`rft/runs`, `.../progress`, `.../samples`) with simple pagination validation and error handling, and exports `rl` from the package.
> 
> Updates tests to cover the new RL tool/module behavior and MCP delegation, and fixes existing `pods.create_pod` validation tests to pass the now-required `data_center_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8384b1ff200d342f767f7d194aeab1d61238c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->