### PR TITLE
Add allow-tunnel-access for hosted evaluations

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -95,6 +95,7 @@ HOSTED_EVAL_CONFIG_EXTRA_FIELDS = {
     "timeout_minutes",
     "allow_sandbox_access",
     "allow_instances_access",
+    "tunnel_id",
     "eval_name",
 }
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
@@ -110,6 +111,7 @@ HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "independent_scoring": (bool, "a boolean"),
     "api_client_type": (str, "a non-empty string"),
     "api_base_url": (str, "a non-empty string"),
+    "tunnel_id": (str, "a non-empty string"),
     "api_key_var": (str, "a non-empty string"),
     "eval_name": (str, "a non-empty string"),
 }
@@ -138,6 +140,7 @@ HOSTED_SUPPORTED_TOML_FIELDS = {
     "api_base_url",
     "api_client_type",
     "api_key_var",
+    "tunnel_id",
     "endpoint_id",
     "endpoints_path",
     "env_id",
@@ -481,6 +484,9 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         "allow_instances_access": config.allow_instances_access,
     }
 
+    if config.api_base_url and config.tunnel_id:
+        raise APIError("use either `--api-base-url` or `--tunnel-id`, not both")
+
     if config.env_args:
         eval_config["env_args"] = config.env_args
     if config.timeout_minutes is not None:
@@ -505,6 +511,8 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         eval_config["api_client_type"] = config.api_client_type
     if config.api_base_url:
         eval_config["api_base_url"] = config.api_base_url
+    if config.tunnel_id:
+        eval_config["tunnel_id"] = config.tunnel_id
     if config.api_key_var:
         eval_config["api_key_var"] = config.api_key_var
 
@@ -1329,6 +1337,11 @@ def run_eval_cmd(
         "--custom-secrets",
         help='Custom secrets for hosted eval as JSON (e.g. \'{"API_KEY":"xxx"}\')',
     ),
