### PR TITLE
prime train: --cluster flag overrides config cluster_name

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -879,6 +879,16 @@ def create_run(
         help="Skip action status check and run even if environment action failed.",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    cluster: Optional[str] = typer.Option(
+        None,
+        "--cluster",
+        help=(
+            "Pin the dispatch to a specific cluster by name. Overrides the "
+            "TOML's `cluster_name` field. The backend hard-fails with a 400 "
+            "error if the cluster is unknown, not allocated, or out of "
+            "capacity — no silent fallback to another cluster."
+        ),
+    ),
 ) -> None:
     """Launch a Hosted Training run from a config file.
 
@@ -890,6 +900,14 @@ def create_run(
 
     console.print(f"[dim]Loading config from {config_path}[/dim]\n")
     cfg = load_config(config_path)
+
+    # `--cluster` overrides the TOML's `cluster_name` so a user can
+    # retarget a single dispatch without editing the config. We don't
+    # validate the name client-side: the backend's picker is the source
+    # of truth for which clusters the caller can hit, and it returns a
+    # clear 400 with the available alternatives when the name is wrong.
+    if cluster is not None:
+        cfg.cluster_name = cluster
 
     # Collect secrets from all sources
     def warn(msg: str) -> None:

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -65,6 +65,134 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert Path("rl.toml").exists()
 
 
+def test_train_help_lists_cluster_flag() -> None:
+    # The flag has to be discoverable from `--help` so users don't have
+    # to grep source to find it. Regression guard against future arg
+    # reorders silently hiding the option.
+    result = runner.invoke(app, ["train", "--help"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "--cluster" in result.output
+
+
+def test_train_cluster_flag_overrides_config_cluster_name(monkeypatch, tmp_path: Path) -> None:
+    # CLI `--cluster` should win over `cluster_name = "..."` in the TOML
+    # so users can retarget a single dispatch without editing the config.
+    # We don't validate the cluster name client-side: the backend's picker
+    # is the source of truth — verify here only that the override reaches
+    # the RLClient payload as `cluster_name`.
+    captured: dict[str, Any] = {}
+
+    def mock_create_run(self: Any, **kwargs: Any) -> Any:
+        captured["kwargs"] = kwargs
+
+        class _Run:
+            id = "run-1"
+            status = "QUEUED"
+            runs_ahead = None
+
+            def model_dump(self_inner) -> dict[str, Any]:
+                return {"id": "run-1", "status": "QUEUED"}
+
+        return _Run()
+
+    def mock_list_models(self: Any, **kwargs: Any) -> list:
+        return []
+
+    monkeypatch.setattr(
+        "prime_cli.api.rl.RLClient.create_run",
+        mock_create_run,
+    )
+    monkeypatch.setattr(
+        "prime_cli.api.rl.RLClient.list_models",
+        mock_list_models,
+    )
+
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3-0.6B"\n'
+        'cluster_name = "config-cluster"\n'
+        "\n"
+        "[[env]]\n"
+        'id = "reverse-text"\n'
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            str(config_path),
+            "--cluster",
+            "flag-cluster",
+            "--output",
+            "json",
+            "--yes",
+            "--skip-action-check",
+        ],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["cluster_name"] == "flag-cluster"
+
+
+def test_train_without_cluster_flag_uses_config_cluster_name(monkeypatch, tmp_path: Path) -> None:
+    # Sanity check the inverse: with no --cluster, the TOML's
+    # cluster_name is what reaches the backend. Without this we'd never
+    # know if the override path silently took over the no-override path.
+    captured: dict[str, Any] = {}
+
+    def mock_create_run(self: Any, **kwargs: Any) -> Any:
+        captured["kwargs"] = kwargs
+
+        class _Run:
+            id = "run-1"
+            status = "QUEUED"
+            runs_ahead = None
+
+            def model_dump(self_inner) -> dict[str, Any]:
+                return {"id": "run-1", "status": "QUEUED"}
+
+        return _Run()
+
+    def mock_list_models(self: Any, **kwargs: Any) -> list:
+        return []
+
+    monkeypatch.setattr(
+        "prime_cli.api.rl.RLClient.create_run",
+        mock_create_run,
+    )
+    monkeypatch.setattr(
+        "prime_cli.api.rl.RLClient.list_models",
+        mock_list_models,
+    )
+
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3-0.6B"\n'
+        'cluster_name = "config-cluster"\n'
+        "\n"
+        "[[env]]\n"
+        'id = "reverse-text"\n'
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            str(config_path),
+            "--output",
+            "json",
+            "--yes",
+            "--skip-action-check",
+        ],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["cluster_name"] == "config-cluster"
+
+
 def test_train_request_submits_model_request(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
Adds a `--cluster <name>` flag to `prime train <config>` so users can retarget a single dispatch without editing the TOML. The flag wins over `cluster_name` in the config and forwards to the backend payload — the server returns a clear 400 if the cluster is unknown or out of capacity.

- New flag piped through to `RLClient.create_run`
- Works for the legacy `prime rl run` alias too (shared entrypoint)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only override of an existing dispatch field; cluster enforcement remains on the backend with no new client-side validation logic.
> 
> **Overview**
> Adds **`--cluster <name>`** to **`prime train <config.toml>`** so a single launch can pin dispatch to a named cluster without editing the TOML. When set, it **overrides** `cluster_name` in the config and is sent to **`RLClient.create_run`** as before; cluster validity and capacity are left to the **backend** (documented as a hard **400**, no client-side name check).
> 
> CLI tests cover **`--help`** visibility, flag-over-TOML behavior, and the unchanged path when the flag is omitted (still uses config `cluster_name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c345a1b13714bc5649d01501151f36553fb3da77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->