### PR TITLE
release: prime CLI 0.6.9

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump `prime` CLI package version from `0.6.8` to `0.6.9`.

## Release contents
- #672: fix `prime images list --output json`
- #674: chore: update prime-cli urls to prime
- #675: surface `notice` field from create-run response (Prime Sprint free-tier acceptance message)

After this merges, `.github/workflows/release-prime.yml` should create tag `v0.6.9` and publish `prime` to PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the packaged version string with no functional code changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.6.8` to `0.6.9` by updating `__version__` in `packages/prime/src/prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5af2c7991169ded5dfdb45b409ec3f9be56fa46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->