### PR TITLE
[ENG-3771] projects-cli-1: default project UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,9 @@ prime env push my-environment
 Prime Lab connects verifiers environments to evaluations, GEPA prompt optimization, and Hosted Training. Start with `prime lab setup` to create a local workspace with starter configs, then use `prime train models` to choose a Hosted Training model with current capacity and pricing.
 
 ```bash
-# Set up a Lab workspace
+# Set up a Lab workspace.
+# If authenticated, setup creates an active project named after this folder.
 prime lab setup
-
-# Create a Lab project and make it active in this workspace
-prime project create "Alphabet Sort Baselines"
 prime project current
 
 # List trainable models, capacity, and token pricing
@@ -165,9 +163,11 @@ prime train models
 # Generate a Hosted Training config
 prime train init
 
-# Launch the run from the generated config
+# Launch the run from the generated config.
+# Runs attach to the active project by default.
 prime train rl.toml
 prime train rl.toml --project <project-id>
+prime train rl.toml --no-project
 
 # Inspect and manage Hosted Training runs
 prime train list
@@ -176,10 +176,14 @@ prime train metrics <run-id>
 prime train checkpoints <run-id>
 ```
 
-Lab projects group related training runs, evaluations, and adapters. Use
-`prime project use <project-id>` to switch the active workspace project, or
-`prime project clear` to clear it. Existing runs and adapters support project
-add/remove/clear; evaluations support assign/clear.
+Lab projects group related training runs, evaluations, and adapters. By default,
+`prime lab setup` creates an active project named after the workspace folder.
+Use `prime lab setup --project <project-id>` to bind an existing project,
+`prime lab setup --project-name "Alphabet Sort Baselines"` to choose the default
+project name, or `prime lab setup --no-project` to keep setup local-only. Later,
+use `prime project use <project-id>` to switch the active workspace project, or
+`prime project clear` to stop using one by default. Existing runs and adapters
+support project add/remove/clear; evaluations support assign/clear.
 
 ```bash
 # Manage projects
@@ -237,6 +241,7 @@ prime eval push
 # Push specific eval directory (verifiers format)
 prime eval push outputs/evals/gsm8k--gpt-4/abc123
 prime eval push outputs/evals/gsm8k--gpt-4/abc123 --project <project-id>
+prime eval push outputs/evals/gsm8k--gpt-4/abc123 --no-project
 
 # Push a public evaluation (default is private)
 prime eval push --public

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -114,11 +114,9 @@ prime sandbox create python:3.11
 Prime Lab connects verifiers environments to evaluations, GEPA prompt optimization, and Hosted Training. Start with `prime lab setup` to create a local workspace with starter configs, then use `prime train models` to choose a Hosted Training model with current capacity and pricing.
 
 ```bash
-# Set up a Lab workspace
+# Set up a Lab workspace.
+# If authenticated, setup creates an active project named after this folder.
 prime lab setup
-
-# Create a Lab project and make it active in this workspace
-prime project create "Alphabet Sort Baselines"
 prime project current
 
 # List trainable models, capacity, and token pricing
@@ -127,9 +125,11 @@ prime train models
 # Generate a Hosted Training config
 prime train init
 
-# Launch the run from the generated config
+# Launch the run from the generated config.
+# Runs attach to the active project by default.
 prime train rl.toml
 prime train rl.toml --project <project-id>
+prime train rl.toml --no-project
 
 # Inspect and manage Hosted Training runs
 prime train list
