### PR TITLE
Security: Silent config file parsing failures

### DIFF
--- a/packages/prime-mcp-server/src/prime_mcp/core/config.py
+++ b/packages/prime-mcp-server/src/prime_mcp/core/config.py
@@ -1,9 +1,12 @@
 """Lightweight configuration for MCP server."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -21,7 +24,12 @@ class Config:
             try:
                 config_data = json.loads(self.config_file.read_text())
                 self.config = config_data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(
+                    "Failed to parse config file %s: %s. Using empty config.",
+                    self.config_file,
+                    e,
+                )
                 self.config = {}
         else:
             self.config = {}


### PR DESCRIPTION
## Summary

Security: Silent config file parsing failures

## Problem

**Severity**: `Medium` | **File**: `packages/prime-mcp-server/src/prime_mcp/core/config.py:L22`

The Config classes in multiple packages (prime-mcp-server, prime-evals, prime-sandboxes, prime-tunnel) silently catch JSONDecodeError and IOError when loading ~/.prime/config.json, defaulting to empty config without warning the user. This can lead to unexpected authentication failures when config files are corrupted or have permissions issues.

## Solution

Add logging or warning when config file exists but fails to parse, so users know their configuration is being ignored.

## Changes

- `packages/prime-mcp-server/src/prime_mcp/core/config.py` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a warning log on config parse/read errors without changing config resolution behavior.
> 
> **Overview**
> Stops silently ignoring a broken `~/.prime/config.json` by adding a module logger and emitting a `logger.warning` when JSON parsing or file I/O fails, while still falling back to an empty config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12310140270f9e1e7f34e293928573f4fdf72335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->