### PR TITLE
Use tracked environment package URLs

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1719,7 +1719,7 @@ def pull(
             console.print(f"[red]Failed to get environment details: {e}[/red]")
             raise typer.Exit(1)
 
-        download_url = details.get("package_url")
+        download_url = _environment_package_download_url(details)
         if not download_url:
             console.print("[red]Error: No downloadable package found[/red]")
             raise typer.Exit(1)
@@ -1757,7 +1757,11 @@ def pull(
                         if client.api_key:
                             headers["Authorization"] = f"Bearer {client.api_key}"
                         with httpx.stream(
-                            "GET", download_url, headers=headers, timeout=60.0
+                            "GET",
+                            download_url,
+                            headers=headers,
+                            timeout=60.0,
+                            follow_redirects=True,
                         ) as resp:
                             resp.raise_for_status()
                             with open(tmp.name, "wb") as f:
@@ -1896,6 +1900,14 @@ def is_valid_url(url: str) -> bool:
         return all([result.scheme in ("http", "https"), result.netloc])
     except Exception:
         return False
+
+
+def _environment_package_download_url(details: Dict[str, Any]) -> Optional[str]:
+    for key in ("tracked_package_url", "trackedPackageUrl", "package_url", "packageUrl"):
+        url = details.get(key)
+        if isinstance(url, str) and is_valid_url(url):
+            return url
+    return None
 
 
 def normalize_package_name(name: str) -> str:
@@ -3026,7 +3038,7 @@ def _pull_and_build_private_env(
     _validate_path_component(name, "name")
     _validate_path_component(version, "version")
 
-    download_url = details.get("package_url")
+    download_url = _environment_package_download_url(details)
     if not download_url:
         raise ValueError("No downloadable package found for private environment")
 
@@ -3057,7 +3069,9 @@ def _pull_and_build_private_env(
             if client.api_key:
                 headers["Authorization"] = f"Bearer {client.api_key}"
 
-            with httpx.stream("GET", download_url, headers=headers, timeout=60.0) as resp:
+            with httpx.stream(
+                "GET", download_url, headers=headers, timeout=60.0, follow_redirects=True
+            ) as resp:
                 resp.raise_for_status()
                 with open(tmp.name, "wb") as f:
                     for chunk in resp.iter_bytes(chunk_size=8192):

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1903,9 +1903,10 @@ def is_valid_url(url: str) -> bool:
 
 
 def _environment_package_download_url(details: Dict[str, Any]) -> Optional[str]:
-    for key in ("tracked_package_url", "trackedPackageUrl", "package_url", "packageUrl"):
+    """Return the platform package URL, preferring tracked public downloads."""
+    for key in ("tracked_package_url", "package_url"):
         url = details.get(key)
-        if isinstance(url, str) and is_valid_url(url):
+        if isinstance(url, str) and url:
             return url
     return None
 

--- a/packages/prime/src/prime_lab_app/cache.py
+++ b/packages/prime/src/prime_lab_app/cache.py
@@ -12,12 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import httpx
-from prime_cli.commands.env import (
-    _environment_package_download_url,
-    _safe_tar_extract,
-    compute_content_hash,
-    is_valid_url,
-)
+from prime_cli.commands.env import _safe_tar_extract, compute_content_hash, is_valid_url
 
 from .models import LabItem, LabSection
 
@@ -330,7 +325,11 @@ def ensure_environment_source(raw: dict[str, Any]) -> CachedEnvironmentSource | 
     owner, name = slug.split("/", 1)
 
     detail = _platform_detail(raw)
-    package_url = _environment_package_download_url(detail)
+    package_url = (
+        detail.get("tracked_package_url")
+        or detail.get("package_url")
+        or detail.get("packageUrl")
+    )
     version = (
         detail.get("semanticVersion")
         or detail.get("semantic_version")

--- a/packages/prime/src/prime_lab_app/cache.py
+++ b/packages/prime/src/prime_lab_app/cache.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import httpx
-from prime_cli.commands.env import _safe_tar_extract, compute_content_hash, is_valid_url
+from prime_cli.commands.env import (
+    _environment_package_download_url,
+    _safe_tar_extract,
+    compute_content_hash,
+    is_valid_url,
+)
 
 from .models import LabItem, LabSection
 
@@ -325,7 +330,7 @@ def ensure_environment_source(raw: dict[str, Any]) -> CachedEnvironmentSource | 
     owner, name = slug.split("/", 1)
 
     detail = _platform_detail(raw)
-    package_url = detail.get("package_url") or detail.get("packageUrl")
+    package_url = _environment_package_download_url(detail)
     version = (
         detail.get("semanticVersion")
         or detail.get("semantic_version")
@@ -478,7 +483,7 @@ def _download_source_archive(url: str, dest: Path) -> None:
     try:
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             temp_file_path = Path(tmp.name)
-            with httpx.stream("GET", url, timeout=60.0) as response:
+            with httpx.stream("GET", url, timeout=60.0, follow_redirects=True) as response:
                 response.raise_for_status()
                 for chunk in response.iter_bytes(chunk_size=8192):
                     tmp.write(chunk)

--- a/packages/prime/src/prime_lab_app/cache.py
+++ b/packages/prime/src/prime_lab_app/cache.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import httpx
-from prime_cli.commands.env import _safe_tar_extract, compute_content_hash, is_valid_url
+from prime_cli.commands.env import (
+    _environment_package_download_url,
+    _safe_tar_extract,
+    compute_content_hash,
+    is_valid_url,
+)
 
 from .models import LabItem, LabSection
 
@@ -325,11 +330,7 @@ def ensure_environment_source(raw: dict[str, Any]) -> CachedEnvironmentSource | 
     owner, name = slug.split("/", 1)
 
     detail = _platform_detail(raw)
-    package_url = (
-        detail.get("tracked_package_url")
-        or detail.get("package_url")
-        or detail.get("packageUrl")
-    )
+    package_url = _environment_package_download_url(detail)
     version = (
         detail.get("semanticVersion")
         or detail.get("semantic_version")

--- a/packages/prime/tests/test_env_pull_path.py
+++ b/packages/prime/tests/test_env_pull_path.py
@@ -38,16 +38,10 @@ def test_environment_package_download_url_prefers_tracked_url():
     assert _environment_package_download_url(details) == "https://example.test/tracked"
 
 
-def test_environment_package_download_url_falls_back_to_package_url():
-    assert (
-        _environment_package_download_url(
-            {
-                "tracked_package_url": "not-a-url",
-                "package_url": "https://example.test/direct",
-            }
-        )
-        == "https://example.test/direct"
-    )
+def test_environment_package_download_url_falls_back_to_package_url_when_untracked():
+    details = {"package_url": "https://example.test/direct"}
+
+    assert _environment_package_download_url(details) == "https://example.test/direct"
 
 
 def test_pull_prefers_tracked_url_and_follows_redirects(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_env_pull_path.py
+++ b/packages/prime/tests/test_env_pull_path.py
@@ -1,4 +1,7 @@
-from prime_cli.commands.env import _resolve_pull_environment_path
+from typing import Any
+
+from prime_cli.commands import env as env_commands
+from prime_cli.commands.env import _environment_package_download_url, _resolve_pull_environment_path
 
 
 def test_defaults_to_cwd_when_environments_dir_missing(tmp_path, monkeypatch):
@@ -24,3 +27,90 @@ def test_respects_explicit_target_path(tmp_path):
     resolved = _resolve_pull_environment_path(target=str(explicit), env_name="my-env")
 
     assert resolved == explicit
+
+
+def test_environment_package_download_url_prefers_tracked_url():
+    details = {
+        "tracked_package_url": "https://example.test/tracked",
+        "package_url": "https://example.test/direct",
+    }
+
+    assert _environment_package_download_url(details) == "https://example.test/tracked"
+
+
+def test_environment_package_download_url_falls_back_to_package_url():
+    assert (
+        _environment_package_download_url(
+            {
+                "tracked_package_url": "not-a-url",
+                "package_url": "https://example.test/direct",
+            }
+        )
+        == "https://example.test/direct"
+    )
+
+
+def test_pull_prefers_tracked_url_and_follows_redirects(tmp_path, monkeypatch):
+    class FakeAPIClient:
+        api_key = "test-token"
+
+        def __init__(self, require_auth: bool = False) -> None:
+            assert require_auth is False
+
+        def get(self, path: str) -> dict[str, Any]:
+            assert path == "/environmentshub/alice/demo/@latest"
+            return {
+                "data": {
+                    "id": "env-1",
+                    "tracked_package_url": "https://example.test/tracked",
+                    "package_url": "https://example.test/direct",
+                    "semantic_version": "0.1.0",
+                    "metadata": {},
+                }
+            }
+
+    class FakeStream:
+        def __enter__(self) -> "FakeStream":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self, chunk_size: int) -> list[bytes]:
+            return [b"archive"]
+
+    class FakeTar:
+        def __enter__(self) -> "FakeTar":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def extractall(self, target: Any) -> None:
+            (target / "README.md").write_text("# Demo\n", encoding="utf-8")
+
+    def fake_stream(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        timeout: float,
+        follow_redirects: bool,
+    ) -> FakeStream:
+        assert method == "GET"
+        assert url == "https://example.test/tracked"
+        assert headers == {"Authorization": "Bearer test-token"}
+        assert timeout == 60.0
+        assert follow_redirects is True
+        return FakeStream()
+
+    target = tmp_path / "demo"
+    monkeypatch.setattr(env_commands, "APIClient", FakeAPIClient)
+    monkeypatch.setattr(env_commands.httpx, "stream", fake_stream)
+    monkeypatch.setattr(env_commands.tarfile, "open", lambda *_args, **_kwargs: FakeTar())
+
+    env_commands.pull("alice/demo", target=str(target), version="latest")
+
+    assert (target / "README.md").read_text(encoding="utf-8") == "# Demo\n"

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -842,6 +842,35 @@ def test_lab_environment_cache_downloads_source_and_writes_manifest(
     )
 
 
+def test_lab_environment_cache_downloads_legacy_camel_package_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    captured: dict[str, str] = {}
+
+    def fake_download(url: str, dest: Path) -> None:
+        captured["url"] = url
+        dest.mkdir(parents=True)
+        (dest / "README.md").write_text("# Cached Env\n", encoding="utf-8")
+
+    monkeypatch.setattr("prime_lab_app.cache._download_source_archive", fake_download)
+
+    cached = ensure_environment_source(
+        {
+            "slug": "research/camel-env",
+            "platform": {
+                "packageUrl": "https://example.test/camel-env.tar.gz",
+                "semanticVersion": "0.2.0",
+            },
+        }
+    )
+
+    assert cached is not None
+    assert captured["url"] == "https://example.test/camel-env.tar.gz"
+    assert (cached.root / "README.md").read_text(encoding="utf-8") == "# Cached Env\n"
+
+
 def test_lab_environment_cache_finds_existing_source_without_package_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -806,10 +806,11 @@ def test_lab_environment_cache_downloads_source_and_writes_manifest(
         def iter_bytes(self, chunk_size: int) -> list[bytes]:
             return [archive[:chunk_size], archive[chunk_size:]]
 
-    def fake_stream(method: str, url: str, timeout: float) -> FakeStream:
+    def fake_stream(method: str, url: str, timeout: float, follow_redirects: bool) -> FakeStream:
         assert method == "GET"
-        assert url == "https://example.test/env.tar.gz"
+        assert url == "https://example.test/tracked-env.tar.gz"
         assert timeout == 60.0
+        assert follow_redirects is True
         return FakeStream()
 
     monkeypatch.setattr("prime_lab_app.cache.httpx.stream", fake_stream)
@@ -818,6 +819,7 @@ def test_lab_environment_cache_downloads_source_and_writes_manifest(
         {
             "slug": "research/cached-env",
             "platform": {
+                "tracked_package_url": "https://example.test/tracked-env.tar.gz",
                 "package_url": "https://example.test/env.tar.gz",
                 "semanticVersion": "0.2.0",
             },

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -842,35 +842,6 @@ def test_lab_environment_cache_downloads_source_and_writes_manifest(
     )
 
 
-def test_lab_environment_cache_downloads_legacy_camel_package_url(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    captured: dict[str, str] = {}
-
-    def fake_download(url: str, dest: Path) -> None:
-        captured["url"] = url
-        dest.mkdir(parents=True)
-        (dest / "README.md").write_text("# Cached Env\n", encoding="utf-8")
-
-    monkeypatch.setattr("prime_lab_app.cache._download_source_archive", fake_download)
-
-    cached = ensure_environment_source(
-        {
-            "slug": "research/camel-env",
-            "platform": {
-                "packageUrl": "https://example.test/camel-env.tar.gz",
-                "semanticVersion": "0.2.0",
-            },
-        }
-    )
-
-    assert cached is not None
-    assert captured["url"] == "https://example.test/camel-env.tar.gz"
-    assert (cached.root / "README.md").read_text(encoding="utf-8") == "# Cached Env\n"
-
-
 def test_lab_environment_cache_finds_existing_source_without_package_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Switch environment package downloads to prefer tracked_package_url while falling back to package_url for compatibility, and follow redirects when streaming package archives.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how environment source archives are fetched in both the CLI and Lab cache; incorrect URL selection or redirect handling could break pulls/installs for some environments, but the change is small and covered by tests.
> 
> **Overview**
> Environment package downloads now **prefer `tracked_package_url` over `package_url`** (with a compatibility fallback) via a shared helper `_environment_package_download_url` used by `prime env pull`, private-env pull/build, and Lab’s environment source cache.
> 
> All archive downloads done via `httpx.stream` now **enable `follow_redirects=True`**, and tests were added/updated to assert tracked-URL preference and redirect-following behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9eb64a89c12efc2e7e592748f3890f33ce75c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->