+    tunnel_id: Optional[str] = typer.Option(
+        None,
+        "--tunnel-id",
+        help="Prime Tunnel ID to use as the hosted eval inference endpoint",
+    ),
     sampling_args: Optional[str] = typer.Option(
         None,
         "--sampling-args",
@@ -1376,6 +1389,7 @@ def run_eval_cmd(
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
             "--custom-secrets": custom_secrets is not None,
+            "--tunnel-id": tunnel_id is not None,
             "--eval-name": eval_name is not None,
         }
         used_hosted_only_args = [flag for flag, used in hosted_only_args.items() if used]
@@ -1427,6 +1441,7 @@ def run_eval_cmd(
                     "extra_env_kwargs": None,
                     "api_client_type": None,
                     "api_base_url": None,
+                    "tunnel_id": None,
                     "api_key_var": None,
                     "eval_name": None,
                 }
@@ -1569,6 +1584,7 @@ def run_eval_cmd(
                         if "api_base_url" in cli_overrides
                         else target_config.get("api_base_url")
                     ),
+                    "tunnel_id": tunnel_id or target_config.get("tunnel_id"),
                     "api_key_var": (
                         parsed_verifiers_args.api_key_var
                         if "api_key_var" in cli_overrides
@@ -1604,6 +1620,7 @@ def run_eval_cmd(
                 _freeze_json_value(target.get("extra_env_kwargs")),
                 target.get("api_client_type"),
                 target.get("api_base_url"),
+                target.get("tunnel_id"),
                 target.get("api_key_var"),
                 target.get("eval_name"),
             )
@@ -1658,6 +1675,7 @@ def run_eval_cmd(
                     extra_env_kwargs=target.get("extra_env_kwargs"),
                     api_client_type=target.get("api_client_type"),
                     api_base_url=target.get("api_base_url"),
+                    tunnel_id=target.get("tunnel_id"),
                     api_key_var=target.get("api_key_var"),
                 )
                 result = _create_hosted_evaluations(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -95,7 +95,7 @@ HOSTED_EVAL_CONFIG_EXTRA_FIELDS = {
     "timeout_minutes",
     "allow_sandbox_access",
     "allow_instances_access",
-    "tunnel_id",
+    "allow_tunnel_access",
     "eval_name",
 }
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
@@ -105,13 +105,13 @@ HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "timeout_minutes": (int, "an integer"),
     "allow_sandbox_access": (bool, "a boolean"),
     "allow_instances_access": (bool, "a boolean"),
+    "allow_tunnel_access": (bool, "a boolean"),
     "max_tokens": (int, "an integer"),
     "max_concurrent": (int, "an integer"),
     "max_retries": (int, "an integer"),
     "independent_scoring": (bool, "a boolean"),
     "api_client_type": (str, "a non-empty string"),
     "api_base_url": (str, "a non-empty string"),
-    "tunnel_id": (str, "a non-empty string"),
     "api_key_var": (str, "a non-empty string"),
     "eval_name": (str, "a non-empty string"),
 }
@@ -137,10 +137,10 @@ HOSTED_SUPPORTED_VERIFIERS_FIELDS = {
 HOSTED_SUPPORTED_TOML_FIELDS = {
     "allow_instances_access",
     "allow_sandbox_access",
+    "allow_tunnel_access",
     "api_base_url",
     "api_client_type",
     "api_key_var",
-    "tunnel_id",
     "endpoint_id",
     "endpoints_path",
     "env_id",
@@ -482,10 +482,8 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         "rollouts_per_example": config.rollouts_per_example,
         "allow_sandbox_access": config.allow_sandbox_access,
         "allow_instances_access": config.allow_instances_access,
+        "allow_tunnel_access": config.allow_tunnel_access,
     }
-
-    if config.api_base_url and config.tunnel_id:
-        raise APIError("use either `--api-base-url` or `--tunnel-id`, not both")
 
     if config.env_args:
         eval_config["env_args"] = config.env_args
@@ -511,8 +509,6 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         eval_config["api_client_type"] = config.api_client_type
     if config.api_base_url:
         eval_config["api_base_url"] = config.api_base_url
-    if config.tunnel_id:
-        eval_config["tunnel_id"] = config.tunnel_id
     if config.api_key_var:
         eval_config["api_key_var"] = config.api_key_var
 
@@ -1332,15 +1328,15 @@ def run_eval_cmd(
         "--allow-instances-access",
         help="Allow instance creation and management for hosted evaluations",
     ),
+    allow_tunnel_access: bool = typer.Option(
+        False,
+        "--allow-tunnel-access",
+        help="Allow tunnel creation and management for hosted evaluations",
+    ),
     custom_secrets: Optional[str] = typer.Option(
         None,
         "--custom-secrets",
         help='Custom secrets for hosted eval as JSON (e.g. \'{"API_KEY":"xxx"}\')',
-    ),
-    tunnel_id: Optional[str] = typer.Option(
-        None,
-        "--tunnel-id",
-        help=("Optional Prime Tunnel ID convenience; for any public tunnel URL use --api-base-url"),
     ),
     sampling_args: Optional[str] = typer.Option(
         None,
@@ -1388,8 +1384,8 @@ def run_eval_cmd(
             "--timeout-minutes": timeout_minutes is not None,
             "--allow-sandbox-access": allow_sandbox_access,
             "--allow-instances-access": allow_instances_access,
+            "--allow-tunnel-access": allow_tunnel_access,
             "--custom-secrets": custom_secrets is not None,
-            "--tunnel-id": tunnel_id is not None,
             "--eval-name": eval_name is not None,
         }
         used_hosted_only_args = [flag for flag, used in hosted_only_args.items() if used]
@@ -1432,6 +1428,7 @@ def run_eval_cmd(
                     "timeout_minutes": None,
                     "allow_sandbox_access": False,
                     "allow_instances_access": False,
+                    "allow_tunnel_access": False,
                     "sampling_args": None,
                     "max_concurrent": None,
                     "max_retries": None,
@@ -1441,7 +1438,6 @@ def run_eval_cmd(
                     "extra_env_kwargs": None,
                     "api_client_type": None,
                     "api_base_url": None,
-                    "tunnel_id": None,
                     "api_key_var": None,
                     "eval_name": None,
                 }
@@ -1513,19 +1509,6 @@ def run_eval_cmd(
                 or None
             )
 
-            effective_api_base_url = (
-                parsed_verifiers_args.api_base_url
-                if "api_base_url" in cli_overrides
-                else target_config.get("api_base_url")
-            )
-            effective_tunnel_id = (
-                tunnel_id if tunnel_id is not None else target_config.get("tunnel_id")
-            )
-            if tunnel_id is not None:
-                effective_api_base_url = None
-            if "api_base_url" in cli_overrides:
-                effective_tunnel_id = None
-
             effective_targets.append(
                 {
                     "env_id": target_config["env_id"],
@@ -1556,6 +1539,11 @@ def run_eval_cmd(
                         allow_instances_access
                         if allow_instances_access
                         else target_config.get("allow_instances_access", False)
+                    ),
+                    "allow_tunnel_access": (
+                        allow_tunnel_access
+                        if allow_tunnel_access
+                        else target_config.get("allow_tunnel_access", False)
                     ),
                     "custom_secrets": parsed_custom_secrets,
                     "sampling_args": effective_sampling_args,
@@ -1592,8 +1580,11 @@ def run_eval_cmd(
                         if "api_client_type" in cli_overrides
                         else target_config.get("api_client_type")
                     ),
-                    "api_base_url": effective_api_base_url,
-                    "tunnel_id": effective_tunnel_id,
+                    "api_base_url": (
+                        parsed_verifiers_args.api_base_url
+                        if "api_base_url" in cli_overrides
+                        else target_config.get("api_base_url")
+                    ),
                     "api_key_var": (
                         parsed_verifiers_args.api_key_var
                         if "api_key_var" in cli_overrides
@@ -1620,6 +1611,7 @@ def run_eval_cmd(
                 target.get("timeout_minutes"),
                 target.get("allow_sandbox_access", False),
                 target.get("allow_instances_access", False),
+                target.get("allow_tunnel_access", False),
                 _freeze_json_value(target.get("sampling_args")),
                 target.get("max_concurrent"),
                 target.get("max_retries"),
@@ -1629,7 +1621,6 @@ def run_eval_cmd(
                 _freeze_json_value(target.get("extra_env_kwargs")),
                 target.get("api_client_type"),
                 target.get("api_base_url"),
-                target.get("tunnel_id"),
                 target.get("api_key_var"),
                 target.get("eval_name"),
             )
@@ -1674,6 +1665,7 @@ def run_eval_cmd(
                     timeout_minutes=target.get("timeout_minutes"),
                     allow_sandbox_access=target.get("allow_sandbox_access", False),
                     allow_instances_access=target.get("allow_instances_access", False),
+                    allow_tunnel_access=target.get("allow_tunnel_access", False),
                     custom_secrets=target.get("custom_secrets"),
                     sampling_args=target.get("sampling_args"),
                     max_concurrent=target.get("max_concurrent"),
@@ -1684,7 +1676,6 @@ def run_eval_cmd(
                     extra_env_kwargs=target.get("extra_env_kwargs"),
                     api_client_type=target.get("api_client_type"),
                     api_base_url=target.get("api_base_url"),
-                    tunnel_id=target.get("tunnel_id"),
                     api_key_var=target.get("api_key_var"),
                 )
                 result = _create_hosted_evaluations(

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1513,6 +1513,19 @@ def run_eval_cmd(
                 or None
             )
 
+            effective_api_base_url = (
+                parsed_verifiers_args.api_base_url
+                if "api_base_url" in cli_overrides
+                else target_config.get("api_base_url")
+            )
+            effective_tunnel_id = (
+                tunnel_id if tunnel_id is not None else target_config.get("tunnel_id")
+            )
+            if tunnel_id is not None:
+                effective_api_base_url = None
+            if "api_base_url" in cli_overrides:
+                effective_tunnel_id = None
+
             effective_targets.append(
                 {
                     "env_id": target_config["env_id"],
@@ -1579,12 +1592,8 @@ def run_eval_cmd(
                         if "api_client_type" in cli_overrides
                         else target_config.get("api_client_type")
                     ),
-                    "api_base_url": (
-                        parsed_verifiers_args.api_base_url
-                        if "api_base_url" in cli_overrides
-                        else target_config.get("api_base_url")
-                    ),
-                    "tunnel_id": tunnel_id or target_config.get("tunnel_id"),
+                    "api_base_url": effective_api_base_url,
+                    "tunnel_id": effective_tunnel_id,
                     "api_key_var": (
                         parsed_verifiers_args.api_key_var
                         if "api_key_var" in cli_overrides

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1340,7 +1340,7 @@ def run_eval_cmd(
     tunnel_id: Optional[str] = typer.Option(
         None,
         "--tunnel-id",
-        help="Prime Tunnel ID to use as the hosted eval inference endpoint",
+        help=("Optional Prime Tunnel ID convenience; for any public tunnel URL use --api-base-url"),
     ),
     sampling_args: Optional[str] = typer.Option(
         None,

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -54,6 +54,7 @@ class HostedEvalConfig:
     extra_env_kwargs: Optional[dict[str, Any]] = None
     api_client_type: Optional[str] = None
     api_base_url: Optional[str] = None
+    tunnel_id: Optional[str] = None
     api_key_var: Optional[str] = None
 
 

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -44,6 +44,7 @@ class HostedEvalConfig:
     timeout_minutes: Optional[int] = None
     allow_sandbox_access: bool = False
     allow_instances_access: bool = False
+    allow_tunnel_access: bool = False
     custom_secrets: Optional[dict[str, str]] = None
     sampling_args: Optional[dict[str, Any]] = None
     max_concurrent: Optional[int] = None
@@ -54,7 +55,6 @@ class HostedEvalConfig:
     extra_env_kwargs: Optional[dict[str, Any]] = None
     api_client_type: Optional[str] = None
     api_base_url: Optional[str] = None
-    tunnel_id: Optional[str] = None
     api_key_var: Optional[str] = None
 
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -131,6 +131,8 @@ def _append_eval_options(help_text: str) -> str:
         "  --allow-instances-access    "
         "Allow instance creation and management for hosted evaluations.",
         "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
+        "  --tunnel-id TEXT            "
+        "Prime Tunnel ID to use as the hosted eval inference endpoint.",
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
     ]
     lines = help_text.rstrip("\n").splitlines()

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -132,7 +132,7 @@ def _append_eval_options(help_text: str) -> str:
         "Allow instance creation and management for hosted evaluations.",
         "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
         "  --tunnel-id TEXT            "
-        "Prime Tunnel ID to use as the hosted eval inference endpoint.",
+        "Optional Prime Tunnel ID convenience; for any public tunnel URL use --api-base-url.",
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
     ]
     lines = help_text.rstrip("\n").splitlines()

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -130,9 +130,9 @@ def _append_eval_options(help_text: str) -> str:
         "  --allow-sandbox-access      Allow sandbox read/write access for hosted evaluations.",
         "  --allow-instances-access    "
         "Allow instance creation and management for hosted evaluations.",
+        "  --allow-tunnel-access       "
+        "Allow tunnel creation and management for hosted evaluations.",
         "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
-        "  --tunnel-id TEXT            "
-        "Optional Prime Tunnel ID convenience; for any public tunnel URL use --api-base-url.",
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
     ]
     lines = help_text.rstrip("\n").splitlines()

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -1,5 +1,5 @@
 from prime_cli.main import app
-from prime_cli.verifiers_bridge import _sanitize_help_text
+from prime_cli.verifiers_bridge import _append_eval_options, _sanitize_help_text
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -37,3 +37,9 @@ def test_sanitize_help_removes_vf_eval_aliases():
     assert "verifiers.cli.commands.eval" not in help_text
     assert "vf-eval" not in help_text
     assert "env_id_or_config" not in help_text
+
+
+def test_append_eval_options_mentions_api_base_url_for_tunnels():
+    help_text = _append_eval_options("Usage: prime eval run [-h] environment\n")
+
+    assert "for any public tunnel URL use --api-base-url" in help_text

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -39,7 +39,7 @@ def test_sanitize_help_removes_vf_eval_aliases():
     assert "env_id_or_config" not in help_text
 
 
-def test_append_eval_options_mentions_api_base_url_for_tunnels():
+def test_append_eval_options_mentions_tunnel_access():
     help_text = _append_eval_options("Usage: prime eval run [-h] environment\n")
 
-    assert "for any public tunnel URL use --api-base-url" in help_text
+    assert "--allow-tunnel-access" in help_text

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -240,6 +240,43 @@ def test_eval_run_hosted_passes_api_base_url_and_key_var(monkeypatch):
     assert captured["api_key_var"] == "OPENAI_API_KEY"
 
 
+def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["tunnel_id"] = config.tunnel_id
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "primeintellect/gsm8k",
+            "--hosted",
+            "--tunnel-id",
+            "t-0-0123456789abcdef",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["tunnel_id"] == "t-0-0123456789abcdef"
+
+
 def test_eval_run_hosted_passes_extra_env_kwargs(monkeypatch):
     captured = {}
 
@@ -474,6 +511,63 @@ def test_create_hosted_evaluation_includes_api_base_url_and_key_var_in_payload(m
     assert captured["json"]["eval_config"]["api_key_var"] == "OPENAI_API_KEY"
 
 
+def test_create_hosted_evaluation_includes_tunnel_id_in_payload(monkeypatch):
+    captured = {}
+
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+            tunnel_id="t-0-0123456789abcdef",
+        )
+    )
+
+    assert captured["endpoint"] == "/hosted-evaluations"
+    assert captured["json"]["eval_config"]["tunnel_id"] == "t-0-0123456789abcdef"
+
+
+def test_create_hosted_evaluation_rejects_api_base_url_and_tunnel_id_together(monkeypatch):
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    with pytest.raises(APIError, match="use either `--api-base-url` or `--tunnel-id`, not both"):
+        _create_hosted_evaluations(
+            HostedEvalConfig(
+                environment_id="env-123",
+                inference_model="openai/gpt-4.1-mini",
+                num_examples=5,
+                rollouts_per_example=3,
+                api_base_url="https://api.openai.com/v1",
+                tunnel_id="t-0-0123456789abcdef",
+            )
+        )
+
+
 def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
     class DummyConfig:
         team_id = None
@@ -554,6 +648,48 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     assert captured["display_tail"] == 1000
     assert captured["display_follow"] is True
     assert captured["display_poll_interval"] == 10.0
+
+
+def test_eval_run_hosted_supports_tunnel_id_from_toml(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'model = "openai/gpt-4.1-mini"',
+                'tunnel_id = "t-0-0123456789abcdef"',
+                "",
+                "[[eval]]",
+                'env_id = "gsm8k"',
+            ]
+        )
+    )
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["tunnel_id"] = config.tunnel_id
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["tunnel_id"] == "t-0-0123456789abcdef"
 
 
 def test_eval_run_hosted_supports_single_eval_toml(monkeypatch, tmp_path):
@@ -1315,6 +1451,16 @@ def test_eval_run_rejects_hosted_only_flags_without_hosted():
     result = runner.invoke(
         app,
         ["eval", "run", "gsm8k", "--follow"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+    assert result.exit_code == 1
+    assert "hosted-only options require `--hosted`" in result.output
+
+
+def test_eval_run_rejects_tunnel_id_without_hosted():
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--tunnel-id", "t-0-0123456789abcdef"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
     assert result.exit_code == 1

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -240,7 +240,7 @@ def test_eval_run_hosted_passes_api_base_url_and_key_var(monkeypatch):
     assert captured["api_key_var"] == "OPENAI_API_KEY"
 
 
-def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
+def test_eval_run_hosted_passes_allow_tunnel_access(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(
@@ -252,8 +252,7 @@ def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
     )
 
     def fake_run_hosted_evaluation(config, environment_ids=None):
-        captured["tunnel_id"] = config.tunnel_id
-        captured["api_base_url"] = config.api_base_url
+        captured["allow_tunnel_access"] = config.allow_tunnel_access
         return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr(
@@ -268,15 +267,13 @@ def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
             "run",
             "primeintellect/gsm8k",
             "--hosted",
-            "--tunnel-id",
-            "t-0-0123456789abcdef",
+            "--allow-tunnel-access",
         ],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
 
     assert result.exit_code == 0, result.output
-    assert captured["tunnel_id"] == "t-0-0123456789abcdef"
-    assert captured["api_base_url"] is None
+    assert captured["allow_tunnel_access"] is True
 
 
 def test_eval_run_hosted_passes_extra_env_kwargs(monkeypatch):
@@ -513,7 +510,7 @@ def test_create_hosted_evaluation_includes_api_base_url_and_key_var_in_payload(m
     assert captured["json"]["eval_config"]["api_key_var"] == "OPENAI_API_KEY"
 
 
-def test_create_hosted_evaluation_includes_tunnel_id_in_payload(monkeypatch):
+def test_create_hosted_evaluation_includes_tunnel_access_in_payload(monkeypatch):
     captured = {}
 
     class DummyConfig:
@@ -536,144 +533,12 @@ def test_create_hosted_evaluation_includes_tunnel_id_in_payload(monkeypatch):
             inference_model="openai/gpt-4.1-mini",
             num_examples=5,
             rollouts_per_example=3,
-            tunnel_id="t-0-0123456789abcdef",
+            allow_tunnel_access=True,
         )
     )
 
     assert captured["endpoint"] == "/hosted-evaluations"
-    assert captured["json"]["eval_config"]["tunnel_id"] == "t-0-0123456789abcdef"
-
-
-def test_eval_run_hosted_tunnel_id_override_clears_config_api_base_url(monkeypatch, tmp_path):
-    captured = {}
-    config_path = tmp_path / "eval.toml"
-    config_path.write_text(
-        "\n".join(
-            [
-                'model = "openai/gpt-4.1-mini"',
-                'api_base_url = "https://api.openai.com/v1"',
-                "",
-                "[[eval]]",
-                'env_id = "gsm8k"',
-            ]
-        )
-    )
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._resolve_hosted_environment",
-        lambda environment, env_dir_path=None, env_path=None: (
-            "primeintellect/gsm8k",
-            "env-123",
-        ),
-    )
-
-    def fake_run_hosted_evaluation(config, environment_ids=None):
-        captured["tunnel_id"] = config.tunnel_id
-        captured["api_base_url"] = config.api_base_url
-        return {"evaluation_id": "eval-123"}
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluations",
-        fake_run_hosted_evaluation,
-    )
-
-    result = runner.invoke(
-        app,
-        [
-            "eval",
-            "run",
-            str(config_path),
-            "--hosted",
-            "--tunnel-id",
-            "t-0-0123456789abcdef",
-        ],
-        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
-    )
-
-    assert result.exit_code == 0, result.output
-    assert captured == {
-        "tunnel_id": "t-0-0123456789abcdef",
-        "api_base_url": None,
-    }
-
-
-def test_eval_run_hosted_api_base_url_override_clears_config_tunnel_id(monkeypatch, tmp_path):
-    captured = {}
-    config_path = tmp_path / "eval.toml"
-    config_path.write_text(
-        "\n".join(
-            [
-                'model = "openai/gpt-4.1-mini"',
-                'tunnel_id = "t-0-0123456789abcdef"',
-                "",
-                "[[eval]]",
-                'env_id = "gsm8k"',
-            ]
-        )
-    )
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._resolve_hosted_environment",
-        lambda environment, env_dir_path=None, env_path=None: (
-            "primeintellect/gsm8k",
-            "env-123",
-        ),
-    )
-
-    def fake_run_hosted_evaluation(config, environment_ids=None):
-        captured["tunnel_id"] = config.tunnel_id
-        captured["api_base_url"] = config.api_base_url
-        return {"evaluation_id": "eval-123"}
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluations",
-        fake_run_hosted_evaluation,
-    )
-
-    result = runner.invoke(
-        app,
-        [
-            "eval",
-            "run",
-            str(config_path),
-            "--hosted",
-            "--api-base-url",
-            "https://api.openai.com/v1",
-        ],
-        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
-    )
-
-    assert result.exit_code == 0, result.output
-    assert captured == {
-        "tunnel_id": None,
-        "api_base_url": "https://api.openai.com/v1",
-    }
-
-
-def test_create_hosted_evaluation_rejects_api_base_url_and_tunnel_id_together(monkeypatch):
-    class DummyConfig:
-        team_id = None
-
-    class DummyAPIClient:
-        def __init__(self):
-            self.config = DummyConfig()
-
-        def post(self, endpoint, json=None):
-            return {"evaluation_id": "eval-123"}
-
-    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
-
-    with pytest.raises(APIError, match="use either `--api-base-url` or `--tunnel-id`, not both"):
-        _create_hosted_evaluations(
-            HostedEvalConfig(
-                environment_id="env-123",
-                inference_model="openai/gpt-4.1-mini",
-                num_examples=5,
-                rollouts_per_example=3,
-                api_base_url="https://api.openai.com/v1",
-                tunnel_id="t-0-0123456789abcdef",
-            )
-        )
+    assert captured["json"]["eval_config"]["allow_tunnel_access"] is True
 
 
 def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
@@ -758,48 +623,6 @@ def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     assert captured["display_poll_interval"] == 10.0
 
 
-def test_eval_run_hosted_supports_tunnel_id_from_toml(monkeypatch, tmp_path):
-    captured = {}
-    config_path = tmp_path / "eval.toml"
-    config_path.write_text(
-        "\n".join(
-            [
-                'model = "openai/gpt-4.1-mini"',
-                'tunnel_id = "t-0-0123456789abcdef"',
-                "",
-                "[[eval]]",
-                'env_id = "gsm8k"',
-            ]
-        )
-    )
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._resolve_hosted_environment",
-        lambda environment, env_dir_path=None, env_path=None: (
-            "primeintellect/gsm8k",
-            "env-123",
-        ),
-    )
-
-    def fake_run_hosted_evaluation(config, environment_ids=None):
-        captured["tunnel_id"] = config.tunnel_id
-        return {"evaluation_id": "eval-123"}
-
-    monkeypatch.setattr(
-        "prime_cli.commands.evals._create_hosted_evaluations",
-        fake_run_hosted_evaluation,
-    )
-
-    result = runner.invoke(
-        app,
-        ["eval", "run", str(config_path), "--hosted"],
-        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
-    )
-
-    assert result.exit_code == 0, result.output
-    assert captured["tunnel_id"] == "t-0-0123456789abcdef"
-
-
 def test_eval_run_hosted_supports_single_eval_toml(monkeypatch, tmp_path):
     captured = {}
     config_path = tmp_path / "eval.toml"
@@ -812,6 +635,7 @@ rollouts_per_example = 2
 timeout_minutes = 180
 allow_sandbox_access = true
 allow_instances_access = true
+allow_tunnel_access = true
 eval_name = "math500 smoke test"
 """
             + "sampling_args = { "
@@ -840,6 +664,7 @@ eval_name = "math500 smoke test"
         captured["timeout_minutes"] = config.timeout_minutes
         captured["allow_sandbox_access"] = config.allow_sandbox_access
         captured["allow_instances_access"] = config.allow_instances_access
+        captured["allow_tunnel_access"] = config.allow_tunnel_access
         captured["sampling_args"] = config.sampling_args
         captured["extra_env_kwargs"] = config.extra_env_kwargs
         captured["name"] = config.name
@@ -871,6 +696,7 @@ eval_name = "math500 smoke test"
         "timeout_minutes": 180,
         "allow_sandbox_access": True,
         "allow_instances_access": True,
+        "allow_tunnel_access": True,
         "sampling_args": {
             "extra_body": {
                 "provider": {
@@ -899,6 +725,7 @@ rollouts_per_example = 2
 timeout_minutes = 180
 allow_sandbox_access = true
 allow_instances_access = true
+allow_tunnel_access = true
 eval_name = "from toml"
 
 [[eval]]
@@ -919,6 +746,7 @@ env_args = { split = "test" }
         captured["timeout_minutes"] = config.timeout_minutes
         captured["allow_sandbox_access"] = config.allow_sandbox_access
         captured["allow_instances_access"] = config.allow_instances_access
+        captured["allow_tunnel_access"] = config.allow_tunnel_access
         captured["sampling_args"] = config.sampling_args
         captured["extra_env_kwargs"] = config.extra_env_kwargs
         captured["name"] = config.name
@@ -967,6 +795,7 @@ env_args = { split = "test" }
         "timeout_minutes": 240,
         "allow_sandbox_access": True,
         "allow_instances_access": True,
+        "allow_tunnel_access": True,
         "sampling_args": {
             "temperature": 0.2,
             "extra_body": {
@@ -1565,20 +1394,20 @@ def test_eval_run_rejects_hosted_only_flags_without_hosted():
     assert "hosted-only options require `--hosted`" in result.output
 
 
-def test_eval_run_rejects_tunnel_id_without_hosted():
+def test_eval_run_rejects_explicit_poll_interval_without_hosted():
     result = runner.invoke(
         app,
-        ["eval", "run", "gsm8k", "--tunnel-id", "t-0-0123456789abcdef"],
+        ["eval", "run", "gsm8k", "--poll-interval", "10"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
     assert result.exit_code == 1
     assert "hosted-only options require `--hosted`" in result.output
 
 
-def test_eval_run_rejects_explicit_poll_interval_without_hosted():
+def test_eval_run_rejects_tunnel_access_without_hosted():
     result = runner.invoke(
         app,
-        ["eval", "run", "gsm8k", "--poll-interval", "10"],
+        ["eval", "run", "gsm8k", "--allow-tunnel-access"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
     assert result.exit_code == 1

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -253,6 +253,7 @@ def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
 
     def fake_run_hosted_evaluation(config, environment_ids=None):
         captured["tunnel_id"] = config.tunnel_id
+        captured["api_base_url"] = config.api_base_url
         return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr(
@@ -275,6 +276,7 @@ def test_eval_run_hosted_passes_tunnel_id(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["tunnel_id"] == "t-0-0123456789abcdef"
+    assert captured["api_base_url"] is None
 
 
 def test_eval_run_hosted_passes_extra_env_kwargs(monkeypatch):
@@ -540,6 +542,112 @@ def test_create_hosted_evaluation_includes_tunnel_id_in_payload(monkeypatch):
 
     assert captured["endpoint"] == "/hosted-evaluations"
     assert captured["json"]["eval_config"]["tunnel_id"] == "t-0-0123456789abcdef"
+
+
+def test_eval_run_hosted_tunnel_id_override_clears_config_api_base_url(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'model = "openai/gpt-4.1-mini"',
+                'api_base_url = "https://api.openai.com/v1"',
+                "",
+                "[[eval]]",
+                'env_id = "gsm8k"',
+            ]
+        )
+    )
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["tunnel_id"] = config.tunnel_id
+        captured["api_base_url"] = config.api_base_url
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            str(config_path),
+            "--hosted",
+            "--tunnel-id",
+            "t-0-0123456789abcdef",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "tunnel_id": "t-0-0123456789abcdef",
+        "api_base_url": None,
+    }
+
+
+def test_eval_run_hosted_api_base_url_override_clears_config_tunnel_id(monkeypatch, tmp_path):
+    captured = {}
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'model = "openai/gpt-4.1-mini"',
+                'tunnel_id = "t-0-0123456789abcdef"',
+                "",
+                "[[eval]]",
+                'env_id = "gsm8k"',
+            ]
+        )
+    )
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["tunnel_id"] = config.tunnel_id
+        captured["api_base_url"] = config.api_base_url
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            str(config_path),
+            "--hosted",
+            "--api-base-url",
+            "https://api.openai.com/v1",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "tunnel_id": None,
+        "api_base_url": "https://api.openai.com/v1",
+    }
 
 
 def test_create_hosted_evaluation_rejects_api_base_url_and_tunnel_id_together(monkeypatch):


### PR DESCRIPTION
Adds a hosted-eval --tunnel-id flow in the CLI and TOML config support to target existing Prime Tunnels for ENG-3278.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new hosted permission that is sent to the backend; misconfiguration could unintentionally grant tunnel-management capabilities during hosted runs. Changes are localized to CLI config parsing/payload building with added test coverage.
> 
> **Overview**
> Adds a new hosted-evaluation permission flag, `allow_tunnel_access`, supported in both `prime eval run --hosted --allow-tunnel-access` and hosted eval TOML configs.
> 
> The flag is validated as a hosted-only option, included in target grouping/config merging, added to `HostedEvalConfig`, and propagated into the `/hosted-evaluations` request payload as `eval_config.allow_tunnel_access`. Help text and tests are updated to ensure the option is documented, rejected without `--hosted`, and correctly passed through to the API payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bfddabb0398c654f461609e60209e6179d83325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->