### PR TITLE
public sandbox images

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -796,6 +796,7 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
             image_reference = rest
         else:
             team_id = None
+            image_reference = rest
 
     if ":" not in image_reference:
         console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -777,8 +777,9 @@ def list_images(
 def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Optional[str]]:
     """Parse refs accepted by mutating image commands.
 
-    Returns ``(image_name, image_tag, team_id)``. Personal image refs use
-    ``name:tag`` and team image refs may use ``team-{teamId}/name:tag``.
+    Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
+    either ``name:tag`` or ``{userId}/name:tag``. Team image refs may use
+    ``team-{teamId}/name:tag``.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
@@ -794,12 +795,7 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
             team_id = extracted_team_id
             image_reference = rest
         else:
-            console.print(
-                f"[red]Error: Unrecognized image namespace '{namespace}'. "
-                "Use 'imagename:tag' for personal images or "
-                "'team-{{teamId}}/imagename:tag' for team images.[/red]"
-            )
-            raise typer.Exit(1)
+            team_id = None
 
     if ":" not in image_reference:
         console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")
@@ -830,7 +826,9 @@ def publish_image(
     image_reference: str = typer.Argument(
         ...,
         help=(
-            "Image reference to make public (e.g., 'myapp:v1.0.0' or 'team-{teamId}/myapp:v1.0.0')"
+            "Image reference to make public "
+            "(e.g., 'myapp:v1.0.0', '<userId>/myapp:v1.0.0', "
+            "or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -840,6 +838,7 @@ def publish_image(
     \b
     Examples:
         prime images publish myapp:v1.0.0
+        prime images publish cmk123/myapp:v1.0.0
         prime images publish team-abc123/myapp:v1.0.0
     """
     try:
