### PR TITLE
Fix Windows CLI startup when tunnel imports are unavailable

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -12,7 +12,6 @@ from prime_tunnel.exceptions import (
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo, TunnelListPage
-from prime_tunnel.tunnel import Tunnel
 
 __all__ = [
     "__version__",
@@ -32,3 +31,11 @@ __all__ = [
     "TunnelConnectionError",
     "TunnelTimeoutError",
 ]
+
+
+def __getattr__(name: str):
+    if name == "Tunnel":
+        from prime_tunnel.tunnel import Tunnel
+
+        return Tunnel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -1,6 +1,6 @@
 import asyncio
 import signal
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import typer
 from rich.table import Table
@@ -17,6 +17,16 @@ from prime_cli.utils.prompt import confirm_or_skip
 
 app = PlainTyper(help="Manage tunnels for exposing local services", no_args_is_help=True)
 console = get_console()
+
+TunnelClient: Any = None
+
+
+def _tunnel_client_class() -> Any:
+    if TunnelClient is not None:
+        return TunnelClient
+    from prime_tunnel.core.client import TunnelClient as loaded_tunnel_client
+
+    return loaded_tunnel_client
 
 
 def _format_tunnel_for_output(tunnel) -> dict:
@@ -157,9 +167,7 @@ def list_tunnels(
     validate_output_format(output, console)
 
     async def fetch_tunnels():
-        from prime_tunnel.core.client import TunnelClient
-
-        client = TunnelClient()
+        client = _tunnel_client_class()()
         try:
             return await client.list_tunnels_page(
                 team_id=team_id,
@@ -248,9 +256,7 @@ def tunnel_status(
     """Get status of a specific tunnel."""
 
     async def fetch_status():
-        from prime_tunnel.core.client import TunnelClient
-
-        client = TunnelClient()
+        client = _tunnel_client_class()()
         try:
             return await client.get_tunnel(tunnel_id)
         finally:
@@ -336,9 +342,7 @@ def stop_tunnel(
     if all:
 
         async def fetch_tunnel_ids() -> List[str]:
-            from prime_tunnel.core.client import TunnelClient
-
-            client = TunnelClient()
+            client = _tunnel_client_class()()
             try:
                 scoped_team_id = team_id
                 if scoped_team_id is None:
@@ -400,9 +404,7 @@ def stop_tunnel(
     if labels:
 
         async def validate_label_scope() -> None:
-            from prime_tunnel.core.client import TunnelClient
-
-            client = TunnelClient()
+            client = _tunnel_client_class()()
             try:
                 scoped_user_id = client.config.user_id if only_mine else None
                 scoped_team_id = team_id if team_id is not None else client.config.team_id
@@ -454,9 +456,7 @@ def stop_tunnel(
         return
 
     async def delete_tunnels() -> tuple[List[str], List[dict], List[dict]]:
-        from prime_tunnel.core.client import TunnelClient
-
-        client = TunnelClient()
+        client = _tunnel_client_class()()
         succeeded: List[str] = []
         not_found: List[dict] = []
         failed: List[dict] = []

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -3,13 +3,6 @@ import signal
 from typing import List, Optional
 
 import typer
-from prime_tunnel import Tunnel
-from prime_tunnel.core.client import TunnelClient
-from prime_tunnel.exceptions import (
-    TunnelConnectionError,
-    TunnelLimitReachedError,
-    TunnelTimeoutError,
-)
 from rich.table import Table
 
 from prime_cli.utils import (
@@ -61,6 +54,13 @@ def start_tunnel(
     """Start a tunnel to expose a local port."""
 
     async def run_tunnel():
+        from prime_tunnel import Tunnel
+        from prime_tunnel.exceptions import (
+            TunnelConnectionError,
+            TunnelLimitReachedError,
+            TunnelTimeoutError,
+        )
+
         tunnel = Tunnel(local_port=port, name=name, team_id=team_id, labels=labels)
 
         shutdown_event = asyncio.Event()
@@ -157,6 +157,8 @@ def list_tunnels(
     validate_output_format(output, console)
 
     async def fetch_tunnels():
+        from prime_tunnel.core.client import TunnelClient
+
         client = TunnelClient()
         try:
             return await client.list_tunnels_page(
@@ -246,6 +248,8 @@ def tunnel_status(
     """Get status of a specific tunnel."""
 
     async def fetch_status():
+        from prime_tunnel.core.client import TunnelClient
+
         client = TunnelClient()
         try:
             return await client.get_tunnel(tunnel_id)
@@ -332,6 +336,8 @@ def stop_tunnel(
     if all:
 
         async def fetch_tunnel_ids() -> List[str]:
+            from prime_tunnel.core.client import TunnelClient
+
             client = TunnelClient()
             try:
                 scoped_team_id = team_id
@@ -394,6 +400,8 @@ def stop_tunnel(
     if labels:
 
         async def validate_label_scope() -> None:
+            from prime_tunnel.core.client import TunnelClient
+
             client = TunnelClient()
             try:
                 scoped_user_id = client.config.user_id if only_mine else None
@@ -446,6 +454,8 @@ def stop_tunnel(
         return
 
     async def delete_tunnels() -> tuple[List[str], List[dict], List[dict]]:
+        from prime_tunnel.core.client import TunnelClient
+
         client = TunnelClient()
         succeeded: List[str] = []
         not_found: List[dict] = []

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -18,15 +18,11 @@ from prime_cli.utils.prompt import confirm_or_skip
 app = PlainTyper(help="Manage tunnels for exposing local services", no_args_is_help=True)
 console = get_console()
 
-TunnelClient: Any = None
 
+def _create_tunnel_client() -> Any:
+    from prime_tunnel.core.client import TunnelClient
 
-def _tunnel_client_class() -> Any:
-    if TunnelClient is not None:
-        return TunnelClient
-    from prime_tunnel.core.client import TunnelClient as loaded_tunnel_client
-
-    return loaded_tunnel_client
+    return TunnelClient()
 
 
 def _format_tunnel_for_output(tunnel) -> dict:
@@ -133,6 +129,11 @@ def start_tunnel(
         asyncio.run(run_tunnel())
     except KeyboardInterrupt:
         pass
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}", style="bold")
+        raise typer.Exit(1)
 
 
 @app.command("list")
@@ -167,7 +168,7 @@ def list_tunnels(
     validate_output_format(output, console)
 
     async def fetch_tunnels():
-        client = _tunnel_client_class()()
+        client = _create_tunnel_client()
         try:
             return await client.list_tunnels_page(
                 team_id=team_id,
@@ -256,7 +257,7 @@ def tunnel_status(
     """Get status of a specific tunnel."""
 
     async def fetch_status():
-        client = _tunnel_client_class()()
+        client = _create_tunnel_client()
         try:
             return await client.get_tunnel(tunnel_id)
         finally:
@@ -342,7 +343,7 @@ def stop_tunnel(
     if all:
 
         async def fetch_tunnel_ids() -> List[str]:
-            client = _tunnel_client_class()()
+            client = _create_tunnel_client()
             try:
                 scoped_team_id = team_id
                 if scoped_team_id is None:
@@ -404,7 +405,7 @@ def stop_tunnel(
     if labels:
 
         async def validate_label_scope() -> None:
-            client = _tunnel_client_class()()
+            client = _create_tunnel_client()
             try:
                 scoped_user_id = client.config.user_id if only_mine else None
                 scoped_team_id = team_id if team_id is not None else client.config.team_id
@@ -456,7 +457,7 @@ def stop_tunnel(
         return
 
     async def delete_tunnels() -> tuple[List[str], List[dict], List[dict]]:
-        client = _tunnel_client_class()()
+        client = _create_tunnel_client()
         succeeded: List[str] = []
         not_found: List[dict] = []
         failed: List[dict] = []

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
@@ -33,6 +34,17 @@ def test_format_tunnel_does_not_derive_created_from_expiration() -> None:
     assert tunnel_data["expires_at"] is not None
 
 
+def test_tunnel_start_import_failure_exits_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.setitem(sys.modules, "prime_tunnel", None)
+
+    result = runner.invoke(app, ["tunnel", "start"])
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_tunnel_list_passes_label_filters(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     captured: dict[str, Any] = {}
@@ -65,7 +77,7 @@ def test_tunnel_list_passes_label_filters(monkeypatch: pytest.MonkeyPatch) -> No
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(
         app,
@@ -89,7 +101,7 @@ def test_tunnel_list_json_outputs_empty_envelope(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "list", "--output", "json"])
 
@@ -117,7 +129,7 @@ def test_tunnel_stop_by_label_uses_bulk_delete(monkeypatch: pytest.MonkeyPatch) 
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--label", "dev", "--yes"])
 
@@ -141,7 +153,7 @@ def test_tunnel_stop_by_label_validates_scope_before_prompt(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     # No --yes: if the scope check ran after the prompt we'd see the confirmation
     # text; instead it must fail fast with a clean error and never prompt.
@@ -179,7 +191,7 @@ def test_tunnel_stop_all_lists_then_bulk_deletes_explicit_ids(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 
@@ -216,7 +228,7 @@ def test_tunnel_stop_all_users_uses_configured_team_scope(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--all-users", "--yes"])
 
@@ -252,7 +264,7 @@ def test_tunnel_stop_all_paginates_before_bulk_delete(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 
@@ -278,7 +290,7 @@ def test_tunnel_stop_all_noops_when_no_active_tunnels(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 
@@ -301,7 +313,7 @@ def test_tunnel_stop_all_requires_current_user_for_only_mine(
         async def close(self) -> None:
             return None
 
-    monkeypatch.setattr("prime_cli.commands.tunnel.TunnelClient", FakeTunnelClient)
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
 
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 

--- a/packages/prime/tests/test_windows_cli.py
+++ b/packages/prime/tests/test_windows_cli.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_prime_help_does_not_import_tunnel_package() -> None:
+    project_root = Path(__file__).resolve().parents[3]
+    pythonpath = os.pathsep.join(
+        [
+            str(project_root / "packages" / "prime" / "src"),
+            str(project_root / "packages" / "prime-tunnel" / "src"),
+            str(project_root / "packages" / "prime-evals" / "src"),
+            str(project_root / "packages" / "prime-mcp-server" / "src"),
+            str(project_root / "packages" / "prime-sandboxes" / "src"),
+        ]
+    )
+    env = {
+        **os.environ,
+        "PRIME_DISABLE_VERSION_CHECK": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONPATH": pythonpath,
+    }
+    script = """
+import builtins
+import sys
+
+real_import = builtins.__import__
+
+
+def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "prime_tunnel" or name.startswith("prime_tunnel."):
+        raise RuntimeError("prime_tunnel imported during CLI startup")
+    return real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = fake_import
+
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+result = CliRunner().invoke(app, ["--help"], env={"PRIME_DISABLE_VERSION_CHECK": "1"})
+if result.exit_code != 0:
+    sys.stderr.write(result.output)
+    raise SystemExit(result.exit_code)
+if "Prime Intellect CLI" not in result.output:
+    sys.stderr.write("missing help banner\\n")
+    raise SystemExit(1)
+sys.stdout.write("ok\\n")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
## Summary
- defer tunnel package imports until tunnel commands execute
- lazy-load the public Tunnel export from prime_tunnel
- add a regression test that prime --help does not import prime_tunnel

## Tests
- uv run pytest packages/prime/tests/test_windows_cli.py packages/prime-tunnel/tests/test_tunnel.py -q
- uv run ruff check packages/prime/src/prime_cli/commands/tunnel.py packages/prime-tunnel/src/prime_tunnel/__init__.py packages/prime/tests/test_windows_cli.py
- PRIME_DISABLE_VERSION_CHECK=1 uv run prime --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI import timing and lazy exports; tunnel behavior unchanged when dependencies are present, with added regression tests.
> 
> **Overview**
> **Defers tunnel dependencies** so the main CLI can start without loading `prime_tunnel` at import time. Tunnel command handlers now import `TunnelClient` (and `Tunnel` / tunnel exceptions for `start`) only when those commands run, and `prime_tunnel` exposes `Tunnel` via module-level `__getattr__` instead of an eager import.
> 
> **Improves failure UX** for `prime tunnel start`: import/runtime errors surface as a single `Error:` line and exit code 1, without a Python traceback.
> 
> **Tests** patch `TunnelClient` at its real module path, add a case where `prime_tunnel` is unavailable on `tunnel start`, and assert `prime --help` never imports `prime_tunnel` (subprocess regression aimed at Windows startup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcf85fd13767575900d07e0cfb9d8a6712dd1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->