### PR TITLE
[codex] Polish Lab TUI agent output

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
@@ -69,6 +69,17 @@ DEPRECATED_CONFIG_FIELDS: tuple[DeprecatedConfigField, ...] = (
 _REPO_TREE_CACHE: dict[tuple[str, str, int], tuple[RepoTreeEntry, ...]] = {}
 
 Emit = Callable[[str], None]
+LabSyncProgressKind = Literal[
+    "started",
+    "lab_assets_prepared",
+    "agent_assets_prepared",
+    "agent_assets_skipped",
+    "templates_refreshed",
+    "guidance_refreshed",
+    "completed",
+    "failed",
+]
+LabSyncProgressEmit = Callable[["LabSyncProgressEvent"], None]
 Runner = Callable[[Sequence[str], Path, Emit], int]
 
 
@@ -113,6 +124,14 @@ class LabSyncResult:
     """Result from a Lab asset sync."""
 
     exit_code: int
+    workspace: Path
+
+
+@dataclass(frozen=True)
+class LabSyncProgressEvent:
+    """One typed Lab sync progress milestone for renderers."""
+
+    kind: LabSyncProgressKind
     workspace: Path
 
 
@@ -325,14 +344,21 @@ def run_lab_sync_service(
     *,
     workspace: Path,
     emit: Emit | None = None,
+    emit_progress: LabSyncProgressEmit | None = None,
 ) -> LabSyncResult:
     """Refresh Lab skills and local agent guidance."""
 
     workspace = workspace.expanduser().resolve()
     emit = emit or (lambda _text: None)
     try:
-        _run_lab_sync_steps(options, workspace=workspace, emit=emit)
+        _run_lab_sync_steps(
+            options,
+            workspace=workspace,
+            emit=emit,
+            emit_progress=emit_progress,
+        )
     except Exception as exc:
+        _emit_sync_progress(emit_progress, "failed", workspace)
         emit(f"Sync failed: {exc}\n")
         return LabSyncResult(exit_code=1, workspace=workspace)
     return LabSyncResult(exit_code=0, workspace=workspace)
@@ -394,29 +420,46 @@ def _run_lab_sync_steps(
     *,
     workspace: Path,
     emit: Emit,
+    emit_progress: LabSyncProgressEmit | None = None,
 ) -> None:
     workspace.mkdir(parents=True, exist_ok=True)
     (workspace / "configs").mkdir(exist_ok=True)
     (workspace / "environments").mkdir(exist_ok=True)
     emit(f"Syncing Lab assets in {workspace}\n")
+    _emit_sync_progress(emit_progress, "started", workspace)
     agents = _resolve_sync_agents(workspace, options.agents, no_agent=options.no_agent)
 
     managed_skill_names = _sync_prime_skills(emit)
     _prepare_workspace_skill_dir(workspace, managed_skill_names, emit)
+    _emit_sync_progress(emit_progress, "lab_assets_prepared", workspace)
     if agents:
         _prepare_agent_skill_dirs(workspace, agents, managed_skill_names, emit)
         _report_missing_agent_requirements(agents, emit)
         _prepare_agent_native_surfaces(workspace, agents, emit)
         _sync_lab_metadata(workspace, agents, setup_source="prime lab sync")
+        _emit_sync_progress(emit_progress, "agent_assets_prepared", workspace)
     else:
         emit("Skipped coding-agent skill roots (--no-agent)\n")
+        _emit_sync_progress(emit_progress, "agent_assets_skipped", workspace)
     _sync_config_templates(workspace, emit)
+    _emit_sync_progress(emit_progress, "templates_refreshed", workspace)
 
     if not options.skip_docs:
         _sync_workspace_guidance(workspace, emit, force=True)
         _write_lab_docs_index(workspace)
+        _emit_sync_progress(emit_progress, "guidance_refreshed", workspace)
 
     emit("Lab sync completed\n")
+    _emit_sync_progress(emit_progress, "completed", workspace)
+
+
+def _emit_sync_progress(
+    emit_progress: LabSyncProgressEmit | None,
+    kind: LabSyncProgressKind,
+    workspace: Path,
+) -> None:
+    if emit_progress is not None:
+        emit_progress(LabSyncProgressEvent(kind=kind, workspace=workspace))
 
 
 def _sync_workspace_guidance(workspace: Path, emit: Emit, *, force: bool = False) -> None:
@@ -849,14 +892,14 @@ def _managed_skill_manifest_check() -> LabDoctorCheck:
     skills = manifest.get("skills")
     if isinstance(skills, dict) and skills:
         return LabDoctorCheck(
-            name="Global Lab skill cache",
+            name="Global Lab asset cache",
             status="PASS",
-            message=f"{len(skills)} managed skill(s) installed.",
+            message=f"{len(skills)} managed asset(s) installed.",
         )
     return LabDoctorCheck(
-        name="Global Lab skill cache",
+        name="Global Lab asset cache",
         status="WARN",
-        message=f"Missing {_global_prime_skills_dir() / PRIME_SKILLS_MANIFEST}",
+        message="Missing local Lab asset cache.",
         remediation="Run prime lab sync.",
     )
 
@@ -881,9 +924,9 @@ def _workspace_managed_skills_check(workspace: Path) -> LabDoctorCheck:
     skill_names = _managed_skill_names_from_manifest()
     if not skill_names:
         return LabDoctorCheck(
-            name="Workspace Lab skills",
+            name="Workspace Lab assets",
             status="WARN",
-            message="No managed Lab skills are installed.",
+            message="No managed Lab assets are installed.",
             remediation="Run prime lab sync.",
         )
     skills_dir = workspace / WORKSPACE_SKILLS_DIR
@@ -894,14 +937,14 @@ def _workspace_managed_skills_check(workspace: Path) -> LabDoctorCheck:
     ]
     if not missing:
         return LabDoctorCheck(
-            name="Workspace Lab skills",
+            name="Workspace Lab assets",
             status="PASS",
-            message=f"{len(skill_names)} managed skill link(s) are present.",
+            message=f"{len(skill_names)} managed asset link(s) are present.",
         )
     return LabDoctorCheck(
-        name="Workspace Lab skills",
+        name="Workspace Lab assets",
         status="WARN",
-        message="Missing " + ", ".join(missing[:5]),
+        message="Missing managed Lab assets: " + ", ".join(missing[:5]),
         remediation="Run prime lab sync.",
     )
 
