### PR TITLE
show time left or timeout for each sandbox in sandbox list

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -7,6 +7,7 @@ import string
 import subprocess
 import tempfile
 import time
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -45,6 +46,7 @@ from ..utils import (
     validate_output_format,
 )
 from ..utils.display import SANDBOX_STATUS_COLORS
+from ..utils.time_utils import now_utc, to_utc
 
 app = PlainTyper(help="Manage code sandboxes", no_args_is_help=True)
 console = get_console()
@@ -53,7 +55,8 @@ console = get_console()
 config = Config()
 
 LIST_SANDBOXES_JSON_HELP = json_output_help(
-    ".sandboxes[] = {id, name, image, status, resources, labels[], created_at}",
+    ".sandboxes[] = {id, name, image, status, resources, labels[], created_at, "
+    "timeout_minutes, expires_at?}",
     ".total = number",
     ".page = number",
     ".per_page = number",
@@ -81,8 +84,52 @@ LIST_SANDBOX_PORTS_JSON_HELP = json_output_help(
 )
 
 
+# Statuses where a sandbox is finished and has no remaining lifetime.
+_TERMINAL_SANDBOX_STATUSES = {"TERMINATED", "TIMEOUT", "ERROR"}
+
+
+def _short_duration(seconds: int) -> str:
+    """Format a positive duration compactly (e.g. '45m', '1h05m', '2d3h')."""
+    if seconds < 60:
+        return "<1m"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        hours, minutes = divmod(seconds // 60, 60)
+        return f"{hours}h{minutes:02d}m" if minutes else f"{hours}h"
+    days, remainder = divmod(seconds, 86400)
+    hours = remainder // 3600
+    return f"{days}d{hours}h" if hours else f"{days}d"
+
+
+def _sandbox_deadline(sandbox: Sandbox) -> Optional[datetime]:
+    """When the sandbox times out, or None if the clock hasn't started.
+
+    Mirrors the backend rule (scheduler): deadline = started_at + timeout_minutes,
+    and the timeout only counts down once the sandbox is RUNNING.
+    """
+    if sandbox.status == "RUNNING" and sandbox.started_at:
+        return to_utc(sandbox.started_at) + timedelta(minutes=sandbox.timeout_minutes)
+    return None
+
+
+def _format_sandbox_expiry(sandbox: Sandbox) -> str:
+    """Human-readable time left before expiry, or the configured timeout budget."""
+    if sandbox.status in _TERMINAL_SANDBOX_STATUSES:
+        return "-"
+    deadline = _sandbox_deadline(sandbox)
+    if deadline is None:
+        # Not running yet — the timeout hasn't started, so show the budget.
+        return f"{sandbox.timeout_minutes}m timeout"
+    remaining = int((deadline - now_utc()).total_seconds())
+    if remaining <= 0:
+        return "expiring"
+    return f"{_short_duration(remaining)} left"
+
+
 def _format_sandbox_for_list(sandbox: Sandbox) -> Dict[str, Any]:
     """Format sandbox data for list display (both table and JSON)"""
+    deadline = _sandbox_deadline(sandbox)
     return {
         "id": sandbox.id,
         "name": sandbox.name,
@@ -94,6 +141,9 @@ def _format_sandbox_for_list(sandbox: Sandbox) -> Dict[str, Any]:
         "labels_list": sandbox.labels,  # For JSON output
         "created_at": iso_timestamp(sandbox.created_at),  # For JSON output
         "age": human_age(sandbox.created_at),  # For table output
+        "expires": _format_sandbox_expiry(sandbox),  # For table output
+        "timeout_minutes": sandbox.timeout_minutes,  # For JSON output
+        "expires_at": iso_timestamp(deadline) if deadline else None,  # For JSON output
     }
 
 
@@ -195,6 +245,7 @@ def list_sandboxes_cmd(
                 ("Resources", "magenta"),
                 ("Labels", "white"),
                 ("Age", "blue"),
+                ("Expires", "yellow"),
             ],
         )
 
@@ -216,6 +267,8 @@ def list_sandboxes_cmd(
                     "region": sandbox_data["region"],
                     "labels": sandbox_data["labels_list"],
                     "created_at": sandbox_data["created_at"],
+                    "timeout_minutes": sandbox_data["timeout_minutes"],
+                    "expires_at": sandbox_data["expires_at"],
                 }
                 sandboxes_data.append(json_sandbox)
 
@@ -242,6 +295,7 @@ def list_sandboxes_cmd(
                     sandbox_data["resources"],
                     sandbox_data["labels"],
                     sandbox_data["age"],
+                    sandbox_data["expires"],
                 )
 
             console.print(table)

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -1,12 +1,35 @@
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from prime_cli.commands.sandbox import _format_sandbox_expiry
 from prime_cli.main import app
 from prime_cli.utils import strip_ansi
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+
+def _fake_sandbox(**overrides: Any) -> SimpleNamespace:
+    """A sandbox stand-in with every field the list formatter reads."""
+    now = datetime.now(timezone.utc)
+    base: dict[str, Any] = dict(
+        id="sbx-1",
+        name="box",
+        docker_image="python:3.12",
+        status="RUNNING",
+        cpu_cores=1.0,
+        memory_gb=2.0,
+        gpu_count=0,
+        region="us",
+        labels=[],
+        created_at=now,
+        started_at=now - timedelta(minutes=10),
+        timeout_minutes=60,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
 def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -378,3 +401,111 @@ def test_sandbox_delete_by_label_all_users_passes_admin_scope(
     assert bulk_kwargs["user_id"] is None
 
     assert "Processed 1 sandbox(es)" in output
+
+
+def test_format_sandbox_expiry_running_shows_time_left() -> None:
+    now = datetime.now(timezone.utc)
+    sb = _fake_sandbox(status="RUNNING", started_at=now - timedelta(minutes=10), timeout_minutes=60)
+    result = _format_sandbox_expiry(sb)
+    # ~50 minutes left; assert the shape, not the exact minute (avoids clock flakiness).
+    assert result.endswith("left")
+    assert "timeout" not in result
+
+
+def test_format_sandbox_expiry_not_started_shows_timeout() -> None:
+    # No started_at yet -> the clock hasn't begun, so show the configured budget.
+    pending = _fake_sandbox(status="PENDING", started_at=None, timeout_minutes=60)
+    provisioning = _fake_sandbox(status="PROVISIONING", started_at=None, timeout_minutes=30)
+    assert _format_sandbox_expiry(pending) == "60m timeout"
+    assert _format_sandbox_expiry(provisioning) == "30m timeout"
+
+
+def test_format_sandbox_expiry_past_deadline_is_expiring() -> None:
+    now = datetime.now(timezone.utc)
+    sb = _fake_sandbox(
+        status="RUNNING", started_at=now - timedelta(minutes=120), timeout_minutes=60
+    )
+    assert _format_sandbox_expiry(sb) == "expiring"
+
+
+@pytest.mark.parametrize("status", ["TERMINATED", "TIMEOUT", "ERROR"])
+def test_format_sandbox_expiry_terminal_has_no_time_left(status: str) -> None:
+    assert _format_sandbox_expiry(_fake_sandbox(status=status)) == "-"
+
+
+def test_sandbox_list_table_has_expires_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.setenv("COLUMNS", "200")  # keep the wide table from wrapping the header
+
+    now = datetime.now(timezone.utc)
+
+    def mock_list(self: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(
+            sandboxes=[
+                _fake_sandbox(
+                    id="sbx-run",
+                    status="RUNNING",
+                    started_at=now - timedelta(minutes=10),
+                    timeout_minutes=60,
+                ),
+                _fake_sandbox(
+                    id="sbx-pending", status="PENDING", started_at=None, timeout_minutes=45
+                ),
+            ],
+            total=2,
+            page=1,
+            per_page=50,
+            has_next=False,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
+
+    result = runner.invoke(app, ["sandbox", "list"])
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Expires" in output
+    assert "left" in output  # running sandbox shows time remaining
+    assert "45m timeout" in output  # pending sandbox shows its configured budget
+
+
+def test_sandbox_list_json_includes_expiry_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    now = datetime.now(timezone.utc)
+
+    def mock_list(self: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(
+            sandboxes=[
+                _fake_sandbox(
+                    id="sbx-run",
+                    status="RUNNING",
+                    started_at=now - timedelta(minutes=10),
+                    timeout_minutes=60,
+                ),
+                _fake_sandbox(
+                    id="sbx-pending", status="PENDING", started_at=None, timeout_minutes=45
+                ),
+            ],
+            total=2,
+            page=1,
+            per_page=50,
+            has_next=False,
+        )
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
+
+    result = runner.invoke(app, ["sandbox", "list", "--output", "json"])
+
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    import json as _json
+
+    data = _json.loads(result.output)
+    by_id = {s["id"]: s for s in data["sandboxes"]}
+    # Running sandbox has a concrete deadline; pending one has none yet.
+    assert by_id["sbx-run"]["timeout_minutes"] == 60
+    assert by_id["sbx-run"]["expires_at"] is not None
+    assert by_id["sbx-pending"]["timeout_minutes"] == 45
+    assert by_id["sbx-pending"]["expires_at"] is None


### PR DESCRIPTION
- `prime sandbox ls` now has an "Expires" column so you can see, at a glance, how long each sandbox has before it's reaped.
- running sandboxes show time remaining (e.g. "47m left"), while not-yet-started ones show their configured budget (e.g. "45m timeout"); the deadline is derived the same way the backend scheduler does it (started_at + timeout_minutes).
- also surfaces timeout_minutes and expires_at in the json output for automation.

<img width="1265" height="224" alt="image" src="https://github.com/user-attachments/assets/a5222b91-bcb2-4641-868d-900025f8c4de" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display and formatting on list output; no API or scheduler behavior changes, with tests for the new fields.
> 
> **Overview**
> **`prime sandbox list`** now surfaces sandbox lifetime in table and JSON output.
> 
> The list table adds an **Expires** column: **RUNNING** sandboxes show compact time remaining (e.g. `47m left`); sandboxes that have not started the clock yet show the configured budget (e.g. `45m timeout`); past-deadline runs show **expiring**; terminal statuses show **-**. The deadline matches the scheduler rule **`started_at + timeout_minutes`**, only when status is **RUNNING** and `started_at` is set.
> 
> JSON list output adds **`timeout_minutes`** and **`expires_at`** (ISO when a deadline exists, else `null`). Help text for JSON output is updated accordingly.
> 
> Tests cover expiry formatting edge cases and list table/JSON integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348e5bc2d5de9289f770004fbef3584f560e197a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->