### PR TITLE
improved tunnel cleanup

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import threading
 import time
-import weakref
 from pathlib import Path
 from typing import Optional
 
@@ -34,7 +33,7 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # Started-but-not-stopped tunnels, so an atexit backstop can delete their backend
 # registrations if the caller never stops them (forgotten cleanup, unhandled
 # exception)
-_active_tunnels: "weakref.WeakSet[Tunnel]" = weakref.WeakSet()
+_active_tunnels: "set[Tunnel]" = set()
 
 
 def _stop_active_tunnels() -> None:

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import threading
 import time
+import weakref
 from pathlib import Path
 from typing import Optional
 
@@ -29,6 +30,22 @@ _LOG_RE = re.compile(
     r"(.+)"
 )
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Started-but-not-stopped tunnels, so an atexit backstop can delete their backend
+# registrations if the caller never stops them (forgotten cleanup, unhandled
+# exception)
+_active_tunnels: "weakref.WeakSet[Tunnel]" = weakref.WeakSet()
+
+
+def _stop_active_tunnels() -> None:
+    for tunnel in list(_active_tunnels):
+        try:
+            tunnel.sync_stop()
+        except Exception:
+            pass
+
+
+atexit.register(_stop_active_tunnels)
 
 
 def _parse_frpc_error(
@@ -206,7 +223,7 @@ class Tunnel:
 
         self._started = True
 
-        atexit.register(self.sync_stop)
+        _active_tunnels.add(self)
 
         return self.url
 
@@ -223,7 +240,7 @@ class Tunnel:
         if not self._started:
             return
 
-        atexit.unregister(self.sync_stop)
+        _active_tunnels.discard(self)
 
         if self._process is not None:
             try:
@@ -263,7 +280,7 @@ class Tunnel:
 
     async def _cleanup(self) -> None:
         """Clean up tunnel resources."""
-        atexit.unregister(self.sync_stop)
+        _active_tunnels.discard(self)
 
         # Stop frpc process (this will cause drain threads to exit via EOF)
         if self._process is not None:

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 import fcntl
 import os
 import re
@@ -205,6 +206,8 @@ class Tunnel:
 
         self._started = True
 
+        atexit.register(self.sync_stop)
+
         return self.url
 
     async def stop(self) -> None:
@@ -219,6 +222,8 @@ class Tunnel:
         """Stop the tunnel synchronously. Safe for signal handlers and atexit."""
         if not self._started:
             return
+
+        atexit.unregister(self.sync_stop)
 
         if self._process is not None:
             try:
@@ -258,6 +263,8 @@ class Tunnel:
 
     async def _cleanup(self) -> None:
         """Clean up tunnel resources."""
+        atexit.unregister(self.sync_stop)
+
         # Stop frpc process (this will cause drain threads to exit via EOF)
         if self._process is not None:
             try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small defensive lifecycle change reusing existing sync_stop; atexit may run extra HTTP deletes on abrupt exit but does not alter normal start/stop behavior.
> 
> **Overview**
> Adds an **atexit backstop** so tunnels that were started but never stopped still run cleanup when the process exits.
> 
> After a successful `start()`, each `Tunnel` is tracked in a module-level `_active_tunnels` set. On normal shutdown paths, `sync_stop` and `_cleanup` remove the instance from that set. At process exit, `_stop_active_tunnels` iterates any remaining entries and calls `sync_stop()` (errors ignored), which should tear down **frpc**, delete the **backend registration**, and remove the **config file**—reducing leaked registrations when cleanup is skipped due to crashes or forgotten `stop()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7784d73bc1d8a2751c2c0f420af3a639f01e3a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->