### PR TITLE
release: prime CLI 0.6.10

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

Bump prime CLI package version from 0.6.9 to 0.6.10.

## Release contents

- #686 : pin typer<0.26 in prime CLI deps to dodge the broken click vendoring layer introduced in typer 0.26.0 (fixes `AttributeError: 'Context' object has no attribute '_param_default_explicit'` on fresh `uv tool install prime`).
- #670 : improve eval sample upload progress.

After this merges, `.github/workflows/release-prime.yml` should create tag `v0.6.10` and publish prime to PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no runtime logic in this diff.
> 
> **Overview**
> Bumps the published **prime** CLI package version from **0.6.9** to **0.6.10** in `prime_cli.__version__`, aligning the tree with the **0.6.10** release (PyPI publish and `v0.6.10` tag via the release workflow after merge).
> 
> This PR’s diff is only that version string; the release notes call out dependency and UX fixes already landed elsewhere (e.g. **typer** upper bound and eval sample upload progress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39406a80324a89d78e2480d3e83e3e5d83ac5ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->