### PR TITLE
ENG-3693: deprecate max_async_level user configuration

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -204,7 +204,6 @@ class RLClient:
         lora_alpha: Optional[int] = None,
         max_inflight_rollouts: Optional[int] = None,
         oversampling_factor: Optional[float] = None,
-        max_async_level: Optional[int] = None,
         checkpoints_config: Optional[Dict[str, Any]] = None,
         adapters_config: Optional[Dict[str, Any]] = None,
         checkpoint_id: Optional[str] = None,
@@ -297,9 +296,6 @@ class RLClient:
 
             if oversampling_factor is not None:
                 payload["oversampling_factor"] = oversampling_factor
-
-            if max_async_level is not None:
-                payload["max_async_level"] = max_async_level
 
             if checkpoints_config:
                 payload["checkpoints"] = checkpoints_config

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -637,7 +637,6 @@ class RLConfig(BaseModel):
     learning_rate: float | None = None
     lora_alpha: int | None = None
     oversampling_factor: float | None = Field(default=None, gt=0)
-    max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
     env: List[EnvConfig] = Field(default_factory=list)
@@ -964,8 +963,6 @@ def create_run(
             console.print(f"  LoRA Alpha:          {cfg.lora_alpha}")
         if cfg.oversampling_factor is not None:
             console.print(f"  Oversampling Factor: {cfg.oversampling_factor}")
-        if cfg.max_async_level is not None:
-            console.print(f"  Max Async Level:     {cfg.max_async_level}")
         if cfg.run_config:
             console.print(f"  Run Config:          {cfg.run_config}")
 
@@ -1156,7 +1153,6 @@ def create_run(
             lora_alpha=cfg.lora_alpha,
             max_inflight_rollouts=cfg.max_inflight_rollouts,
             oversampling_factor=cfg.oversampling_factor,
-            max_async_level=cfg.max_async_level,
             checkpoints_config=cfg.checkpoints.to_api_dict(),
             adapters_config=cfg.adapters.to_api_dict(),
             checkpoint_id=cfg.checkpoint_id,

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -25,7 +25,6 @@ def training_config_toml(raw: dict[str, Any]) -> str:
         "lora_alpha",
         "oversampling_factor",
         "max_inflight_rollouts",
-        "max_async_level",
         "checkpoint_id",
         "cluster_name",
     ):


### PR DESCRIPTION
removed in https://github.com/PrimeIntellect-ai/prime-rl/pull/2631

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow removal of an optional tuning knob from create/config paths; read models unchanged aside from no longer sending the field on new runs.
> 
> **Overview**
> Removes **`max_async_level`** as a user-settable Hosted Training option across the Prime CLI and lab tooling, matching its removal from the training runtime.
> 
> **`RLClient.create_run`** no longer accepts or sends `max_async_level` in create payloads. **`RLConfig`** / **`prime train run`** drop the TOML field, confirmation summary line, and wiring into `create_run`. **`training_config_toml`** stops copying the key when exporting a run config for rerun.
> 
> Existing runs may still return the field from the API; **`RLRun`** keeps the optional field for display only. Lab configs that still set it should rely on existing deprecation warnings (e.g. lab doctor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c4f88e273fc2f5912c22ccbc65411a84320dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->