### PR TITLE
[ENG-3911] improvement: add [eval.sampling] block to rl.toml schema

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -439,6 +439,29 @@ class TeacherConfig(BaseModel):
         return result
 
 
+class EvalSamplingConfig(BaseModel):
+    """Eval-time sampling overrides.
+
+    ``enable_thinking`` / ``reasoning_effort`` are convenience flags the
+     platform merges into ``extra_body.chat_template_kwargs`` for supported models;
+    they cannot both be set on the same block.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_tokens: int | None = None
+    temperature: float | None = None
+    extra_body: Dict[str, Any] | None = None
+    enable_thinking: bool | None = None
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
+
+    @model_validator(mode="after")
+    def _reasoning_controls_mutually_exclusive(self) -> "EvalSamplingConfig":
+        if self.enable_thinking is not None and self.reasoning_effort is not None:
+            raise ValueError("enable_thinking and reasoning_effort cannot both be set")
+        return self
+
+
 class EvalConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -447,6 +470,7 @@ class EvalConfig(BaseModel):
     rollouts_per_example: int | None = None
     eval_base_model: bool | None = None
     env: List[EvalEnvConfig] = Field(default_factory=list)
+    sampling: EvalSamplingConfig | None = None
 
     def to_api_dict(self) -> Dict[str, Any] | None:
         if not self.env:
@@ -460,6 +484,10 @@ class EvalConfig(BaseModel):
             result["rollouts_per_example"] = self.rollouts_per_example
         if self.eval_base_model is not None:
             result["eval_base_model"] = self.eval_base_model
+        if self.sampling is not None:
+            sampling_dict = self.sampling.model_dump(exclude_none=True)
+            if sampling_dict:
+                result["sampling"] = sampling_dict
         return result
 
 

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -142,6 +142,73 @@ def test_load_config_accepts_sampling_enable_thinking(tmp_path: Path) -> None:
     assert cfg.sampling.reasoning_effort is None
 
 
+def test_load_config_accepts_eval_sampling_enable_thinking(tmp_path: Path) -> None:
+    """[eval.sampling] block carries enable_thinking through to the API payload."""
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-35B-A3B"\n'
+        "[[eval.env]]\n"
+        'id = "primeintellect/vf-math"\n'
+        "[eval.sampling]\n"
+        "enable_thinking = false\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.eval.sampling is not None
+    assert cfg.eval.sampling.enable_thinking is False
+    assert cfg.eval.sampling.reasoning_effort is None
+    assert cfg.eval.to_api_dict() == {
+        "environments": [{"id": "primeintellect/vf-math"}],
+        "sampling": {"enable_thinking": False},
+    }
+
+
+def test_load_config_accepts_eval_sampling_reasoning_effort(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        "[[eval.env]]\n"
+        'id = "primeintellect/vf-math"\n'
+        "[eval.sampling]\n"
+        'reasoning_effort = "high"\n'
+        "temperature = 0.0\n"
+        "max_tokens = 2048\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.eval.sampling is not None
+    assert cfg.eval.sampling.reasoning_effort == "high"
+    assert cfg.eval.sampling.temperature == 0.0
+    assert cfg.eval.sampling.max_tokens == 2048
+    assert cfg.eval.to_api_dict() == {
+        "environments": [{"id": "primeintellect/vf-math"}],
+        "sampling": {
+            "reasoning_effort": "high",
+            "temperature": 0.0,
+            "max_tokens": 2048,
+        },
+    }
+
+
+def test_load_config_rejects_eval_sampling_with_both_reasoning_controls(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\n'
+        "[[eval.env]]\n"
+        'id = "primeintellect/vf-math"\n'
+        "[eval.sampling]\n"
+        "enable_thinking = false\n"
+        'reasoning_effort = "low"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
 def test_load_config_accepts_max_inflight_rollouts(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text('model = "dummy"\nmax_inflight_rollouts = 96\n')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI config validation and API payload shaping only; behavior mirrors existing `[sampling]` patterns with new tests.
> 
> **Overview**
> Adds **`[eval.sampling]`** to the Hosted Training `rl.toml` schema so online eval can use **different inference settings** than training rollouts.
> 
> `EvalConfig` now accepts an optional `EvalSamplingConfig` with `max_tokens`, `temperature`, `extra_body`, and the same **`enable_thinking` / `reasoning_effort`** convenience flags as top-level `[sampling]` (mutually exclusive). Parsed values are included under **`sampling`** in `eval.to_api_dict()` when launching a run.
> 
> Tests cover TOML loading, API serialization, and rejection when both reasoning controls are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc28e4c6861eef02062a79ed9ce0ac3d6eacb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->