### PR TITLE
ENG-3847: deprecate repetition_penalty, min_tokens, and seed from sampling config

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -185,9 +185,6 @@ class RLClient:
         max_steps: int = 100,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
-        repetition_penalty: Optional[float] = None,
-        min_tokens: Optional[int] = None,
-        seed: Optional[int] = None,
         temp_scheduler: Optional[Dict[str, Any]] = None,
         extra_body: Optional[Dict[str, Any]] = None,
         batch_size: int = 128,
@@ -260,15 +257,6 @@ class RLClient:
 
             if temperature is not None:
                 payload["temperature"] = temperature
-
-            if repetition_penalty is not None:
-                payload["repetition_penalty"] = repetition_penalty
-
-            if min_tokens is not None:
-                payload["min_tokens"] = min_tokens
-
-            if seed is not None:
-                payload["seed"] = seed
 
             if temp_scheduler is not None:
                 payload["temp_scheduler"] = temp_scheduler

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -380,9 +380,6 @@ class SamplingConfig(BaseModel):
 
     max_tokens: int | None = None
     temperature: float | None = None
-    repetition_penalty: float | None = None
-    min_tokens: int | None = None
-    seed: int | None = None
     temp_scheduler: TemperatureSchedulerConfig | None = None
     extra_body: Dict[str, Any] | None = None
     enable_thinking: bool | None = None
@@ -970,9 +967,6 @@ def create_run(
         has_sampling = (
             cfg.sampling.max_tokens
             or cfg.sampling.temperature is not None
-            or cfg.sampling.repetition_penalty is not None
-            or cfg.sampling.min_tokens is not None
-            or cfg.sampling.seed is not None
             or cfg.sampling.temp_scheduler is not None
             or cfg.sampling.extra_body is not None
             or cfg.sampling.enable_thinking is not None
@@ -984,12 +978,6 @@ def create_run(
                 console.print(f"  Max Tokens:          {cfg.sampling.max_tokens}")
             if cfg.sampling.temperature is not None:
                 console.print(f"  Temperature:         {cfg.sampling.temperature}")
-            if cfg.sampling.repetition_penalty is not None:
-                console.print(f"  Repetition Penalty:  {cfg.sampling.repetition_penalty}")
-            if cfg.sampling.min_tokens is not None:
-                console.print(f"  Min Tokens:          {cfg.sampling.min_tokens}")
-            if cfg.sampling.seed is not None:
-                console.print(f"  Seed:                {cfg.sampling.seed}")
             if cfg.sampling.temp_scheduler is not None:
                 ts = cfg.sampling.temp_scheduler
                 sched = f"{ts.type} ({ts.start_temperature} → {ts.end_temperature})"
@@ -1132,9 +1120,6 @@ def create_run(
             max_steps=cfg.max_steps,
             max_tokens=cfg.sampling.max_tokens,
             temperature=cfg.sampling.temperature,
-            repetition_penalty=cfg.sampling.repetition_penalty,
-            min_tokens=cfg.sampling.min_tokens,
-            seed=cfg.sampling.seed,
             temp_scheduler=cfg.sampling.temp_scheduler.model_dump(exclude_none=True)
             if cfg.sampling.temp_scheduler
             else None,


### PR DESCRIPTION
deprecated from prime-rl: https://github.com/PrimeIntellect-ai/prime-rl/pull/2656

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking change for TOML configs that still set the removed sampling keys; run creation behavior changes only for users relying on those deprecated API fields.
> 
> **Overview**
> Removes **`repetition_penalty`**, **`min_tokens`**, and **`seed`** from Hosted Training **sampling** configuration in the Prime CLI and API client, aligning the client with deprecated platform fields.
> 
> **`SamplingConfig`** no longer accepts those keys (`extra="forbid"`), so existing `rl.toml` files that still set them will fail validation at load time. **`RLClient.create_run`** drops the parameters and stops sending them in the create-run payload. The pre-launch **Sampling** summary and the **`create_run`** call path no longer surface or forward these options.
> 
> **`[buffer].seed`** and other non-sampling settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2278a3c16a71e4fde1109275ce801c5a6c1053ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->