### PR TITLE
rl: surface notice field from create-run response

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -95,6 +95,7 @@ class RLRun(BaseModel):
     # Queue info
     runs_ahead: Optional[int] = Field(None, alias="runsAhead")
     queue_reason: Optional[str] = Field(None, alias="queueReason")
+    notice: Optional[str] = Field(None, alias="notice")
 
     # Timestamps
     started_at: Optional[datetime] = Field(None, alias="startedAt")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1129,6 +1129,9 @@ def create_run(
         else:
             console.print("[green]✓ Run created successfully![/green]")
 
+        if run.notice:
+            console.print(f"[cyan]{run.notice}[/cyan]")
+
         dashboard_url = f"{app_config.frontend_url}/dashboard/training/{run.id}"
         console.print("\n[cyan]Monitor run at:[/cyan]")
         console.print(f"  [link={dashboard_url}]{dashboard_url}[/link]")


### PR DESCRIPTION
Adds the optional `notice` field on the create-run response so `prime train` prints things like the Prime Sprint free-tier acceptance message.

- New `RFTRun.notice` (alias `notice`)
- Printed after the queue/success block in `commands/rl.py`

Pairs with platform PR https://github.com/PrimeIntellect-ai/platform/pull/2381 (merged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional response field to the `RLRun` model and conditionally prints it after run creation, without affecting request payloads or control flow beyond extra output.
> 
> **Overview**
> Surfaces a new optional `notice` string returned from the Hosted Training create-run API by adding `RLRun.notice` in `api/rl.py`.
> 
> Updates `prime train` run creation output (`commands/rl.py`) to print this notice (in cyan) after the queued/success message, enabling backend-sent informational messages (e.g., free-tier acceptance) to be shown to users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90257accc66dce39a9f48154c49ad97653e91e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->