### PR TITLE
fix (sft): add teacher client configuration

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -230,7 +230,7 @@ rollouts_per_example = 8
 # checkpoint_id = "..."
 
 # Optional: SFT distillation teacher
-# To use SFT, change loss to "sft" and uncomment this block. [teacher.client] is required — the platform has no default inference endpoint; the example below points at PI inference.
+# To use SFT, change loss to "sft" and uncomment this block ([teacher.client] is required).
 # [teacher]
 # model = "openai/gpt-oss-120b"
 #

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -230,14 +230,13 @@ rollouts_per_example = 8
 # checkpoint_id = "..."
 
 # Optional: SFT distillation teacher
-# To use SFT, change loss to "sft" and uncomment this block ([teacher.client] is required).
+# To use SFT, change loss to "sft" and uncomment this block. [teacher.client] defaults to Prime Inference; include it only to point at a custom OAI-compatible endpoint (OpenAI, OpenRouter, self-hosted vLLM).
 # [teacher]
 # model = "openai/gpt-oss-120b"
 #
-# [teacher.client]
-# base_url = "https://api.pinference.ai/api/v1"
-# api_key_var = "PRIME_API_KEY"
-# headers_from_env = {{ X-Prime-Team-ID = "PRIME_TEAM_ID" }}
+# [teacher.client] # optional override; remove this section to use Prime Inference defaults
+# base_url = "https://api.openai.com/v1"
+# api_key_var = "OPENAI_API_KEY"
 #
 # [teacher.sampling]
 # max_tokens = 2048
@@ -429,14 +428,13 @@ class TeacherConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     model: str
-    client: TeacherClientConfig
+    client: TeacherClientConfig | None = None
     sampling: TeacherSamplingConfig | None = None
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
-            "model": {"name": self.model},
-            "client": self.client.model_dump(exclude_none=True),
-        }
+        result: Dict[str, Any] = {"model": {"name": self.model}}
+        if self.client is not None:
+            result["client"] = self.client.model_dump(exclude_none=True)
         if self.sampling is not None:
             result["sampling"] = self.sampling.model_dump(exclude_none=True)
         return result

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -231,8 +231,8 @@ rollouts_per_example = 8
 
 # Optional: SFT distillation teacher
 # To use SFT, change loss to "sft" and uncomment this block.
-# [teacher.client] defaults to Prime Inference; include it only to point at a custom
-# OAI-compatible endpoint (OpenAI, OpenRouter, self-hosted vLLM).
+# To use the default Prime Inference endpoint, leave [teacher.client] commented.
+# To use a custom OAI-compatible endpoint (OpenAI, OpenRouter, vLLM), uncomment [teacher.client].
 # [teacher]
 # model = "openai/gpt-oss-120b"
 #

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -230,7 +230,9 @@ rollouts_per_example = 8
 # checkpoint_id = "..."
 
 # Optional: SFT distillation teacher
-# To use SFT, change loss to "sft" and uncomment this block. [teacher.client] defaults to Prime Inference; include it only to point at a custom OAI-compatible endpoint (OpenAI, OpenRouter, self-hosted vLLM).
+# To use SFT, change loss to "sft" and uncomment this block.
+# [teacher.client] defaults to Prime Inference; include it only to point at a custom
+# OAI-compatible endpoint (OpenAI, OpenRouter, self-hosted vLLM).
 # [teacher]
 # model = "openai/gpt-oss-120b"
 #

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -423,7 +423,7 @@ class TeacherClientConfig(BaseModel):
     base_url: str = Field(..., min_length=1)
     api_key_var: str = Field(..., min_length=1)
     headers_from_env: Dict[str, str] | None = None
-    skip_model_check: bool = False
+    skip_model_check: bool | None = None
 
 
 class TeacherConfig(BaseModel):

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -230,19 +230,19 @@ rollouts_per_example = 8
 # checkpoint_id = "..."
 
 # Optional: SFT distillation teacher
-# To use SFT, change loss to "sft" and uncomment this block.
-# To use the default Prime Inference endpoint, leave [teacher.client] commented.
-# To use a custom OAI-compatible endpoint (OpenAI, OpenRouter, vLLM), uncomment [teacher.client].
+# To use SFT, change loss to "sft" and uncomment this block. Defaults to Prime Inference.
 # [teacher]
 # model = "openai/gpt-oss-120b"
