### PR TITLE
Fix sandbox test isolation

### DIFF
--- a/packages/prime-sandboxes/tests/conftest.py
+++ b/packages/prime-sandboxes/tests/conftest.py
@@ -11,15 +11,19 @@ from prime_sandboxes import APIClient, SandboxClient
 
 @pytest.fixture(scope="session")
 def sandbox_client(tmp_path_factory):
-    """Create a shared sandbox client for all tests with isolated config per worker"""
+    """Create a shared sandbox client for live tests with isolated config per worker"""
+    api_key = os.environ.get("PRIME_API_KEY")
+    if not api_key:
+        pytest.skip("live sandbox tests require PRIME_API_KEY")
+
     # Create a unique config directory for this test worker to avoid file collisions
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
     config_dir = tmp_path_factory.mktemp(f"prime_config_{worker_id}", numbered=False)
 
-    # Patch Path.home() to return our isolated config directory for this worker
+    # Isolate the client config without leaking Path.home() to the rest of pytest.
     with patch("pathlib.Path.home", return_value=config_dir):
-        client = APIClient()
-        yield SandboxClient(client)
+        client = APIClient(api_key=api_key)
+    yield SandboxClient(client)
 
 
 @pytest.fixture

--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -1,3 +1,7 @@
+import os
+
+import pytest
+
 from prime_sandboxes import (
     APIClient,
     CreateSandboxRequest,
@@ -5,11 +9,15 @@ from prime_sandboxes import (
 )
 
 
-def test_command_timeout():
+@pytest.mark.skipif(
+    not os.environ.get("PRIME_API_KEY"), reason="live sandbox tests require PRIME_API_KEY"
+)
+def test_command_timeout(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
     sandbox = None
 
     try:
-        client = APIClient()
+        client = APIClient(api_key=os.environ["PRIME_API_KEY"])
         sandbox_client = SandboxClient(client)
 
         print("\nCreating sandbox...")


### PR DESCRIPTION
## Summary
- skip live sandbox integration tests unless PRIME_API_KEY is explicitly set
- keep sandbox test config isolation local to API client construction so Path.home does not leak across the full pytest session
- make the standalone sandbox timeout test use explicit credentials and isolated HOME

## Tests
- uv run ruff check packages/prime-sandboxes/tests/conftest.py packages/prime-sandboxes/tests/test_cmd_timeout.py
- uv run pytest packages/prime-sandboxes/tests/test_cmd_timeout.py packages/prime-sandboxes/tests/test_command_execution.py packages/prime-sandboxes/tests/test_sandbox_operations.py packages/prime/tests/test_config_delete.py -q
- uv run pytest -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to fixtures and one integration test; no production sandbox or API behavior.
> 
> **Overview**
> Live sandbox integration tests now **skip unless `PRIME_API_KEY` is set**, so CI and local runs without credentials do not hit the real API.
> 
> The session **`sandbox_client` fixture** builds `APIClient` with that key and limits **`Path.home` patching** to client construction only, so the mock does not stay active for the whole pytest session. The standalone **`test_command_timeout`** is gated the same way, uses an explicit API key, and isolates config via **`HOME`** on a temp directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078bee8d31412adac0f5d8744ad57fbee125913f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->