@@ -138,10 +138,14 @@ prime train metrics <run-id>
 prime train checkpoints <run-id>
 ```
 
-Lab projects group related training runs, evaluations, and adapters. Use
-`prime project use <project-id>` to switch the active workspace project, or
-`prime project clear` to clear it. Existing runs and adapters support project
-add/remove/clear; evaluations support assign/clear.
+Lab projects group related training runs, evaluations, and adapters. By default,
+`prime lab setup` creates an active project named after the workspace folder.
+Use `prime lab setup --project <project-id>` to bind an existing project,
+`prime lab setup --project-name "Alphabet Sort Baselines"` to choose the default
+project name, or `prime lab setup --no-project` to keep setup local-only. Later,
+use `prime project use <project-id>` to switch the active workspace project, or
+`prime project clear` to stop using one by default. Existing runs and adapters
+support project add/remove/clear; evaluations support assign/clear.
 
 ```bash
 # Manage projects

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1223,12 +1223,12 @@ def push_eval(
     project: Optional[str] = typer.Option(
         None,
         "--project",
-        help="Project ID or slug to attach to this evaluation.",
+        help="Project ID or slug. Defaults to the active project for this workspace.",
     ),
     no_project: bool = typer.Option(
         False,
         "--no-project",
-        help="Do not attach this evaluation to a project.",
+        help="Do not attach this evaluation to the active project.",
     ),
 ) -> None:
     """Push evaluation data to Prime Evals.
@@ -1260,7 +1260,11 @@ def push_eval(
             console.print("  prime eval push outputs/evals/env--model/run-id --eval-id <eval-id>")
             raise typer.Exit(1)
 
-        project_id = resolve_project_id(project, no_project=no_project)
+        project_id = resolve_project_id(
+            project,
+            no_project=no_project,
+            use_active_project=eval_id is None,
+        )
         clear_project = bool(eval_id and no_project)
 
         if config_path is None:
@@ -1510,12 +1514,12 @@ def run_eval_cmd(
     project: Optional[str] = typer.Option(
         None,
         "--project",
-        help="Project ID or slug to attach to this evaluation.",
+        help="Project ID or slug. Defaults to the active project for this workspace.",
     ),
     no_project: bool = typer.Option(
         False,
         "--no-project",
-        help="Do not attach this evaluation to a project.",
+        help="Do not attach this evaluation to the active project.",
     ),
 ) -> None:
     """Run an evaluation with local-first environment resolution."""
@@ -1537,7 +1541,11 @@ def run_eval_cmd(
 
     env_dir_path: Optional[str] = None
     try:
-        project_id = resolve_project_id(project, no_project=no_project)
+        project_id = resolve_project_id(
+            project,
+            no_project=no_project,
+            use_active_project=True,
+        )
     except APIError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc

--- a/packages/prime/src/prime_cli/commands/projects.py
+++ b/packages/prime/src/prime_cli/commands/projects.py
@@ -51,7 +51,7 @@ PROJECT_USAGE_HELP = _usage_help(
     ),
     (
         "prime project current",
-        "Show the active project for this workspace.",
+        "Show the active project that new Lab runs and evals will use.",
     ),
     (
         "prime project use <project-id>",
@@ -137,7 +137,7 @@ PROJECT_USE_HELP = _usage_help(
     ),
     (
         "prime project current",
-        "Confirm which project is active for this workspace.",
+        "Confirm which project this workspace will use by default.",
     ),
     json_help_text=PROJECT_JSON_HELP,
 )
@@ -173,7 +173,7 @@ PROJECT_UPDATE_HELP = _usage_help(
 PROJECT_CLEAR_HELP = _usage_help(
     (
         "prime project clear",
-        "Clear this workspace's active project.",
+        "Stop attaching new Lab runs and evals to a workspace project by default.",
     ),
 )
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -906,12 +906,12 @@ def create_run(
     project: Optional[str] = typer.Option(
         None,
         "--project",
-        help="Project ID or slug to attach to this run.",
+        help="Project ID or slug. Defaults to the active project for this workspace.",
     ),
     no_project: bool = typer.Option(
         False,
         "--no-project",
-        help="Do not attach this run to a project.",
+        help="Do not attach this run to the active project.",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
@@ -970,6 +970,7 @@ def create_run(
         project_id = resolve_project_id(
             project,
             no_project=no_project,
+            use_active_project=True,
             config=app_config,
             client=api_client,
         )

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from .api.projects import ProjectsClient
+from .core import APIClient, APIError, Config
 from .lab_agents import (
     agent_capability,
     agent_project_skills_dirs,
@@ -39,6 +42,14 @@ from .lab_hygiene import (
     missing_lab_gitignore_patterns,
     run_lab_hygiene_preflight,
     tracked_lab_hygiene_paths,
+)
+from .utils.projects import (
+    PROJECT_CONTEXT_CLEARED_KEY,
+    PROJECT_CONTEXT_ENV,
+    ensure_active_project_scope,
+    get_active_project_id,
+    read_project_context,
+    write_project_context,
 )
 
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
@@ -93,6 +104,9 @@ class LabSetupOptions:
     skip_agents_md: bool = False
     skip_install: bool = False
     agents: tuple[str, ...] = ()
+    no_project: bool = False
+    project_ref: str | None = None
+    project_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -245,7 +259,27 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
         action="store_true",
         help="Use setup defaults without prompts.",
     )
+    parser.add_argument(
+        "--no-project",
+        action="store_true",
+        help="Skip creating or selecting a Lab project during setup.",
+    )
+    parser.add_argument(
+        "--project",
+        dest="project_ref",
+        help="Project ID or slug to make active instead of creating a default project.",
+    )
+    parser.add_argument(
+        "--project-name",
+        help="Name for the default project created during setup.",
+    )
     namespace = parser.parse_args(args)
+    if namespace.no_project and namespace.project_ref:
+        raise ValueError("--project and --no-project cannot be used together.")
+    if namespace.no_project and namespace.project_name:
+        raise ValueError("--project-name and --no-project cannot be used together.")
+    if namespace.project_ref and namespace.project_name:
+        raise ValueError("--project and --project-name cannot be used together.")
     return LabSetupOptions(
         skip_agents_md=bool(namespace.skip_agents_md),
         skip_install=bool(namespace.skip_install),
@@ -253,6 +287,9 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
             namespace.agents,
             no_interactive=bool(namespace.no_interactive),
         ),
+        no_project=bool(namespace.no_project),
+        project_ref=namespace.project_ref,
+        project_name=namespace.project_name,
     )
 
 
@@ -378,6 +415,7 @@ def _run_lab_setup_steps(
     _report_missing_agent_requirements(options.agents, emit)
     _prepare_agent_native_surfaces(workspace, options.agents, emit)
     _sync_lab_metadata(workspace, options.agents, setup_source="prime lab setup")
+    _ensure_setup_project(options, workspace=workspace, emit=emit)
 
     if not options.skip_agents_md:
         _sync_workspace_guidance(workspace, options.agents, emit, force=True)
@@ -1388,6 +1426,185 @@ def _ensure_uv_project(workspace: Path, emit: Emit, runner: Runner) -> None:
 
     emit("Adding verifiers dependency\n")
     _check_command(["uv", "add", "verifiers"], workspace, emit, runner)
+
+
+def _default_project_name(workspace: Path) -> str:
+    parts = [part for part in re.split(r"[^A-Za-z0-9]+", workspace.name) if part]
+    if not parts:
+        return "Lab Project"
+    return " ".join(f"{part[:1].upper()}{part[1:]}" for part in parts)
+
+
+def _default_project_slug(workspace: Path) -> str:
+    parts = [part.lower() for part in re.split(r"[^A-Za-z0-9]+", workspace.name) if part]
+    return "-".join(parts) or "lab-project"
+
+
+def _project_context_matches_scope(context: dict, config: Config) -> bool:
+    if context.get("base_url") and context.get("base_url") != config.base_url:
+        return False
+    if context.get("team_id") != config.team_id:
+        return False
+    return True
+
+
+def _project_context_cleared_for_scope(context: dict, config: Config) -> bool:
+    return context.get(PROJECT_CONTEXT_CLEARED_KEY) is True and _project_context_matches_scope(
+        context,
+        config,
+    )
+
+
+def _project_context_has_active_project(
+    context: dict,
+    config: Config,
+    project_id: str,
+) -> bool:
+    context_project_id = context.get("project_id")
+    return (
+        context_project_id is not None
+        and str(context_project_id) == project_id
+        and _project_context_matches_scope(context, config)
+    )
+
+
+def _emit_project_setup_api_failure(exc: APIError, emit: Emit) -> None:
+    emit(f"Skipped Lab project setup because the Projects API request failed: {exc}\n")
+    emit("Run prime project create later to attach new Lab runs and evals by default.\n")
+
+
+def _activate_setup_project(
+    project: Any,
+    config: Config,
+    *,
+    workspace: Path,
+    emit: Emit,
+    action: str,
+) -> bool:
+    try:
+        ensure_active_project_scope(project.team_id, config, action=action)
+    except APIError as exc:
+        emit(f"Skipped Lab project setup because the project scope is not active: {exc}\n")
+        emit("Switch account context first, or rerun setup with --no-project.\n")
+        return False
+
+    write_project_context(project, config, workspace=workspace)
+    return True
+
+
+def _ensure_setup_project(
+    options: LabSetupOptions,
+    *,
+    workspace: Path,
+    emit: Emit,
+) -> None:
+    if options.no_project:
+        emit("Skipped Lab project setup (--no-project)\n")
+        return
+
+    config = Config()
+    if not config.api_key:
+        emit(
+            "Skipped Lab project setup because no API key is configured; "
+            "run prime login, then prime project create later.\n"
+        )
+        return
+
+    explicit_project_requested = options.project_ref is not None or options.project_name is not None
+    project_context = read_project_context(workspace)
+    if not explicit_project_requested and _project_context_cleared_for_scope(
+        project_context,
+        config,
+    ):
+        emit("Skipped Lab project setup because this workspace cleared its active project.\n")
+        emit("Run prime project use, or rerun setup with --project or --project-name.\n")
+        return
+
+    api_client = APIClient()
+    projects_client = ProjectsClient(api_client)
+    try:
+        active_project_id = get_active_project_id(
+            config,
+            workspace=workspace,
+            client=api_client,
+        )
+    except APIError as exc:
+        active_project_id = None
+        emit(f"Ignored {PROJECT_CONTEXT_ENV} because it is not valid for this CLI context: {exc}\n")
+    if active_project_id and not explicit_project_requested:
+        if not _project_context_has_active_project(project_context, config, active_project_id):
+            try:
+                project = projects_client.get(active_project_id, team_id=config.team_id)
+            except APIError as exc:
+                _emit_project_setup_api_failure(exc, emit)
+                return
+            if not _activate_setup_project(
+                project,
+                config,
+                workspace=workspace,
+                emit=emit,
+                action="set an active project",
+            ):
+                return
+        emit(f"Using active Lab project {active_project_id}\n")
+        return
+
+    if options.project_ref:
+        try:
+            project = projects_client.get(options.project_ref, team_id=config.team_id)
+        except APIError as exc:
+            _emit_project_setup_api_failure(exc, emit)
+            return
+
+        if _activate_setup_project(
+            project,
+            config,
+            workspace=workspace,
+            emit=emit,
+            action="set an active project",
+        ):
+            emit(f"Using Lab project {project.name} ({project.slug})\n")
+        return
+
+    if options.project_name is None:
+        try:
+            project = projects_client.get(
+                _default_project_slug(workspace),
+                team_id=config.team_id,
+            )
+        except APIError:
+            project = None
+        if project is not None:
+            if _activate_setup_project(
+                project,
+                config,
+                workspace=workspace,
+                emit=emit,
+                action="set an active project",
+            ):
+                emit(f"Using Lab project {project.name} ({project.slug})\n")
+            return
+
+    project_name = options.project_name or _default_project_name(workspace)
+    project_slug = None if options.project_name else _default_project_slug(workspace)
+    try:
+        project = projects_client.create(
+            name=project_name,
+            slug=project_slug,
+            team_id=config.team_id,
+        )
+    except APIError as exc:
+        _emit_project_setup_api_failure(exc, emit)
+        return
+
+    if _activate_setup_project(
+        project,
+        config,
+        workspace=workspace,
+        emit=emit,
+        action="create and set an active project",
+    ):
+        emit(f"Created Lab project {project.name} ({project.slug})\n")
 
 
 def _post_setup_call_to_action(options: LabSetupOptions) -> Panel:

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -59,7 +59,7 @@ def push_eval_results_to_hub(
     env_path: Optional[Path] = None,
     upstream_slug: Optional[str] = None,
     project_id: Optional[str] = None,
-    use_active_project: bool = False,
+    use_active_project: bool = True,
 ) -> None:
     """
     Push evaluation results to Prime Evals Hub after `prime eval run` completes.