-#
-# [teacher.client] # optional override; remove this section to use Prime Inference defaults
-# base_url = "https://api.openai.com/v1"
-# api_key_var = "OPENAI_API_KEY"
 #
 # [teacher.sampling]
 # max_tokens = 2048
 # reasoning_effort = "medium"
+
+# Optional: override the Prime Inference default with a custom OAI-compatible endpoint.
+# Uncomment this block only when pointing at OpenAI, OpenRouter, self-hosted vLLM, etc.
+# [teacher.client]
+# base_url = "https://api.openai.com/v1"
+# api_key_var = "OPENAI_API_KEY"
 
 [sampling]
 max_tokens = 2048

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -230,9 +230,14 @@ rollouts_per_example = 8
 # checkpoint_id = "..."
 
 # Optional: SFT distillation teacher
-# To use SFT, change the top-level loss to "sft" and uncomment this block.
+# To use SFT, change loss to "sft" and uncomment this block. [teacher.client] is required — the platform has no default inference endpoint; the example below points at PI inference.
 # [teacher]
 # model = "openai/gpt-oss-120b"
+#
+# [teacher.client]
+# base_url = "https://api.pinference.ai/api/v1"
+# api_key_var = "PRIME_API_KEY"
+# headers_from_env = {{ X-Prime-Team-ID = "PRIME_TEAM_ID" }}
 #
 # [teacher.sampling]
 # max_tokens = 2048
@@ -411,14 +416,27 @@ class TeacherSamplingConfig(BaseModel):
         return self
 
 
+class TeacherClientConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    base_url: str = Field(..., min_length=1)
+    api_key_var: str = Field(..., min_length=1)
+    headers_from_env: Dict[str, str] | None = None
+    skip_model_check: bool = False
+
+
 class TeacherConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     model: str
+    client: TeacherClientConfig
     sampling: TeacherSamplingConfig | None = None
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {"model": {"name": self.model}}
+        result: Dict[str, Any] = {
+            "model": {"name": self.model},
+            "client": self.client.model_dump(exclude_none=True),
+        }
         if self.sampling is not None:
             result["sampling"] = self.sampling.model_dump(exclude_none=True)
         return result

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -262,6 +262,7 @@ def test_load_config_rejects_unknown_teacher_client_field(tmp_path: Path) -> Non
         'model = "qwen/qwen-2.5-7b-instruct"\n'
         "[teacher.client]\n"
         'base_url = "https://example.com/inference/api/v1"\n'
+        'api_key_var = "PRIME_API_KEY"\n'
         'bogus = "value"\n'
     )
 

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -180,6 +180,9 @@ def test_load_config_accepts_sft_teacher(tmp_path: Path) -> None:
         'loss = "sft"\n'
         "[teacher]\n"
         'model = "openai/gpt-oss-120b"\n'
+        "[teacher.client]\n"
+        'base_url = "https://api.pinference.ai/api/v1"\n'
+        'api_key_var = "PRIME_API_KEY"\n'
         "[teacher.sampling]\n"
         "max_tokens = 2048\n"
         'reasoning_effort = "medium"\n'
@@ -190,15 +193,80 @@ def test_load_config_accepts_sft_teacher(tmp_path: Path) -> None:
     assert cfg.loss == "sft"
     assert cfg.teacher is not None
     assert cfg.teacher.model == "openai/gpt-oss-120b"
+    assert cfg.teacher.client.base_url == "https://api.pinference.ai/api/v1"
+    assert cfg.teacher.client.api_key_var == "PRIME_API_KEY"
+    assert cfg.teacher.client.skip_model_check is False
     assert cfg.teacher.sampling is not None
     assert cfg.teacher.sampling.max_tokens == 2048
     assert cfg.teacher.to_api_dict() == {
         "model": {"name": "openai/gpt-oss-120b"},
+        "client": {
+            "base_url": "https://api.pinference.ai/api/v1",
+            "api_key_var": "PRIME_API_KEY",
+            "skip_model_check": False,
+        },
         "sampling": {
             "max_tokens": 2048,
             "reasoning_effort": "medium",
         },
     }
