### PR TITLE
Fix release E2E runner and Lab doctor templates

### DIFF
--- a/packages/prime/scripts/release_e2e.py
+++ b/packages/prime/scripts/release_e2e.py
@@ -47,8 +47,8 @@ SECRET_FILE_PATTERNS = (
     ".pypirc",
     "credentials.json",
     "service-account",
-    "secrets.",
 )
+SECRET_SOURCE_MODULE_NAMES = ("secrets.py",)
 SECRET_FILE_SUFFIXES = (".key", ".pem")
 
 
@@ -159,8 +159,12 @@ def default_run_suffix() -> str:
 
 def is_secret_file(path: Path) -> bool:
     name = path.name.lower()
-    return name.endswith(SECRET_FILE_SUFFIXES) or any(
-        name == pattern or name.startswith(pattern) for pattern in SECRET_FILE_PATTERNS
+    if name in SECRET_SOURCE_MODULE_NAMES:
+        return False
+    return (
+        name.startswith("secrets.")
+        or name.endswith(SECRET_FILE_SUFFIXES)
+        or any(name == pattern or name.startswith(pattern) for pattern in SECRET_FILE_PATTERNS)
     )
 
 
@@ -386,12 +390,18 @@ def remote_script(config: RemoteConfig) -> str:
 
 
         def latest_eval_dir() -> Path:
+            output_roots = (LAB_ROOT / "outputs", ENV_DIR / "outputs")
             candidates = sorted(
-                (path.parent for path in LAB_ROOT.glob("outputs/evals/**/results.jsonl")),
+                (
+                    path.parent
+                    for output_root in output_roots
+                    for path in output_root.glob("evals/**/results.jsonl")
+                ),
                 key=lambda path: path.stat().st_mtime,
             )
             if not candidates:
-                raise RuntimeError("No eval output directory found under outputs/evals")
+                searched = ", ".join(str(path) for path in output_roots)
+                raise RuntimeError(f"No eval output directory found under: {searched}")
             return candidates[-1]
 
 
@@ -585,6 +595,7 @@ def remote_script(config: RemoteConfig) -> str:
                         "1",
                         "--env-path",
                         str(ENV_DIR),
+                        "--save-results",
                         "--skip-upload",
                     ],
                     cwd=LAB_ROOT,
@@ -707,10 +718,11 @@ def run_in_sandbox(
 ) -> int:
     client.upload_file(sandbox_id, "/workspace/prime-src.tar.gz", str(archive_path), timeout=600)
     upload_bytes(client, sandbox_id, "/workspace/release_e2e_remote.py", remote_script(config))