--- a/packages/prime/src/prime_cli/utils/projects.py
+++ b/packages/prime/src/prime_cli/utils/projects.py
@@ -133,28 +133,25 @@ def clear_project_context(
 ) -> bool:
     path = _find_project_context_path(workspace)
     env_project_id = _env_project_id()
-    if env_project_id:
-        config = config or Config()
-        path = path or _write_project_context_path(workspace)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(
-                {
-                    "project_id": None,
-                    PROJECT_CONTEXT_CLEARED_KEY: True,
-                    "team_id": config.team_id,
-                    "base_url": config.base_url,
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        return True
-
-    if path is None:
+    if path is None and not env_project_id:
         return False
-    path.unlink()
+
+    config = config or Config()
+    path = path or _write_project_context_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "project_id": None,
+                PROJECT_CONTEXT_CLEARED_KEY: True,
+                "team_id": config.team_id,
+                "base_url": config.base_url,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     return True
 
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -141,8 +141,8 @@ def _append_eval_options(help_text: str) -> str:
         "Allow tunnel creation and management for hosted evaluations.",
         "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
-        "  --project TEXT              Project ID or slug to attach to this evaluation.",
-        "  --no-project                Do not attach this evaluation to a project.",
+        "  --project TEXT              Project ID or slug. Defaults to the active project.",
+        "  --no-project                Do not attach this evaluation to the active project.",
     ]
     lines = help_text.rstrip("\n").splitlines()
     for extra_line in extra_lines:
@@ -950,7 +950,7 @@ def run_eval_passthrough(
     skip_upload: bool,
     env_path: Optional[str],
     project_id: Optional[str] = None,
-    use_active_project: bool = False,
+    use_active_project: bool = True,
 ) -> None:
     plugin = load_verifiers_prime_plugin(console=console)
     config = Config()

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -352,7 +352,7 @@ def test_push_eval_forwards_resolved_project_id(monkeypatch, tmp_path):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     monkeypatch.setattr(
         "prime_cli.commands.evals.resolve_project_id",
-        lambda project, no_project=False: "project-123",
+        lambda project, no_project=False, use_active_project=False: "project-123",
     )
 
     captured = {}
@@ -403,6 +403,49 @@ def test_push_eval_forwards_resolved_project_id(monkeypatch, tmp_path):
         "project_id": "project-123",
         "clear_project": False,
     }
