### PR TITLE
fix(env): add --system flag to uv pip install for environments without virtualenv

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -2040,6 +2040,7 @@ def get_install_command(
             # Use -P to only upgrade this package, not its dependencies
             cmd.extend(["-P", package_name])
         cmd.append(wheel_url)
+        cmd.append("--system")
         return cmd
     elif tool == "pip":
         cmd = ["pip", "install"]
@@ -2500,6 +2501,7 @@ def install(
                             # Use -P to only upgrade this package, not its dependencies
                             cmd_parts.extend(["-P", normalized_name])
                         cmd_parts.append(str(wheel_path))
+                        cmd_parts.append("--system")
                         if prerelease:
                             cmd_parts.append("--prerelease=allow")
                     else:
@@ -3204,6 +3206,7 @@ def _build_install_command(
             # Add URL dependencies as direct requirements (uv requires this)
             if url_dependencies:
                 cmd.extend(url_dependencies)
+            cmd.append("--system")
             cmd.extend(["--extra-index-url", simple_index_url])
             # Hub simple index doesn't emit PEP 700 upload-time metadata, so any
             # exclude-newer cutoff on the consumer side filters hub wheels
@@ -3281,6 +3284,7 @@ def _install_single_environment(env_slug: str, tool: str = "uv", prerelease: boo
                 cmd_parts = _uv_pip_command("install", "-P", normalized_name, str(wheel_path))
                 if prerelease:
                     cmd_parts.append("--prerelease=allow")
+                cmd_parts.append("--system")
             else:
                 cmd_parts = ["pip", "install", "--upgrade", str(wheel_path)]
                 if prerelease:


### PR DESCRIPTION
## Problem

Fixes PrimeIntellect-ai/community-environments#455

When running `prime env install <owner>/<env-name>` outside a virtualenv, `uv pip install` fails with:

```
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
```

This happens because uv, unlike pip, requires an explicit flag to install outside a virtualenv.

## Solution

Added `--system` flag to all four `uv pip install` code paths in the `env.py` install functions:

1. `get_install_command()` - used for wheel-based installs
2. `_install_single_environment()` private env wheel path - used for private environment builds
3. `_build_install_command()` - used for indexed environment installs
4. `install()` command private env wheel path - used in the multi-env install flow

This allows `prime env install` to work in environments without a pre-existing virtualenv. When a virtualenv is already active, `--system` is a no-op (uv detects the venv and uses it).

## Related

- Issue: PrimeIntellect-ai/community-environments#455
- This PR adds the `--system` flag mentioned in [CodeAgentCN's comment](https://github.com/PrimeIntellect-ai/community-environments/issues/455#issuecomment-2651306727)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts generated `uv pip install` command args to support system installs; behavior for existing virtualenv users should remain effectively unchanged.
> 
> **Overview**
> Fixes `prime env install` when run outside a virtualenv by appending `--system` to all `uv pip install` command paths (wheel URL installs, simple-index installs, and private-env wheel installs in both single- and multi-env flows). Pip-based install commands are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159f7359fc9ad75da134162282bb3514347def97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->