### PR TITLE
[codex] Add Lab local agent guidance support

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -35,7 +35,7 @@ from .lab_agents import (
 )
 
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
-VERIFIERS_REF = "7d8a522df67308327cb9b8931ce6a5873a99834a"
+VERIFIERS_REF = "f43e42c1fabfe2604afc95b9ce62779a8f55d487"
 VERIFIERS_CONFIG_REF = "main"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
@@ -44,8 +44,12 @@ LAB_CONFIG_FOLDERS = ("rl", "gepa", "eval", "sft", "opd", "fft")
 SUPPORTED_AGENTS = known_agent_names()
 LAB_GITIGNORE_PATTERNS = (
     ".env",
+    "/AGENTS.md",
+    "/CLAUDE.md",
+    "/CLAUDE.local.md",
     "/outputs/",
     "/prime-rl/",
+    "/environments/AGENTS.md",
     "/environments/*/outputs/",
     "/environments/*/dist/",
     "/environments/*/*.egg-info/",
@@ -54,6 +58,17 @@ LAB_GITIGNORE_PATTERNS = (
     "*.py[cod]",
     ".pytest_cache/",
     ".ruff_cache/",
+)
+LOCAL_CLAUDE_MD = "CLAUDE.local.md"
+LAB_GUIDANCE_GITIGNORE_PATHS = ("AGENTS.md", "CLAUDE.md", LOCAL_CLAUDE_MD, "environments/AGENTS.md")
+LOCAL_CLAUDE_GUIDANCE_TEMPLATE = "\n".join(
+    [
+        "# CLAUDE.local.md",
+        "",
+        "Add personal Claude guidance for this Lab workspace here.",
+        "Prime Lab preserves this file during setup and sync.",
+        "",
+    ]
 )
 PRIME_SKILLS_MANIFEST = ".prime-managed.json"
 WORKSPACE_SKILLS_DIR = Path(".prime") / "skills"
@@ -220,7 +235,7 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
     parser.add_argument(
         "--skip-agents-md",
         action="store_true",
-        help="Skip AGENTS.md, CLAUDE.md, and environments/AGENTS.md.",
+        help="Skip AGENTS.md, CLAUDE.md, CLAUDE.local.md, and environments/AGENTS.md.",
     )
     parser.add_argument(
         "--skip-install",
@@ -269,7 +284,7 @@ def parse_lab_sync_args(args: list[str]) -> LabSyncOptions:
     parser.add_argument(
         "--skip-docs",
         action="store_true",
-        help="Skip AGENTS.md, CLAUDE.md, and environments/AGENTS.md refresh.",
+        help="Skip AGENTS.md, CLAUDE.md, CLAUDE.local.md, and environments/AGENTS.md refresh.",
     )
     parser.add_argument(
         "--no-agent",
@@ -395,6 +410,7 @@ def _run_lab_sync_steps(
     workspace.mkdir(parents=True, exist_ok=True)
     (workspace / "configs").mkdir(exist_ok=True)
     (workspace / "environments").mkdir(exist_ok=True)
+    _append_gitignore(workspace)
     emit(f"Syncing Lab assets in {workspace}\n")
     agents = _resolve_sync_agents(workspace, options.agents, no_agent=options.no_agent)
     guidance_agents = agents
@@ -432,8 +448,9 @@ def _sync_workspace_guidance(
     force: bool = False,
 ) -> None:
     _download_file(AGENTS_MD_SRC, workspace / "AGENTS.md", emit, force=force, quiet=True)
+    _download_file(CLAUDE_MD_SRC, workspace / "CLAUDE.md", emit, force=force, quiet=True)
     if "claude" in agents:
-        _download_file(CLAUDE_MD_SRC, workspace / "CLAUDE.md", emit, force=force, quiet=True)
+        _ensure_claude_local_guidance(workspace)
     _download_file(
         ENVS_AGENTS_MD_SRC,
         workspace / "environments" / "AGENTS.md",
@@ -442,6 +459,13 @@ def _sync_workspace_guidance(
         quiet=True,
     )
     emit("Refreshed workspace guidance\n")
+
+
+def _ensure_claude_local_guidance(workspace: Path) -> None:
+    path = workspace / LOCAL_CLAUDE_MD
+    if path.exists() or path.is_symlink():
+        return
+    path.write_text(LOCAL_CLAUDE_GUIDANCE_TEMPLATE, encoding="utf-8")
 
 
 def _sync_prime_skills(emit: Emit) -> tuple[str, ...]:
@@ -864,6 +888,7 @@ def _lab_doctor_checks(options: LabDoctorOptions, workspace: Path) -> list[LabDo
             "Run prime lab doctor --fix.",
         ),
         _gitignore_check(workspace),
+        _lab_guidance_tracking_check(workspace, fix=options.fix),
         _config_validity_check(workspace),
         _config_deprecated_fields_check(workspace),
         _config_environment_reference_check(workspace),
@@ -1116,15 +1141,61 @@ def _gitignore_check(workspace: Path) -> LabDoctorCheck:
     missing = _missing_gitignore_patterns(existing)
     if not missing:
         return LabDoctorCheck(
-            name="Gitignore outputs",
+            name="Lab gitignore",
             status="PASS",
-            message="Standard output and generated source paths are ignored.",
+            message="Standard Lab generated and local paths are ignored.",
         )
     return LabDoctorCheck(
-        name="Gitignore outputs",
+        name="Lab gitignore",
         status="WARN",
         message="Missing " + ", ".join(missing),
-        remediation="Run prime lab doctor --fix to add standard output ignores.",
+        remediation="Run prime lab doctor --fix to add standard Lab ignores.",
+    )
+
+
+def _lab_guidance_tracking_check(workspace: Path, *, fix: bool) -> LabDoctorCheck:
+    tracked = _tracked_git_paths(workspace, LAB_GUIDANCE_GITIGNORE_PATHS)
+    if tracked and fix:
+        _untrack_git_paths(workspace, tracked)
+        tracked = _tracked_git_paths(workspace, LAB_GUIDANCE_GITIGNORE_PATHS)
+    if not tracked:
+        return LabDoctorCheck(
+            name="Lab guidance tracking",
+            status="PASS",
+            message="Lab generated and local guidance files are untracked.",
+        )
+    paths = " ".join(tracked)
+    return LabDoctorCheck(
+        name="Lab guidance tracking",
+        status="WARN",
+        message="Tracked Lab generated/local guidance files: " + ", ".join(tracked),
+        remediation=f"Run git rm --cached {paths} && prime lab sync.",
+    )
+
+
+def _tracked_git_paths(workspace: Path, paths: tuple[str, ...]) -> tuple[str, ...]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", *paths],
+            cwd=workspace,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return ()
+    if result.returncode != 0:
+        return ()
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _untrack_git_paths(workspace: Path, paths: tuple[str, ...]) -> None:
+    subprocess.run(
+        ["git", "rm", "--cached", "--force", "--quiet", "--", *paths],
+        cwd=workspace,
+        check=False,
+        capture_output=True,
+        text=True,
     )
 
 
@@ -1422,10 +1493,11 @@ def _write_lab_docs_index(workspace: Path, agents: tuple[str, ...]) -> None:
     docs_dir.mkdir(parents=True, exist_ok=True)
     guidance_files = [
         "- `AGENTS.md`",
+        "- `CLAUDE.md`",
         "- `environments/AGENTS.md`",
     ]
     if "claude" in agents:
-        guidance_files.insert(1, "- `CLAUDE.md`")
+        guidance_files.insert(2, f"- `{LOCAL_CLAUDE_MD}`")
     index = docs_dir / "index.md"
     index.write_text(
         "\n".join(

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -131,6 +132,16 @@ def _render_emitted(items: list[Any]) -> str:
     return console.export_text()
 
 
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_lab_setup_parses_selected_agents_and_all() -> None:
     selected = parse_lab_setup_args(["--agent", "factory-droid,amp-code,claude-code,letta-code"])
     all_agents = parse_lab_sync_args(["--agents", "all"])
@@ -253,6 +264,8 @@ def test_lab_setup_service_downloads_upstream_assets_without_agent_installs(
     assert (tmp_path / ".prime" / "lab" / "docs" / "index.md").is_file()
     gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
     assert "/outputs/" in gitignore.splitlines()
+    assert "/AGENTS.md" in gitignore.splitlines()
+    assert "/CLAUDE.md" in gitignore.splitlines()
     assert (tmp_path / ".pi" / "extensions" / "prime-lab" / "index.ts").is_file()
     output = _render_emitted(emitted)
     assert "pi-acp" not in output
@@ -288,6 +301,40 @@ def test_lab_setup_service_emits_post_setup_call_to_action(
     assert "prime gepa run my-env -m openai/gpt-5.4-nano" in output
 
 
+def test_lab_setup_ignores_managed_guidance_and_skips_claude_local_for_codex(
+    tmp_path: Path,
+    monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=False, agents=("codex",)),
+        workspace=tmp_path,
+        emit=lambda _text: None,
+    )
+
+    docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
+    gitignore_lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert result.exit_code == 0
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    assert not (tmp_path / "CLAUDE.local.md").exists()
+    assert "- `AGENTS.md`" in docs_index
+    assert "- `CLAUDE.md`" in docs_index
+    assert "- `CLAUDE.local.md`" not in docs_index
+    assert "- `environments/AGENTS.md`" in docs_index
+    for pattern in (
+        "/AGENTS.md",
+        "/CLAUDE.md",
+        "/CLAUDE.local.md",
+        "/environments/AGENTS.md",
+    ):
+        assert pattern in gitignore_lines
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+
+
 def test_lab_setup_refreshes_existing_workspace_guidance(
     tmp_path: Path,
     monkeypatch: Any,
@@ -298,6 +345,7 @@ def test_lab_setup_refreshes_existing_workspace_guidance(
     existing_files = {
         tmp_path / "AGENTS.md": "workspace agents\n",
         tmp_path / "CLAUDE.md": "workspace claude\n",
+        tmp_path / "CLAUDE.local.md": "workspace claude local guidance\n",
         tmp_path / "environments" / "AGENTS.md": "environment agents\n",
     }
     for path, text in existing_files.items():
@@ -314,13 +362,17 @@ def test_lab_setup_refreshes_existing_workspace_guidance(
     assert result.exit_code == 0
     for path in (
         tmp_path / "AGENTS.md",
+        tmp_path / "CLAUDE.md",
         tmp_path / "environments" / "AGENTS.md",
     ):
         assert path.read_text(encoding="utf-8").startswith("downloaded from ")
-    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8") == "workspace claude\n"
+    assert (tmp_path / "CLAUDE.local.md").read_text(encoding="utf-8") == (
+        "workspace claude local guidance\n"
+    )
     docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
-    assert "- `CLAUDE.md`" not in docs_index
-    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+    assert "- `CLAUDE.md`" in docs_index
+    assert "- `CLAUDE.local.md`" not in docs_index
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert "already exists" not in _render_emitted(emitted)
 
 
@@ -339,9 +391,29 @@ def test_lab_setup_refreshes_claude_guidance_for_claude_agent(
 
     assert result.exit_code == 0
     assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    claude_local = tmp_path / "CLAUDE.local.md"
+    assert claude_local.read_text(encoding="utf-8") == lab_setup.LOCAL_CLAUDE_GUIDANCE_TEMPLATE
     docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
     assert "- `CLAUDE.md`" in docs_index
+    assert "- `CLAUDE.local.md`" in docs_index
     assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+
+
+def test_lab_setup_preserves_user_owned_claude_local_guidance(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    (tmp_path / "CLAUDE.local.md").write_text("claude local guidance\n", encoding="utf-8")
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=False, agents=("claude",)),
+        workspace=tmp_path,
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / "CLAUDE.local.md").read_text(encoding="utf-8") == ("claude local guidance\n")
 
 
 def test_lab_sync_refreshes_existing_workspace_guidance(
@@ -370,11 +442,12 @@ def test_lab_sync_refreshes_existing_workspace_guidance(
     assert result.exit_code == 0
     for path in (
         tmp_path / "AGENTS.md",
+        tmp_path / "CLAUDE.md",
         tmp_path / "environments" / "AGENTS.md",
     ):
         assert path.read_text(encoding="utf-8").startswith("downloaded from ")
-    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8") == "stale guidance\n"
-    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+    assert not (tmp_path / "CLAUDE.local.md").exists()
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert not any("already exists" in line for line in emitted)
 
 
@@ -401,13 +474,14 @@ def test_lab_sync_without_configured_agent_refreshes_shared_assets(
         .read_text(encoding="utf-8")
         .startswith("downloaded from ")
     )
-    assert not (tmp_path / "CLAUDE.md").exists()
-    assert "- `CLAUDE.md`" not in (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    assert not (tmp_path / "CLAUDE.local.md").exists()
+    assert "- `CLAUDE.md`" in (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(
         encoding="utf-8"
     )
     assert (tmp_path / ".prime" / "lab" / "templates" / "configs" / "rl" / "gsm8k.toml").is_file()
     assert not (tmp_path / ".agents" / "skills").exists()
-    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert any("no configured agent; pass --agent to configure one" in line for line in emitted)
 
 
@@ -440,8 +514,12 @@ def test_lab_sync_no_agent_keeps_stored_claude_guidance(
 
     assert result.exit_code == 0
     assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    assert (tmp_path / "CLAUDE.local.md").read_text(
+        encoding="utf-8"
+    ) == lab_setup.LOCAL_CLAUDE_GUIDANCE_TEMPLATE
     docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
     assert "- `CLAUDE.md`" in docs_index
+    assert "- `CLAUDE.local.md`" in docs_index
     assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert not (tmp_path / ".claude" / "skills").exists()
     assert any("Skipped coding-agent skill roots (--no-agent)" in line for line in emitted)
@@ -805,12 +883,94 @@ def test_lab_doctor_fix_writes_standard_gitignore_patterns(tmp_path: Path) -> No
     assert "custom.log" in gitignore
     assert ".env.local" in gitignore_lines
     assert ".env" in gitignore_lines
+    assert "/AGENTS.md" in gitignore_lines
+    assert "/CLAUDE.md" in gitignore_lines
+    assert "/CLAUDE.local.md" in gitignore_lines
     assert "/outputs/" in gitignore_lines
     assert "/prime-rl/" in gitignore_lines
+    assert "/environments/AGENTS.md" in gitignore_lines
     assert "/environments/*/outputs/" in gitignore_lines
     assert "*.py[cod]" in gitignore_lines
     assert ".pytest_cache/" in gitignore_lines
     assert ".ruff_cache/" in gitignore_lines
+
+
+def test_lab_doctor_warns_about_tracked_lab_guidance(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    guidance_paths = ("AGENTS.md", "CLAUDE.md", "CLAUDE.local.md", "environments/AGENTS.md")
+    for relative_path in guidance_paths:
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("guidance\n", encoding="utf-8")
+    _git(tmp_path, "add", *guidance_paths)
+
+    result = run_lab_doctor_service(LabDoctorOptions(), workspace=tmp_path)
+    checks = {check.name: check for check in result.checks}
+
+    check = checks["Lab guidance tracking"]
+    assert check.status == "WARN"
+    assert "AGENTS.md" in check.message
+    assert "CLAUDE.md" in check.message
+    assert "CLAUDE.local.md" in check.message
+    assert "environments/AGENTS.md" in check.message
+    assert "git rm --cached" in check.remediation
+
+
+def test_lab_doctor_fix_untracks_lab_guidance(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    guidance_paths = ("AGENTS.md", "CLAUDE.md", "CLAUDE.local.md", "environments/AGENTS.md")
+    for relative_path in guidance_paths:
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("guidance\n", encoding="utf-8")
+    _git(tmp_path, "add", *guidance_paths)
+
+    result = run_lab_doctor_service(LabDoctorOptions(fix=True), workspace=tmp_path)
+    checks = {check.name: check for check in result.checks}
+    tracked = _git(tmp_path, "ls-files", "--", *guidance_paths)
+
+    assert checks["Lab guidance tracking"].status == "PASS"
+    assert tracked.stdout == ""
+    assert (tmp_path / "AGENTS.md").is_file()
+    assert (tmp_path / "CLAUDE.md").is_file()
+    assert (tmp_path / "CLAUDE.local.md").is_file()
+    assert (tmp_path / "environments" / "AGENTS.md").is_file()
+    assert result.exit_code == 1
+
+
+def test_lab_doctor_fix_untracks_staged_and_modified_lab_guidance(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    guidance_paths = ("AGENTS.md", "CLAUDE.md", "CLAUDE.local.md", "environments/AGENTS.md")
+    for relative_path in guidance_paths:
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("committed guidance\n", encoding="utf-8")
+    _git(tmp_path, "add", *guidance_paths)
+    _git(
+        tmp_path,
+        "-c",
+        "user.email=lab@example.com",
+        "-c",
+        "user.name=Prime Lab",
+        "commit",
+        "-m",
+        "track guidance",
+    )
+    for relative_path in guidance_paths:
+        (tmp_path / relative_path).write_text("staged guidance\n", encoding="utf-8")
+    _git(tmp_path, "add", *guidance_paths)
+    for relative_path in guidance_paths:
+        (tmp_path / relative_path).write_text("working guidance\n", encoding="utf-8")
+
+    result = run_lab_doctor_service(LabDoctorOptions(fix=True), workspace=tmp_path)
+    checks = {check.name: check for check in result.checks}
+    tracked = _git(tmp_path, "ls-files", "--", *guidance_paths)
+
+    assert checks["Lab guidance tracking"].status == "PASS"
+    assert tracked.stdout == ""
+    for relative_path in guidance_paths:
+        assert (tmp_path / relative_path).read_text(encoding="utf-8") == "working guidance\n"
+    assert result.exit_code == 1
 
 
 def test_lab_doctor_validates_environment_table_refs(tmp_path: Path) -> None:

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -2020,9 +2020,7 @@ def test_prime_lab_doctor_service_checks_and_fixes_workspace(tmp_path: Path) -> 
     assert any(
         check.name == "Workspace metadata" and check.status == "FAIL" for check in result.checks
     )
-    assert any(
-        check.name == "Gitignore outputs" and check.status == "WARN" for check in result.checks
-    )
+    assert any(check.name == "Lab gitignore" and check.status == "WARN" for check in result.checks)
 
     fixed = run_lab_doctor_service(LabDoctorOptions(fix=True), workspace=tmp_path)
 
@@ -2031,8 +2029,12 @@ def test_prime_lab_doctor_service_checks_and_fixes_workspace(tmp_path: Path) -> 
     gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
     gitignore_lines = set(gitignore.splitlines())
     assert ".env" in gitignore_lines
+    assert "/AGENTS.md" in gitignore_lines
+    assert "/CLAUDE.md" in gitignore_lines
+    assert "/CLAUDE.local.md" in gitignore_lines
     assert "/outputs/" in gitignore_lines
     assert "/prime-rl/" in gitignore_lines
+    assert "/environments/AGENTS.md" in gitignore_lines
     assert "*.py[cod]" in gitignore_lines
     assert any(
         check.name == "Configs directory" and check.status == "PASS" for check in fixed.checks


### PR DESCRIPTION
## Summary
- Treat root `AGENTS.md`, root `CLAUDE.md`, and `environments/AGENTS.md` as Prime-managed guidance refreshed by `prime lab setup` / `prime lab sync`.
- Use Claude-native `CLAUDE.local.md` as the local write space when Claude is configured; preserve it and never overwrite it.
- Add Lab git hygiene guardrails: ignore generated guidance, Claude local guidance, outputs, caches, and environment build artifacts.
- Add `prime lab doctor` checks and `--fix` support to detect and untrack Lab generated/local guidance files that were already added to git.
- Bump `VERIFIERS_REF` to the merged Verifiers guidance ref `f43e42c1fabfe2604afc95b9ce62779a8f55d487`.

## Validation
- `uv run pytest packages/prime/tests/test_lab_setup.py -q`
- `uv run pytest packages/prime/tests/test_lab_view.py::test_prime_lab_sync_service_refreshes_agent_assets -q`
- `uv run ruff check packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py`
- `uv run ruff format --check packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py`
- `git diff --check -- packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lab CLI workspace scaffolding and optional git index cleanup on doctor --fix; no auth, payments, or production runtime paths.
> 
> **Overview**
> Prime Lab now treats root **`AGENTS.md`**, **`CLAUDE.md`**, and **`environments/AGENTS.md`** as Prime-managed files refreshed on **`prime lab setup`** / **`prime lab sync`**, with **`CLAUDE.md`** refreshed for all agents (not only Claude). **`CLAUDE.local.md`** is the user-owned Claude overlay: created from a template when Claude is configured, never overwritten if it already exists, and omitted for non-Claude setups.
> 
> **Git hygiene** expands standard **`.gitignore`** entries for those guidance files plus existing Lab artifacts; sync/setup also appends ignores. **`prime lab doctor`** adds a **Lab guidance tracking** check (warn if those paths are still tracked) and **`--fix`** can **`git rm --cached`** them while leaving files on disk. Doctor renames the gitignore check to **Lab gitignore**.
> 
> The Lab docs index and CLI help text now mention **`CLAUDE.local.md`**. **`VERIFIERS_REF`** is bumped so downloaded lab guidance/skills match the new upstream assets. Tests cover guidance refresh, preservation, gitignore, and doctor untrack behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad00867935928dfc43d48438feb1feee2e40112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->