+
+
+def test_push_eval_id_does_not_resolve_active_project(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    resolve_calls = []
+
+    def fake_resolve_project_id(project, no_project=False, use_active_project=False):
+        resolve_calls.append((project, no_project, use_active_project))
+        return "active-project" if use_active_project else None
+
+    captured = {}
+
+    def fake_push_single_eval(
+        config_path,
+        env_slug,
+        run_id,
+        eval_id,
+        is_public,
+        name,
+        project_id=None,
+        clear_project=False,
+    ):
+        captured["eval_id"] = eval_id
+        captured["project_id"] = project_id
+        captured["clear_project"] = clear_project
+        return "eval-123"
+
+    monkeypatch.setattr("prime_cli.commands.evals.resolve_project_id", fake_resolve_project_id)
+    monkeypatch.setattr("prime_cli.commands.evals._push_single_eval", fake_push_single_eval)
+
+    (tmp_path / "metadata.json").write_text(json.dumps({"env": "gsm8k", "model": "gpt-4"}))
+    (tmp_path / "results.jsonl").write_text("")
+
+    result = runner.invoke(
+        app,
+        ["eval", "push", ".", "--eval-id", "eval-123"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert resolve_calls == [(None, False, False)]
+    assert captured == {"eval_id": "eval-123", "project_id": None, "clear_project": False}
 
 
 class TestPushSingleEval:

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1521,8 +1521,8 @@ def test_eval_run_local_passes_resolved_project_without_active_relookup(monkeypa
     captured = {}
     resolve_calls = []
 
-    def fake_resolve_project_id(project, *, no_project=False):
-        resolve_calls.append((project, no_project))
+    def fake_resolve_project_id(project, *, no_project=False, use_active_project=False):
+        resolve_calls.append((project, no_project, use_active_project))
         return "project-123"
 
     def fake_run_eval_passthrough(
@@ -1550,7 +1550,7 @@ def test_eval_run_local_passes_resolved_project_without_active_relookup(monkeypa
     )
 
     assert result.exit_code == 0, result.output
-    assert resolve_calls == [(None, False)]
+    assert resolve_calls == [(None, False, True)]
     assert captured == {
         "environment": "gsm8k",
         "passthrough_args": [],
@@ -1623,7 +1623,7 @@ def test_eval_run_hosted_forwards_resolved_project_id(monkeypatch):
 
     monkeypatch.setattr(
         "prime_cli.commands.evals.resolve_project_id",
-        lambda project, no_project=False: "project-123",
+        lambda project, no_project=False, use_active_project=False: "project-123",
     )
     monkeypatch.setattr(
         "prime_cli.commands.evals._resolve_hosted_environment",

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -9,6 +9,7 @@ from urllib.error import URLError
 
 import pytest
 from prime_cli import lab_setup
+from prime_cli.api.projects import Project
 from prime_cli.commands.lab import app as lab_cli_app
 from prime_cli.lab_agents import AgentCapability, known_agent_names
 from prime_cli.lab_setup import (
@@ -21,6 +22,10 @@ from prime_cli.lab_setup import (
     run_lab_doctor_service,
     run_lab_setup_service,
     run_lab_sync_service,
+)
+from prime_cli.utils.projects import (
+    PROJECT_CONTEXT_CLEARED_KEY,
+    PROJECT_CONTEXT_ENV_OVERRIDE_KEY,
 )
 from rich.console import Console
 from typer.testing import CliRunner
@@ -35,6 +40,10 @@ def _git_init(path: Path) -> None:
 
 @pytest.fixture(autouse=True)
 def fake_lab_asset_downloads(monkeypatch: Any) -> list[str]:
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+    monkeypatch.delenv("PRIME_PROJECT_ID", raising=False)
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
     urls: list[str] = []
     skill_names = (
         "create-environments",
@@ -148,13 +157,32 @@ def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_lab_setup_parses_selected_agents_and_all() -> None:
-    selected = parse_lab_setup_args(
-        ["--agent", "factory-droid,amp-code,claude-code,letta-code,grok"]
+def _project(
+    *,
+    id: str = "project-123",
+    name: str = "Alphabet Sort",
+    slug: str = "alphabet-sort",
+    team_id: str | None = None,
+) -> Project:
+    return Project.model_validate(
+        {
+            "id": id,
+            "name": name,
+            "slug": slug,
+            "status": "ACTIVE",
+            "userId": "user-123",
+            "teamId": team_id,
+            "createdAt": "2026-05-20T12:00:00Z",
+            "updatedAt": "2026-05-20T12:00:00Z",
+        }
     )
+
+
+def test_lab_setup_parses_selected_agents_and_all() -> None:
+    selected = parse_lab_setup_args(["--agent", "factory-droid,amp-code,claude-code,letta-code"])
     all_agents = parse_lab_sync_args(["--agents", "all"])
 
-    assert selected.agents == ("droid", "amp", "claude", "letta", "grok")
+    assert selected.agents == ("droid", "amp", "claude", "letta")
     assert all_agents.agents == known_agent_names()
 
 
@@ -162,6 +190,31 @@ def test_lab_setup_no_interactive_uses_codex_default() -> None:
     options = parse_lab_setup_args(["--no-interactive"])
 
     assert options.agents == ("codex",)
+
+
+def test_lab_setup_parses_project_options() -> None:
+    existing = parse_lab_setup_args(["--agent", "codex", "--project", "project-123"])
+    named = parse_lab_setup_args(["--agent", "codex", "--project-name", "Alphabet Sort Baselines"])
+    skipped = parse_lab_setup_args(["--agent", "codex", "--no-project"])
+
+    assert existing.project_ref == "project-123"
+    assert existing.project_name is None
+    assert named.project_name == "Alphabet Sort Baselines"
+    assert named.project_ref is None
+    assert skipped.no_project is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--agent", "codex", "--project", "project-123", "--no-project"],
+        ["--agent", "codex", "--project-name", "Alphabet Sort", "--no-project"],
+        ["--agent", "codex", "--project", "project-123", "--project-name", "Alphabet Sort"],
+    ],
+)
+def test_lab_setup_rejects_conflicting_project_options(args: list[str]) -> None:
+    with pytest.raises(ValueError):
+        parse_lab_setup_args(args)
 
 
 def test_lab_setup_help_lists_supported_agents(capsys: Any) -> None:
@@ -294,6 +347,7 @@ def test_lab_setup_service_downloads_upstream_assets_without_agent_installs(
     assert "/CLAUDE.md" in gitignore.splitlines()
     assert "/CLAUDE.local.md" in gitignore.splitlines()
     assert "/.prime/" in gitignore.splitlines()
+    assert "/.agents/skills/" in gitignore.splitlines()
     assert (tmp_path / ".pi" / "extensions" / "prime-lab" / "index.ts").is_file()
     output = _render_emitted(emitted)
     assert "pi-acp" not in output
@@ -324,6 +378,527 @@ def test_lab_setup_hygiene_preflight_nudges_tracked_guidance(
     assert result.exit_code == 0
     assert "untracked generated Lab files: AGENTS.md" in output
     assert _git(tmp_path, "ls-files", "--", "AGENTS.md").stdout == ""
+
+
+def test_lab_setup_creates_default_project_from_workspace_name(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    workspace = tmp_path / "alphabet-sort"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    captured: dict[str, Any] = {}
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            raise lab_setup.APIError("not found")
+
+        def create(
+            self,
+            name: str,
+            slug: str | None = None,
+            description: str | None = None,
+            team_id: str | None = None,
+        ) -> Project:
+            captured.update(
+                {
+                    "name": name,
+                    "slug": slug,
+                    "description": description,
+                    "team_id": team_id,
+                }
+            )
+            return _project(name=name, slug="alphabet-sort", team_id=team_id)
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+    monkeypatch.setattr("prime_cli.utils.projects.ProjectsClient", DummyProjectsClient)
+
+    emitted: list[Any] = []
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=workspace,
+        emit=emitted.append,
+    )
+
+    context = json.loads((workspace / ".prime" / "lab" / "context.json").read_text())
+    assert result.exit_code == 0
+    assert captured == {
+        "name": "Alphabet Sort",
+        "slug": "alphabet-sort",
+        "description": None,
+        "team_id": None,
+    }
+    assert context["project_id"] == "project-123"
+    assert context["project_slug"] == "alphabet-sort"
+    assert "Created Lab project Alphabet Sort (alphabet-sort)" in _render_emitted(emitted)
+
+
+def test_lab_setup_reuses_existing_default_project_by_workspace_slug(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    workspace = tmp_path / "alphabet-sort"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    captured: dict[str, Any] = {}
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            captured["project_ref"] = project_ref
+            captured["team_id"] = team_id
+            return _project(name="Alphabet Sort", slug="alphabet-sort", team_id=team_id)
+
+        def create(
+            self,
+            name: str,
+            slug: str | None = None,
+            description: str | None = None,
+            team_id: str | None = None,
+        ) -> Project:
+            raise AssertionError("should not create a duplicate default project")
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+    monkeypatch.setattr("prime_cli.utils.projects.ProjectsClient", DummyProjectsClient)
+
+    emitted: list[Any] = []
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=workspace,
+        emit=emitted.append,
+    )
+
+    context = json.loads((workspace / ".prime" / "lab" / "context.json").read_text())
+    assert result.exit_code == 0
+    assert captured == {"project_ref": "alphabet-sort", "team_id": None}
+    assert context["project_id"] == "project-123"
+    assert context["project_slug"] == "alphabet-sort"
+    assert "Using Lab project Alphabet Sort (alphabet-sort)" in _render_emitted(emitted)
+
+
+def test_lab_setup_ignores_invalid_env_project_and_reuses_default_slug(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    workspace = tmp_path / "alphabet-sort"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setenv("PRIME_PROJECT_ID", "team-project")
+    monkeypatch.setenv("PRIME_TEAM_ID", "team-123")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    calls: list[tuple[str, str | None]] = []
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            calls.append((project_ref, team_id))
+            if project_ref == "team-project":
+                return _project(
+                    id="project-other-team",
+                    name="Other Team",
+                    slug="other-team",
+                    team_id="other-team",
+                )
+            if project_ref == "alphabet-sort":
+                return _project(name="Alphabet Sort", slug="alphabet-sort", team_id=team_id)
+            raise AssertionError(f"unexpected project ref {project_ref}")
+
+        def create(
+            self,
+            name: str,
+            slug: str | None = None,
+            description: str | None = None,
+            team_id: str | None = None,
+        ) -> Project:
+            raise AssertionError("should reuse the default project instead of creating")
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+    monkeypatch.setattr("prime_cli.utils.projects.ProjectsClient", DummyProjectsClient)
+
+    emitted: list[Any] = []
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=workspace,
+        emit=emitted.append,
+    )
+
+    context = json.loads((workspace / ".prime" / "lab" / "context.json").read_text())
+    output = _render_emitted(emitted)
+    assert result.exit_code == 0
+    assert calls == [("team-project", "team-123"), ("alphabet-sort", "team-123")]
+    assert context["project_id"] == "project-123"
+    assert context["team_id"] == "team-123"
+    assert "Ignored PRIME_PROJECT_ID because it is not valid for this CLI context" in output
+    assert "Using Lab project Alphabet Sort (alphabet-sort)" in output
+
+
+def test_lab_setup_persists_env_active_project(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setenv("PRIME_PROJECT_ID", "env-project")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    calls: list[tuple[str, str | None]] = []
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            calls.append((project_ref, team_id))
+            assert project_ref == "env-project"
+            assert team_id is None
+            return _project(
+                id="env-project",
+                name="Env Project",
+                slug="env-project",
+            )
+
+        def create(
+            self,
+            name: str,
+            slug: str | None = None,
+            description: str | None = None,
+            team_id: str | None = None,
+        ) -> Project:
+            raise AssertionError("should use the active project instead of creating")
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+    monkeypatch.setattr("prime_cli.utils.projects.ProjectsClient", DummyProjectsClient)
+    emitted: list[Any] = []
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    context = json.loads((tmp_path / ".prime" / "lab" / "context.json").read_text())
+    assert result.exit_code == 0
+    assert calls
+    assert all(call == ("env-project", None) for call in calls)
+    assert context["project_id"] == "env-project"
+    assert context["project_slug"] == "env-project"
+    assert context[PROJECT_CONTEXT_ENV_OVERRIDE_KEY] is True
+    assert "Using active Lab project env-project" in _render_emitted(emitted)
+
+
+def test_lab_setup_uses_existing_project_option(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    captured: dict[str, Any] = {}
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            captured["project_ref"] = project_ref
+            captured["team_id"] = team_id
+            return _project(name="Existing Project", slug="existing-project")
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+
+    result = run_lab_setup_service(
+        LabSetupOptions(
+            skip_install=True,
+            skip_agents_md=True,
+            agents=("codex",),
+            project_ref="existing-project",
+        ),
+        workspace=tmp_path,
+        emit=lambda _item: None,
+    )
+
+    context = json.loads((tmp_path / ".prime" / "lab" / "context.json").read_text())
+    assert result.exit_code == 0
+    assert captured == {"project_ref": "existing-project", "team_id": None}
+    assert context["project_name"] == "Existing Project"
+
+
+def test_lab_setup_project_option_overrides_active_project(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    context_dir = tmp_path / ".prime" / "lab"
+    context_dir.mkdir(parents=True)
+    (context_dir / "context.json").write_text(
+        json.dumps(
+            {
+                "project_id": "old-project",
+                "project_slug": "old-project",
+                "project_name": "Old Project",
+                "team_id": None,
+                "base_url": "https://api.primeintellect.ai",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            assert project_ref == "new-project"
+            assert team_id is None
+            return _project(
+                id="new-project",
+                name="New Project",
+                slug="new-project",
+            )
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+
+    result = run_lab_setup_service(
+        LabSetupOptions(
+            skip_install=True,
+            skip_agents_md=True,
+            agents=("codex",),
+            project_ref="new-project",
+        ),
+        workspace=tmp_path,
+        emit=lambda _item: None,
+    )
+
+    context = json.loads((context_dir / "context.json").read_text())
+    assert result.exit_code == 0
+    assert context["project_id"] == "new-project"
+    assert context["project_name"] == "New Project"
+
+
+def test_lab_setup_project_name_overrides_active_project(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+    context_dir = tmp_path / ".prime" / "lab"
+    context_dir.mkdir(parents=True)
+    (context_dir / "context.json").write_text(
+        json.dumps(
+            {
+                "project_id": "old-project",
+                "project_slug": "old-project",
+                "project_name": "Old Project",
+                "team_id": None,
+                "base_url": "https://api.primeintellect.ai",
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def create(
+            self,
+            name: str,
+            slug: str | None = None,
+            description: str | None = None,
+            team_id: str | None = None,
+        ) -> Project:
+            captured.update(
+                {
+                    "name": name,
+                    "slug": slug,
+                    "description": description,
+                    "team_id": team_id,
+                }
+            )
+            return _project(
+                id="new-project",
+                name=name,
+                slug="new-project",
+            )
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+
+    result = run_lab_setup_service(
+        LabSetupOptions(
+            skip_install=True,
+            skip_agents_md=True,
+            agents=("codex",),
+            project_name="New Project",
+        ),
+        workspace=tmp_path,
+        emit=lambda _item: None,
+    )
+
+    context = json.loads((context_dir / "context.json").read_text())
+    assert result.exit_code == 0
+    assert captured == {
+        "name": "New Project",
+        "slug": None,
+        "description": None,
+        "team_id": None,
+    }
+    assert context["project_id"] == "new-project"
+    assert context["project_name"] == "New Project"
+
+
+def test_lab_setup_does_not_activate_mismatched_team_project(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr("prime_cli.lab_setup.APIClient", lambda: object())
+
+    class DummyProjectsClient:
+        def __init__(self, _api_client: object) -> None:
+            pass
+
+        def get(self, project_ref: str, team_id: str | None = None) -> Project:
+            assert project_ref == "team-project"
+            assert team_id is None
+            return _project(
+                name="Team Project",
+                slug="team-project",
+                team_id="team-123",
+            )
+
+    monkeypatch.setattr("prime_cli.lab_setup.ProjectsClient", DummyProjectsClient)
+    emitted: list[Any] = []
+
+    result = run_lab_setup_service(
+        LabSetupOptions(
+            skip_install=True,
+            skip_agents_md=True,
+            agents=("codex",),
+            project_ref="team-project",
+        ),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    output = _render_emitted(emitted)
+    assert result.exit_code == 0
+    assert not (tmp_path / ".prime" / "lab" / "context.json").exists()
+    assert "project scope is not active" in output
+    assert "Cannot set an active project for team team-123" in output
+    assert "Projects API request failed" not in output
+
+
+def test_lab_setup_no_project_skips_project_api(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr(
+        "prime_cli.lab_setup.ProjectsClient",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("should not construct ProjectsClient")
+        ),
+    )
+    emitted: list[Any] = []
+
+    result = run_lab_setup_service(
+        LabSetupOptions(
+            skip_install=True,
+            skip_agents_md=True,
+            agents=("codex",),
+            no_project=True,
+        ),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    assert result.exit_code == 0
+    assert not (tmp_path / ".prime" / "lab" / "context.json").exists()
+    assert "Skipped Lab project setup (--no-project)" in _render_emitted(emitted)
+
+
+def test_lab_setup_respects_cleared_project_context(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    monkeypatch.setattr(
+        "prime_cli.lab_setup.ProjectsClient",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("should not construct ProjectsClient")
+        ),
+    )
+    context_dir = tmp_path / ".prime" / "lab"
+    context_dir.mkdir(parents=True)
+    context_path = context_dir / "context.json"
+    context_path.write_text(
+        json.dumps(
+            {
+                "project_id": None,
+                PROJECT_CONTEXT_CLEARED_KEY: True,
+                "team_id": None,
+                "base_url": "https://api.primeintellect.ai",
+            }
+        ),
+        encoding="utf-8",
+    )
+    emitted: list[Any] = []
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    context = json.loads(context_path.read_text())
+    assert result.exit_code == 0
+    assert context["project_id"] is None
+    assert context[PROJECT_CONTEXT_CLEARED_KEY] is True
+    assert "cleared its active project" in _render_emitted(emitted)
+
+
+def test_lab_setup_without_api_key_continues_without_project(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    emitted: list[Any] = []
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=True, agents=("codex",)),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    assert result.exit_code == 0
+    assert not (tmp_path / ".prime" / "lab" / "context.json").exists()
+    assert "Skipped Lab project setup because no API key is configured" in _render_emitted(emitted)
 
 
 def test_lab_setup_service_emits_post_setup_call_to_action(

--- a/packages/prime/tests/test_projects_cli.py
+++ b/packages/prime/tests/test_projects_cli.py
@@ -424,7 +424,7 @@ def test_project_update_requires_field(monkeypatch, tmp_path) -> None:
     assert "Provide --name, --slug, --description, or --clear-description" in result.output
 
 
-def test_project_clear_removes_active_context(monkeypatch, tmp_path) -> None:
+def test_project_clear_marks_active_context_cleared(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
@@ -441,7 +441,10 @@ def test_project_clear_removes_active_context(monkeypatch, tmp_path) -> None:
 
     assert result.exit_code == 0, result.output
     assert "Active project cleared" in result.output
-    assert not context_path.exists()
+    context = json.loads(context_path.read_text())
+    assert context["project_id"] is None
+    assert context[PROJECT_CONTEXT_CLEARED_KEY] is True
+    assert get_active_project_id() is None
 
 
 def test_project_clear_disables_env_project_for_workspace(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- stack on #730 and add the behavior-changing project defaults
- make `prime lab setup` create, select, or bind an active Lab project unless `--no-project` is passed
- have train/eval creation paths use the active project by default, while `prime eval push --eval-id` avoids implicit reassignment
- update README guidance for the default-project workflow

## Review notes
This PR intentionally contains only the default UX layer on top of #730. The explicit projects CLI, API clients, assignment commands, and explicit `--project` plumbing live in #730.

## Validation
- `uv run pytest packages/prime/tests/test_rl_config.py packages/prime/tests/test_lab_setup.py packages/prime/tests/test_eval_push.py packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_projects_cli.py packages/prime/tests/test_rl_api.py packages/prime/tests/test_deployments.py packages/prime-evals/tests/test_evals.py -q`
- `uv run ruff check packages/prime/src/prime_cli/commands/rl.py packages/prime/src/prime_cli/lab_setup.py packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/utils/eval_push.py packages/prime/src/prime_cli/verifiers_bridge.py packages/prime/tests/test_lab_setup.py packages/prime/tests/test_eval_push.py packages/prime/tests/test_hosted_eval.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default project attachment for new training runs and evaluations; users who relied on no project must use --no-project or project clear, but eval-id push avoids silent reassignment.
> 
> **Overview**
> **Default Lab project UX** so authenticated workspaces get an active project without a separate `prime project create` step, and new train/eval artifacts attach to it unless opted out.
> 
> `prime lab setup` now runs project setup via `_ensure_setup_project`: when logged in it creates a project named from the workspace folder (or reuses the matching slug), honors `--project` / `--project-name`, and skips with `--no-project`. It respects a workspace that previously ran `prime project clear` (stored as a cleared flag in context instead of deleting context).
> 
> **Train and eval paths** resolve the active workspace project by default (`resolve_project_id(..., use_active_project=True)` on `prime train`, `prime eval run`, and most `prime eval push` flows). `prime eval push --eval-id` does **not** implicitly attach the active project, avoiding accidental reassignment on updates. Post-run hub upload defaults to using the active project as well.
> 
> README and CLI help text document `--no-project` and the setup flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be637096ce19cd2eb0b8660b16c378549181abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->