### PR TITLE
ENG-3310: Document hosted training rollout commands for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ prime pods terminate <pod-id>
 prime pods ssh <pod-id>
 ```
 
+### Hosted RL Training Monitoring
+
+Inspect hosted training runs and rollout samples from the CLI; these commands return JSON, so they also work well for coding agents and scripts.
+
+```bash
+# List hosted training runs
+prime rl list
+
+# See which steps currently have rollout samples available
+prime rl progress <run-id>
+
+# Fetch rollout samples for a specific training step
+prime rl rollouts <run-id> --step 50
+
+# Inspect a single sample with jq
+prime rl rollouts <run-id> --step 50 --num 20 | jq '.samples[0]'
+```
+
 ### Evaluations
 
 Push and manage evaluation results to the Environments Hub.

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -167,6 +167,24 @@ prime sandbox download <sandbox-id> /remote/file.txt ./local/
 prime sandbox delete <sandbox-id>
 ```
 
+### Hosted RL Training Monitoring
+
+Inspect hosted training runs and rollout samples from the CLI; these commands emit machine-readable JSON and work well for coding agents and scripts.
+
+```bash
+# List hosted training runs
+prime rl list
+
+# See which steps currently have rollout samples available
+prime rl progress <run-id>
+
+# Fetch rollout samples for a specific training step
+prime rl rollouts <run-id> --step 50
+
+# Inspect a single sample with jq
+prime rl rollouts <run-id> --step 50 --num 20 | jq '.samples[0]'
+```
+
 ### Team Management
 
 Manage resources across personal and team contexts:


### PR DESCRIPTION
## Summary
- document the existing CLI commands for hosted RL run inspection and rollout retrieval
- clarify that `prime rl progress` and `prime rl rollouts` are the right machine-readable surface for coding agents

## Testing
- not run (docs-only change)

Closes ENG-3310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only update; no runtime behavior changes, just new README guidance that could mildly confuse users if commands/options drift.
> 
> **Overview**
> Adds a new **Hosted RL Training Monitoring** section to both `README.md` and `packages/prime/README.md` documenting existing `prime rl` CLI commands for listing runs, checking rollout availability (`prime rl progress`), and fetching rollout samples (`prime rl rollouts`) with JSON/jq-friendly examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d6379f3014889d6ad820ef2ff3a278a68c7d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->