@@ -857,7 +856,9 @@ def unpublish_image(
     image_reference: str = typer.Argument(
         ...,
         help=(
-            "Image reference to make private (e.g., 'myapp:v1.0.0' or 'team-{teamId}/myapp:v1.0.0')"
+            "Image reference to make private "
+            "(e.g., 'myapp:v1.0.0', '<userId>/myapp:v1.0.0', "
+            "or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -867,6 +868,7 @@ def unpublish_image(
     \b
     Examples:
         prime images unpublish myapp:v1.0.0
+        prime images unpublish cmk123/myapp:v1.0.0
         prime images unpublish team-abc123/myapp:v1.0.0
     """
     try:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -790,8 +790,8 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     """Parse refs accepted by mutating image commands.
 
     Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
-    either ``name:tag`` or ``{userId}/name:tag``. Team image refs may use
-    ``team-{teamId}/name:tag``.
+    either ``name:tag`` or ``{currentUserId}/name:tag``. Team image refs may
+    use ``team-{teamId}/name:tag``.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
@@ -806,9 +806,17 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
                 raise typer.Exit(1)
             team_id = extracted_team_id
             image_reference = rest
-        else:
+        elif namespace == config.user_id:
             team_id = None
             image_reference = rest
+        else:
+            console.print(
+                f"[red]Error: Unrecognized image namespace '{namespace}'. "
+                "Use 'imagename:tag' for personal images, "
+                "'{userId}/imagename:tag' with your current user ID, or "
+                "'team-{teamId}/imagename:tag' for team images.[/red]"
+            )
+            raise typer.Exit(1)
 
     if ":" not in image_reference:
         console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")
@@ -842,7 +850,7 @@ def publish_image(
         ...,
         help=(
             "Image reference to make public "
-            "(e.g., 'myapp:v1.0.0', '<userId>/myapp:v1.0.0', "
+            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
             "or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
@@ -872,7 +880,7 @@ def unpublish_image(
         ...,
         help=(
             "Image reference to make private "
-            "(e.g., 'myapp:v1.0.0', '<userId>/myapp:v1.0.0', "
+            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
             "or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
@@ -900,7 +908,11 @@ def unpublish_image(
 def delete_image(
     image_reference: str = typer.Argument(
         ...,
-        help="Image reference to delete (e.g., 'myapp:v1.0.0' or 'team-{teamId}/myapp:v1.0.0')",
+        help=(
+            "Image reference to delete "
+            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
+            "or 'team-{teamId}/myapp:v1.0.0')"
+        ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ):
@@ -914,44 +926,14 @@ def delete_image(
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes
+        prime images delete cmk123/myapp:v1.0.0
         prime images delete team-abc123/myapp:v1.0.0
     """
     # Store original input for error messages
     original_reference = image_reference
 
     try:
-        # Check for team-prefixed format: team-{teamId}/imagename:tag
-        team_id = config.team_id
-        if "/" in image_reference:
-            namespace, rest = image_reference.split("/", 1)
-            if namespace.startswith("team-"):
-                # Extract team ID from the reference
-                extracted_team_id = namespace[5:]  # Remove "team-" prefix
-                if not extracted_team_id:
-                    console.print(
-                        "[red]Error: Invalid team image reference. "
-                        "Expected format: team-{teamId}/imagename:tag[/red]"
-                    )
-                    raise typer.Exit(1)
-                team_id = extracted_team_id
-                image_reference = rest
-            else:
-                # Unrecognized namespace (not team-prefixed)
-                console.print(
-                    f"[red]Error: Unrecognized image namespace '{namespace}'. "
-                    "Use 'imagename:tag' for personal images or "
-                    "'team-{{teamId}}/imagename:tag' for team images.[/red]"
-                )
-                raise typer.Exit(1)
-
-        # Validate image reference has a tag (after team-prefix parsing)
-        if ":" not in image_reference:
-            console.print(
-                "[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]"
-            )
-            raise typer.Exit(1)
-
-        image_name, image_tag = image_reference.rsplit(":", 1)
+        image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
 
         context = f" (team: {team_id})" if team_id else ""
         if not yes:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -5,6 +5,7 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
@@ -23,6 +24,12 @@ console = get_console()
 PACKAGED_DOCKERFILE_PATH = ".__prime_dockerfile__"
 
 config = Config()
+
+
+class ImageVisibility(str, Enum):
+    PRIVATE = "PRIVATE"
+    PUBLIC = "PUBLIC"
+
 
 LIST_IMAGES_JSON_HELP = json_output_help(
     "Raw API response is printed unchanged.",
@@ -207,8 +214,12 @@ _STATUS_LABELS: dict[str, str] = {
 
 
 def _render_visibility(value: Any) -> str:
-    visibility = str(value or "PRIVATE").upper()
-    if visibility == "PUBLIC":
+    try:
+        visibility = ImageVisibility(str(value or ImageVisibility.PRIVATE.value).upper())
+    except ValueError:
+        visibility = ImageVisibility.PRIVATE
+
+    if visibility == ImageVisibility.PUBLIC:
         return "[green]Public[/green]"
     return "[dim]Private[/dim]"
 
@@ -493,9 +504,9 @@ def push_image(
                 if config.team_id:
                     build_payload["team_id"] = config.team_id
                 if public:
-                    build_payload["visibility"] = "PUBLIC"
+                    build_payload["visibility"] = ImageVisibility.PUBLIC.value
                 elif private:
-                    build_payload["visibility"] = "PRIVATE"
+                    build_payload["visibility"] = ImageVisibility.PRIVATE.value
 
                 build_response = client.request(
                     "POST",
@@ -562,7 +573,8 @@ def push_image(
             console.print(f"[bold]Build ID:[/bold] {build_id}")
             console.print(f"[bold]Image:[/bold] {full_image_path}")
             if public or private:
-                console.print(f"[bold]Visibility:[/bold] {'PUBLIC' if public else 'PRIVATE'}")
+                requested_visibility = ImageVisibility.PUBLIC if public else ImageVisibility.PRIVATE
+                console.print(f"[bold]Visibility:[/bold] {requested_visibility.value}")
             else:
                 console.print(
                     "[bold]Visibility:[/bold] PRIVATE for new images "
@@ -806,9 +818,9 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     return image_name, image_tag, team_id
 
 
-def _set_image_visibility(image_reference: str, visibility: str) -> None:
+def _set_image_visibility(image_reference: str, visibility: ImageVisibility) -> None:
     image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
-    payload: dict[str, str] = {"visibility": visibility}
+    payload: dict[str, str] = {"visibility": visibility.value}
     if team_id:
         payload["teamId"] = team_id
 
@@ -819,7 +831,9 @@ def _set_image_visibility(image_reference: str, visibility: str) -> None:
         json=payload,
     )
     context = f" (team: {team_id})" if team_id else ""
-    console.print(f"[green]✓[/green] Updated {image_name}:{image_tag}{context} to {visibility}")
+    console.print(
+        f"[green]✓[/green] Updated {image_name}:{image_tag}{context} to {visibility.value}"
+    )
 
 
 @app.command("publish")
@@ -843,7 +857,7 @@ def publish_image(
         prime images publish team-abc123/myapp:v1.0.0
     """
     try:
-        _set_image_visibility(image_reference, "PUBLIC")
+        _set_image_visibility(image_reference, ImageVisibility.PUBLIC)
     except UnauthorizedError:
         console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
         raise typer.Exit(1)
@@ -873,7 +887,7 @@ def unpublish_image(
         prime images unpublish team-abc123/myapp:v1.0.0
     """
     try:
-        _set_image_visibility(image_reference, "PRIVATE")
+        _set_image_visibility(image_reference, ImageVisibility.PRIVATE)
     except UnauthorizedError:
         console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -27,7 +27,7 @@ config = Config()
 LIST_IMAGES_JSON_HELP = json_output_help(
     "Raw API response is printed unchanged.",
     ".data[] = {displayRef?, fullImagePath?, imageName, imageTag, status, "
-    "artifactType, ownerType, sizeBytes?, createdAt, pushedAt?}",
+    "artifactType, ownerType, visibility, sizeBytes?, createdAt, pushedAt?}",
 )
 
 # ---------------------------------------------------------------------------
@@ -206,6 +206,13 @@ _STATUS_LABELS: dict[str, str] = {
 }
 
 
+def _render_visibility(value: Any) -> str:
+    visibility = str(value or "PRIVATE").upper()
+    if visibility == "PUBLIC":
+        return "[green]Public[/green]"
+    return "[dim]Private[/dim]"
+
+
 def _render_status_slot(part: Optional[ArtifactPartition]) -> str:
     """Render the raw status of the latest row for this artifact type.
 
@@ -278,6 +285,7 @@ def _image_ref_column_width(console_width: int, is_team_listing: bool) -> int:
 
         Type     ~14 chars ("Container / VM")
         Status   ~20 chars ("Uploading / Uploading")
+        Visibility ~9 chars
         Size     ~10 chars
         Created  ~17 chars ("YYYY-MM-DD HH:MM ")
         Owner    ~10 chars (team listings only)
@@ -287,8 +295,8 @@ def _image_ref_column_width(console_width: int, is_team_listing: bool) -> int:
     so the column is neither absurdly wide on large terminals nor unusable on
     tiny ones.
     """
-    reserved = 14 + 20 + 10 + 17 + (10 if is_team_listing else 0)
-    num_cols = 5 + (1 if is_team_listing else 0)
+    reserved = 14 + 20 + 9 + 10 + 17 + (10 if is_team_listing else 0)
+    num_cols = 6 + (1 if is_team_listing else 0)
     reserved += 3 * num_cols
     budget = console_width - reserved
     return max(30, min(80, budget))
@@ -356,17 +364,35 @@ def push_image(
         click_type=click.Choice(["linux/amd64", "linux/arm64"]),
         help="Target platform (defaults to linux/amd64 for Kubernetes compatibility)",
     ),
+    public: bool = typer.Option(
+        False,
+        "--public",
+        help="Make the image public when the build completes",
+    ),
+    private: bool = typer.Option(
+        False,
+        "--private",
+        help="Make the image private when the build completes",
+    ),
 ):
     """
     Build and push a Docker image to Prime Intellect registry.
+
+    New image tags are private by default. Re-pushing an existing tag keeps
+    its current visibility unless --public or --private is provided.
 
     \b
     Examples:
         prime images push myapp:v1.0.0
         prime images push myapp:latest --context ./app --dockerfile ../docker/Dockerfile.prod
         prime images push myapp:v1 --platform linux/arm64
+        prime images push myapp:v1 --public
     """
     try:
+        if public and private:
+            console.print("[red]Error: --public and --private cannot be used together[/red]")
+            raise typer.Exit(1)
+
         # Parse image reference
         if ":" in image_reference:
             image_name, image_tag = image_reference.rsplit(":", 1)
@@ -466,6 +492,10 @@ def push_image(
                 }
                 if config.team_id:
                     build_payload["team_id"] = config.team_id
+                if public:
+                    build_payload["visibility"] = "PUBLIC"
+                elif private:
+                    build_payload["visibility"] = "PRIVATE"
 
                 build_response = client.request(
                     "POST",
@@ -531,6 +561,13 @@ def push_image(
             console.print()
             console.print(f"[bold]Build ID:[/bold] {build_id}")
             console.print(f"[bold]Image:[/bold] {full_image_path}")
+            if public or private:
+                console.print(f"[bold]Visibility:[/bold] {'PUBLIC' if public else 'PRIVATE'}")
+            else:
+                console.print(
+                    "[bold]Visibility:[/bold] PRIVATE for new images "
+                    "(existing tags keep their current visibility)"
+                )
             console.print()
             console.print("[cyan]Your image is being built.[/cyan]")
             console.print()
@@ -663,6 +700,7 @@ def list_images(
         # Worst-case label is ``Cancelled / Cancelled`` (21 chars); pin to 21
         # so Rich never wraps the status text across two lines.
         table.add_column("Status", justify="center", no_wrap=True, min_width=21)
+        table.add_column("Visibility", justify="center", no_wrap=True)
         table.add_column("Size", justify="right", no_wrap=True)
         table.add_column("Created", style="dim", no_wrap=True, min_width=16)
 
@@ -687,6 +725,7 @@ def list_images(
             )
             type_display: str = _render_type_column(partition)
             status_display: str = _render_status_column(partition)
+            visibility_display: str = _render_visibility(preferred.get("visibility"))
             size_mb: str = _completed_size_mb(partition)
             date_str: str = _display_created(partition)
 
@@ -699,7 +738,7 @@ def list_images(
                     "[blue]Team[/blue]" if owner_type == "team" else "[dim]Personal[/dim]"
                 )
                 row.append(owner_display)
-            row.extend([status_display, size_mb, date_str])
+            row.extend([status_display, visibility_display, size_mb, date_str])
             table.add_row(*row)
 
         console.print()
@@ -727,6 +766,111 @@ def list_images(
             console.print(f"[dim]Total: {shown_groups} image(s)[/dim]")
         console.print()
 
+    except UnauthorizedError:
+        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
+def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Optional[str]]:
+    """Parse refs accepted by mutating image commands.
+
+    Returns ``(image_name, image_tag, team_id)``. Personal image refs use
+    ``name:tag`` and team image refs may use ``team-{teamId}/name:tag``.
+    """
+    team_id: Optional[str] = config.team_id
+    if "/" in image_reference:
+        namespace, rest = image_reference.split("/", 1)
+        if namespace.startswith("team-"):
+            extracted_team_id = namespace[5:]
+            if not extracted_team_id:
+                console.print(
+                    "[red]Error: Invalid team image reference. "
+                    "Expected format: team-{teamId}/imagename:tag[/red]"
+                )
+                raise typer.Exit(1)
+            team_id = extracted_team_id
+            image_reference = rest
+        else:
+            console.print(
+                f"[red]Error: Unrecognized image namespace '{namespace}'. "
+                "Use 'imagename:tag' for personal images or "
+                "'team-{{teamId}}/imagename:tag' for team images.[/red]"
+            )
+            raise typer.Exit(1)
+
+    if ":" not in image_reference:
+        console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")
+        raise typer.Exit(1)
+
+    image_name, image_tag = image_reference.rsplit(":", 1)
+    return image_name, image_tag, team_id
+
+
+def _set_image_visibility(image_reference: str, visibility: str) -> None:
+    image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
+    payload: dict[str, str] = {"visibility": visibility}
+    if team_id:
+        payload["teamId"] = team_id
+
+    client = APIClient()
+    client.request(
+        "PATCH",
+        f"/images/{image_name}/{image_tag}/visibility",
+        json=payload,
+    )
+    context = f" (team: {team_id})" if team_id else ""
+    console.print(f"[green]✓[/green] Updated {image_name}:{image_tag}{context} to {visibility}")
+
+
+@app.command("publish")
+def publish_image(
+    image_reference: str = typer.Argument(
+        ...,
+        help=(
+            "Image reference to make public (e.g., 'myapp:v1.0.0' or 'team-{teamId}/myapp:v1.0.0')"
+        ),
+    ),
+):
+    """
+    Make an image public so other Prime users can run it.
+
+    \b
+    Examples:
+        prime images publish myapp:v1.0.0
+        prime images publish team-abc123/myapp:v1.0.0
+    """
+    try:
+        _set_image_visibility(image_reference, "PUBLIC")
+    except UnauthorizedError:
+        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command("unpublish")
+def unpublish_image(
+    image_reference: str = typer.Argument(
+        ...,
+        help=(
+            "Image reference to make private (e.g., 'myapp:v1.0.0' or 'team-{teamId}/myapp:v1.0.0')"
+        ),
+    ),
+):
+    """
+    Make a public image private again.
+
+    \b
+    Examples:
+        prime images unpublish myapp:v1.0.0
+        prime images unpublish team-abc123/myapp:v1.0.0
+    """
+    try:
+        _set_image_visibility(image_reference, "PRIVATE")
     except UnauthorizedError:
         console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
         raise typer.Exit(1)

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -143,6 +143,31 @@ def test_publish_image_calls_visibility_endpoint(monkeypatch):
     assert captured["json"] == {"visibility": "PUBLIC", "teamId": "abc123"}
 
 
+def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "cmk123/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/cmk123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
 def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -164,7 +164,7 @@ def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/cmk123/rehl/latest/visibility"
+    assert captured["path"] == "/images/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -159,13 +159,57 @@ def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
     result = runner.invoke(
         app,
         ["images", "publish", "cmk123/rehl:latest"],
-        env=TEST_ENV,
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
     assert captured["path"] == "/images/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_publish_image_rejects_other_user_prefixed_personal_ref(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "other-user/rehl:latest"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 1
+    assert "Unrecognized image namespace 'other-user'" in result.output
+
+
+def test_delete_image_accepts_owner_prefixed_personal_ref(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["params"] = params
+            return {"success": True, "message": "ok"}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "delete", "cmk123/rehl:latest", "--yes"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/images/rehl/latest"
+    assert captured["params"] is None
 
 
 def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -59,6 +59,9 @@ def test_push_image_defaults_dockerfile_to_context(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["build_payload"]["dockerfile_path"] == PACKAGED_DOCKERFILE_PATH
+    assert "visibility" not in captured["build_payload"]
+    assert "PRIVATE for new images" in result.output
+    assert "existing tags keep their current visibility" in result.output
 
     with tarfile.open(fileobj=io.BytesIO(captured["tar_bytes"]), mode="r:gz") as tar:
         names = set(tar.getnames())
@@ -67,6 +70,77 @@ def test_push_image_defaults_dockerfile_to_context(tmp_path, monkeypatch):
         dockerfile_member = tar.extractfile(PACKAGED_DOCKERFILE_PATH)
         assert dockerfile_member is not None
         assert dockerfile_member.read().decode() == (context_path / "Dockerfile").read_text()
+
+
+def test_push_image_public_sends_visibility(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    context_path = tmp_path / "context"
+    context_path.mkdir()
+    (context_path / "Dockerfile").write_text("FROM busybox\n")
+
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            if method == "POST" and path == "/images/build":
+                captured["build_payload"] = json
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://example.test/upload",
+                    "fullImagePath": "rehl:latest",
+                }
+
+            if method == "POST" and path == "/images/build/build-123/start":
+                return {}
+
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    class DummyUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    def fake_put(url, content, headers, timeout):
+        return DummyUploadResponse()
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "rehl:latest", "--context", "context", "--public"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["build_payload"]["visibility"] == "PUBLIC"
+    assert "Visibility:" in result.output
+
+
+def test_publish_image_calls_visibility_endpoint(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "team-abc123/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC", "teamId": "abc123"}
 
 
 def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI paths that change image visibility (public vs private) and sends new `visibility` payloads to the images API, which could unintentionally expose images if misused or if backend expectations differ.
> 
> **Overview**
> Adds first-class *image visibility* support to `prime images`: `list` now shows a **Visibility** column, and `push` accepts `--public/--private` (mutually exclusive) to request visibility on build.
> 
> Introduces `prime images publish`/`unpublish` commands that `PATCH /images/{name}/{tag}/visibility`, plus shared parsing to allow `name:tag`, `<currentUserId>/name:tag`, and `team-{teamId}/name:tag` refs; `delete` is updated to use the same parsing. Tests are expanded to cover default visibility behavior, `--public` payloads, new publish endpoint calls, and owner-prefixed ref handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f24b21907bf01e0df7ccc6cf2d499d24918d930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->