-    response = client.execute_command(
+    response = client.run_background_job(
         sandbox_id,
         "python /workspace/release_e2e_remote.py",
         timeout=timeout_seconds,
+        poll_interval=5,
     )
     if response.stdout:
         print(response.stdout, end="" if response.stdout.endswith("\n") else "\n")

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -890,11 +890,10 @@ def _lab_doctor_checks(options: LabDoctorOptions, workspace: Path) -> list[LabDo
         _managed_skill_manifest_check(),
         _global_lab_templates_check(),
         _workspace_managed_skills_check(workspace),
-        _path_check(
+        _lab_template_configs_check(
             "Lab templates",
-            workspace / ".prime" / "lab" / "templates" / "configs" / "rl" / "gsm8k.toml",
+            workspace / ".prime" / "lab" / "templates" / "configs",
             "Run prime lab sync.",
-            warning=True,
         ),
         _path_check(
             "Lab docs index",
@@ -955,18 +954,21 @@ def _managed_skill_manifest_check() -> LabDoctorCheck:
 
 
 def _global_lab_templates_check() -> LabDoctorCheck:
-    path = _global_lab_templates_dir() / "configs" / "rl" / "gsm8k.toml"
-    if path.is_file():
-        return LabDoctorCheck(
-            name="Global Lab template cache",
-            status="PASS",
-            message=f"Installed at {_global_lab_templates_dir()}.",
-        )
+    return _lab_template_configs_check(
+        "Global Lab template cache",
+        _global_lab_templates_dir() / "configs",
+        "Run prime lab sync.",
+    )
+
+
+def _lab_template_configs_check(name: str, configs_dir: Path, remediation: str) -> LabDoctorCheck:
+    if configs_dir.is_dir() and any(configs_dir.rglob("*.toml")):
+        return LabDoctorCheck(name=name, status="PASS", message=str(configs_dir.parent))
     return LabDoctorCheck(
-        name="Global Lab template cache",
+        name=name,
         status="WARN",
-        message=f"Missing {_global_lab_templates_dir()}",
-        remediation="Run prime lab sync.",
+        message=f"Missing {configs_dir.parent}",
+        remediation=remediation,
     )
 
 

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -897,6 +897,26 @@ def test_lab_sync_fully_refreshes_global_and_workspace_config_templates(
         assert not (root / "configs" / "local").exists()
 
 
+def test_lab_doctor_accepts_current_template_config_names(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    global_configs = home / ".prime" / "lab" / "templates" / "configs" / "rl"
+    workspace_configs = tmp_path / ".prime" / "lab" / "templates" / "configs" / "rl"
+    global_configs.mkdir(parents=True)
+    workspace_configs.mkdir(parents=True)
+    (global_configs / "qwen.toml").write_text('model = "qwen"\n', encoding="utf-8")
+    (workspace_configs / "qwen.toml").write_text('model = "qwen"\n', encoding="utf-8")
+
+    result = run_lab_doctor_service(LabDoctorOptions(), workspace=tmp_path)
+    checks = {check.name: check for check in result.checks}
+
+    assert checks["Global Lab template cache"].status == "PASS"
+    assert checks["Lab templates"].status == "PASS"
+
+
 def test_lab_doctor_reports_missing_selected_agent_guidance(
     tmp_path: Path,
     monkeypatch: Any,

--- a/packages/prime/tests/test_release_e2e_script.py
+++ b/packages/prime/tests/test_release_e2e_script.py
@@ -3,6 +3,7 @@ import py_compile
 import sys
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_PATH = REPO_ROOT / "packages" / "prime" / "scripts" / "release_e2e.py"
@@ -32,26 +33,35 @@ def test_env_int_treats_empty_environment_value_as_unset(monkeypatch):
     assert release_e2e.env_int("PRIME_E2E_TEST_INT", "120") == 240
 
 
-def test_source_archive_excludes_generated_secret_and_symlink_paths(tmp_path):
+def test_secret_file_detection_keeps_python_secret_command_modules():
+    release_e2e = load_release_e2e_module()
+
+    assert not release_e2e.is_secret_file(Path("secrets.py"))
+    assert release_e2e.is_secret_file(Path("secrets.ini"))
+    assert release_e2e.is_secret_file(Path("secrets.local"))
+    assert release_e2e.is_secret_file(Path("secrets.toml"))
+    assert release_e2e.is_secret_file(Path("service-account-prod.json"))
+
+
+def test_source_archive_excludes_generated_secret_and_symlink_paths(tmp_path, monkeypatch):
     release_e2e = load_release_e2e_module()
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     (repo_root / "safe.py").write_text("print('ok')\n")
-    (repo_root / ".env").write_text("SECRET=1\n")
-    (repo_root / "service-account-prod.json").write_text("{}\n")
+    (repo_root / "blocked.txt").write_text("skip\n")
     (repo_root / "build").mkdir()
     (repo_root / "build" / "artifact.py").write_text("print('skip')\n")
     (repo_root / ".venv").mkdir()
     (repo_root / ".venv" / "installed.py").write_text("print('skip')\n")
     (repo_root / "safe-link.py").symlink_to(repo_root / "safe.py")
+    monkeypatch.setattr(release_e2e, "is_secret_file", lambda path: path.name == "blocked.txt")
 
     archive = release_e2e.create_source_archive(repo_root)
     with tarfile.open(archive) as tar:
         names = set(tar.getnames())
 
     assert "prime/safe.py" in names
-    assert "prime/.env" not in names
-    assert "prime/service-account-prod.json" not in names
+    assert "prime/blocked.txt" not in names
     assert "prime/build/artifact.py" not in names
     assert "prime/.venv/installed.py" not in names
     assert "prime/safe-link.py" not in names
@@ -76,6 +86,52 @@ def test_remote_script_compiles_and_keeps_cleanup_best_effort(tmp_path):
     assert "def best_effort_cancel_hosted_evals" in script
     assert "Warning: failed to delete temporary environment" in script
     assert 'line.rsplit(":", 1)[-1]' in script
+    assert script.index('"--save-results"') < script.index('"--skip-upload"')
+    assert 'ENV_DIR / "outputs"' in script
+
+
+def test_run_in_sandbox_uses_background_job_for_long_timeout(tmp_path, capsys):
+    release_e2e = load_release_e2e_module()
+    archive = tmp_path / "prime-src.tar.gz"
+    archive.write_bytes(b"archive")
+    config = release_e2e.RemoteConfig(
+        model="deepseek/deepseek-chat",
+        hosted_mode="submit",
+        env_prefix="prime-e2e",
+        hosted_timeout_minutes=120,
+        cleanup_remote_env=True,
+        run_suffix="test",
+    )
+
+    class FakeClient:
+        def __init__(self):
+            self.uploads = []
+            self.background_call = None
+
+        def upload_file(self, sandbox_id, remote_path, local_path, timeout):
+            self.uploads.append((sandbox_id, remote_path, local_path, timeout))
+
+        def upload_bytes(self, sandbox_id, path, data, filename, timeout):
+            self.uploads.append((sandbox_id, path, filename, timeout, data))
+
+        def run_background_job(self, sandbox_id, command, timeout, poll_interval):
+            self.background_call = (sandbox_id, command, timeout, poll_interval)
+            return SimpleNamespace(exit_code=7, stdout="remote stdout\n", stderr="remote stderr\n")
+
+    client = FakeClient()
+
+    exit_code = release_e2e.run_in_sandbox(client, "sandbox-1", archive, config, 7200)
+    captured = capsys.readouterr()
+
+    assert exit_code == 7
+    assert client.background_call == (
+        "sandbox-1",
+        "python /workspace/release_e2e_remote.py",
+        7200,
+        5,
+    )
+    assert "remote stdout" in captured.out
+    assert "remote stderr" in captured.err
 
 
 def test_release_e2e_workflow_uses_standard_name_and_safe_inputs():


### PR DESCRIPTION
Fixes release E2E sandbox execution/output discovery and removes stale Lab doctor template checks found during release validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release validation (sandbox API, archive filtering, eval artifact paths) rather than production user paths, but failures could block releases or miss regressions.
> 
> **Overview**
> **Release E2E** hardens the sandbox release smoke path: long-running remote work uses `run_background_job` (with polling) instead of a one-shot execute; local eval discovery scans both lab and environment `outputs` and passes `--save-results` so `results.jsonl` is found; `secrets.py` is no longer treated as a secret when building the source tarball.
> 
> **Lab doctor** stops requiring the legacy `gsm8k.toml` template path and instead passes if the template `configs` tree contains any `*.toml`, with tests for current names like `qwen.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737d1358bcd1f18f14237727a669329ab0b7f84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->