@@ -910,9 +953,9 @@ def _agent_managed_skills_check(label: str, agent_skill_dir: Path, agent: str) -
     skill_names = _managed_skill_names_from_manifest()
     if not skill_names:
         return LabDoctorCheck(
-            name=f"{label} skills",
+            name=f"{label} assets",
             status="WARN",
-            message="No managed Lab skills are installed.",
+            message="No managed Lab assets are installed.",
             remediation="Run prime lab sync.",
         )
     missing = [
@@ -923,14 +966,14 @@ def _agent_managed_skills_check(label: str, agent_skill_dir: Path, agent: str) -
     ]
     if not missing:
         return LabDoctorCheck(
-            name=f"{label} skills",
+            name=f"{label} assets",
             status="PASS",
-            message=f"{len(skill_names)} managed skill link(s) are present.",
+            message=f"{len(skill_names)} managed asset link(s) are present.",
         )
     return LabDoctorCheck(
-        name=f"{label} skills",
+        name=f"{label} assets",
         status="WARN",
-        message="Missing " + ", ".join(missing[:5]),
+        message="Missing managed Lab assets: " + ", ".join(missing[:5]),
         remediation=f"Run prime lab sync --agent {agent}.",
     )
 
@@ -1753,6 +1796,8 @@ __all__ = [
     "LabSetupOptions",
     "LabSetupResult",
     "LabSyncOptions",
+    "LabSyncProgressEvent",
+    "LabSyncProgressKind",
     "LabSyncResult",
     "SUPPORTED_AGENTS",
     "parse_lab_doctor_args",

--- a/packages/prime/src/prime_lab_app/agent_cards.py
+++ b/packages/prime/src/prime_lab_app/agent_cards.py
@@ -29,6 +29,7 @@ from .agent_widget_model import (
     build_agent_widget_model,
     widget_payload,
 )
+from .agent_widget_titles import config_picker_summary
 from .config_screen import ConfigBuildResult
 from .launch_runner import ConfigLaunchRunner, extract_training_log_follow_command
 from .palette import PRIMARY, STATUS_ERROR, STATUS_WARNING, SUCCESS
@@ -502,10 +503,14 @@ def _widget_card_heading(model: AgentWidgetModel) -> Group:
 def _widget_card_body(model: AgentWidgetModel) -> Group:
     payload = widget_payload(model.action)
     description = str(payload.get("description") or "").strip()
+    kind = str(payload.get("kind") or "").strip()
+    config_kind = str(payload.get("config_kind") or "").strip()
     table = Table.grid(padding=(0, 2))
     table.add_column(style="bold dim", no_wrap=True)
     table.add_column()
-    if config_path := str(payload.get("config_path") or "").strip():
+    if kind in {"config_editor", "run_launcher"} and config_kind:
+        table.add_row("Pickers", config_picker_summary(config_kind))
+    elif config_path := str(payload.get("config_path") or "").strip():
         table.add_row("Path", _short_path(config_path))
     if description:
         table.add_row("Summary", description)

--- a/packages/prime/src/prime_lab_app/agent_runtime.py
+++ b/packages/prime/src/prime_lab_app/agent_runtime.py
@@ -28,22 +28,6 @@ AgentRole = Literal["user", "assistant", "system"]
 _ASSISTANT_STREAM_KEY = "__assistant_stream__"
 _ASSISTANT_CHUNK_SEEN_KEY = "__assistant_chunk_seen__"
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-_INTERNAL_SKILL_LINE_PREFIXES = (
-    "using ",
-    "loading ",
-    "loaded ",
-    "applying ",
-    "activated ",
-    "selected ",
-    "running ",
-    "i'm using ",
-    "i'm loading ",
-    "i'll use ",
-    "i will use ",
-    "i\u2019m using ",
-    "i\u2019m loading ",
-    "i\u2019ll use ",
-)
 
 
 @dataclass(frozen=True)
@@ -742,31 +726,27 @@ class AgentRuntime:
             self._append_streaming_assistant_text(event.text)
             return
         if event.kind in {"tool_call", "tool_update"}:
-            self._record_acp_tool_event(event.title, event.status, event.text)
+            self._record_acp_tool_event(event.title, event.tool_kind, event.status, event.text)
             return
 
-    def _record_acp_tool_event(self, title: str, status: str, text: str) -> None:
+    def _record_acp_tool_event(
+        self,
+        title: str,
+        tool_kind: str,
+        status: str,
+        text: str,
+    ) -> None:
         title = title.strip()
+        tool_kind = tool_kind.strip()
         status = status.strip()
         text = _clean_agent_output_text(text.strip())
-        if _is_internal_skill_disclosure_line(title):
-            if not text:
-                return
-            title = "Agent update"
-        if not title and not text:
+        if not text:
             return
         if text and _is_lab_widget_tool_result_text(text):
             return
         label = title or "Tool"
-        content = label if not text else f"{label}\n{text}"
+        content = f"{label}\n{text}"
         with self._lock:
-            if (
-                not text
-                and _is_lab_widget_tool_event_title(label)
-                and self._messages
-                and self._messages[-1].status == "widget"
-            ):
-                return
             if (
                 self._messages
                 and self._messages[-1].role == "system"
@@ -777,7 +757,7 @@ class AgentRuntime:
                     "system",
                     content,
                     "tool",
-                    {"title": label, "tool_status": status},
+                    {"title": label, "tool_kind": tool_kind, "tool_status": status},
                 )
             else:
                 self._messages.append(
@@ -785,7 +765,7 @@ class AgentRuntime:
                         "system",
                         content,
                         "tool",
-                        {"title": label, "tool_status": status},
+                        {"title": label, "tool_kind": tool_kind, "tool_status": status},
                     )
                 )
             self._emit_messages_locked()
@@ -1214,27 +1194,7 @@ def _is_chunk_message(value: Any) -> bool:
 def _clean_agent_output_text(text: str) -> str:
     if not text:
         return ""
