### PR TITLE
fix sandbox create idempotency key

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 
 class SandboxStatus(str, Enum):
@@ -78,6 +78,8 @@ class SandboxListResponse(BaseModel):
 
 class CreateSandboxRequest(BaseModel):
     """Create sandbox request model"""
+
+    _generated_idempotency_key: Optional[str] = PrivateAttr(default=None)
 
     name: str
     docker_image: str

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -72,6 +72,21 @@ GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS = (
     httpx.PoolTimeout,  # No connection available in pool
 )
 
+
+def _create_idempotency_key(request: CreateSandboxRequest) -> str:
+    """Return a stable generated key across failed outer create retries."""
+    if request.idempotency_key:
+        return request.idempotency_key
+    if request._generated_idempotency_key is None:
+        request._generated_idempotency_key = uuid.uuid4().hex
+    return request._generated_idempotency_key
+
+
+def _clear_generated_create_idempotency_key(request: CreateSandboxRequest) -> None:
+    if request.idempotency_key is None:
+        request._generated_idempotency_key = None
+
+
 # Response-read failures: the server may have already processed the request
 # (TCP connection dropped mid-response body). Only safe to retry on idempotent
 # methods (GET/HEAD/PUT/DELETE), where a duplicate request is a no-op.
@@ -634,7 +649,7 @@ class SandboxClient:
         # Auto-populate team_id from config if not specified
         if request.team_id is None and self.client.config.team_id is not None:
             payload["team_id"] = self.client.config.team_id
-        payload["idempotency_key"] = request.idempotency_key or uuid.uuid4().hex
+        payload["idempotency_key"] = _create_idempotency_key(request)
 
         response = self.client.request(
             "POST",
@@ -642,7 +657,9 @@ class SandboxClient:
             json=payload,
             idempotent_post=True,
         )
-        return Sandbox.model_validate(response)
+        sandbox = Sandbox.model_validate(response)
+        _clear_generated_create_idempotency_key(request)
+        return sandbox
 
     def list(
         self,
@@ -1546,7 +1563,7 @@ class AsyncSandboxClient:
         payload = request.model_dump(by_alias=False, exclude_none=True)
         if request.team_id is None and self.client.config.team_id is not None:
             payload["team_id"] = self.client.config.team_id
-        payload["idempotency_key"] = request.idempotency_key or uuid.uuid4().hex
+        payload["idempotency_key"] = _create_idempotency_key(request)
 
         response = await self.client.request(
             "POST",
@@ -1554,7 +1571,9 @@ class AsyncSandboxClient:
             json=payload,
             idempotent_post=True,
         )
-        return Sandbox.model_validate(response)
+        sandbox = Sandbox.model_validate(response)
+        _clear_generated_create_idempotency_key(request)
+        return sandbox
 
     async def list(
         self,

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -139,6 +139,14 @@ class RecordingCreateAPIClient:
         return _sandbox_response(f"sandbox-{len(self.calls)}")
 
 
+class FailOnceRecordingCreateAPIClient(RecordingCreateAPIClient):
+    def request(self, method: str, path: str, **kwargs):
+        self.calls.append((method, path, kwargs))
+        if len(self.calls) == 1:
+            raise APIError("temporary create failure")
+        return _sandbox_response(f"sandbox-{len(self.calls)}")
+
+
 class AsyncRecordingCreateAPIClient:
     def __init__(self):
         self.config = SimpleNamespace(team_id="team-1")
@@ -146,6 +154,14 @@ class AsyncRecordingCreateAPIClient:
 
     async def request(self, method: str, path: str, **kwargs):
         self.calls.append((method, path, kwargs))
+        return _sandbox_response(f"sandbox-{len(self.calls)}")
+
+
+class AsyncFailOnceRecordingCreateAPIClient(AsyncRecordingCreateAPIClient):
+    async def request(self, method: str, path: str, **kwargs):
+        self.calls.append((method, path, kwargs))
+        if len(self.calls) == 1:
+            raise APIError("temporary create failure")
         return _sandbox_response(f"sandbox-{len(self.calls)}")
 
 
@@ -442,6 +458,25 @@ class TestCreateSandboxIdempotencyPayload:
         assert request.idempotency_key is None
         assert request.team_id is None
 
+    def test_sync_create_reuses_generated_idempotency_key_after_failure(self):
+        client = SandboxClient(APIClient(api_key="test-key"))
+        recording = FailOnceRecordingCreateAPIClient()
+        client.client = recording
+        request = CreateSandboxRequest(name="sandbox", docker_image="python:3.11-slim")
+
+        with pytest.raises(APIError, match="temporary create failure"):
+            client.create(request)
+        client.create(request)
+        client.create(request)
+
+        first_payload = recording.calls[0][2]["json"]
+        retry_payload = recording.calls[1][2]["json"]
+        next_payload = recording.calls[2][2]["json"]
+        assert first_payload["idempotency_key"] == retry_payload["idempotency_key"]
+        assert retry_payload["idempotency_key"] != next_payload["idempotency_key"]
+        assert request.idempotency_key is None
+        assert request.team_id is None
+
     @pytest.mark.asyncio
     async def test_async_create_does_not_reuse_generated_idempotency_key_on_request_reuse(self):
         client = AsyncSandboxClient(api_key="test-key")
@@ -457,6 +492,26 @@ class TestCreateSandboxIdempotencyPayload:
         assert first_payload["idempotency_key"] != second_payload["idempotency_key"]
         assert first_payload["team_id"] == "team-1"
         assert second_payload["team_id"] == "team-1"
+        assert request.idempotency_key is None
+        assert request.team_id is None
+
+    @pytest.mark.asyncio
+    async def test_async_create_reuses_generated_idempotency_key_after_failure(self):
+        client = AsyncSandboxClient(api_key="test-key")
+        recording = AsyncFailOnceRecordingCreateAPIClient()
+        client.client = recording
+        request = CreateSandboxRequest(name="sandbox", docker_image="python:3.11-slim")
+
+        with pytest.raises(APIError, match="temporary create failure"):
+            await client.create(request)
+        await client.create(request)
+        await client.create(request)
+
+        first_payload = recording.calls[0][2]["json"]
+        retry_payload = recording.calls[1][2]["json"]
+        next_payload = recording.calls[2][2]["json"]
+        assert first_payload["idempotency_key"] == retry_payload["idempotency_key"]
+        assert retry_payload["idempotency_key"] != next_payload["idempotency_key"]
         assert request.idempotency_key is None
         assert request.team_id is None
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `create` generates and persists `idempotency_key` across transient failures; if incorrect, could cause unintended duplicate sandbox creation or prevent legitimate retries. Scope is limited to sandbox create payload construction and associated tests.
> 
> **Overview**
> Fixes sandbox creation idempotency so **automatic idempotency keys are stable across a failed `create` retry**.
> 
> `CreateSandboxRequest` now stores a private `_generated_idempotency_key`, and sync/async `SandboxClient.create()` uses a helper to reuse the same generated key until a successful response clears it (while still honoring user-supplied `idempotency_key`). Adds coverage to ensure key reuse after a failure and key rotation on subsequent successful creates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cc9d3f8056180c899a34a3b5225f6d2fb40ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->