### PR TITLE
clean up tunnel bulk delete

### DIFF
--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -342,13 +342,11 @@ def stop_tunnel(
 
     if all:
 
-        async def fetch_tunnel_ids() -> List[str]:
+        async def validate_all_scope() -> None:
             client = _create_tunnel_client()
             try:
-                scoped_team_id = team_id
-                if scoped_team_id is None:
-                    scoped_team_id = client.config.team_id
                 scoped_user_id = client.config.user_id if only_mine else None
+                scoped_team_id = team_id if team_id is not None else client.config.team_id
                 if only_mine and not scoped_user_id:
                     raise ValueError(
                         "Cannot resolve current user ID for scoped bulk delete. "
@@ -356,51 +354,14 @@ def stop_tunnel(
                     )
                 if not only_mine and not scoped_team_id:
                     raise ValueError("all_users requires a team ID")
-
-                # TODO: remove this migration compatibility path after
-                # old tunnel registrations have aged out past their
-                # 7-day TTL.
-                # When removing this block, restore the commented --all branch
-                # in delete_tunnels().
-                ids: List[str] = []
-                seen_ids: set[str] = set()
-                page = 1
-                max_pages = 1000
-                while page <= max_pages:
-                    result = await client.list_tunnels_page(
-                        team_id=scoped_team_id,
-                        page=page,
-                        per_page=1000,
-                    )
-                    for tunnel in result.tunnels:
-                        if only_mine and tunnel.user_id != scoped_user_id:
-                            continue
-                        if tunnel.tunnel_id not in seen_ids:
-                            ids.append(tunnel.tunnel_id)
-                            seen_ids.add(tunnel.tunnel_id)
-
-                    if not result.has_next or not result.tunnels:
-                        break
-                    page += 1
-
-                return ids
             finally:
                 await client.close()
 
         try:
-            parsed_ids = asyncio.run(fetch_tunnel_ids())
+            asyncio.run(validate_all_scope())
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}", style="bold")
             raise typer.Exit(1)
-
-        if not parsed_ids:
-            console.print("[yellow]No active tunnels to stop[/yellow]")
-            if only_mine:
-                console.print(
-                    "\n[dim]Note: --all only deletes your own tunnels by default. "
-                    "Use --all-users to delete tunnels from all team members.[/dim]"
-                )
-            return
 
     if labels:
 
@@ -478,17 +439,14 @@ def stop_tunnel(
                     user_id=scoped_user_id,
                     all_users=not only_mine,
                 )
-            # TODO: uncomment this branch after Redis-backed tunnel
-            # registrations have aged out and the --all pre-listing fallback
-            # above is removed.
-            # elif all:
-            #     if scoped_team_id is None:
-            #         scoped_team_id = client.config.team_id
-            #     result = await client.bulk_delete_tunnels(
-            #         team_id=scoped_team_id,
-            #         user_id=scoped_user_id,
-            #         all_users=not only_mine,
-            #     )
+            elif all:
+                if scoped_team_id is None:
+                    scoped_team_id = client.config.team_id
+                result = await client.bulk_delete_tunnels(
+                    team_id=scoped_team_id,
+                    user_id=scoped_user_id,
+                    all_users=not only_mine,
+                )
             else:
                 result = await client.bulk_delete_tunnels(parsed_ids)
             succeeded = result.get("succeeded", [])

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -239,7 +239,7 @@ def test_tunnel_stop_by_label_validates_scope_before_prompt(
     assert "Failed to delete" not in result.output
 
 
-def test_tunnel_stop_all_lists_then_bulk_deletes_explicit_ids(
+def test_tunnel_stop_all_uses_scoped_bulk_delete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
@@ -249,18 +249,11 @@ def test_tunnel_stop_all_lists_then_bulk_deletes_explicit_ids(
         config = SimpleNamespace(user_id="user-1", team_id=None)
 
         async def list_tunnels_page(self, **kwargs: Any) -> Any:
-            captured["list_kwargs"] = kwargs
-            return SimpleNamespace(
-                tunnels=[
-                    SimpleNamespace(tunnel_id="t-owned", user_id="user-1"),
-                    SimpleNamespace(tunnel_id="t-other", user_id="user-2"),
-                ],
-                has_next=False,
-            )
+            raise AssertionError("--all should not pre-list tunnels; it must scope the delete")
 
-        async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict[str, Any]:
-            captured["tunnel_ids"] = tunnel_ids
-            return {"succeeded": tunnel_ids, "failed": [], "message": "ok"}
+        async def bulk_delete_tunnels(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"succeeded": ["t-owned"], "failed": [], "message": "ok"}
 
         async def close(self) -> None:
             return None
@@ -270,10 +263,10 @@ def test_tunnel_stop_all_lists_then_bulk_deletes_explicit_ids(
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 
     assert result.exit_code == 0, result.output
-    assert captured["list_kwargs"]["team_id"] is None
-    assert captured["list_kwargs"]["page"] == 1
-    assert captured["list_kwargs"]["per_page"] == 1000
-    assert captured["tunnel_ids"] == ["t-owned"]
+    assert "tunnel_ids" not in captured
+    assert captured["user_id"] == "user-1"
+    assert captured["all_users"] is False
+    assert captured.get("team_id") is None
 
 
 def test_tunnel_stop_all_users_uses_configured_team_scope(
@@ -286,18 +279,11 @@ def test_tunnel_stop_all_users_uses_configured_team_scope(
         config = SimpleNamespace(user_id=None, team_id="team-1")
 
         async def list_tunnels_page(self, **kwargs: Any) -> Any:
-            captured["list_kwargs"] = kwargs
-            return SimpleNamespace(
-                tunnels=[
-                    SimpleNamespace(tunnel_id="t-owned", user_id="user-1"),
-                    SimpleNamespace(tunnel_id="t-other", user_id="user-2"),
-                ],
-                has_next=False,
-            )
+            raise AssertionError("--all should not pre-list tunnels; it must scope the delete")
 
-        async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict[str, Any]:
-            captured["tunnel_ids"] = tunnel_ids
-            return {"succeeded": tunnel_ids, "failed": [], "message": "ok"}
+        async def bulk_delete_tunnels(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"succeeded": ["t-owned", "t-other"], "failed": [], "message": "ok"}
 
         async def close(self) -> None:
             return None
@@ -307,33 +293,24 @@ def test_tunnel_stop_all_users_uses_configured_team_scope(
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--all-users", "--yes"])
 
     assert result.exit_code == 0, result.output
-    assert captured["list_kwargs"]["team_id"] == "team-1"
-    assert captured["tunnel_ids"] == ["t-owned", "t-other"]
+    assert "tunnel_ids" not in captured
+    assert captured["team_id"] == "team-1"
+    assert captured["all_users"] is True
+    assert captured.get("user_id") is None
 
 
-def test_tunnel_stop_all_paginates_before_bulk_delete(
+def test_tunnel_stop_all_exits_cleanly_when_nothing_matches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
-    captured: dict[str, Any] = {"pages": []}
-
-    page_1 = [SimpleNamespace(tunnel_id=f"t-{i}", user_id="user-1") for i in range(1, 1001)]
-    page_2 = [SimpleNamespace(tunnel_id="t-1001", user_id="user-1")]
+    captured: dict[str, Any] = {}
 
     class FakeTunnelClient:
         config = SimpleNamespace(user_id="user-1", team_id=None)
 
-        async def list_tunnels_page(self, **kwargs: Any) -> Any:
-            captured["pages"].append(kwargs["page"])
-            if kwargs["page"] == 1:
-                return SimpleNamespace(tunnels=page_1, has_next=True)
-            if kwargs["page"] == 2:
-                return SimpleNamespace(tunnels=page_2, has_next=False)
-            return SimpleNamespace(tunnels=[], has_next=False)
-
-        async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict[str, Any]:
-            captured["tunnel_ids"] = tunnel_ids
-            return {"succeeded": tunnel_ids, "failed": [], "message": "ok"}
+        async def bulk_delete_tunnels(self, **kwargs: Any) -> dict[str, Any]:
+            captured["called"] = True
+            return {"succeeded": [], "failed": [], "message": "ok"}
 
         async def close(self) -> None:
             return None
@@ -343,34 +320,8 @@ def test_tunnel_stop_all_paginates_before_bulk_delete(
     result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
 
     assert result.exit_code == 0, result.output
-    assert captured["pages"] == [1, 2]
-    assert captured["tunnel_ids"] == [f"t-{i}" for i in range(1, 1002)]
-
-
-def test_tunnel_stop_all_noops_when_no_active_tunnels(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
-
-    class FakeTunnelClient:
-        config = SimpleNamespace(user_id="user-1", team_id=None)
-
-        async def list_tunnels_page(self, **kwargs: Any) -> Any:
-            return SimpleNamespace(tunnels=[], has_next=False)
-
-        async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict[str, Any]:
-            raise AssertionError("bulk delete should not be called for an empty --all result")
-
-        async def close(self) -> None:
-            return None
-
-    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
-
-    result = runner.invoke(app, ["tunnel", "stop", "--all", "--yes"])
-
-    assert result.exit_code == 0, result.output
-    assert "No active tunnels to stop" in result.output
-    assert "--all-users" in result.output
+    assert captured.get("called") is True
+    assert "Processed 0 tunnel(s)" in result.output
 
 
 def test_tunnel_stop_all_requires_current_user_for_only_mine(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes bulk-delete behavior for a destructive CLI path; scope validation is preserved but empty-match UX and API call pattern differ from the old list-first flow.
> 
> **Overview**
> **`prime tunnel stop --all`** no longer paginates through `list_tunnels_page` to collect tunnel IDs before deleting. The temporary migration fallback and related TODOs are removed.
> 
> Bulk stop for `--all` now calls **`bulk_delete_tunnels`** with scope kwargs (`team_id`, `user_id`, `all_users`), matching the label-based path. The pre-delete step for `--all` only **validates** scope (user/team requirements); it does not load tunnel lists.
> 
> When nothing matches, the CLI still runs the scoped bulk delete and reports **`Processed 0 tunnel(s)`** instead of short-circuiting with “No active tunnels to stop.” Tests were updated to assert no pre-listing and to cover scoped bulk delete behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec691fd4cd37f388808cb8e14d888bad5a42bb7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->