### PR TITLE
release: cli 0.5.65

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.64"
+__version__ = "0.5.65"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.5.65.

- Picks up #513 (hosted eval arg parity + rejection of unsupported passthrough flags).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no functional code modifications.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.64` to `0.5.65` (via `prime_cli/__init__.py`) for the release cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd2921b4a39fb623831df5f750ddc68b3fe7c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->