### PR TITLE
test: add Prime CLI runtime regression checks

### DIFF
--- a/packages/prime/scripts/release_e2e.py
+++ b/packages/prime/scripts/release_e2e.py
@@ -381,6 +381,49 @@ def remote_script(config: RemoteConfig) -> str:
             run(["prime", "--version"], timeout=120)
 
 
+        def installed_runtime_regression_checks() -> None:
+            run(
+                [
+                    str(VENV / "bin" / "python"),
+                    "-c",
+                    textwrap.dedent(
+                        '''
+                        import inspect
+
+                        from prime_cli.commands import evals
+                        from prime_tunnel import Tunnel
+
+                        if "labels" not in inspect.signature(Tunnel).parameters:
+                            raise SystemExit("prime_tunnel.Tunnel must accept labels")
+
+                        calls = []
+
+                        class OldEvalsClient:
+                            def push_samples(self, evaluation_id, samples):
+                                calls.append((evaluation_id, samples))
+
+                        class TerminalConsole:
+                            is_terminal = True
+
+                        original_console = evals.console
+                        evals.console = TerminalConsole()
+                        try:
+                            samples = [{"example_id": "1"}]
+                            evals._push_samples_with_progress(
+                                OldEvalsClient(), "eval-123", samples
+                            )
+                        finally:
+                            evals.console = original_console
+
+                        if calls != [("eval-123", [{"example_id": "1"}])]:
+                            raise SystemExit("old prime-evals push_samples compatibility failed")
+                        '''
+                    ),
+                ],
+                timeout=120,
+            )
+
+
         def read_remote_env_slug() -> str:
             metadata_path = ENV_DIR / ".prime" / ".env-metadata.json"
             metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
@@ -568,6 +611,7 @@ def remote_script(config: RemoteConfig) -> str:
             LAB_ROOT.mkdir(parents=True, exist_ok=True)
             run(["tar", "-xzf", str(WORKSPACE / "prime-src.tar.gz"), "-C", str(WORKSPACE)])
             install_candidate_cli()
+            installed_runtime_regression_checks()
             write_smoke_environment()
 
             try:

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -209,6 +209,53 @@ def test_push_samples_with_progress_supports_old_prime_evals_client(monkeypatch)
     assert calls == [("eval-123", samples)]
 
 
