### PR TITLE
release: cli 0.5.66

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.65"
+__version__ = "0.5.66"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.5.66.

- Picks up #523 (`update` as an alias for `upgrade`).
- Picks up #527 (allow-tunnel-access for hosted evaluations).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the exported `__version__` string and does not change runtime behavior.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.65` to `0.5.66` in `prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1db443e21cc3c8229ee14314e7b149a082239c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->