### PR TITLE
release: prime CLI 0.6.14

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.13"
+__version__ = "0.6.14"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps the Prime CLI package version to 0.6.14.

Validation:
- `uv run pytest packages/prime/tests -q` on fresh `main` before the bump: 809 passed, 5 skipped
- `uv run pytest packages/prime/tests -q` after the bump: 809 passed, 5 skipped
- `(cd packages/prime && uv build --out-dir /tmp/prime-cli-0.6.14-dist)` built `prime-0.6.14` wheel and sdist
- `uv run prime --version` prints `Prime CLI version: 0.6.14`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version constant change with no logic or dependency updates in the diff.
> 
> **Overview**
> **Release bump** for the Prime CLI package: `__version__` in `prime_cli/__init__.py` is updated from **0.6.13** to **0.6.14**.
> 
> No functional code changes in this diff—only the version string for the 0.6.14 release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e037de6dbc2008065f8212fc5a026a8896cdf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->