+def test_push_eval_cli_supports_old_prime_evals_client(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class TerminalConsole:
+        is_terminal = True
+
+        def print(self, *_args, **_kwargs):
+            return None
+
+    class OldEvalsClient:
+        def __init__(self, _api_client):
+            return None
+
+        def create_evaluation(self, **kwargs):
+            captured["create"] = kwargs
+            return {"evaluation_id": "eval-123"}
+
+        def push_samples(self, evaluation_id, samples):
+            captured["push"] = (evaluation_id, samples)
+
+        def finalize_evaluation(self, evaluation_id, metrics=None):
+            captured["finalize"] = (evaluation_id, metrics)
+            return {}
+
+    monkeypatch.setattr("prime_cli.commands.evals.console", TerminalConsole())
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+    monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", OldEvalsClient)
+
+    (tmp_path / "metadata.json").write_text(
+        json.dumps({"env": "owner/gsm8k", "model": "gpt-4", "avg_reward": 1.0})
+    )
+    (tmp_path / "results.jsonl").write_text(json.dumps({"id": 1, "reward": 1.0}) + "\n")
+
+    result = runner.invoke(
+        app,
+        ["eval", "push", "."],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["create"]["environments"] == [{"slug": "owner/gsm8k"}]
+    assert captured["push"] == ("eval-123", [{"id": 1, "reward": 1.0, "example_id": 1}])
+    assert captured["finalize"] == ("eval-123", {"reward": 1.0})
+
+
 def test_push_samples_with_progress_skips_callback_when_signature_is_uninspectable(monkeypatch):
     calls = []
 

--- a/packages/prime/tests/test_release_e2e_script.py
+++ b/packages/prime/tests/test_release_e2e_script.py
@@ -84,8 +84,16 @@ def test_remote_script_compiles_and_keeps_cleanup_best_effort(tmp_path):
 
     py_compile.compile(str(remote_path), doraise=True)
     assert "def best_effort_cancel_hosted_evals" in script
+    assert "def installed_runtime_regression_checks" in script
+    assert "prime_tunnel.Tunnel must accept labels" in script
+    assert "old prime-evals push_samples compatibility failed" in script
     assert "Warning: failed to delete temporary environment" in script
     assert 'line.rsplit(":", 1)[-1]' in script
+    assert (
+        "install_candidate_cli()\n"
+        "    installed_runtime_regression_checks()\n"
+        "    write_smoke_environment()" in script
+    )
     assert script.index('"--save-results"') < script.index('"--skip-upload"')
     assert 'ENV_DIR / "outputs"' in script
 

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -18,11 +18,72 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def test_prime_requires_tunnel_sdk_with_label_support() -> None:
+def test_prime_requires_runtime_sdks_with_cli_feature_support() -> None:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
+    assert "prime-evals>=0.2.3" in pyproject["project"]["dependencies"]
     assert "prime-tunnel>=0.1.8" in pyproject["project"]["dependencies"]
+
+
+def test_tunnel_start_cli_passes_labels_to_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    captured: dict[str, Any] = {}
+
+    class DoneEvent:
+        def is_set(self) -> bool:
+            return True
+
+        def set(self) -> None:
+            return None
+
+        async def wait(self) -> None:
+            return None
+
+    class FakeTunnel:
+        tunnel_id = "t-test123"
+        is_running = True
+        recent_output: list[str] = []
+
+        def __init__(
+            self,
+            *,
+            local_port: int,
+            name: str | None,
+            team_id: str | None,
+            labels: list[str] | None,
+        ) -> None:
+            captured.update(
+                {
+                    "local_port": local_port,
+                    "name": name,
+                    "team_id": team_id,
+                    "labels": labels,
+                }
+            )
+
+        async def start(self) -> str:
+            return "https://t-test123.example.com"
+
+        async def stop(self) -> None:
+            captured["stopped"] = True
+
+    monkeypatch.setattr("prime_cli.commands.tunnel.asyncio.Event", DoneEvent)
+    monkeypatch.setattr("prime_tunnel.Tunnel", FakeTunnel)
+
+    result = runner.invoke(
+        app,
+        ["tunnel", "start", "--port", "8765", "--label", "dev", "--label", "preview"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "local_port": 8765,
+        "name": None,
+        "team_id": None,
+        "labels": ["dev", "preview"],
+        "stopped": True,
+    }
 
 
 def test_format_tunnel_does_not_derive_created_from_expiration() -> None:


### PR DESCRIPTION
Adds command-level and release-e2e regression checks for tunnel labels and old prime-evals push-sample compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and release-script changes only; no production CLI behavior modified in this diff.
> 
> **Overview**
> Adds **runtime regression coverage** so release and unit tests catch SDK/CLI contract drift for tunnel labels and legacy eval uploads.
> 
> **Release e2e:** After installing the candidate CLI in the sandbox, a new `installed_runtime_regression_checks()` step runs before smoke env setup. It asserts `prime_tunnel.Tunnel` accepts a `labels` parameter and that `evals._push_samples_with_progress` still works with an old-style `EvalsClient` that only implements two-argument `push_samples` (no progress callback).
> 
> **Unit tests:** `test_eval_push` gains an end-to-end `prime eval push` case with a stubbed old `EvalsClient`. `test_tunnel_cli` asserts `pyproject.toml` pins `prime-evals>=0.2.3` and `prime-tunnel>=0.1.8`, and that `tunnel start` forwards repeated `--label` flags into the SDK. `test_release_e2e_script` asserts the generated remote script includes the new helper and call order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35c9a51e6bc1e0fd1265ae895234624b4c3f4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->