### PR TITLE
improvement(inference): drop created column, add search/sort to models

### DIFF
--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -64,10 +64,10 @@ def _sort_models(models: List[Dict[str, Any]], sort: str, order: str) -> List[Di
 def list_models(
     output: str = typer.Option("table", "--output", "-o", help="table|json"),
     search: Optional[str] = typer.Option(
-        None, "--search", "-s", help="Case-insensitive substring match on model id"
+        None, "--search", "-q", help="Case-insensitive substring match on model id"
     ),
-    sort: str = typer.Option("id", "--sort", help="Sort by: id, input, output"),
-    order: str = typer.Option("asc", "--order", help="Sort order: asc, desc"),
+    sort: str = typer.Option("id", "--sort", "-s", help="Sort by: id, input, output"),
+    order: str = typer.Option("asc", "--order", "-d", help="Sort order (direction): asc, desc"),
 ) -> None:
     """List available models from Prime Inference (/v1/models)."""
     validate_output_format(output, console)

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime as _dt
 import sys
 from typing import Any, Dict, Iterable, List, Optional, cast
 
@@ -29,29 +28,62 @@ MODELS_JSON_HELP = json_output_help(
     "Compatibility fallback: .models[] may be present instead of .data[]",
 )
 
+_SORT_KEYS = ("id", "input", "output")
+_ORDER_KEYS = ("asc", "desc")
 
-def _fmt_created(val: str) -> str:
-    """Format created timestamp for display"""
+
+def _price(m: Dict[str, Any], key: str) -> Optional[float]:
+    pricing = m.get("pricing") or {}
+    val = pricing.get(key)
+    if val is None:
+        return None
     try:
-        # if epoch seconds
-        ts = int(val)
-        return _dt.datetime.fromtimestamp(ts, _dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-    except Exception:
-        return val or ""
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sort_models(models: List[Dict[str, Any]], sort: str, order: str) -> List[Dict[str, Any]]:
+    reverse = order == "desc"
+    if sort == "id":
+        return sorted(models, key=lambda m: str(m.get("id", "")).lower(), reverse=reverse)
+
+    price_key = "input_usd_per_mtok" if sort == "input" else "output_usd_per_mtok"
+
+    # Null pricing always sorts last regardless of order.
+    def key(m: Dict[str, Any]) -> tuple:
+        p = _price(m, price_key)
+        if p is None:
+            return (1, 0.0)
+        return (0, -p if reverse else p)
+
+    return sorted(models, key=key)
 
 
 @app.command("models", epilog=MODELS_JSON_HELP)
 def list_models(
     output: str = typer.Option("table", "--output", "-o", help="table|json"),
+    search: Optional[str] = typer.Option(
+        None, "--search", "-s", help="Case-insensitive substring match on model id"
+    ),
+    sort: str = typer.Option("id", "--sort", help="Sort by: id, input, output"),
+    order: str = typer.Option("asc", "--order", help="Sort order: asc, desc"),
 ) -> None:
     """List available models from Prime Inference (/v1/models)."""
     validate_output_format(output, console)
+    if sort not in _SORT_KEYS:
+        console.print(f"[red]Error:[/red] --sort must be one of: {', '.join(_SORT_KEYS)}")
+        raise typer.Exit(1)
+    if order not in _ORDER_KEYS:
+        console.print(f"[red]Error:[/red] --order must be one of: {', '.join(_ORDER_KEYS)}")
+        raise typer.Exit(1)
+
     try:
         client = InferenceClient(require_auth=False)
         data = client.list_models()
 
         # Expect OpenAI-style: {"object":"list","data":[{"id":..., ...}, ...]}
-        models = []
+        models: List[Dict[str, Any]] = []
         if isinstance(data, dict):
             if "data" in data and isinstance(data["data"], list):
                 models = data["data"]
@@ -60,8 +92,24 @@ def list_models(
         elif isinstance(data, list):
             models = data
 
+        if search:
+            needle = search.lower()
+            models = [m for m in models if needle in str(m.get("id", "")).lower()]
+
+        models = _sort_models(models, sort, order)
+
         if output == "json":
-            output_data_as_json(data, console)
+            if isinstance(data, dict):
+                payload = dict(data)
+                if "data" in payload:
+                    payload["data"] = models
+                elif "models" in payload:
+                    payload["models"] = models
+                else:
+                    payload = {"data": models}
+                output_data_as_json(payload, console)
+            else:
+                output_data_as_json(models, console)
             return
 
         if not models:
@@ -70,20 +118,17 @@ def list_models(
 
         table = Table(title="Prime Inference — Models")
         table.add_column("id", style="cyan")
-        table.add_column("created", style="magenta")
         table.add_column("input $/1M tok", style="green", justify="right")
         table.add_column("output $/1M tok", style="green", justify="right")
 
         for m in models:
             mid = str(m.get("id", ""))
-            created = _fmt_created(str(m.get("created", "")))
             pricing = m.get("pricing") or {}
             pin = pricing.get("input_usd_per_mtok")
             pout = pricing.get("output_usd_per_mtok")
 
             table.add_row(
                 mid,
-                created,
                 format_price_per_mtok(pin),
                 format_price_per_mtok(pout),
             )

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -76,3 +76,140 @@ def test_models_command_uses_optional_auth_client(monkeypatch: pytest.MonkeyPatc
     assert result.exit_code == 0, result.output
     assert seen_kwargs["require_auth"] is False
     assert '"id": "qwen/qwen3-8b"' in result.output
+
+
+def _models_fixture() -> Dict[str, Any]:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "zeta/cheap",
+                "pricing": {"input_usd_per_mtok": 0.10, "output_usd_per_mtok": 0.40},
+            },
+            {
+                "id": "alpha/premium",
+                "pricing": {"input_usd_per_mtok": 5.00, "output_usd_per_mtok": 15.00},
+            },
+            {
+                "id": "mid/standard",
+                "pricing": {"input_usd_per_mtok": 1.00, "output_usd_per_mtok": 2.00},
+            },
+            {"id": "no/pricing"},
+        ],
+    }
+
+
+def _patch_models(monkeypatch: pytest.MonkeyPatch, payload: Any) -> None:
+    class DummyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def list_models(self) -> Any:
+            return payload
+
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+
+def _ids_in_order(stdout: str, ids: list[str]) -> list[int]:
+    return [stdout.find(i) for i in ids]
+
+
+def test_models_default_table_omits_created_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, {"object": "list", "data": [{"id": "x", "created": 1700000000}]})
+
+    result = CliRunner().invoke(app, ["inference", "models"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "created" not in result.output.lower()
+    assert "x" in result.output
+
+
+def test_models_search_filters_by_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models", "--search", "ALPHA"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "alpha/premium" in result.output
+    assert "zeta/cheap" not in result.output
+    assert "mid/standard" not in result.output
+
+
+def test_models_sort_by_input_price_ascending(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models", "--sort", "input"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    positions = _ids_in_order(
+        result.output, ["zeta/cheap", "mid/standard", "alpha/premium", "no/pricing"]
+    )
+    assert all(p >= 0 for p in positions)
+    assert positions == sorted(positions)
+
+
+def test_models_sort_by_output_price_descending(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(
+        app,
+        ["inference", "models", "--sort", "output", "--order", "desc"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    positions = _ids_in_order(
+        result.output, ["alpha/premium", "mid/standard", "zeta/cheap", "no/pricing"]
+    )
+    assert all(p >= 0 for p in positions)
+    assert positions == sorted(positions)
+
+
+def test_models_sort_id_default_is_alphabetical(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    positions = _ids_in_order(
+        result.output, ["alpha/premium", "mid/standard", "no/pricing", "zeta/cheap"]
+    )
+    assert all(p >= 0 for p in positions)
+    assert positions == sorted(positions)
+
+
+def test_models_invalid_sort_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models", "--sort", "nope"], env=TEST_ENV)
+
+    assert result.exit_code == 1
+    assert "--sort must be one of" in result.output
+
+
+def test_models_json_output_applies_search_and_sort(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "inference",
+            "models",
+            "--output",
+            "json",
+            "--search",
+            "/",
+            "--sort",
+            "input",
+            "--order",
+            "desc",
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    positions = _ids_in_order(
+        result.output, ["alpha/premium", "mid/standard", "zeta/cheap", "no/pricing"]
+    )
+    assert all(p >= 0 for p in positions)
+    assert positions == sorted(positions)

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -187,6 +187,23 @@ def test_models_invalid_sort_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "--sort must be one of" in result.output
 
 
+def test_models_short_flags_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(
+        app,
+        ["inference", "models", "-q", "/", "-s", "input", "-d", "desc"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    positions = _ids_in_order(
+        result.output, ["alpha/premium", "mid/standard", "zeta/cheap", "no/pricing"]
+    )
+    assert all(p >= 0 for p in positions)
+    assert positions == sorted(positions)
+
+
 def test_models_json_output_applies_search_and_sort(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_models(monkeypatch, _models_fixture())
 


### PR DESCRIPTION
The `prime inference models` table showed a `created` timestamp passed through from OpenAI's `/v1/models` schema. It isn't useful when picking a model and ate horizontal space. Also, no way to filter or sort by price.

- Drops the `created` column from the default table (still in JSON since it's part of the upstream schema).
- Adds `--search/-s` for case-insensitive substring match on model id.
- Adds `--sort id|input|output` (default `id`) and `--order asc|desc` (default `asc`). Models with null pricing sort last on price sorts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation and local list processing for `/v1/models`; no auth, API, or billing logic changes.
> 
> **Overview**
> The **`prime inference models`** command is tightened for model shopping: the default **table** no longer shows a **`created`** column (upstream fields remain in raw **JSON**).
> 
> New client-side controls filter and reorder the model list before display: **`--search` / `-q`** does a case-insensitive substring match on model **id**; **`--sort`** (`id`, `input`, `output`, default `id`) and **`--order`** (`asc` / `desc`) sort alphabetically or by per-million-token pricing, with models missing pricing always last on price sorts. Invalid sort/order values exit with an error. **JSON** output applies the same filter/sort by rewriting the `data` or `models` array in the response envelope.
> 
> Tests cover table layout, search, sort orders, short flags, validation, and JSON behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49af0b08436bf9d7c9aa1912589eb977e7c7200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->