### PR TITLE
feature: idle_timeout_minutes for sandboxes

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -151,6 +151,23 @@ class UpdateSandboxRequest(BaseModel):
     secrets: Optional[Dict[str, str]] = None
     network_access: Optional[bool] = None
 
+    @model_validator(mode="after")
+    def validate_idle_timeout(self) -> "UpdateSandboxRequest":
+        if self.idle_timeout_minutes is None:
+            return self
+        if self.idle_timeout_minutes < 1:
+            raise ValueError("idle_timeout_minutes must be >= 1")
+        if (
+            self.timeout_minutes is not None
+            and self.timeout_minutes > 0
+            and self.idle_timeout_minutes > self.timeout_minutes
+        ):
+            raise ValueError(
+                "idle_timeout_minutes must be <= timeout_minutes "
+                f"(got idle={self.idle_timeout_minutes}, lifetime={self.timeout_minutes})"
+            )
+        return self
+
 
 class CommandRequest(BaseModel):
     """Execute command request model"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -44,6 +44,8 @@ class Sandbox(BaseModel):
     network_access: bool = Field(True, alias="networkAccess")
     status: str
     timeout_minutes: int = Field(..., alias="timeoutMinutes")
+    idle_timeout_minutes: Optional[int] = Field(None, alias="idleTimeoutMinutes")
+    termination_reason: Optional[str] = Field(None, alias="terminationReason")
     environment_vars: Optional[Dict[str, Any]] = Field(None, alias="environmentVars")
     secrets: Optional[Dict[str, Any]] = Field(None, alias="secrets")
     advanced_configs: Optional[AdvancedConfigs] = Field(None, alias="advancedConfigs")
@@ -90,6 +92,7 @@ class CreateSandboxRequest(BaseModel):
     vm: bool = False
     network_access: bool = True
     timeout_minutes: int = 60
+    idle_timeout_minutes: Optional[int] = None
     environment_vars: Optional[Dict[str, str]] = None
     secrets: Optional[Dict[str, str]] = None
     labels: List[str] = Field(default_factory=list)
@@ -116,6 +119,19 @@ class CreateSandboxRequest(BaseModel):
             raise ValueError("guaranteed is not supported for VM sandboxes")
         return self
 
+    @model_validator(mode="after")
+    def validate_idle_timeout(self) -> "CreateSandboxRequest":
+        if self.idle_timeout_minutes is None:
+            return self
+        if self.idle_timeout_minutes < 1:
+            raise ValueError("idle_timeout_minutes must be >= 1")
+        if self.timeout_minutes > 0 and self.idle_timeout_minutes > self.timeout_minutes:
+            raise ValueError(
+                "idle_timeout_minutes must be <= timeout_minutes "
+                f"(got idle={self.idle_timeout_minutes}, lifetime={self.timeout_minutes})"
+            )
+        return self
+
 
 class UpdateSandboxRequest(BaseModel):
     """Update sandbox request model"""
@@ -129,6 +145,7 @@ class UpdateSandboxRequest(BaseModel):
     gpu_count: Optional[int] = None
     gpu_type: Optional[str] = None
     timeout_minutes: Optional[int] = None
+    idle_timeout_minutes: Optional[int] = None
     environment_vars: Optional[Dict[str, str]] = None
     registry_credentials_id: Optional[str] = None
     secrets: Optional[Dict[str, str]] = None

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -596,6 +596,17 @@ def create(
             )
             raise typer.Exit(1)
 
+        if idle_timeout_minutes is not None:
+            if idle_timeout_minutes < 1:
+                console.print("[red]--idle-timeout-minutes must be at least 1.[/red]")
+                raise typer.Exit(1)
+            if timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:
+                console.print(
+                    "[red]--idle-timeout-minutes must be <= --timeout-minutes "
+                    f"(got idle={idle_timeout_minutes}, lifetime={timeout_minutes}).[/red]"
+                )
+                raise typer.Exit(1)
+
         if not docker_image:
             console.print(
                 "[red]Docker image is required.[/red] Provide a DOCKER_IMAGE positional argument."

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -166,6 +166,8 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
         "vm": sandbox.vm,
         "network_access": sandbox.network_access,
         "timeout_minutes": sandbox.timeout_minutes,
+        "idle_timeout_minutes": sandbox.idle_timeout_minutes,
+        "termination_reason": sandbox.termination_reason,
         "labels": sandbox.labels,
         "created_at": iso_timestamp(sandbox.created_at),
         "user_id": sandbox.user_id,
@@ -408,6 +410,10 @@ def get(
             )
             table.add_row("Network Access", network_display)
             table.add_row("Timeout (minutes)", str(sandbox_data["timeout_minutes"]))
+            if sandbox_data.get("idle_timeout_minutes") is not None:
+                table.add_row("Idle Timeout (minutes)", str(sandbox_data["idle_timeout_minutes"]))
+            if sandbox_data.get("termination_reason"):
+                table.add_row("Termination Reason", sandbox_data["termination_reason"])
 
             # Show labels
             labels_display = ", ".join(sandbox_data["labels"]) if sandbox_data["labels"] else "None"
@@ -494,6 +500,14 @@ def create(
         help="Allow outbound internet access (enabled by default)",
     ),
     timeout_minutes: int = typer.Option(60, help="Timeout in minutes"),
+    idle_timeout_minutes: Optional[int] = typer.Option(
+        None,
+        "--idle-timeout-minutes",
+        help=(
+            "Terminate the sandbox if no /exec, /upload, /download, or "
+            "/read-file request is seen for this many minutes. Disabled by default."
+        ),
+    ),
     team_id: Optional[str] = typer.Option(
         None, help="Team ID (uses config team_id if not specified)"
     ),
@@ -621,6 +635,7 @@ def create(
             vm=vm,
             network_access=network_access,
             timeout_minutes=timeout_minutes,
+            idle_timeout_minutes=idle_timeout_minutes,
             environment_vars=env_vars if env_vars else None,
             secrets=secrets_vars if secrets_vars else None,
             labels=labels if labels else [],
@@ -644,6 +659,8 @@ def create(
         network_status = "[green]Enabled[/green]" if network_access else "[yellow]Disabled[/yellow]"
         console.print(f"Network Access: {network_status}")
         console.print(f"Timeout: {timeout_minutes} minutes")
+        if idle_timeout_minutes is not None:
+            console.print(f"Idle Timeout: {idle_timeout_minutes} minutes")
         console.print(f"Team: {team_id or 'Personal'}")
         console.print(f"Region: {region or 'Backend default'}")
         if registry_credentials_id:

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -166,8 +166,12 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
         "vm": sandbox.vm,
         "network_access": sandbox.network_access,
         "timeout_minutes": sandbox.timeout_minutes,
-        "idle_timeout_minutes": sandbox.idle_timeout_minutes,
-        "termination_reason": sandbox.termination_reason,
+        # Read with getattr so an older installed prime-sandboxes wheel
+        # (without these fields) still renders the details view instead of
+        # raising AttributeError. The SDK floor will be bumped in a follow-up
+        # release PR.
+        "idle_timeout_minutes": getattr(sandbox, "idle_timeout_minutes", None),
+        "termination_reason": getattr(sandbox, "termination_reason", None),
         "labels": sandbox.labels,
         "created_at": iso_timestamp(sandbox.created_at),
         "user_id": sandbox.user_id,
@@ -634,6 +638,20 @@ def create(
             suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
             name = f"{base_name}-{suffix}"
 
+        # Only forward idle_timeout_minutes if the installed prime-sandboxes
+        # SDK actually defines the field; older wheels would silently drop it
+        # via Pydantic's extra="ignore" default, hiding the misconfiguration
+        # from the user. SDK version floor is bumped in a follow-up release PR.
+        request_kwargs: Dict[str, Any] = {}
+        if idle_timeout_minutes is not None:
+            if "idle_timeout_minutes" in CreateSandboxRequest.model_fields:
+                request_kwargs["idle_timeout_minutes"] = idle_timeout_minutes
+            else:
+                console.print(
+                    "[yellow]Warning:[/yellow] installed prime-sandboxes SDK "
+                    "does not support --idle-timeout-minutes; ignoring."
+                )
+
         request = CreateSandboxRequest(
             name=name,
             docker_image=docker_image,
@@ -646,13 +664,13 @@ def create(
             vm=vm,
             network_access=network_access,
             timeout_minutes=timeout_minutes,
-            idle_timeout_minutes=idle_timeout_minutes,
             environment_vars=env_vars if env_vars else None,
             secrets=secrets_vars if secrets_vars else None,
             labels=labels if labels else [],
             team_id=team_id,
             region=region,
             registry_credentials_id=registry_credentials_id,
+            **request_kwargs,
             guaranteed=guaranteed,
         )
 

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -688,7 +688,9 @@ def create(
         network_status = "[green]Enabled[/green]" if network_access else "[yellow]Disabled[/yellow]"
         console.print(f"Network Access: {network_status}")
         console.print(f"Timeout: {timeout_minutes} minutes")
-        if idle_timeout_minutes is not None:
+        # Only show the idle timeout in the summary when the SDK actually
+        # accepted it; otherwise we'd display a value the backend never sees.
+        if idle_timeout_minutes is not None and "idle_timeout_minutes" in request_kwargs:
             console.print(f"Idle Timeout: {idle_timeout_minutes} minutes")
         console.print(f"Team: {team_id or 'Personal'}")
         console.print(f"Region: {region or 'Backend default'}")


### PR DESCRIPTION
## Summary

- Adds \`idle_timeout_minutes\` to \`CreateSandboxRequest\` / \`UpdateSandboxRequest\` (SDK).
- Surfaces \`idle_timeout_minutes\` and \`termination_reason\` on the \`Sandbox\` response.
- New \`--idle-timeout-minutes\` flag on \`prime sandbox create\`; the value shows up in details + JSON output.

Pairs with platform PR PrimeIntellect-ai/platform#2784, which is the backend + sidecar side that actually enforces it. Until that lands, sending the field is a no-op (platform ignores unknown nullable columns).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API/CLI fields with local validation; enforcement lives in a separate platform PR, and the CLI guards mixed SDK versions explicitly.
> 
> **Overview**
> Adds **sandbox idle timeout** to the `prime-sandboxes` SDK and `prime sandbox` CLI, ahead of platform enforcement in a paired backend PR.
> 
> The SDK now exposes optional **`idle_timeout_minutes`** on create/update requests and on the **`Sandbox`** response, plus **`termination_reason`** when a sandbox ends. Pydantic validators require idle timeout ≥ 1 and **idle ≤ lifetime** (`timeout_minutes`) when both apply.
> 
> **`prime sandbox create`** gains **`--idle-timeout-minutes`** (terminate after no exec/upload/download/read-file activity). Create flow validates the same bounds, shows idle timeout in the pre-create summary when accepted, and only sends the field if the installed SDK defines it—older wheels get a warning instead of silently dropping the flag. **`prime sandbox get`** (table + JSON) shows idle timeout and termination reason when present, using `getattr` so older SDK versions still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c207bc6dd39c713fd02776751e28bd26fa252453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->