### PR TITLE
Fix env install on older uv when exclude-newer-package=false is unsupported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ENV/
 test_env/
 .DS_Store
 .claude/worktrees/
+.codegraph/

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -131,11 +131,7 @@ def _uv_supports_exclude_newer_package_false() -> bool:
                 "uv",
                 "pip",
                 "install",
-                "--dry-run",
-                "--system",
-                "--exclude-newer-package",
-                "typing-extensions=false",
-                "typing-extensions",
+                "--help",
             ],
             capture_output=True,
             text=True,
@@ -145,7 +141,7 @@ def _uv_supports_exclude_newer_package_false() -> bool:
     except (FileNotFoundError, OSError, subprocess.SubprocessError):
         return False
 
-    return result.returncode == 0
+    return result.returncode == 0 and "--exclude-newer-package" in result.stdout
 
 
 def _parse_environment_slug(environment: str) -> Tuple[str, str]:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -22,6 +22,7 @@ import httpx
 import toml
 import typer
 from gitignore_parser import parse_gitignore
+from packaging.version import InvalidVersion, Version
 from rich.table import Table
 from rich.text import Text
 
@@ -126,6 +127,13 @@ def _uv_pip_command(subcommand: str, *args: str) -> List[str]:
 def _uv_supports_exclude_newer_package_false() -> bool:
     """Return whether the installed uv accepts `<package>=false` for per-package cutoffs."""
     try:
