### PR TITLE
release: cli 0.5.63

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.62"
+__version__ = "0.5.63"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2127,6 +2127,11 @@ def install(
         "--no-upgrade",
         help="Don't upgrade existing packages. Useful with locked dependencies (uv.lock).",
     ),
+    prerelease: bool = typer.Option(
+        False,
+        "--prerelease",
+        help="Allow pre-release versions (e.g., verifiers>=0.1.12.dev3).",
+    ),
 ) -> None:
     """Install a verifiers environment.
 
@@ -2276,6 +2281,7 @@ def install(
                 with_tool,
                 no_upgrade,
                 url_dependencies,
+                prerelease=prerelease,
             )
             if not cmd_parts:
                 skipped_envs.append((f"{env_id}@{target_version}", "No installation method"))
@@ -2912,6 +2918,7 @@ def _build_install_command(
     tool: str = "uv",
     no_upgrade: bool = False,
     url_dependencies: Optional[List[str]] = None,
+    prerelease: bool = False,
 ) -> Optional[List[str]]:
     """Build install command for an environment. Returns None if no install method available.
 
@@ -2940,11 +2947,15 @@ def _build_install_command(
             if url_dependencies:
                 cmd.extend(url_dependencies)
             cmd.extend(["--extra-index-url", simple_index_url])
+            if prerelease:
+                cmd.append("--prerelease=allow")
             return cmd
         else:  # pip
             cmd = ["pip", "install"]
             if not no_upgrade:
                 cmd.append("--upgrade")
+            if prerelease:
+                cmd.append("--pre")
             if version and version != "latest":
                 cmd.append(f"{normalized_name}=={version}")
             else:
@@ -2967,7 +2978,7 @@ def _build_install_command(
     return None
 
 
-def _install_single_environment(env_slug: str, tool: str = "uv") -> bool:
+def _install_single_environment(env_slug: str, tool: str = "uv", prerelease: bool = False) -> bool:
     """Install a single environment from the hub. Returns True on success."""
     try:
         env_id, target_version = validate_env_id(env_slug)
@@ -3014,7 +3025,8 @@ def _install_single_environment(env_slug: str, tool: str = "uv") -> bool:
         return False
 
     cmd_parts = _build_install_command(
-        name, target_version, simple_index_url, wheel_url, tool, url_dependencies=url_dependencies
+        name, target_version, simple_index_url, wheel_url, tool, url_dependencies=url_dependencies,
+        prerelease=prerelease,
     )
     if not cmd_parts:
         console.print(f"[red]Failed to build install command for {env_slug}[/red]")

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2246,10 +2246,14 @@ def install(
                             # Use -P to only upgrade this package, not its dependencies
                             cmd_parts.extend(["-P", normalized_name])
                         cmd_parts.append(str(wheel_path))
+                        if prerelease:
+                            cmd_parts.append("--prerelease=allow")
                     else:
                         cmd_parts = ["pip", "install", str(wheel_path)]
                         if not no_upgrade:
                             cmd_parts.append("--upgrade")
+                        if prerelease:
+                            cmd_parts.append("--pre")
                     installable_envs.append((cmd_parts, env_id, resolved_version, name))
                     console.print(f"[green]✓ Built {env_id}@{resolved_version}[/green]")
                 except Exception as e:
@@ -2971,6 +2975,11 @@ def _build_install_command(
             # Add URL dependencies for wheel-only installs too
             if url_dependencies:
                 cmd.extend(url_dependencies)
+            if prerelease:
+                if tool == "uv":
+                    cmd.append("--prerelease=allow")
+                else:
+                    cmd.append("--pre")
             return cmd
         except ValueError:
             return None
@@ -3012,8 +3021,12 @@ def _install_single_environment(env_slug: str, tool: str = "uv", prerelease: boo
             normalized_name = normalize_package_name(name)
             if tool == "uv":
                 cmd_parts = _uv_pip_command("install", "-P", normalized_name, str(wheel_path))
+                if prerelease:
+                    cmd_parts.append("--prerelease=allow")
             else:
                 cmd_parts = ["pip", "install", "--upgrade", str(wheel_path)]
+                if prerelease:
+                    cmd_parts.append("--pre")
             execute_install_command(cmd_parts, env_id, resolved_version, tool)
             return True
         except Exception as e:


### PR DESCRIPTION
## Changes since v0.5.62

- Add `--prerelease` flag to `prime env install` (#518)
  - Environments depending on dev releases (e.g. `verifiers>=0.1.12.dev5`) fail without this flag
  - Passes `--prerelease=allow` to uv / `--pre` to pip
  - Threaded through `_install_single_environment` for orchestrator compatibility

## Usage
```bash
prime env install primeintellect/opencode-math --prerelease
```

## Merge order
1. prime#518 (`--prerelease` flag)
2. **This PR** (release CLI 0.5.63, tag v0.5.63)
3. prime-rl#2279 (`env_install_prerelease` config + `prime>=0.5.63` bump)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds an opt-in CLI flag that appends standard pre-release install switches to `uv`/`pip`, plus a version bump.
> 
> **Overview**
> Bumps the Prime CLI version to `0.5.63`.
> 
> Adds a new `--prerelease` flag to `prime env install` and threads it through environment install paths (including `_build_install_command` and `_install_single_environment`), so installs can opt into pre-release dependencies by passing `--prerelease=allow` to `uv` or `--pre` to `pip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fefe0e587b72d8b07d292d63d98bf2ead8b3646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->