### PR TITLE
chore: update urls 

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ prime switch <team-slug>
 
 ```bash
 # Clone the repository
-git clone https://github.com/PrimeIntellect-ai/prime-cli
-cd prime-cli
+git clone https://github.com/PrimeIntellect-ai/prime
+cd prime
 
 # Set up workspace (installs all packages in editable mode)
 uv sync

--- a/packages/prime-evals/pyproject.toml
+++ b/packages/prime-evals/pyproject.toml
@@ -29,9 +29,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
-Documentation = "https://github.com/PrimeIntellect-ai/prime-cli/tree/main/packages/prime-evals"
-Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
+Homepage = "https://github.com/PrimeIntellect-ai/prime"
+Documentation = "https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-evals"
+Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -248,7 +248,7 @@ asyncio.run(run_training())
 
 ## Documentation
 
-Full API reference: https://github.com/PrimeIntellect-ai/prime-cli/tree/main/packages/prime-sandboxes
+Full API reference: https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes
 
 ## Related Packages
 

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -33,9 +33,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
-Documentation = "https://github.com/PrimeIntellect-ai/prime-cli/tree/main/packages/prime-sandboxes"
-Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
+Homepage = "https://github.com/PrimeIntellect-ai/prime"
+Documentation = "https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes"
+Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/prime-tunnel/README.md
+++ b/packages/prime-tunnel/README.md
@@ -40,7 +40,7 @@ prime tunnel status <tunnel_id>
 
 ## Documentation
 
-Full API reference: https://github.com/PrimeIntellect-ai/prime-cli/tree/main/packages/prime-tunnel
+Full API reference: https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-tunnel
 
 ## Related Packages
 

--- a/packages/prime-tunnel/pyproject.toml
+++ b/packages/prime-tunnel/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
-Documentation = "https://github.com/PrimeIntellect-ai/prime-cli/tree/main/packages/prime-tunnel"
-Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
+Homepage = "https://github.com/PrimeIntellect-ai/prime"
+Documentation = "https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-tunnel"
+Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -323,7 +323,7 @@ prime pods ssh <pod-id>
 
 ## Support & Resources
 
-- **Documentation**: [github.com/PrimeIntellect-ai/prime-cli](https://github.com/PrimeIntellect-ai/prime-cli)
+- **Documentation**: [github.com/PrimeIntellect-ai/prime](https://github.com/PrimeIntellect-ai/prime)
 - **Dashboard**: [app.primeintellect.ai](https://app.primeintellect.ai)
 - **API Docs**: [api.primeintellect.ai/docs](https://api.primeintellect.ai/docs)
 - **Discord**: [discord.gg/primeintellect](https://discord.gg/primeintellect)
@@ -335,4 +335,4 @@ prime pods ssh <pod-id>
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/PrimeIntellect-ai/prime-cli/blob/main/LICENSE) file for details.
+MIT License - see [LICENSE](https://github.com/PrimeIntellect-ai/prime/blob/main/LICENSE) file for details.

--- a/packages/prime/dev/render_lab_screens.py
+++ b/packages/prime/dev/render_lab_screens.py
@@ -117,7 +117,7 @@ def _settings(console: Console, *, width: int, frame: int) -> None:
             "Settings\nWorkspaces 2   Profiles 1   Local assets 8   Setup 3\n\n"
             "[Set up Lab workspace] [Sync Lab assets] [Check workspace]\n\n"
             "verifiers       active\n~/dev/verifiers\n\n"
-            "prime-cli       inactive\n~/dev/prime-cli"
+            "prime           inactive\n~/dev/prime"
         ),
         _panel_text(
             "verifiers\n~/dev/verifiers\n\nStatus       active\nAuth         authenticated\n"

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -44,9 +44,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
-Documentation = "https://github.com/PrimeIntellect-ai/prime-cli#readme"
-Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
+Homepage = "https://github.com/PrimeIntellect-ai/prime"
+Documentation = "https://github.com/PrimeIntellect-ai/prime#readme"
+Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 Changelog = "https://github.com/PrimeIntellect-ai/prime/releases"
 
 [project.scripts]

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -1442,7 +1442,7 @@ def _write_lab_docs_index(workspace: Path, agents: tuple[str, ...]) -> None:
                 "",
                 "## Prime docs",
                 "",
-                "- Prime CLI: https://github.com/PrimeIntellect-ai/prime-cli",
+                "- Prime CLI: https://github.com/PrimeIntellect-ai/prime",
                 "- Verifiers: https://github.com/PrimeIntellect-ai/verifiers",
                 "- Environments Hub: https://app.primeintellect.ai/dashboard/environments",
                 "",


### PR DESCRIPTION
🍒

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates documentation and package metadata URLs, with no runtime logic or API behavior changes.
> 
> **Overview**
> Updates repository links across the monorepo to point from `PrimeIntellect-ai/prime-cli` to `PrimeIntellect-ai/prime`, including root/package READMEs, `pyproject.toml` `project.urls`, and the Lab docs index generated by `prime_cli.lab_setup`.
> 
> Also refreshes a developer-only Lab TUI sketch (`render_lab_screens.py`) to reference `~/dev/prime` instead of `~/dev/prime-cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc895061ff7d85a20515a2ee58d41f02043351c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->