### PR TITLE
release: prime CLI 0.6.12

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Release PR for prime CLI 0.6.12.\n\nValidation run locally:\n- uv run pytest packages/prime/tests/test_inference_models.py packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_rl_config.py packages/prime/tests/test_lab_setup.py packages/prime/tests/test_windows_cli.py -q\n- uv run pytest packages/prime/tests -q\n- uv run ruff check packages/prime/src packages/prime/tests\n- uv run ty check packages/prime/src\n- uv build packages/prime --out-dir /tmp/prime-cli-dist-0612 and fresh-venv wheel smoke for prime --version/--help\n- uv pip compile packages/prime/pyproject.toml --python-platform windows --python-version 3.11 --all-extras\n\nManual smokes:\n- prime inference models --output json --search qwen --sort input --order desc\n- prime lab setup --no-interactive --agent grok --skip-install --skip-agents-md in a temp workspace\n- prime train init --force template check for SFT teacher client and removed deprecated knobs\n- prime eval run --help contains hosted sandbox/tunnel flags\n\nNotes:\n- Linux remote validation also passed focused tests, full prime tests, lint/type checks, build/install smoke.\n- Native Windows runtime was not available on the Linux dev box; Windows coverage is dependency resolution plus the dedicated no-tunnel-import startup regression test.\n- Live prime-sandboxes tests were not run locally because PRIME_API_KEY is absent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant version string change with no runtime logic impact.
> 
> **Overview**
> Bumps the published **prime** CLI package version from **0.6.11** to **0.6.12** by updating `__version__` in `prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4616078e7b273d1129b6d3c14313966ca16d2c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->