+
+
+def test_load_config_accepts_teacher_client(tmp_path: Path) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "qwen/qwen-2.5-7b-instruct"\n'
+        "[teacher.client]\n"
+        'base_url = "https://example.com/inference/api/v1"\n'
+        'api_key_var = "PRIME_API_KEY"\n'
+        "skip_model_check = true\n"
+        "[teacher.client.headers_from_env]\n"
+        'X-Prime-Team-ID = "PRIME_TEAM_ID"\n'
+        "[teacher.sampling]\n"
+        "temperature = 0.7\n"
+        "max_tokens = 256\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.teacher is not None
+    assert cfg.teacher.client is not None
+    assert cfg.teacher.client.base_url == "https://example.com/inference/api/v1"
+    assert cfg.teacher.client.api_key_var == "PRIME_API_KEY"
+    assert cfg.teacher.client.headers_from_env == {"X-Prime-Team-ID": "PRIME_TEAM_ID"}
+    assert cfg.teacher.client.skip_model_check is True
+    assert cfg.teacher.to_api_dict() == {
+        "model": {"name": "qwen/qwen-2.5-7b-instruct"},
+        "client": {
+            "base_url": "https://example.com/inference/api/v1",
+            "api_key_var": "PRIME_API_KEY",
+            "headers_from_env": {"X-Prime-Team-ID": "PRIME_TEAM_ID"},
+            "skip_model_check": True,
+        },
+        "sampling": {
+            "temperature": 0.7,
+            "max_tokens": 256,
+        },
+    }
+
+
+def test_load_config_rejects_unknown_teacher_client_field(tmp_path: Path) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "qwen/qwen-2.5-7b-instruct"\n'
+        "[teacher.client]\n"
+        'base_url = "https://example.com/inference/api/v1"\n'
+        'bogus = "value"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
 
 
 def test_load_config_rejects_teacher_temp_scheduler(tmp_path: Path) -> None:
@@ -208,10 +276,56 @@ def test_load_config_rejects_teacher_temp_scheduler(tmp_path: Path) -> None:
         'loss = "sft"\n'
         "[teacher]\n"
         'model = "openai/gpt-oss-120b"\n'
+        "[teacher.client]\n"
+        'base_url = "https://api.pinference.ai/api/v1"\n'
+        'api_key_var = "PRIME_API_KEY"\n'
         "[teacher.sampling.temp_scheduler]\n"
         'type = "linear"\n'
         "start_temperature = 1.0\n"
         "end_temperature = 0.1\n"
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_teacher_without_client(tmp_path: Path) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_teacher_client_without_base_url(tmp_path: Path) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        "[teacher.client]\n"
+        'api_key_var = "PRIME_API_KEY"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_teacher_client_without_api_key_var(tmp_path: Path) -> None:
+    config_path = tmp_path / "sft.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        'loss = "sft"\n'
+        "[teacher]\n"
+        'model = "openai/gpt-oss-120b"\n'
+        "[teacher.client]\n"
+        'base_url = "https://api.pinference.ai/api/v1"\n'
     )
 
     with pytest.raises(typer.Exit):

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -99,6 +99,7 @@ def test_generate_rl_config_template_sft_example_loads(tmp_path: Path) -> None:
     assert cfg.loss == "sft"
     assert cfg.teacher is not None
     assert cfg.teacher.model == "openai/gpt-oss-120b"