+        version_result = subprocess.run(
+            ["uv", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
         result = subprocess.run(
             [
                 "uv",
@@ -141,7 +149,20 @@ def _uv_supports_exclude_newer_package_false() -> bool:
     except (FileNotFoundError, OSError, subprocess.SubprocessError):
         return False
 
-    return result.returncode == 0 and "--exclude-newer-package" in result.stdout
+    if result.returncode != 0 or "--exclude-newer-package" not in result.stdout:
+        return False
+
+    if version_result.returncode != 0:
+        return False
+
+    version_parts = version_result.stdout.strip().split()
+    if len(version_parts) < 2:
+        return False
+
+    try:
+        return Version(version_parts[1]) >= Version("0.11.3")
+    except InvalidVersion:
+        return False
 
 
 def _parse_environment_slug(environment: str) -> Tuple[str, str]:

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -9,6 +9,7 @@ import tarfile
 import tempfile
 import time
 import zipfile
+from functools import lru_cache
 from datetime import datetime
 
 # Wheel METADATA files use RFC 822 format (PEP 566), same as email headers
@@ -119,6 +120,32 @@ ENV_VAR_DETAIL_JSON_HELP = json_output_help(
 def _uv_pip_command(subcommand: str, *args: str) -> List[str]:
     """Run uv pip against the workspace interpreter."""
     return ["uv", "pip", subcommand, "--python", resolve_workspace_python(), *args]
+
+
+@lru_cache(maxsize=1)
+def _uv_supports_exclude_newer_package_false() -> bool:
+    """Return whether the installed uv accepts `<package>=false` for per-package cutoffs."""
+    try:
+        result = subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--dry-run",
+                "--system",
+                "--exclude-newer-package",
+                "typing-extensions=false",
+                "typing-extensions",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return False
+
+    return result.returncode == 0
 
 
 def _parse_environment_slug(environment: str) -> Tuple[str, str]:
@@ -3207,8 +3234,10 @@ def _build_install_command(
             cmd.extend(["--extra-index-url", simple_index_url])
             # Hub simple index doesn't emit PEP 700 upload-time metadata, so any
             # exclude-newer cutoff on the consumer side filters hub wheels
-            # regardless of how permissive the cutoff is. Disable per-package.
-            cmd.extend(["--exclude-newer-package", f"{normalized_name}=false"])
+            # regardless of how permissive the cutoff is. Disable per-package
+            # on uv versions that support the `package=false` escape hatch.
+            if _uv_supports_exclude_newer_package_false():
+                cmd.extend(["--exclude-newer-package", f"{normalized_name}=false"])
             if prerelease:
                 cmd.append("--prerelease=allow")
             return cmd

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -264,10 +264,12 @@ class TestBuildInstallCommand:
         from prime_cli.commands.env import _uv_supports_exclude_newer_package_false
 
         _uv_supports_exclude_newer_package_false.cache_clear()
-        seen = {}
+        seen = []
 
         def fake_run(cmd, capture_output, text, timeout, check):
-            seen["cmd"] = cmd
+            seen.append(cmd)
+            if cmd == ["uv", "--version"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="uv 0.11.7\n", stderr="")
             return subprocess.CompletedProcess(
                 cmd,
                 0,
@@ -278,7 +280,29 @@ class TestBuildInstallCommand:
         monkeypatch.setattr("prime_cli.commands.env.subprocess.run", fake_run)
 
         assert _uv_supports_exclude_newer_package_false() is True
-        assert seen["cmd"] == ["uv", "pip", "install", "--help"]
+        assert seen == [["uv", "--version"], ["uv", "pip", "install", "--help"]]
+
+    def test_uv_support_probe_rejects_old_versions_even_when_flag_exists(self, monkeypatch):
+        """The opt-out syntax landed later than the flag itself."""
+        import subprocess
+
+        from prime_cli.commands.env import _uv_supports_exclude_newer_package_false
+
+        _uv_supports_exclude_newer_package_false.cache_clear()
+
+        def fake_run(cmd, capture_output, text, timeout, check):
+            if cmd == ["uv", "--version"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="uv 0.9.4\n", stderr="")
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="Usage...\n      --exclude-newer-package <EXCLUDE_NEWER_PACKAGE>\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr("prime_cli.commands.env.subprocess.run", fake_run)
+
+        assert _uv_supports_exclude_newer_package_false() is False
 
     def test_uv_simple_index_skips_false_flag_when_uv_lacks_support(self, monkeypatch):
         """Old uv versions reject `<package>=false`, so we should omit the flag."""

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -254,6 +254,53 @@ class TestPathComponentValidation:
         _validate_path_component("v2.3.4-beta.1", "version")
 
 
+class TestBuildInstallCommand:
+    """Tests for install command construction."""
+
+    def test_uv_simple_index_skips_false_flag_when_uv_lacks_support(self, monkeypatch):
+        """Old uv versions reject `<package>=false`, so we should omit the flag."""
+        from prime_cli.commands.env import _build_install_command
+
+        monkeypatch.setattr(
+            "prime_cli.commands.env._uv_supports_exclude_newer_package_false",
+            lambda: False,
+        )
+
+        cmd = _build_install_command(
+            name="alphabet-sort",
+            version="latest",
+            simple_index_url="https://hub.primeintellect.ai/will/simple/",
+            wheel_url=None,
+            tool="uv",
+        )
+
+        assert cmd is not None
+        assert "--exclude-newer-package" not in cmd
+        assert "alphabet_sort=false" not in cmd
+
+    def test_uv_simple_index_uses_false_flag_when_uv_supports_it(self, monkeypatch):
+        """New uv versions accept `<package>=false`, so keep the hub compatibility flag."""
+        from prime_cli.commands.env import _build_install_command
+
+        monkeypatch.setattr(
+            "prime_cli.commands.env._uv_supports_exclude_newer_package_false",
+            lambda: True,
+        )
+
+        cmd = _build_install_command(
+            name="alphabet-sort",
+            version="latest",
+            simple_index_url="https://hub.primeintellect.ai/will/simple/",
+            wheel_url=None,
+            tool="uv",
+        )
+
+        assert cmd is not None
+        assert "--exclude-newer-package" in cmd
+        flag_index = cmd.index("--exclude-newer-package")
+        assert cmd[flag_index + 1] == "alphabet_sort=false"
+
+
 class TestSafeTarExtract:
     """Tests for tar extraction security (tar-slip prevention)."""
 

--- a/packages/prime/tests/test_private_env_install.py
+++ b/packages/prime/tests/test_private_env_install.py
@@ -257,6 +257,29 @@ class TestPathComponentValidation:
 class TestBuildInstallCommand:
     """Tests for install command construction."""
 
+    def test_uv_support_probe_uses_help_output_not_network_resolution(self, monkeypatch):
+        """Capability checks should depend on local CLI help, not dependency resolution."""
+        import subprocess
+
+        from prime_cli.commands.env import _uv_supports_exclude_newer_package_false
+
+        _uv_supports_exclude_newer_package_false.cache_clear()
+        seen = {}
+
+        def fake_run(cmd, capture_output, text, timeout, check):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="Usage...\n      --exclude-newer-package <EXCLUDE_NEWER_PACKAGE>\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr("prime_cli.commands.env.subprocess.run", fake_run)
+
+        assert _uv_supports_exclude_newer_package_false() is True
+        assert seen["cmd"] == ["uv", "pip", "install", "--help"]
+
     def test_uv_simple_index_skips_false_flag_when_uv_lacks_support(self, monkeypatch):
         """Old uv versions reject `<package>=false`, so we should omit the flag."""
         from prime_cli.commands.env import _build_install_command


### PR DESCRIPTION
Problem

`prime env install` unconditionally appends:

`--exclude-newer-package <normalized_name>=false`

for uv installs against the Hub simple index.

That works on newer uv releases, but issue #667 shows that `uv 0.9.4`
rejects `<package>=false` and fails before installation starts.

Failure mechanism

The current install command builder always emits the per-package
`exclude-newer` escape hatch in
`packages/prime/src/prime_cli/commands/env.py`.

On older uv versions, the flag only accepts date-like values, so the command
fails with:

`invalid value '<pkg>=false' for '--exclude-newer-package ...'`

Semantic change

This change gates the flag behind a small runtime capability probe.

If the installed uv accepts `<package>=false`, we keep the existing behavior.
If it does not, we omit the flag so `prime env install` remains usable on
older uv versions.

Preserved invariant

We still preserve the existing Hub simple-index workaround on uv versions that
support it.

Testing

Added unit coverage for both branches:
- omit the flag when uv lacks support
- keep the flag when uv supports `<package>=false`

Notes

I also ignored `.codegraph/` in `.gitignore` to avoid committing local index
artifacts.

Refs #667

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI install-path change with unit tests; no auth, secrets, or API contract changes.
> 
> **Overview**
> **`prime env install`** no longer always passes **`--exclude-newer-package <pkg>=false`** for Hub simple-index **`uv`** installs. Older **`uv`** (e.g. 0.9.4) reject that value and abort before install.
> 
> A cached runtime probe (**`uv --version`** ≥ **0.11.3** plus **`uv pip install --help`** showing the flag) decides whether to append the per-package opt-out. Supported **`uv`** keeps the existing Hub workaround; unsupported **`uv`** omits the flag so installs proceed.
> 
> Unit tests cover the probe and both install-command branches. **`.codegraph/`** is added to **`.gitignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43b7890e0ce72e9aa317f5b5a1bda0f73ca1949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->