### PR TITLE
fix: keep eval push compatible with released prime-evals

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 dependencies = [
     "prime-sandboxes>=0.2.26",
-    "prime-evals>=0.2.1",
+    "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1030,7 +1030,7 @@ def _push_samples_accepts_progress_callback(client: EvalsClient) -> bool:
     try:
         parameters = inspect.signature(client.push_samples).parameters.values()
     except (TypeError, ValueError):
-        return True
+        return False
     return any(
         parameter.name == "progress_callback" or parameter.kind is inspect.Parameter.VAR_KEYWORD
         for parameter in parameters

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 import json
 import re
 import time
@@ -1012,7 +1013,7 @@ def _resolve_eval_viewer_url(evaluation_id: str, response: Optional[dict[str, An
 def _push_samples_with_progress(
     client: EvalsClient, evaluation_id: str, samples: list[dict[str, Any]]
 ) -> None:
-    if not console.is_terminal:
+    if not console.is_terminal or not _push_samples_accepts_progress_callback(client):
         client.push_samples(evaluation_id, samples)
         return
 
@@ -1023,6 +1024,17 @@ def _push_samples_with_progress(
             samples,
             progress_callback=lambda uploaded: progress.update(task_id, advance=uploaded),
         )
+
+
+def _push_samples_accepts_progress_callback(client: EvalsClient) -> bool:
+    try:
+        parameters = inspect.signature(client.push_samples).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        parameter.name == "progress_callback" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
 
 
 def _require_published_environment_for_eval_push(env_name: str, eval_path: Path) -> None:

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -209,6 +209,33 @@ def test_push_samples_with_progress_supports_old_prime_evals_client(monkeypatch)
     assert calls == [("eval-123", samples)]
 
 
+def test_push_samples_with_progress_skips_callback_when_signature_is_uninspectable(monkeypatch):
+    calls = []
+
+    class DummyClient:
+        def push_samples(self, evaluation_id, samples):
+            calls.append((evaluation_id, samples))
+
+    class DummyConsole:
+        is_terminal = True
+
+    class UnexpectedProgress:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("uninspectable clients should skip progress callbacks")
+
+    monkeypatch.setattr("prime_cli.commands.evals.console", DummyConsole())
+    monkeypatch.setattr("prime_cli.commands.evals.Progress", UnexpectedProgress)
+    monkeypatch.setattr(
+        "prime_cli.commands.evals.inspect.signature",
+        lambda _callable: (_ for _ in ()).throw(ValueError("no signature")),
+    )
+
+    samples = [{"example_id": "1"}]
+    _push_samples_with_progress(DummyClient(), "eval-123", samples)
+
+    assert calls == [("eval-123", samples)]
+
+
 class TestPushSingleEval:
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
         metadata = {"env": "owner/gsm8k", "model": "gpt-4"}

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -5,6 +5,7 @@ import typer
 from prime_cli.commands.evals import (
     _has_eval_files,
     _load_eval_directory,
+    _push_samples_with_progress,
     _push_single_eval,
     _validate_eval_path,
 )
@@ -183,6 +184,29 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
         "is_public": False,
         "name": "custom eval",
     }
+
+
+def test_push_samples_with_progress_supports_old_prime_evals_client(monkeypatch):
+    calls = []
+
+    class DummyClient:
+        def push_samples(self, evaluation_id, samples):
+            calls.append((evaluation_id, samples))
+
+    class DummyConsole:
+        is_terminal = True
+
+    class UnexpectedProgress:
+        def __init__(self, *_args, **_kwargs):
+            raise AssertionError("old prime-evals clients should skip progress callbacks")
+
+    monkeypatch.setattr("prime_cli.commands.evals.console", DummyConsole())
+    monkeypatch.setattr("prime_cli.commands.evals.Progress", UnexpectedProgress)
+
+    samples = [{"example_id": "1"}]
+    _push_samples_with_progress(DummyClient(), "eval-123", samples)
+
+    assert calls == [("eval-123", samples)]
 
 
 class TestPushSingleEval:


### PR DESCRIPTION
Splits the eval-push fix out of the Prime CLI 0.6.12 release PR.

Root cause:
- `prime==0.6.10/0.6.11` calls `EvalsClient.push_samples(..., progress_callback=...)` for terminal progress display.
- PyPI `prime-evals==0.2.2` reports version 0.2.2 but its `push_samples` signature does not include `progress_callback`.
- Result: terminal `prime eval push` fails after creating the evaluation with `unexpected keyword argument 'progress_callback'`.

Changes:
- Keep `prime eval push` compatible with older/released `prime-evals` by checking whether `push_samples` accepts `progress_callback` before passing it.
- Add a regression test for the old client shape.
- Bump `prime-evals` to 0.2.3 and require `prime-evals>=0.2.3` for future `prime` installs.

Validation:
- `uv run pytest packages/prime/tests/test_eval_push.py packages/prime-evals/tests/test_evals.py -q`
- `uv run ruff check packages/prime/src/prime_cli/commands/evals.py packages/prime/tests/test_eval_push.py packages/prime-evals/src/prime_evals/__init__.py`
- `uv run ty check packages/prime/src`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI compatibility guard and dependency pin; no auth or data-path changes beyond safer eval upload behavior.
> 
> **Overview**
> Fixes terminal **`prime eval push`** failing against older PyPI **`prime-evals`** builds that lack a **`progress_callback`** argument on **`EvalsClient.push_samples`**.
> 
> **`prime_cli`** now inspects **`push_samples`** at runtime and only enables Rich upload progress when the client accepts **`progress_callback`** (or `**kwargs`); otherwise it calls the two-argument API. Regression tests cover legacy clients and uninspectable signatures.
> 
> **`prime-evals`** is bumped to **0.2.3**, and **`prime`** requires **`prime-evals>=0.2.3`** so new installs align with the SDK that supports progress callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9201e87b953909a1f92c05bb6dd371554d9da941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->