### PR TITLE
release: cli 0.6.13 + sandbox 0.2.27

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -47,7 +47,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.26"
+__version__ = "0.2.27"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.26",
+    "prime-sandboxes>=0.2.27",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.8",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.12"
+__version__ = "0.6.13"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## prime-sandboxes 0.2.26 → 0.2.27

- #722 idle_timeout_minutes on Create/Update/Sandbox + validators
- #674 chore: update prime-cli urls to prime

## prime 0.6.12 → 0.6.13

- #722 `--idle-timeout-minutes` flag, summary + get rendering, SDK-floor-aware warning
- #716 image search CLI
- #723 fix: require tunnel SDK with label support
- #724 test: runtime regression checks

Also bumps `prime-sandboxes>=0.2.26` → `>=0.2.27` in `packages/prime/pyproject.toml` so the new idle-timeout code path is guaranteed to find the SDK field (per the inline comment in #722).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version strings and a dependency lower bound change; no runtime logic in the diff.
> 
> **Overview**
> Release coordination PR: bumps **prime-sandboxes** `0.2.26` → **`0.2.27`** and **prime** CLI `0.6.12` → **`0.6.13`**, and raises the `prime` package’s `prime-sandboxes` dependency floor from `>=0.2.26` to **`>=0.2.27`** so installs of this CLI version always pull the sandboxes SDK that includes `idle_timeout_minutes` on create/update models.
> 
> No functional code changes appear in this diff; it ships versions that bundle work already merged elsewhere (idle-timeout CLI/SDK support, image search CLI, tunnel SDK requirement, runtime regression tests, and related sandboxes SDK updates per the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f98b60de01f20c52a31ab5582958a78dbb380d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->