### PR TITLE
ENG-3887 Default hosted eval sandbox and tunnel access

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1535,9 +1535,9 @@ def run_eval_cmd(
                     "rollouts_per_example": HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE,
                     "env_args": None,
                     "timeout_minutes": None,
-                    "allow_sandbox_access": False,
+                    "allow_sandbox_access": True,
                     "allow_instances_access": False,
-                    "allow_tunnel_access": False,
+                    "allow_tunnel_access": True,
                     "sampling_args": None,
                     "max_concurrent": None,
                     "max_retries": None,
@@ -1645,7 +1645,7 @@ def run_eval_cmd(
                     "allow_sandbox_access": (
                         allow_sandbox_access
                         if allow_sandbox_access
-                        else target_config.get("allow_sandbox_access", False)
+                        else target_config.get("allow_sandbox_access", True)
                     ),
                     "allow_instances_access": (
                         allow_instances_access
@@ -1655,7 +1655,7 @@ def run_eval_cmd(
                     "allow_tunnel_access": (
                         allow_tunnel_access
                         if allow_tunnel_access
-                        else target_config.get("allow_tunnel_access", False)
+                        else target_config.get("allow_tunnel_access", True)
                     ),
                     "custom_secrets": parsed_custom_secrets,
                     "sampling_args": effective_sampling_args,
@@ -1726,9 +1726,9 @@ def run_eval_cmd(
                 target["rollouts_per_example"],
                 _freeze_json_value(target.get("env_args")),
                 target.get("timeout_minutes"),
-                target.get("allow_sandbox_access", False),
+                target.get("allow_sandbox_access", True),
                 target.get("allow_instances_access", False),
-                target.get("allow_tunnel_access", False),
+                target.get("allow_tunnel_access", True),
                 _freeze_json_value(target.get("sampling_args")),
                 target.get("max_concurrent"),
                 target.get("max_retries"),
@@ -1781,9 +1781,9 @@ def run_eval_cmd(
                     env_args=target.get("env_args"),
                     name=target.get("eval_name"),
                     timeout_minutes=target.get("timeout_minutes"),
-                    allow_sandbox_access=target.get("allow_sandbox_access", False),
+                    allow_sandbox_access=target.get("allow_sandbox_access", True),
                     allow_instances_access=target.get("allow_instances_access", False),
-                    allow_tunnel_access=target.get("allow_tunnel_access", False),
+                    allow_tunnel_access=target.get("allow_tunnel_access", True),
                     custom_secrets=target.get("custom_secrets"),
                     sampling_args=target.get("sampling_args"),
                     max_concurrent=target.get("max_concurrent"),

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -42,9 +42,9 @@ class HostedEvalConfig:
     env_args: Optional[dict[str, Any]] = None
     name: Optional[str] = None
     timeout_minutes: Optional[int] = None
-    allow_sandbox_access: bool = False
+    allow_sandbox_access: bool = True
     allow_instances_access: bool = False
-    allow_tunnel_access: bool = False
+    allow_tunnel_access: bool = True
     custom_secrets: Optional[dict[str, str]] = None
     sampling_args: Optional[dict[str, Any]] = None
     max_concurrent: Optional[int] = None

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -117,6 +117,9 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
         captured["inference_model"] = config.inference_model
         captured["num_examples"] = config.num_examples
         captured["rollouts_per_example"] = config.rollouts_per_example
+        captured["allow_sandbox_access"] = config.allow_sandbox_access
+        captured["allow_instances_access"] = config.allow_instances_access
+        captured["allow_tunnel_access"] = config.allow_tunnel_access
         return {"evaluation_id": "eval-123"}
 
     monkeypatch.setattr(
@@ -136,6 +139,9 @@ def test_eval_run_hosted_invokes_hosted_runner(monkeypatch):
     assert captured["inference_model"] == "openai/gpt-4.1-mini"
     assert captured["num_examples"] == 5
     assert captured["rollouts_per_example"] == 3
+    assert captured["allow_sandbox_access"] is True
+    assert captured["allow_instances_access"] is False
+    assert captured["allow_tunnel_access"] is True
     assert "Hosted evaluation started" in result.output
     assert "prime eval logs eval-123 -f" in result.output
 
@@ -353,6 +359,9 @@ def test_create_hosted_evaluation_adds_team_id_to_payload(monkeypatch):
     assert result["evaluation_id"] == "eval-123"
     assert captured["endpoint"] == "/hosted-evaluations"
     assert captured["json"]["team_id"] == "team-123"
+    assert captured["json"]["eval_config"]["allow_sandbox_access"] is True
+    assert captured["json"]["eval_config"]["allow_instances_access"] is False
+    assert captured["json"]["eval_config"]["allow_tunnel_access"] is True
 
 
 def test_create_hosted_evaluation_includes_sampling_args_in_payload(monkeypatch):


### PR DESCRIPTION
Implements the Prime CLI side of ENG-3887 by defaulting hosted eval CLI runs and payloads to sandbox and tunnel access while leaving instances opt-in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens default hosted-eval isolation boundaries (sandbox I/O and tunnels) for all runs that omit explicit config, which increases exposure if environments misuse those capabilities; instances are unchanged.
> 
> **Overview**
> **Hosted eval defaults now enable sandbox and tunnel access** for Prime CLI runs and API payloads, while **`allow_instances_access` stays off** unless explicitly set (CLI flag or TOML).
> 
> Changes span `HostedEvalConfig`, the hosted `eval run` path (inline defaults, TOML/CLI merge fallbacks, target grouping keys, and `HostedEvalConfig` construction), and tests that assert the new defaults on CLI invocation and `/hosted-evaluations` `eval_config` payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a5c0a823bd1c115f7784eaccc6695f877118b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->