### PR TITLE
add prime logout command

### DIFF
--- a/packages/prime/src/prime_cli/commands/logout.py
+++ b/packages/prime/src/prime_cli/commands/logout.py
@@ -1,0 +1,46 @@
+import os
+
+import typer
+
+from prime_cli.core import Config
+
+from ..utils import PlainTyper, get_console
+
+app = PlainTyper(help="Log out of Prime Intellect", no_args_is_help=False)
+console = get_console()
+
+
+@app.callback(invoke_without_command=True)
+def logout(
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Clear the stored API key, team selection, and user id."""
+    config = Config()
+
+    if not config.config.get("api_key") and not config.config.get("user_id"):
+        console.print("[yellow]Not logged in.[/yellow]")
+        if os.getenv("PRIME_API_KEY"):
+            console.print(
+                "[dim]PRIME_API_KEY is set in your environment; unset it to fully log out.[/dim]"
+            )
+        raise typer.Exit(0)
+
+    env_name = config.current_environment
+    if not yes and not typer.confirm(
+        f"Log out of '{env_name}' (clears API key, team, and user id)?",
+        default=True,
+    ):
+        raise typer.Exit(0)
+
+    config.set_api_key("")
+    config.set_team(None)
+    config.set_user_id(None)
+    config.update_current_environment_file()
+
+    console.print("[green]Logged out.[/green]")
+
+    if os.getenv("PRIME_API_KEY"):
+        console.print(
+            "[yellow]Note:[/yellow] PRIME_API_KEY is set in your environment "
+            "and will still authenticate requests. Unset it to fully log out."
+        )

--- a/packages/prime/src/prime_cli/commands/logout.py
+++ b/packages/prime/src/prime_cli/commands/logout.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import typer
@@ -10,6 +11,42 @@ app = PlainTyper(help="Log out of Prime Intellect", no_args_is_help=False)
 console = get_console()
 
 
+_ENV_OVERRIDES = ("PRIME_API_KEY", "PRIME_TEAM_ID", "PRIME_USER_ID")
+
+
+def _clear_env_file(config: Config) -> None:
+    """Rewrite the current environment's saved file from raw cleared config values.
+
+    Config.update_current_environment_file() reads env-precedence properties, so
+    PRIME_* shell vars would otherwise leak back onto disk right after logout.
+    """
+    if config.current_environment == "production":
+        return
+    try:
+        sanitized = config._sanitize_environment_name(config.current_environment)
+    except ValueError:
+        return
+    env_file = config.environments_dir / f"{sanitized}.json"
+    if not env_file.exists():
+        return
+    raw = config.config
+    env_file.write_text(
+        json.dumps(
+            {
+                "api_key": raw.get("api_key", ""),
+                "team_id": raw.get("team_id"),
+                "team_name": raw.get("team_name"),
+                "team_role": raw.get("team_role"),
+                "user_id": raw.get("user_id"),
+                "base_url": raw.get("base_url", Config.DEFAULT_BASE_URL),
+                "frontend_url": raw.get("frontend_url", Config.DEFAULT_FRONTEND_URL),
+                "inference_url": raw.get("inference_url", Config.DEFAULT_INFERENCE_URL),
+            },
+            indent=2,
+        )
+    )
+
+
 @app.callback(invoke_without_command=True)
 def logout(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -17,11 +54,14 @@ def logout(
     """Clear the stored API key, team selection, and user id."""
     config = Config()
 
-    if not config.config.get("api_key") and not config.config.get("user_id"):
+    raw = config.config
+    if not raw.get("api_key") and not raw.get("user_id") and not raw.get("team_id"):
         console.print("[yellow]Not logged in.[/yellow]")
-        if os.getenv("PRIME_API_KEY"):
+        set_overrides = [name for name in _ENV_OVERRIDES if os.getenv(name)]
+        if set_overrides:
             console.print(
-                "[dim]PRIME_API_KEY is set in your environment; unset it to fully log out.[/dim]"
+                f"[dim]{', '.join(set_overrides)} set in your environment; "
+                "unset to fully log out.[/dim]"
             )
         raise typer.Exit(0)
 
@@ -35,12 +75,13 @@ def logout(
     config.set_api_key("")
     config.set_team(None)
     config.set_user_id(None)
-    config.update_current_environment_file()
+    _clear_env_file(config)
 
     console.print("[green]Logged out.[/green]")
 
-    if os.getenv("PRIME_API_KEY"):
+    set_overrides = [name for name in _ENV_OVERRIDES if os.getenv(name)]
+    if set_overrides:
         console.print(
-            "[yellow]Note:[/yellow] PRIME_API_KEY is set in your environment "
-            "and will still authenticate requests. Unset it to fully log out."
+            f"[yellow]Note:[/yellow] {', '.join(set_overrides)} set in your environment "
+            "and will override the cleared config. Unset to fully log out."
         )

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -18,6 +18,7 @@ from .commands.images import app as images_app
 from .commands.inference import app as inference_app
 from .commands.lab import app as lab_app
 from .commands.login import app as login_app
+from .commands.logout import app as logout_app
 from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
 from .commands.rl import app as train_app
@@ -68,6 +69,7 @@ app.add_typer(inference_app, name="inference", rich_help_panel="Compute")
 
 # Account commands
 app.add_typer(login_app, name="login", rich_help_panel="Account")
+app.add_typer(logout_app, name="logout", rich_help_panel="Account")
 app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
 app.add_typer(switch_app, name="switch", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")


### PR DESCRIPTION
Adds a `prime logout` command — clears the stored API key, team selection, and user id from the active environment.

- Prompts for confirmation, `--yes` to skip
- No-op (with a hint) if already logged out
- Warns when `PRIME_API_KEY` is set in the shell, since that overrides config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local credential clearing only; the env-file rewrite is scoped to non-production named environments and mirrors existing Config patterns.
> 
> **Overview**
> Adds **`prime logout`** under Account commands to clear stored credentials for the active config environment.
> 
> The command clears the API key, team selection, and user id (with confirmation and **`--yes`**), exits early with guidance when nothing is stored, and warns if **`PRIME_API_KEY`**, **`PRIME_TEAM_ID`**, or **`PRIME_USER_ID`** are set in the shell. For non-production environments it rewrites the per-environment JSON from **raw** cleared values so env-precedence properties do not persist shell overrides back to disk after logout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9af79b6af59423630807fb4eb4d540906f1a2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->