### PR TITLE
Fix eval upload sample payload limit handling

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -35,6 +35,13 @@ def _samples_upload_headers(api_key: Optional[str]) -> Dict[str, str]:
     return headers
 
 
+def _oversized_sample_message(idx: int, sample_size: int, max_payload_bytes: int) -> str:
+    return (
+        f"Sample {idx} exceeds maximum payload size "
+        f"({sample_size} bytes > {max_payload_bytes - 20} bytes limit)"
+    )
+
+
 class EvalsClient:
     """
     Client for the Prime Evals API
@@ -225,6 +232,7 @@ class EvalsClient:
         max_payload_bytes: int = 25 * 1024 * 1024,
         max_workers: int = 4,
         progress_callback: Optional[Callable[[int], None]] = None,
+        skip_oversized_samples: bool = False,
     ) -> Dict[str, Any]:
         """Push evaluation samples in adaptive batches with concurrent uploads."""
         if not samples:
@@ -232,7 +240,9 @@ class EvalsClient:
         if max_workers < 1:
             raise ValueError("max_workers must be at least 1")
 
-        batches, skipped_count = self._build_batches(samples, max_payload_bytes)
+        batches, skipped_count = self._build_batches(
+            samples, max_payload_bytes, skip_oversized_samples
+        )
         if skipped_count and progress_callback is not None:
             progress_callback(skipped_count)
 
@@ -288,7 +298,10 @@ class EvalsClient:
             raise EvalsAPIError(f"Request failed: {e}") from e
 
     def _build_batches(
-        self, samples: List[Dict[str, Any]], max_payload_bytes: int
+        self,
+        samples: List[Dict[str, Any]],
+        max_payload_bytes: int,
+        skip_oversized_samples: bool,
     ) -> Tuple[List[List[Dict[str, Any]]], int]:
         """Build batches that fit within payload size limit."""
         batches: List[List[Dict[str, Any]]] = []
@@ -300,11 +313,13 @@ class EvalsClient:
             sample_size = len(json.dumps(sample)) + 1
 
             if sample_size + 20 > max_payload_bytes:
-                warnings.warn(
-                    f"Sample {idx} exceeds maximum payload size "
-                    f"({sample_size} bytes > {max_payload_bytes - 20} bytes limit), skipping",
-                    stacklevel=3,
-                )
+                message = _oversized_sample_message(idx, sample_size, max_payload_bytes)
+                if not skip_oversized_samples:
+                    raise EvalsAPIError(
+                        f"{message}. Reduce the sample size before uploading, or pass "
+                        "skip_oversized_samples=True to upload the remaining samples."
+                    )
+                warnings.warn(f"{message}, skipping", stacklevel=3)
                 skipped_count += 1
                 continue
 
@@ -583,6 +598,7 @@ class AsyncEvalsClient:
         max_payload_bytes: int = 25 * 1024 * 1024,
         max_concurrent: int = 4,
         progress_callback: Optional[Callable[[int], None]] = None,
+        skip_oversized_samples: bool = False,
     ) -> Dict[str, Any]:
         """Push evaluation samples in adaptive batches with concurrent uploads."""
         if not samples:
@@ -590,7 +606,9 @@ class AsyncEvalsClient:
         if max_concurrent < 1:
             raise ValueError("max_concurrent must be at least 1")
 
-        batches, skipped_count = self._build_batches(samples, max_payload_bytes)
+        batches, skipped_count = self._build_batches(
+            samples, max_payload_bytes, skip_oversized_samples
+        )
         if skipped_count and progress_callback is not None:
             progress_callback(skipped_count)
 
@@ -640,7 +658,10 @@ class AsyncEvalsClient:
         return {"samples_pushed": sum(results), "samples_skipped": skipped_count}
 
     def _build_batches(
-        self, samples: List[Dict[str, Any]], max_payload_bytes: int
+        self,
+        samples: List[Dict[str, Any]],
+        max_payload_bytes: int,
+        skip_oversized_samples: bool,
     ) -> Tuple[List[List[Dict[str, Any]]], int]:
         """Build batches that fit within payload size limit."""
         batches: List[List[Dict[str, Any]]] = []
@@ -652,11 +673,13 @@ class AsyncEvalsClient:
             sample_size = len(json.dumps(sample)) + 1
 
             if sample_size + 20 > max_payload_bytes:
-                warnings.warn(
-                    f"Sample {idx} exceeds maximum payload size "
-                    f"({sample_size} bytes > {max_payload_bytes - 20} bytes limit), skipping",
-                    stacklevel=3,
-                )
+                message = _oversized_sample_message(idx, sample_size, max_payload_bytes)
+                if not skip_oversized_samples:
+                    raise EvalsAPIError(
+                        f"{message}. Reduce the sample size before uploading, or pass "
+                        "skip_oversized_samples=True to upload the remaining samples."
+                    )
+                warnings.warn(f"{message}, skipping", stacklevel=3)
                 skipped_count += 1
                 continue
 

--- a/packages/prime-evals/tests/test_evals.py
+++ b/packages/prime-evals/tests/test_evals.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from prime_evals import EvalsAPIError
 from prime_evals.evals import AsyncEvalsClient, EvalsClient
 from prime_evals.models import (
     CreateEvaluationRequest,
@@ -163,6 +164,7 @@ def test_push_samples_reports_progress_and_reuses_http_client(monkeypatch):
             max_payload_bytes=35,
             max_workers=1,
             progress_callback=progress.append,
+            skip_oversized_samples=True,
         )
 
     assert result == {"samples_pushed": 2, "samples_skipped": 1}
@@ -170,6 +172,18 @@ def test_push_samples_reports_progress_and_reuses_http_client(monkeypatch):
     assert len(posts) == 2
     assert len(created_clients) == 1
     assert posts[0]["headers"]["Authorization"] == "Bearer secret-token"
+
+
+def test_push_samples_rejects_oversized_samples_by_default():
+    client = EvalsClient(SimpleNamespace(base_url="https://api.example", api_key="secret-token"))
+
+    with pytest.raises(EvalsAPIError, match="Sample 1 exceeds maximum payload size"):
+        client.push_samples(
+            "eval-1",
+            [{"x": "a"}, {"x": "b" * 50}],
+            max_payload_bytes=35,
+            max_workers=1,
+        )
 
 
 def test_async_push_samples_reports_progress_and_reuses_http_client(monkeypatch):
@@ -218,6 +232,21 @@ def test_async_push_samples_reports_progress_and_reuses_http_client(monkeypatch)
     assert len(posts) == 2
     assert len(created_clients) == 1
     assert posts[0]["headers"]["Authorization"] == "Bearer secret-token"
+
+
+def test_async_push_samples_rejects_oversized_samples_by_default():
+    client = AsyncEvalsClient.__new__(AsyncEvalsClient)
+    client.client = SimpleNamespace(base_url="https://api.example", api_key="secret-token")
+
+    with pytest.raises(EvalsAPIError, match="Sample 1 exceeds maximum payload size"):
+        asyncio.run(
+            client.push_samples(
+                "eval-1",
+                [{"x": "a"}, {"x": "b" * 50}],
+                max_payload_bytes=35,
+                max_concurrent=1,
+            )
+        )
 
 
 def test_evals_client_context_manager():

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -24,7 +24,7 @@ from ..utils import (
 )
 from ..utils.display import get_eval_viewer_url
 from ..utils.env_metadata import find_environment_metadata
-from ..utils.eval_push import load_results_jsonl
+from ..utils.eval_push import load_results_jsonl, push_eval_samples
 from ..utils.hosted_eval import (
     EvalStatus,
     HostedEvalConfig,
@@ -1013,12 +1013,13 @@ def _push_samples_with_progress(
     client: EvalsClient, evaluation_id: str, samples: list[dict[str, Any]]
 ) -> None:
     if not console.is_terminal:
-        client.push_samples(evaluation_id, samples)
+        push_eval_samples(client, evaluation_id, samples)
         return
 
     with Progress(console=console, transient=True) as progress:
         task_id = progress.add_task("Uploading samples", total=len(samples))
-        client.push_samples(
+        push_eval_samples(
+            client,
             evaluation_id,
             samples,
             progress_callback=lambda uploaded: progress.update(task_id, advance=uploaded),

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -1,7 +1,8 @@
 import json
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from prime_evals import EvalsAPIError, EvalsClient
 
@@ -12,6 +13,36 @@ from .env_metadata import find_environment_metadata
 from .plain import get_console
 
 console = get_console()
+
+EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024
+
+
+def push_eval_samples(
+    client: EvalsClient,
+    evaluation_id: str,
+    samples: list[dict[str, Any]],
+    progress_callback: Optional[Callable[[int], None]] = None,
+) -> None:
+    if progress_callback is None:
+        result = client.push_samples(
+            evaluation_id,
+            samples,
+            max_payload_bytes=EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES,
+        )
+    else:
+        result = client.push_samples(
+            evaluation_id,
+            samples,
+            max_payload_bytes=EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES,
+            progress_callback=progress_callback,
+        )
+    skipped_count = int(result.get("samples_skipped") or 0)
+    if skipped_count:
+        limit_mib = EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES // (1024 * 1024)
+        raise ValueError(
+            f"{skipped_count} evaluation sample(s) exceed the {limit_mib} MiB upload payload "
+            "limit and were skipped. Reduce saved sample size before uploading."
+        )
 
 
 def load_results_jsonl(path: Path) -> list[dict]:
@@ -209,7 +240,7 @@ def push_eval_results_to_hub(
         raise EvalsAPIError("Failed to get evaluation ID from create_evaluation response")
 
     if converted_results:
-        evals_client.push_samples(eval_id, converted_results)
+        push_eval_samples(evals_client, eval_id, converted_results)
 
     evals_client.finalize_evaluation(eval_id, metrics=metrics)
 

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -9,6 +9,7 @@ from prime_cli.commands.evals import (
     _validate_eval_path,
 )
 from prime_cli.main import app
+from prime_cli.utils.eval_push import EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES, push_eval_samples
 from typer.testing import CliRunner
 from typing_extensions import cast
 
@@ -185,6 +186,34 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
     }
 
 
+def test_push_eval_samples_uses_large_payload_limit():
+    captured = {}
+
+    class DummyEvalsClient:
+        def push_samples(self, evaluation_id, samples, **kwargs):
+            captured.update({"evaluation_id": evaluation_id, "samples": samples, "kwargs": kwargs})
+            return {"samples_pushed": len(samples), "samples_skipped": 0}
+
+    samples = [{"answer": "ok"}]
+
+    push_eval_samples(DummyEvalsClient(), "eval-123", samples)
+
+    assert captured == {
+        "evaluation_id": "eval-123",
+        "samples": samples,
+        "kwargs": {"max_payload_bytes": EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES},
+    }
+
+
+def test_push_eval_samples_errors_when_samples_are_skipped():
+    class DummyEvalsClient:
+        def push_samples(self, _evaluation_id, _samples, **_kwargs):
+            return {"samples_pushed": 0, "samples_skipped": 1}
+
+    with pytest.raises(ValueError, match="exceed the 25 MiB upload payload limit"):
+        push_eval_samples(DummyEvalsClient(), "eval-123", [{"answer": "too large"}])
+
+
 class TestPushSingleEval:
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
         metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
@@ -213,6 +242,40 @@ class TestPushSingleEval:
         assert eval_id == "eval-123"
         assert captured["is_public"] is False
         assert captured["environments"] == [{"slug": "owner/gsm8k"}]
+
+    def test_push_single_eval_uses_large_payload_limit_for_samples(self, tmp_path, monkeypatch):
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text(json.dumps({"id": 1, "reward": 1.0}))
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **_kwargs):
+                return {"evaluation_id": "eval-123"}
+
+            def push_samples(self, evaluation_id, samples, **kwargs):
+                captured.update(
+                    {"evaluation_id": evaluation_id, "samples": samples, "kwargs": kwargs}
+                )
+                return {"samples_pushed": len(samples), "samples_skipped": 0}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, None)
+
+        assert eval_id == "eval-123"
+        assert captured["evaluation_id"] == "eval-123"
+        assert captured["samples"][0]["example_id"] == 1
+        assert captured["kwargs"]["max_payload_bytes"] == EVAL_SAMPLE_UPLOAD_MAX_PAYLOAD_BYTES
 
     def test_create_evaluation_requires_pushed_environment(self, tmp_path, capsys):
         metadata = {"env": "gsm8k", "model": "gpt-4"}


### PR DESCRIPTION
Ensures eval sample uploads use the larger payload limit and fail loudly if samples would still be skipped.\n\nLinear: ENG-3848

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes eval upload error handling and CLI wrappers only; no auth or data-model changes, with clearer failure modes for large samples.
> 
> **Overview**
> Eval sample uploads now treat oversized payloads as **errors by default** instead of silently skipping them.
> 
> In **prime-evals**, `push_samples` (sync and async) gains `skip_oversized_samples=False` by default: samples over the batch limit raise `EvalsAPIError` with guidance to shrink data or opt in with `skip_oversized_samples=True`. The previous warn-and-skip path remains behind that flag, with a shared `_oversized_sample_message` helper.
> 
> The **Prime CLI** routes eval pushes through `push_eval_samples`, which always passes the **25 MiB** `max_payload_bytes` and raises `ValueError` if the API reports any skipped samples—so `prime eval push` and post-run hub uploads fail loudly instead of uploading partial results.
> 
> Tests cover default rejection, optional skip behavior, and CLI wiring for the payload limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d225540cba44dad960c58aad6a81525577c775ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->