### PR TITLE
APR-57: add hosted OPD CLI config

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -215,7 +215,7 @@ def generate_rl_config_template(environment: str | None = None) -> str:
 
     return f'''\
 model = "Qwen/Qwen3.5-0.8B"
-loss = "rl" # "rl" | "sft"; OPD is not yet supported on hosted runtimes
+loss = "rl" # "rl" | "sft" | "opd"
 max_steps = 100
 
 # env_files = ["secrets.env"] # optional file(s) for secrets
@@ -229,8 +229,9 @@ rollouts_per_example = 8
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
 
-# Optional: SFT distillation teacher
-# To use SFT, change loss to "sft" and uncomment this block. Defaults to Prime Inference.
+# Optional: distillation teacher
+# To use SFT or OPD, change the top-level loss and uncomment this block.
+# To use Prime Inference, omit [teacher.client]; it is the default.
 # [teacher]
 # model = "openai/gpt-oss-120b"
 #
@@ -691,13 +692,8 @@ class RLConfig(BaseModel):
             raise ValueError("max_inflight_rollouts must be at least rollouts_per_example")
         if self.loss == "rl" and self.teacher is not None:
             raise ValueError("teacher can only be set when loss is 'sft' or 'opd'")
-        if self.loss == "sft" and self.teacher is None:
-            raise ValueError("teacher is required when loss is 'sft'")
-        if self.loss == "opd":
-            raise ValueError(
-                "loss='opd' is not supported for hosted runs yet; OPD requires "
-                "teacher logprob scoring support in the hosted runtime"
-            )
+        if self.loss in {"sft", "opd"} and self.teacher is None:
+            raise ValueError(f"teacher is required when loss is '{self.loss}'")
         return self
 
 

--- a/packages/prime/tests/test_rl_api.py
+++ b/packages/prime/tests/test_rl_api.py
@@ -143,6 +143,23 @@ def test_create_run_sends_sft_loss_and_teacher_config() -> None:
     }
 
 
+def test_create_run_sends_opd_loss_and_teacher_config() -> None:
+    api_client = FakeAPIClient()
+    client = RLClient(api_client)  # type: ignore[arg-type]
+
+    client.create_run(
+        model_name="openai/gpt-oss-20b",
+        environments=[{"id": "primeintellect/reverse-text"}],
+        loss="opd",
+        teacher={"model": {"name": "openai/gpt-oss-120b"}},
+    )
+
+    assert api_client.posts[0][0] == "/rft/runs"
+    payload = api_client.posts[0][1]
+    assert payload["loss"] == "opd"
+    assert payload["teacher"] == {"model": {"name": "openai/gpt-oss-120b"}}
+
+
 def test_create_run_omits_default_rl_loss() -> None:
     api_client = FakeAPIClient()
     client = RLClient(api_client)  # type: ignore[arg-type]

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -70,14 +70,14 @@ def test_generate_rl_config_template_keeps_default_surface_minimal() -> None:
 def test_generate_rl_config_template_sft_example_loads(tmp_path: Path) -> None:
     template = generate_rl_config_template()
     template = template.replace(
-        'loss = "rl" # "rl" | "sft"; OPD is not yet supported on hosted runtimes',
-        'loss = "sft" # "rl" | "sft"; OPD is not yet supported on hosted runtimes',
+        'loss = "rl" # "rl" | "sft" | "opd"',
+        'loss = "sft" # "rl" | "sft" | "opd"',
     )
 
     lines: list[str] = []
     in_teacher_example = False
     for line in template.splitlines():
-        if line == "# Optional: SFT distillation teacher":
+        if line == "# Optional: distillation teacher":
             in_teacher_example = True
             lines.append(line)
             continue
@@ -399,11 +399,22 @@ def test_load_config_rejects_sft_without_teacher(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
-def test_load_config_rejects_opd_until_hosted_scoring_exists(tmp_path: Path) -> None:
+def test_load_config_accepts_opd_teacher(tmp_path: Path) -> None:
     config_path = tmp_path / "opd.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\nloss = "opd"\n[teacher]\nmodel = "openai/gpt-oss-120b"\n'
     )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.loss == "opd"
+    assert cfg.teacher is not None
+    assert cfg.teacher.model == "openai/gpt-oss-120b"
+
+
+def test_load_config_rejects_opd_without_teacher(tmp_path: Path) -> None:
+    config_path = tmp_path / "opd.toml"
+    config_path.write_text('model = "openai/gpt-oss-20b"\nloss = "opd"\n')
 
     with pytest.raises(typer.Exit):
         load_config(str(config_path))


### PR DESCRIPTION
## Summary
- allow Hosted Training configs to use `loss = "opd"` with `[teacher]`
- keep `loss = "rl"` as the generated template default while documenting OPD as an accepted option
- send OPD loss and teacher config through the existing `/rft/runs` payload

## Scope
This is CLI-only. It does not implement hosted/platform acceptance or teacher-logprob runtime wiring.

Ready for review, but merge should remain ordered behind the hosted API/runtime path for OPD.

## Verification
- `.venv/bin/python -m pytest packages/prime/tests/test_rl_config.py packages/prime/tests/test_rl_api.py` (`51 passed`)
- `.venv/bin/ruff format packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_rl_api.py packages/prime/tests/test_rl_config.py`
- `.venv/bin/ruff check packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_rl_api.py packages/prime/tests/test_rl_config.py`
- `git diff --check`

## Review Notes
- Codex CLI review found no actionable regressions
- Claude review could not run because the org had hit its monthly usage limit at the time of the earlier review

Linear: APR-57

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation and documentation changes plus tests; no auth or runtime logic. Users could submit OPD runs before the backend supports them if merged ahead of the API.
> 
> **Overview**
> **Hosted Training CLI** now treats **`loss = "opd"`** like SFT for config and API: OPD is documented in the generated template, validation no longer rejects OPD as unsupported, and **`[teacher]` is required** for both `sft` and `opd` (still forbidden for `rl`).
> 
> Template comments were broadened from SFT-only distillation to **SFT/OPD** with shared teacher setup. Tests cover loading OPD TOML, rejecting OPD without a teacher, and asserting **`/rft/runs`** payloads include `loss: "opd"` and teacher config.
> 
> This is **CLI-only**; platform/runtime OPD support is assumed to land separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961bcdb46669bd890d48dce283111715f522dd80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->