+    assert cfg.teacher.client is None
 
 
 def test_flatten_config_schema_expands_optional_nested_models() -> None:

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -285,10 +285,7 @@ def test_to_api_dict_omits_client_when_unspecified(tmp_path: Path) -> None:
     default kicks in without policy drift."""
     config_path = tmp_path / "sft.toml"
     config_path.write_text(
-        'model = "openai/gpt-oss-20b"\n'
-        'loss = "sft"\n'
-        "[teacher]\n"
-        'model = "openai/gpt-oss-120b"\n'
+        'model = "openai/gpt-oss-20b"\nloss = "sft"\n[teacher]\nmodel = "openai/gpt-oss-120b"\n'
     )
 
     cfg = load_config(str(config_path))
@@ -338,10 +335,7 @@ def test_load_config_rejects_sft_without_teacher(tmp_path: Path) -> None:
 def test_load_config_rejects_opd_until_hosted_scoring_exists(tmp_path: Path) -> None:
     config_path = tmp_path / "opd.toml"
     config_path.write_text(
-        'model = "openai/gpt-oss-20b"\n'
-        'loss = "opd"\n'
-        "[teacher]\n"
-        'model = "openai/gpt-oss-120b"\n'
+        'model = "openai/gpt-oss-20b"\nloss = "opd"\n[teacher]\nmodel = "openai/gpt-oss-120b"\n'
     )
 
     with pytest.raises(typer.Exit):

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -173,16 +173,14 @@ def test_load_config_rejects_max_inflight_and_oversampling(tmp_path: Path) -> No
         load_config(str(config_path))
 
 
-def test_load_config_accepts_sft_teacher(tmp_path: Path) -> None:
+def test_load_config_accepts_sft_teacher_without_client(tmp_path: Path) -> None:
+    """Omitting [teacher.client] is allowed; the API defaults it to PI Inference."""
     config_path = tmp_path / "sft.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\n'
         'loss = "sft"\n'
         "[teacher]\n"
         'model = "openai/gpt-oss-120b"\n'
-        "[teacher.client]\n"
-        'base_url = "https://api.pinference.ai/api/v1"\n'
-        'api_key_var = "PRIME_API_KEY"\n'
         "[teacher.sampling]\n"
         "max_tokens = 2048\n"
         'reasoning_effort = "medium"\n'
@@ -193,18 +191,9 @@ def test_load_config_accepts_sft_teacher(tmp_path: Path) -> None:
     assert cfg.loss == "sft"
     assert cfg.teacher is not None
     assert cfg.teacher.model == "openai/gpt-oss-120b"
-    assert cfg.teacher.client.base_url == "https://api.pinference.ai/api/v1"
-    assert cfg.teacher.client.api_key_var == "PRIME_API_KEY"
-    assert cfg.teacher.client.skip_model_check is False
-    assert cfg.teacher.sampling is not None
-    assert cfg.teacher.sampling.max_tokens == 2048
+    assert cfg.teacher.client is None
     assert cfg.teacher.to_api_dict() == {
         "model": {"name": "openai/gpt-oss-120b"},
-        "client": {
-            "base_url": "https://api.pinference.ai/api/v1",
-            "api_key_var": "PRIME_API_KEY",
-            "skip_model_check": False,
-        },
         "sampling": {
             "max_tokens": 2048,
             "reasoning_effort": "medium",
@@ -290,7 +279,10 @@ def test_load_config_rejects_teacher_temp_scheduler(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
-def test_load_config_rejects_teacher_without_client(tmp_path: Path) -> None:
+def test_to_api_dict_omits_client_when_unspecified(tmp_path: Path) -> None:
+    """CLI must not duplicate the platform default — when the user omits
+    [teacher.client], the API payload also omits ``client`` so the server's
+    default kicks in without policy drift."""
     config_path = tmp_path / "sft.toml"
     config_path.write_text(
         'model = "openai/gpt-oss-20b"\n'
@@ -299,8 +291,10 @@ def test_load_config_rejects_teacher_without_client(tmp_path: Path) -> None:
         'model = "openai/gpt-oss-120b"\n'
     )
 
-    with pytest.raises(typer.Exit):
-        load_config(str(config_path))
+    cfg = load_config(str(config_path))
+
+    assert cfg.teacher is not None
+    assert "client" not in cfg.teacher.to_api_dict()
 
 
 def test_load_config_rejects_teacher_client_without_base_url(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI config and serialization only; no auth or training runtime logic changes beyond passing through optional teacher client settings.
> 
> **Overview**
> Adds optional **`[teacher.client]`** to Hosted Training / SFT configs so distillation teachers can use a custom OpenAI-compatible endpoint (`base_url`, `api_key_var`, optional `headers_from_env` and `skip_model_check`) instead of only Prime Inference.
> 
> When **`[teacher.client]`** is omitted, behavior is unchanged: the CLI documents Prime Inference as the default and **`TeacherConfig.to_api_dict()`** leaves **`client`** out of the API payload so the server default applies without the CLI baking in a duplicate default. The **`prime train init`** template gains commented examples for SFT and custom clients. Tests cover parsing, validation (required fields, unknown keys), and API serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d944092fec44679ad1120fc40d1bfc0821306fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->