### PR TITLE
Warn on SDK config load failures

### DIFF
--- a/packages/prime-evals/src/prime_evals/core/config.py
+++ b/packages/prime-evals/src/prime_evals/core/config.py
@@ -1,9 +1,12 @@
 """Lightweight configuration for SDK packages."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -25,7 +28,12 @@ class Config:
             try:
                 config_data = json.loads(self.config_file.read_text())
                 self.config = config_data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "Failed to load config file %s: %s. Using empty config.",
+                    self.config_file,
+                    exc,
+                )
                 self.config = {}
         else:
             self.config = {}

--- a/packages/prime-mcp-server/src/prime_mcp/core/config.py
+++ b/packages/prime-mcp-server/src/prime_mcp/core/config.py
@@ -1,9 +1,12 @@
 """Lightweight configuration for MCP server."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -21,7 +24,12 @@ class Config:
             try:
                 config_data = json.loads(self.config_file.read_text())
                 self.config = config_data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "Failed to load config file %s: %s. Using empty config.",
+                    self.config_file,
+                    exc,
+                )
                 self.config = {}
         else:
             self.config = {}

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -1,9 +1,12 @@
 """Lightweight configuration for SDK packages."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -26,7 +29,12 @@ class Config:
             try:
                 config_data = json.loads(self.config_file.read_text())
                 self.config = config_data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "Failed to load config file %s: %s. Using empty config.",
+                    self.config_file,
+                    exc,
+                )
                 self.config = {}
         else:
             self.config = {}

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class Config:
@@ -24,7 +27,12 @@ class Config:
             try:
                 config_data = json.loads(self.config_file.read_text())
                 self.config = config_data if isinstance(config_data, dict) else {}
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "Failed to load config file %s: %s. Using empty config.",
+                    self.config_file,
+                    exc,
+                )
                 self.config = {}
         else:
             self.config = {}

--- a/packages/prime/tests/test_sdk_config_load_warnings.py
+++ b/packages/prime/tests/test_sdk_config_load_warnings.py
@@ -1,0 +1,41 @@
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "prime_mcp.core.config",
+        "prime_sandboxes.core.config",
+        "prime_evals.core.config",
+        "prime_tunnel.core.config",
+    ],
+)
+def test_config_warns_and_uses_empty_config_for_invalid_file(
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_dir = tmp_path / ".prime"
+    config_dir.mkdir()
+    config_file = config_dir / "config.json"
+    config_file.write_text("{invalid json", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    caplog.set_level(logging.WARNING, logger=module_name)
+    module = importlib.import_module(module_name)
+    caplog.clear()
+
+    config = module.Config()
+
+    assert config.config == {}
+    assert any(
+        record.name == module_name
+        and "Failed to load config file" in record.message
+        and str(config_file) in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
Adds warning logs when SDK config files cannot be parsed/read across MCP, evals, sandboxes, and tunnel packages, with a caplog regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds warning logs and slightly broadens exception handling when reading local config files; no behavior change beyond improved visibility and consistent fallback.
> 
> **Overview**
> Adds **warning logs** across the various SDK `Config` loaders (evals, MCP server, sandboxes, tunnel) when `~/.prime/config.json` cannot be read or parsed, and standardizes the failure path to **fall back to an empty config** (catching `OSError` instead of `IOError`).
> 
> Introduces a regression test (`test_sdk_config_load_warnings.py`) that parametrically verifies each package emits the warning and returns `{}` when the config file contains invalid JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7a284dc455e50abc27b2e8c0a6ce0e5c5e4bc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->