-    cleaned = _ANSI_RE.sub("", text)
-    cleaned = _strip_internal_skill_disclosures(cleaned)
-    if cleaned != text and not cleaned.strip():
-        return ""
-    return cleaned
-
-
-def _strip_internal_skill_disclosures(text: str) -> str:
-    lines = text.splitlines(keepends=True)
-    if not lines:
-        return "" if _is_internal_skill_disclosure_line(text) else text
-    return "".join(
-        raw_line for raw_line in lines if not _is_internal_skill_disclosure_line(raw_line)
-    )
-
-
-def _is_internal_skill_disclosure_line(line: str) -> bool:
-    normalized = " ".join(line.strip().lower().split())
-    if "skill" not in normalized:
-        return False
-    return normalized.startswith(_INTERNAL_SKILL_LINE_PREFIXES)
+    return _ANSI_RE.sub("", text)
 
 
 def _dynamic_tool_chat_content(
@@ -1254,16 +1214,8 @@ def _dynamic_tool_chat_content(
                 payload_title = str(payload.get("title") or "").strip()
                 if payload_title:
                     return payload_title
-        return _first_nonempty_line(content) or "Action ready"
+        return "Action ready"
     return content
-
-
-def _first_nonempty_line(text: str) -> str:
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped:
-            return stripped
-    return ""
 
 
 def _is_lab_widget_tool_result_text(text: str) -> bool:
@@ -1300,11 +1252,6 @@ def _contains_lab_widget_tool_result(value: Any) -> bool:
             except json.JSONDecodeError:
                 continue
     return False
-
-
-def _is_lab_widget_tool_event_title(value: str) -> bool:
-    normalized = value.strip().lower().replace("-", "_")
-    return normalized.startswith(("prime_lab_", "mcp_prime_lab_"))
 
 
 def _merge_stream_text(existing: str, delta: str) -> str:

--- a/packages/prime/src/prime_lab_app/agent_runtime.py
+++ b/packages/prime/src/prime_lab_app/agent_runtime.py
@@ -28,6 +28,22 @@ AgentRole = Literal["user", "assistant", "system"]
 _ASSISTANT_STREAM_KEY = "__assistant_stream__"
 _ASSISTANT_CHUNK_SEEN_KEY = "__assistant_chunk_seen__"
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_INTERNAL_SKILL_LINE_PREFIXES = (
+    "using ",
+    "loading ",
+    "loaded ",
+    "applying ",
+    "activated ",
+    "selected ",
+    "running ",
+    "i'm using ",
+    "i'm loading ",
+    "i'll use ",
+    "i will use ",
+    "i\u2019m using ",
+    "i\u2019m loading ",
+    "i\u2019ll use ",
+)
 
 
 @dataclass(frozen=True)
@@ -732,7 +748,11 @@ class AgentRuntime:
     def _record_acp_tool_event(self, title: str, status: str, text: str) -> None:
         title = title.strip()
         status = status.strip()
-        text = text.strip()
+        text = _clean_agent_output_text(text.strip())
+        if _is_internal_skill_disclosure_line(title):
+            if not text:
+                return
+            title = "Agent update"
         if not title and not text:
             return
         if text and _is_lab_widget_tool_result_text(text):
@@ -813,9 +833,12 @@ class AgentRuntime:
         content: str,
         action: dict[str, Any] | None = None,
     ) -> None:
+        display_content = _dynamic_tool_chat_content(status, content, action)
+        if display_content is None:
+            return
         with self._lock:
             self._finish_latest_streaming_assistant_locked(fallback="")
-            self._messages.append(AgentChatMessage("system", content, status, action or {}))
+            self._messages.append(AgentChatMessage("system", display_content, status, action or {}))
             self._emit_messages_locked()
 
     def _record_codex_turn(self, result: dict[str, Any]) -> None:
@@ -1192,9 +1215,55 @@ def _clean_agent_output_text(text: str) -> str:
     if not text:
         return ""
     cleaned = _ANSI_RE.sub("", text)
+    cleaned = _strip_internal_skill_disclosures(cleaned)
     if cleaned != text and not cleaned.strip():
         return ""
     return cleaned
+
+
+def _strip_internal_skill_disclosures(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return "" if _is_internal_skill_disclosure_line(text) else text
+    return "".join(
+        raw_line for raw_line in lines if not _is_internal_skill_disclosure_line(raw_line)
+    )
+
+
+def _is_internal_skill_disclosure_line(line: str) -> bool:
+    normalized = " ".join(line.strip().lower().split())
+    if "skill" not in normalized:
+        return False
+    return normalized.startswith(_INTERNAL_SKILL_LINE_PREFIXES)
+
+
+def _dynamic_tool_chat_content(
+    status: str,
+    content: str,
+    action: dict[str, Any] | None,
+) -> str | None:
+    if status == "tool":
+        return None
+    if status == "widget":
+        if isinstance(action, dict):
+            title = str(action.get("title") or "").strip()
+            if title:
+                return title
+            payload = action.get("payload")
+            if isinstance(payload, dict):
+                payload_title = str(payload.get("title") or "").strip()
+                if payload_title:
+                    return payload_title
+        return _first_nonempty_line(content) or "Action ready"
+    return content
+
+
+def _first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
 
 
 def _is_lab_widget_tool_result_text(text: str) -> bool:

--- a/packages/prime/src/prime_lab_app/agent_widget_model.py
+++ b/packages/prime/src/prime_lab_app/agent_widget_model.py
@@ -327,6 +327,9 @@ def _widget_field_specs(context: dict[str, Any] | None) -> tuple[AgentWidgetFiel
                 value = str(model_options[0][1])
             widget = "select"
             options = model_options
+        if config_kind == "eval" and name == "envs" and value:
+            widget = "select"
+            options = ((value, value),)
         fields.append(
             AgentWidgetFieldSpec(
                 name=name,

--- a/packages/prime/src/prime_lab_app/agent_widget_titles.py
+++ b/packages/prime/src/prime_lab_app/agent_widget_titles.py
@@ -10,3 +10,13 @@ def clean_widget_title(value: str) -> str:
         if lowered.startswith(prefix):
             return title[len(prefix) :].strip() or title
     return title
+
+
+def config_picker_summary(config_kind: str) -> str:
+    if config_kind == "eval":
+        return "Environment, model, examples, rollouts, tokens, concurrency"
+    if config_kind == "rl":
+        return "Environment, model, steps, rollouts, batch, tokens"
+    if config_kind == "gepa":
+        return "Environment, model"
+    return "Environment, model"

--- a/packages/prime/src/prime_lab_app/app.py
+++ b/packages/prime/src/prime_lab_app/app.py
@@ -2169,7 +2169,7 @@ def _with_workspace_agent_choice(item: LabItem, workspace: Path, agent: str) -> 
             key=item.key,
             section=item.section,
             title=item.title,
-            subtitle=f"{agent} · refresh templates, skills, docs, and local guidance",
+            subtitle=f"{agent} · refresh Lab assets and local guidance",
             status=item.status,
             status_style=item.status_style,
             metadata=_replace_metadata(

--- a/packages/prime/src/prime_lab_app/chat_parts.py
+++ b/packages/prime/src/prime_lab_app/chat_parts.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from .agent_runtime import AgentChatMessage, AgentConnectionState
-from .agent_widget_titles import clean_widget_title
+from .agent_widget_titles import clean_widget_title, config_picker_summary
 from .palette import PRIMARY, STATUS_ERROR, STATUS_SUCCESS, STATUS_WARNING, SUCCESS
 
 ReferenceKind = Literal["environment", "config", "run", "eval", "file"]
@@ -161,11 +161,15 @@ def _render_widget_turn(message: AgentChatMessage) -> Panel:
     action = payload if isinstance(payload, dict) else message.metadata
     title = clean_widget_title(str(action.get("title") or "Action"))
     description = str(action.get("description") or "").strip()
+    kind = str(action.get("kind") or "").strip()
+    config_kind = str(action.get("config_kind") or "").strip()
 
     body = Table.grid(padding=(0, 2))
     body.add_column(style="bold dim", no_wrap=True)
     body.add_column()
-    if config_path := str(action.get("config_path") or "").strip():
+    if kind in {"config_editor", "run_launcher"} and config_kind:
+        body.add_row("Pickers", config_picker_summary(config_kind))
+    elif config_path := str(action.get("config_path") or "").strip():
         body.add_row("Path", config_path)
     if description:
         body.add_row("Summary", description)

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -1292,7 +1292,7 @@ def _workspace_agent_sync_item(workspace: Path, lab_metadata: dict[str, Any]) ->
         key=f"workspace:agent-sync:{_workspace_cache_key(workspace)}",
         section="workspace",
         title="Sync Lab assets",
-        subtitle=f"{agent} · refresh templates, skills, docs, and local guidance",
+        subtitle=f"{agent} · refresh Lab assets and local guidance",
         status="sync",
         status_style=STATUS_INFO,
         metadata=(

--- a/packages/prime/src/prime_lab_app/details.py
+++ b/packages/prime/src/prime_lab_app/details.py
@@ -331,7 +331,7 @@ def _workspace_detail_chunks(item: LabItem) -> list[Any]:
             [
                 Text(""),
                 Text("Lab Asset Sync", style="bold dim"),
-                Text("Open this row to refresh templates, skills, docs, and agent guidance."),
+                Text("Open this row to refresh Lab assets and local guidance."),
             ]
         )
         return chunks

--- a/packages/prime/src/prime_lab_app/setup_screens.py
+++ b/packages/prime/src/prime_lab_app/setup_screens.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -185,7 +186,7 @@ class SetupScreen(Screen[None]):
 
 
 class AgentSyncScreen(Screen[None]):
-    """Refresh Lab templates, skills, docs, and local agent guidance."""
+    """Refresh Lab assets and local agent guidance."""
 
     BINDINGS = [
         Binding("escape", "back", "Back", key_display="Esc"),
@@ -263,7 +264,10 @@ class AgentSyncScreen(Screen[None]):
         self.app.call_from_thread(self._finish_sync, result)
 
     def _append_sync_output(self, text: str) -> None:
-        self._output = (self._output + text)[-50000:]
+        visible_text = _user_visible_sync_output(text)
+        if not visible_text:
+            return
+        self._output = (self._output + visible_text)[-50000:]
         self.query_one("#sync-output", Static).update(Text(self._output))
 
     def _finish_sync(self, result: LabSyncResult) -> None:
@@ -435,7 +439,7 @@ def _agent_sync_body(item: LabItem) -> Group:
     table.add_row("Agent", str(item.raw.get("agent") or "codex"))
     table.add_row("Command", str(item.raw.get("command") or "prime lab sync"))
     note = Text(
-        "Refresh Prime-owned templates, skills, docs, and agent guidance for this workspace.",
+        "Refresh Prime-owned Lab assets and local guidance for this workspace.",
         style="dim",
     )
     return Group(Text("Lab asset sync", style="bold"), table, Text(""), note)
@@ -469,8 +473,59 @@ def _doctor_result_table(result: LabDoctorResult) -> Table:
         }.get(check.status, "dim")
         table.add_row(
             Text(check.status, style=status_style),
-            check.name,
-            check.message,
-            check.remediation,
+            _user_visible_lab_asset_text(check.name),
+            _user_visible_lab_asset_text(check.message),
+            _user_visible_lab_asset_text(check.remediation),
         )
     return table
+
+
+def _user_visible_sync_output(text: str) -> str:
+    lines: list[str] = []
+    previous_visible_line = ""
+    for raw_line in text.splitlines(keepends=True):
+        line = raw_line.rstrip("\r\n")
+        ending = raw_line[len(line) :]
+        visible_line = _user_visible_sync_line(line)
+        if visible_line and visible_line != previous_visible_line:
+            lines.append(f"{visible_line}{ending}")
+            previous_visible_line = visible_line
+    return "".join(lines)
+
+
+def _user_visible_sync_line(line: str) -> str:
+    normalized = line.strip().lower()
+    if "skill" not in normalized:
+        return line
+    if normalized.startswith("prepared "):
+        return "Prepared local Lab assets"
+    if normalized.startswith("skipped coding-agent"):
+        return "Skipped coding-agent local assets (--no-agent)"
+    if normalized.startswith("skipped ") and "user-owned" in normalized:
+        return "Skipped user-owned local Lab asset"
+    if normalized.startswith("warning: removed stale managed"):
+        return "Warning: removed stale managed Lab asset"
+    if normalized.startswith("sync failed:"):
+        return "Sync failed: Lab asset refresh failed"
+    return ""
+
+
+def _user_visible_lab_asset_text(text: str) -> str:
+    rendered = str(text)
+    rendered = re.sub(
+        r"Missing .*/\.prime/skills/\.prime-managed\.json",
+        "Missing local Lab asset cache",
+        rendered,
+    )
+    replacements = {
+        "Global Lab skill cache": "Global Lab asset cache",
+        "Workspace Lab skills": "Workspace Lab assets",
+        "managed skill(s)": "managed asset(s)",
+        "managed skill link(s)": "managed asset link(s)",
+        "No managed Lab skills are installed.": "No managed Lab assets are installed.",
+        " skills": " assets",
+        " skill": " asset",
+    }
+    for old, new in replacements.items():
+        rendered = rendered.replace(old, new)
+    return rendered

--- a/packages/prime/src/prime_lab_app/setup_screens.py
+++ b/packages/prime/src/prime_lab_app/setup_screens.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -12,6 +11,7 @@ from prime_cli.lab_setup import (
     LabSetupOptions,
     LabSetupResult,
     LabSyncOptions,
+    LabSyncProgressEvent,
     LabSyncResult,
     run_lab_doctor_service,
     run_lab_setup_service,
@@ -34,6 +34,16 @@ from .palette import STATUS_ERROR, STATUS_SUCCESS, STATUS_WARNING
 from .shell import lab_header
 
 SetupCompleteAction = Callable[[], None]
+_SYNC_PROGRESS_TEXT = {
+    "started": "Syncing Lab assets",
+    "lab_assets_prepared": "Prepared local Lab assets",
+    "agent_assets_prepared": "Prepared agent surfaces",
+    "agent_assets_skipped": "Skipped agent surfaces",
+    "templates_refreshed": "Refreshed Lab templates",
+    "guidance_refreshed": "Updated local guidance",
+    "completed": "Lab sync completed",
+    "failed": "Lab sync failed",
+}
 
 
 class SetupScreen(Screen[None]):
@@ -259,15 +269,18 @@ class AgentSyncScreen(Screen[None]):
         result = run_lab_sync_service(
             LabSyncOptions(agents=(agent,)),
             workspace=workspace,
-            emit=lambda text: self.app.call_from_thread(self._append_sync_output, text),
+            emit_progress=lambda event: self.app.call_from_thread(
+                self._append_sync_progress,
+                event,
+            ),
         )
         self.app.call_from_thread(self._finish_sync, result)
 
-    def _append_sync_output(self, text: str) -> None:
-        visible_text = _user_visible_sync_output(text)
-        if not visible_text:
+    def _append_sync_progress(self, event: LabSyncProgressEvent) -> None:
+        visible_text = _sync_progress_text(event)
+        if not visible_text or self._output.splitlines()[-1:] == [visible_text]:
             return
-        self._output = (self._output + visible_text)[-50000:]
+        self._output = (self._output + visible_text + "\n")[-50000:]
         self.query_one("#sync-output", Static).update(Text(self._output))
 
     def _finish_sync(self, result: LabSyncResult) -> None:
@@ -473,59 +486,12 @@ def _doctor_result_table(result: LabDoctorResult) -> Table:
         }.get(check.status, "dim")
         table.add_row(
             Text(check.status, style=status_style),
-            _user_visible_lab_asset_text(check.name),
-            _user_visible_lab_asset_text(check.message),
-            _user_visible_lab_asset_text(check.remediation),
+            check.name,
+            check.message,
+            check.remediation,
         )
     return table
 
 
-def _user_visible_sync_output(text: str) -> str:
-    lines: list[str] = []
-    previous_visible_line = ""
-    for raw_line in text.splitlines(keepends=True):
-        line = raw_line.rstrip("\r\n")
-        ending = raw_line[len(line) :]
-        visible_line = _user_visible_sync_line(line)
-        if visible_line and visible_line != previous_visible_line:
-            lines.append(f"{visible_line}{ending}")
-            previous_visible_line = visible_line
-    return "".join(lines)
-
-
-def _user_visible_sync_line(line: str) -> str:
-    normalized = line.strip().lower()
-    if "skill" not in normalized:
-        return line
-    if normalized.startswith("prepared "):
-        return "Prepared local Lab assets"
-    if normalized.startswith("skipped coding-agent"):
-        return "Skipped coding-agent local assets (--no-agent)"
-    if normalized.startswith("skipped ") and "user-owned" in normalized:
-        return "Skipped user-owned local Lab asset"
-    if normalized.startswith("warning: removed stale managed"):
-        return "Warning: removed stale managed Lab asset"
-    if normalized.startswith("sync failed:"):
-        return "Sync failed: Lab asset refresh failed"
-    return ""
-
-
-def _user_visible_lab_asset_text(text: str) -> str:
-    rendered = str(text)
-    rendered = re.sub(
-        r"Missing .*/\.prime/skills/\.prime-managed\.json",
-        "Missing local Lab asset cache",
-        rendered,
-    )
-    replacements = {
-        "Global Lab skill cache": "Global Lab asset cache",
-        "Workspace Lab skills": "Workspace Lab assets",
-        "managed skill(s)": "managed asset(s)",
-        "managed skill link(s)": "managed asset link(s)",
-        "No managed Lab skills are installed.": "No managed Lab assets are installed.",
-        " skills": " assets",
-        " skill": " asset",
-    }
-    for old, new in replacements.items():
-        rendered = rendered.replace(old, new)
-    return rendered
+def _sync_progress_text(event: LabSyncProgressEvent) -> str:
+    return _SYNC_PROGRESS_TEXT[event.kind]

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -31,6 +31,8 @@ from prime_cli.lab_setup import (
     LabSetupOptions,
     LabSetupResult,
     LabSyncOptions,
+    LabSyncProgressEvent,
+    LabSyncProgressKind,
     parse_lab_doctor_args,
     parse_lab_setup_args,
     parse_lab_sync_args,
@@ -167,7 +169,7 @@ from prime_lab_app.setup_screens import (
     _agent_sync_body,
     _doctor_result_table,
     _setup_body,
-    _user_visible_sync_output,
+    _sync_progress_text,
 )
 from prime_lab_app.shell import (
     compact_path,
@@ -2147,6 +2149,7 @@ def test_prime_lab_sync_service_refreshes_agent_assets(
         lambda command: "/bin/pi" if command == "pi" else None,
     )
     emitted: list[str] = []
+    progress: list[LabSyncProgressEvent] = []
 
     assert parse_lab_sync_args(["--agent", "pi"]).agents == ("pi",)
     assert parse_lab_sync_args([]).agents == ()
@@ -2155,9 +2158,18 @@ def test_prime_lab_sync_service_refreshes_agent_assets(
         LabSyncOptions(agents=("pi",)),
         workspace=tmp_path,
         emit=emitted.append,
+        emit_progress=progress.append,
     )
 
     assert result.exit_code == 0
+    assert [event.kind for event in progress] == [
+        "started",
+        "lab_assets_prepared",
+        "agent_assets_prepared",
+        "templates_refreshed",
+        "guidance_refreshed",
+        "completed",
+    ]
     assert (tmp_path / ".prime" / "skills" / "create-environments" / "SKILL.md").is_file()
     assert (tmp_path / ".pi" / "skills" / "create-environments").exists()
     assert not any("pi-acp" in line for line in emitted)
@@ -2167,7 +2179,7 @@ def test_prime_lab_sync_service_refreshes_agent_assets(
     assert downloads
 
 
-def test_agent_sync_screen_keeps_skill_details_internal(tmp_path: Path) -> None:
+def test_agent_sync_screen_renders_asset_copy(tmp_path: Path) -> None:
     item = LabItem(
         key="workspace:sync",
         section="workspace",
@@ -2190,47 +2202,44 @@ def test_agent_sync_screen_keeps_skill_details_internal(tmp_path: Path) -> None:
     assert "Lab assets" in rendered
 
 
-def test_agent_sync_output_keeps_skill_paths_internal(tmp_path: Path) -> None:
-    visible = _user_visible_sync_output(
-        "\n".join(
-            [
-                f"Prepared {tmp_path / '.prime' / 'skills'}",
-                f"Prepared {tmp_path / '.agents' / 'skills'}",
-                (
-                    f"Skipped {tmp_path / '.agents' / 'skills' / 'create-environments'} "
-                    "because a user-owned skill already exists"
-                ),
-                f"Warning: removed stale managed skill {tmp_path / '.prime' / 'skills' / 'old'}",
-                "Lab sync completed",
-            ]
-        )
-        + "\n"
+def test_agent_sync_progress_renders_typed_events(tmp_path: Path) -> None:
+    kinds: tuple[LabSyncProgressKind, ...] = (
+        "started",
+        "lab_assets_prepared",
+        "agent_assets_prepared",
+        "templates_refreshed",
+        "guidance_refreshed",
+        "completed",
     )
+    rendered = [
+        _sync_progress_text(LabSyncProgressEvent(kind=kind, workspace=tmp_path)) for kind in kinds
+    ]
 
-    assert "skill" not in visible.lower()
-    assert str(tmp_path) not in visible
-    assert visible.count("Prepared local Lab assets") == 1
-    assert "Prepared local Lab assets" in visible
-    assert "Skipped user-owned local Lab asset" in visible
-    assert "Warning: removed stale managed Lab asset" in visible
-    assert "Lab sync completed" in visible
+    assert rendered == [
+        "Syncing Lab assets",
+        "Prepared local Lab assets",
+        "Prepared agent surfaces",
+        "Refreshed Lab templates",
+        "Updated local guidance",
+        "Lab sync completed",
+    ]
 
 
-def test_doctor_screen_keeps_skill_details_internal(tmp_path: Path) -> None:
+def test_doctor_screen_renders_source_check_copy(tmp_path: Path) -> None:
     result = LabDoctorResult(
         exit_code=1,
         workspace=tmp_path,
         checks=(
             LabDoctorCheck(
-                name="Global Lab skill cache",
+                name="Global Lab asset cache",
                 status="WARN",
-                message=f"Missing {tmp_path / '.prime' / 'skills' / '.prime-managed.json'}",
+                message="Missing local Lab asset cache.",
                 remediation="Run prime lab sync.",
             ),
             LabDoctorCheck(
-                name="Codex skills",
+                name="Codex assets",
                 status="PASS",
-                message="1 managed skill link(s) are present.",
+                message="1 managed asset link(s) are present.",
             ),
         ),
     )
@@ -2671,42 +2680,27 @@ def test_agent_runtime_filters_wrapped_lab_widget_tool_results() -> None:
     assert _is_lab_widget_tool_result_text(wrapped) is True
 
 
-def test_agent_runtime_suppresses_empty_lab_tool_update_after_widget() -> None:
-    messages: tuple[Any, ...] = ()
+def test_agent_runtime_ignores_empty_acp_tool_event() -> None:
+    runtime = AgentRuntime()
 
-    def on_messages(value: Any) -> None:
-        nonlocal messages
-        messages = value
+    runtime._record_acp_tool_event("Lab choose", "mcp", "completed", "")
 
-    runtime = AgentRuntime(on_messages=on_messages)
-    runtime._messages = [
-        AgentChatMessage(
-            "system",
-            "Lab tool diagnostic",
-            "widget",
-            {"tool": "choose", "kind": "choice_picker"},
-        )
-    ]
+    assert runtime.messages() == ()
 
-    runtime._record_acp_tool_event("prime_lab_choose", "completed", "")
 
-    assert len(messages) == 0
+def test_agent_runtime_records_text_acp_tool_event() -> None:
+    runtime = AgentRuntime()
+
+    runtime._record_acp_tool_event("Read config", "read", "completed", "ok")
+
     assert runtime.messages() == (
         AgentChatMessage(
             "system",
-            "Lab tool diagnostic",
-            "widget",
-            {"tool": "choose", "kind": "choice_picker"},
+            "Read config\nok",
+            "tool",
+            {"title": "Read config", "tool_kind": "read", "tool_status": "completed"},
         ),
     )
-
-
-def test_agent_runtime_suppresses_internal_skill_tool_events() -> None:
-    runtime = AgentRuntime()
-
-    runtime._record_acp_tool_event("Using skill create-environments", "running", "")
-
-    assert runtime.messages() == ()
 
 
 def test_agent_widget_choice_body_does_not_repeat_heading(tmp_path: Path) -> None:
@@ -4188,7 +4182,7 @@ def test_agent_stream_delta_ignores_lab_widget_ack_payload() -> None:
     assert text == ""
 
 
-def test_agent_stream_delta_ignores_internal_skill_disclosures() -> None:
+def test_agent_stream_delta_preserves_assistant_content() -> None:
     text = _extract_stream_delta(
         {
             "type": "assistant",
@@ -4200,7 +4194,7 @@ def test_agent_stream_delta_ignores_internal_skill_disclosures() -> None:
         {},
     )
 
-    assert text == "Ready."
+    assert text == "Using skill create-environments for local setup.\nReady."
 
 
 def test_agent_stream_delta_ignores_final_snapshot_after_streamed_chunks() -> None:

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -25,7 +25,9 @@ from prime_cli.commands.lab import app as lab_cli_app
 from prime_cli.commands.rl import RLConfig as HostedRLConfig
 from prime_cli.lab_mcp import _serve_lab_mcp_stdio, lab_mcp_tool_definitions
 from prime_cli.lab_setup import (
+    LabDoctorCheck,
     LabDoctorOptions,
+    LabDoctorResult,
     LabSetupOptions,
     LabSetupResult,
     LabSyncOptions,
@@ -158,7 +160,15 @@ from prime_lab_app.platform_preview import preview_lab_config
 from prime_lab_app.readme import readme_links as _readme_links
 from prime_lab_app.readme import readme_markdown as _readme_markdown
 from prime_lab_app.rows import item_badges_text
-from prime_lab_app.setup_screens import AgentSyncScreen, DoctorScreen, SetupScreen, _setup_body
+from prime_lab_app.setup_screens import (
+    AgentSyncScreen,
+    DoctorScreen,
+    SetupScreen,
+    _agent_sync_body,
+    _doctor_result_table,
+    _setup_body,
+    _user_visible_sync_output,
+)
 from prime_lab_app.shell import (
     compact_path,
     configured_workspace_agent,
@@ -2157,6 +2167,82 @@ def test_prime_lab_sync_service_refreshes_agent_assets(
     assert downloads
 
 
+def test_agent_sync_screen_keeps_skill_details_internal(tmp_path: Path) -> None:
+    item = LabItem(
+        key="workspace:sync",
+        section="workspace",
+        title="Sync Lab assets",
+        subtitle="codex",
+        status="sync",
+        status_style="",
+        metadata=(),
+        raw={
+            "type": "agent_sync",
+            "workspace": str(tmp_path),
+            "agent": "codex",
+            "command": "prime lab sync --agent codex",
+        },
+    )
+
+    rendered = _render_renderable(_agent_sync_body(item))
+
+    assert "skill" not in rendered.lower()
+    assert "Lab assets" in rendered
+
+
+def test_agent_sync_output_keeps_skill_paths_internal(tmp_path: Path) -> None:
+    visible = _user_visible_sync_output(
+        "\n".join(
+            [
+                f"Prepared {tmp_path / '.prime' / 'skills'}",
+                f"Prepared {tmp_path / '.agents' / 'skills'}",
+                (
+                    f"Skipped {tmp_path / '.agents' / 'skills' / 'create-environments'} "
+                    "because a user-owned skill already exists"
+                ),
+                f"Warning: removed stale managed skill {tmp_path / '.prime' / 'skills' / 'old'}",
+                "Lab sync completed",
+            ]
+        )
+        + "\n"
+    )
+
+    assert "skill" not in visible.lower()
+    assert str(tmp_path) not in visible
+    assert visible.count("Prepared local Lab assets") == 1
+    assert "Prepared local Lab assets" in visible
+    assert "Skipped user-owned local Lab asset" in visible
+    assert "Warning: removed stale managed Lab asset" in visible
+    assert "Lab sync completed" in visible
+
+
+def test_doctor_screen_keeps_skill_details_internal(tmp_path: Path) -> None:
+    result = LabDoctorResult(
+        exit_code=1,
+        workspace=tmp_path,
+        checks=(
+            LabDoctorCheck(
+                name="Global Lab skill cache",
+                status="WARN",
+                message=f"Missing {tmp_path / '.prime' / 'skills' / '.prime-managed.json'}",
+                remediation="Run prime lab sync.",
+            ),
+            LabDoctorCheck(
+                name="Codex skills",
+                status="PASS",
+                message="1 managed skill link(s) are present.",
+            ),
+        ),
+    )
+
+    rendered = _render_renderable(_doctor_result_table(result))
+
+    assert "skill" not in rendered.lower()
+    assert "Global Lab asset cache" in rendered
+    assert "Missing local Lab asset cache" in rendered
+    assert "Codex assets" in rendered
+
+
 def test_prime_lab_sync_service_preserves_workspace_agent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -2613,6 +2699,14 @@ def test_agent_runtime_suppresses_empty_lab_tool_update_after_widget() -> None:
             {"tool": "choose", "kind": "choice_picker"},
         ),
     )
+
+
+def test_agent_runtime_suppresses_internal_skill_tool_events() -> None:
+    runtime = AgentRuntime()
+
+    runtime._record_acp_tool_event("Using skill create-environments", "running", "")
+
+    assert runtime.messages() == ()
 
 
 def test_agent_widget_choice_body_does_not_repeat_heading(tmp_path: Path) -> None:
@@ -3835,12 +3929,22 @@ def test_agent_runtime_exposes_codex_lab_widget_tools(tmp_path: Path) -> None:
     assert tool_responses[-1]["success"] is True
     assert _wait_for(lambda: messages and messages[-1].status == "widget")
     latest_message = _last_message(messages)
-    assert "Pick a config" in latest_message.content
+    assert latest_message.content == "Pick a config"
+    assert "widget-1" not in latest_message.content
+    assert "Candidates" not in latest_message.content
     assert actions[-1]["type"] == "widget_requested"
     assert actions[-1]["tool"] == "choose"
     assert actions[-1]["kind"] == "choice_picker"
     assert actions[-1]["title"] == "Pick a config"
     runtime.stop()
+
+
+def test_agent_runtime_hides_codex_non_widget_tool_chatter() -> None:
+    runtime = AgentRuntime()
+
+    runtime._record_dynamic_tool_call("tool", "Environment search\n2 result(s)")
+
+    assert runtime.messages() == ()
 
 
 def test_agent_chat_transcript_renders_assistant_markdown() -> None:
@@ -3903,7 +4007,9 @@ def test_agent_chat_transcript_renders_lab_widget_card() -> None:
     assert "alphabet-sort" in rendered
     assert "Eval: alphabet-sort" not in rendered
     assert "Run launcher" not in rendered
-    assert "configs/eval/alphabet-sort.toml" in rendered
+    assert "configs/eval/alphabet-sort.toml" not in rendered
+    assert "Pickers" in rendered
+    assert "Environment, model" in rendered
 
 
 def test_agent_chat_parts_parse_lab_references() -> None:
@@ -4080,6 +4186,21 @@ def test_agent_stream_delta_ignores_lab_widget_ack_payload() -> None:
     )
 
     assert text == ""
+
+
+def test_agent_stream_delta_ignores_internal_skill_disclosures() -> None:
+    text = _extract_stream_delta(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": "Using skill create-environments for local setup.\nReady.",
+            },
+        },
+        {},
+    )
+
+    assert text == "Ready."
 
 
 def test_agent_stream_delta_ignores_final_snapshot_after_streamed_chunks() -> None:
@@ -4983,13 +5104,13 @@ async def test_prime_lab_app_chat_mounts_lab_widget_cards(tmp_path: Path) -> Non
         input_values = {
             input_widget.name: input_widget.value for input_widget in cards[0].query(ClearableInput)
         }
-        assert input_values["envs"] == "primeintellect/alphabet-sort"
+        select_values = {select.name: select.value for select in cards[0].query(Select)}
+        assert select_values["envs"] == "primeintellect/alphabet-sort"
         assert input_values["num_examples"] == "50"
         assert input_values["rollouts_per_example"] == "3"
         assert "max_concurrent" in input_values
         assert input_values["max_concurrent"] == "auto"
         assert input_values["model"] == ""
-        assert not list(cards[0].query(Select))
         button_labels = {str(button.label) for button in app.screen.query(Button)}
         assert "Launch" in button_labels
         assert "Stop" in button_labels
@@ -5757,8 +5878,8 @@ async def test_prime_lab_app_chat_widget_prefills_local_env_and_endpoint_model(
             input_widget.name: input_widget.value for input_widget in card.query(ClearableInput)
         }
         selects = {select.name: select.value for select in card.query(Select)}
-        assert fields["envs"] == "reverse-text"
-        assert "envs" not in selects
+        assert "envs" not in fields
+        assert selects["envs"] == "reverse-text"
         assert selects["model"] == "local/reverse-model"
 
 
@@ -5826,13 +5947,13 @@ async def test_prime_lab_app_chat_widget_prefills_existing_eval_config(
         fields = {
             input_widget.name: input_widget.value for input_widget in card.query(ClearableInput)
         }
-        model_select = card.query_one(Select)
-        assert fields["envs"] == "reverse-text"
+        selects = {select.name: select.value for select in card.query(Select)}
+        assert selects["envs"] == "reverse-text"
         assert fields["num_examples"] == "12"
         assert fields["rollouts_per_example"] == "5"
         assert fields["max_tokens"] == "2048"
         assert fields["max_concurrent"] == "3"
-        assert model_select.value == "existing/model"
+        assert selects["model"] == "existing/model"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Replace Lab sync TUI log filtering with typed `LabSyncProgressEvent` milestones; the TUI renders only those event kinds.
- Move doctor row copy to the check source so the TUI displays source-provided Lab asset labels directly.
- Keep agent transcript presentation deterministic: non-widget dynamic tool calls stay hidden by status, widgets use action metadata, ACP tool events render only text-bearing updates, and assistant text is no longer filtered by phrases.
- Make eval config widgets foreground picker controls instead of config paths, including environment/model selects when values are known.

## Validation

- `uv run --project packages/prime pytest packages/prime/tests/test_lab_view.py -q` -> `209 passed`
- Focused Lab TUI slice -> `17 passed, 192 deselected`
- `uv run --project packages/prime ruff check packages/prime/src/prime_lab_app/agent_runtime.py packages/prime/src/prime_cli/lab_setup.py packages/prime/src/prime_lab_app/setup_screens.py packages/prime/tests/test_lab_view.py` -> passed
- `uv run --project packages/prime ty check packages/prime/src/prime_lab_app/agent_runtime.py packages/prime/src/prime_cli/lab_setup.py packages/prime/src/prime_lab_app/setup_screens.py` -> passed
- `git diff --check` -> passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `prime lab sync` progress and agent/tool events are emitted and rendered in the Lab TUI, which can affect user-visible status updates and chat transcript behavior. Risk is moderate due to modified message-filtering logic across multiple agent transports, but changes are largely presentation-focused and covered by updated tests.
> 
> **Overview**
> Lab sync now emits typed progress milestones (`LabSyncProgressEvent`) and the TUI renders only these events, replacing raw log streaming; sync failure also reports a `failed` milestone.
> 
> Lab doctor and sync UI copy is updated to consistently refer to **Lab assets** (not skills/templates/docs) and to show clearer sync progress messages.
> 
> Agent chat output rendering is tightened: ACP tool events are recorded only when they include non-empty text and now include `tool_kind` metadata; non-widget dynamic tool chatter is hidden, widget messages use action titles for deterministic display, and eval/run widget cards/transcripts show a picker summary instead of config paths.
> 
> Eval config widgets adjust field rendering so known `envs` values use a `Select` control, and tests are expanded/updated to assert the new progress events, copy, and transcript behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994af56cb87d2003a5e2e89ecae5935c0f42655f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->