### PR TITLE
Clarify Prime Inference OpenAI auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,17 @@ See [prime-sandboxes documentation](./packages/prime-sandboxes/) for SDK usage.
 #### API Key Setup
 
 ```bash
-# Interactive mode (recommended - hides input)
+# Interactive login (recommended)
+prime login
+
+# Store a key in the active Prime config
 prime config set-api-key
 
-# Non-interactive mode (for automation)
-prime config set-api-key YOUR_API_KEY
-
-# Environment variable (most secure for scripts)
-export PRIME_API_KEY="your-api-key-here"
+# Process-scoped override for one command
+PRIME_API_KEY="your-api-key-here" python script.py
 ```
+
+Avoid exporting `PRIME_API_KEY` globally unless you want it to override your active Prime config in every project. For project-specific tools that require env vars, prefer a project-scoped `.env`/direnv setup.
 
 #### Other Configuration
 
@@ -123,7 +125,7 @@ prime config set-ssh-key-path
 prime config view
 ```
 
-**Security Note**: When using non-interactive mode, the API key may be visible in your shell history. For enhanced security, use interactive mode or environment variables.
+**Security Note**: Passing API keys as command arguments can leave them in shell history. Prefer `prime login` or the interactive `prime config set-api-key` prompt; use environment variables only as process- or project-scoped overrides.
 
 ### Environments Hub
 
@@ -199,6 +201,30 @@ prime pods create --name my-pod # With custom name
 prime pods status <pod-id>
 prime pods terminate <pod-id>
 prime pods ssh <pod-id>
+```
+
+### Prime Inference from Python
+
+Prime Inference is OpenAI-compatible. Configure the standard OpenAI client from the active Prime context instead of reading `PRIME_API_KEY` directly:
+
+```python
+from openai import OpenAI
+from prime_cli import Config
+
+prime = Config()
+client_kwargs = {
+    "base_url": prime.inference_url,
+    "api_key": prime.api_key,
+}
+if prime.team_id:
+    client_kwargs["default_headers"] = {"X-Prime-Team-ID": prime.team_id}
+
+client = OpenAI(**client_kwargs)
+response = client.chat.completions.create(
+    model="qwen/qwen3-30b-a3b-instruct-2507",
+    messages=[{"role": "user", "content": "Say hi."}],
+)
+print(response.choices[0].message.content)
 ```
 
 ### Evaluations

--- a/README.md
+++ b/README.md
@@ -209,17 +209,14 @@ Prime Inference is OpenAI-compatible. Configure the standard OpenAI client from 
 
 ```python
 from openai import OpenAI
-from prime_cli import Config
+from prime import Config
 
 prime = Config()
-client_kwargs = {
-    "base_url": prime.inference_url,
-    "api_key": prime.api_key,
-}
-if prime.team_id:
-    client_kwargs["default_headers"] = {"X-Prime-Team-ID": prime.team_id}
-
-client = OpenAI(**client_kwargs)
+client = OpenAI(
+    base_url=prime.inference_url,
+    api_key=prime.api_key,
+    default_headers=prime.inference_headers,
+)
 response = client.chat.completions.create(
     model="qwen/qwen3-30b-a3b-instruct-2507",
     messages=[{"role": "user", "content": "Say hi."}],

--- a/packages/prime-evals/README.md
+++ b/packages/prime-evals/README.md
@@ -27,8 +27,8 @@ pip install prime-evals
 ```python
 from prime_evals import APIClient, EvalsClient
 
-# Initialize client
-api_client = APIClient(api_key="your-api-key")
+# Initialize client from prime login / active config
+api_client = APIClient()
 client = EvalsClient(api_client)
 
 # Create an evaluation
@@ -79,7 +79,7 @@ import asyncio
 from prime_evals import AsyncEvalsClient
 
 async def main():
-    async with AsyncEvalsClient(api_key="your-api-key") as client:
+    async with AsyncEvalsClient() as client:
         # Create evaluation
         eval_response = client.create_evaluation(
             name="my-evaluation",
@@ -105,16 +105,18 @@ asyncio.run(main())
 The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
-2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: `~/.prime/config.json` (created by `prime login` CLI command)
+2. **Process environment override**: `PRIME_API_KEY="sk-..." python script.py`
+3. **Config file**: `~/.prime/config.json` (created by `prime login`)
+
+Prefer `prime login` when using the full Prime CLI. If a standalone script needs an env var, scope `PRIME_API_KEY` to that process or project instead of exporting it globally.
 
 ## Complete Example
 
 ```python
 from prime_evals import APIClient, EvalsClient
 
-# Initialize
-api_client = APIClient(api_key="your-api-key")
+# Initialize from prime login / active config
+api_client = APIClient()
 client = EvalsClient(api_client)
 
 # Create evaluation with full metadata

--- a/packages/prime-evals/examples/basic_usage.py
+++ b/packages/prime-evals/examples/basic_usage.py
@@ -13,8 +13,8 @@ from prime_evals import APIClient, EvalsClient
 
 def main():
     """Run the basic evaluation example."""
-    # Initialize client (uses PRIME_API_KEY env var, ~/.prime/config.json,
-    # or pass in directly here as env var)
+    # Initialize client from prime login / active config, or from a process-scoped
+    # PRIME_API_KEY override. Standalone scripts may also pass api_key directly.
     api_client = APIClient()
     client = EvalsClient(api_client)
 

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -27,8 +27,8 @@ pip install prime-sandboxes
 ```python
 from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest
 
-# Initialize
-client = APIClient(api_key="your-api-key")
+# Initialize from prime login / active config
+client = APIClient()
 sandbox_client = SandboxClient(client)
 
 # Create a sandbox
@@ -60,7 +60,7 @@ import asyncio
 from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
 async def main():
-    async with AsyncSandboxClient(api_key="your-api-key") as client:
+    async with AsyncSandboxClient() as client:
         # Create sandbox
         sandbox = await client.create(CreateSandboxRequest(
             name="async-sandbox",
@@ -83,8 +83,10 @@ asyncio.run(main())
 The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
-2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: `~/.prime/config.json` (created by `prime login` CLI command)
+2. **Process environment override**: `PRIME_API_KEY="sk-..." python script.py`
+3. **Config file**: `~/.prime/config.json` (created by `prime login`)
+
+Prefer `prime login` when using the full Prime CLI. If a standalone script needs an env var, scope `PRIME_API_KEY` to that process or project instead of exporting it globally.
 
 ## Advanced Features
 

--- a/packages/prime-sandboxes/examples/async_background.py
+++ b/packages/prime-sandboxes/examples/async_background.py
@@ -86,7 +86,7 @@ async def main() -> None:
         await run_background_count_example()
     except APIError as exc:
         print(f"✗ API error: {exc}")
-        print("  Make sure PRIME_API_KEY is set or run 'prime login' before executing.")
+        print("  Run 'prime login' or pass a process-scoped PRIME_API_KEY before executing.")
     except Exception as exc:
         print(f"✗ Unexpected error: {exc}")
 

--- a/packages/prime-sandboxes/examples/basic_usage.py
+++ b/packages/prime-sandboxes/examples/basic_usage.py
@@ -16,7 +16,8 @@ from prime_sandboxes import (
 def main():
     """Basic sandbox lifecycle example"""
     try:
-        # Initialize client (uses PRIME_API_KEY env var or ~/.prime/config.json)
+        # Initialize client from prime login / active config, or from a process-scoped
+        # PRIME_API_KEY override. Standalone scripts may also pass api_key directly.
         client = APIClient()
         sandbox_client = SandboxClient(client)
 
@@ -51,7 +52,7 @@ def main():
 
     except APIError as e:
         print(f"✗ API Error: {e}")
-        print("  Make sure PRIME_API_KEY is set or run 'prime login' first")
+        print("  Run 'prime login' or pass a process-scoped PRIME_API_KEY for this script")
     except Exception as e:
         print(f"✗ Error: {e}")
 

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -267,17 +267,14 @@ Prime Inference is OpenAI-compatible. Configure the standard OpenAI client from 
 
 ```python
 from openai import OpenAI
-from prime_cli import Config
+from prime import Config
 
 prime = Config()
-client_kwargs = {
-    "base_url": prime.inference_url,
-    "api_key": prime.api_key,
-}
-if prime.team_id:
-    client_kwargs["default_headers"] = {"X-Prime-Team-ID": prime.team_id}
-
-client = OpenAI(**client_kwargs)
+client = OpenAI(
+    base_url=prime.inference_url,
+    api_key=prime.api_key,
+    default_headers=prime.inference_headers,
+)
 response = client.chat.completions.create(
     model="qwen/qwen3-30b-a3b-instruct-2507",
     messages=[{"role": "user", "content": "Say hi."}],

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -69,14 +69,14 @@ pip install prime
 # Interactive login (recommended)
 prime login
 
-# Or set API key directly
+# Or set API key directly in the active Prime config
 prime config set-api-key
 
-# Or use environment variable
-export PRIME_API_KEY="your-api-key-here"
+# For one-off scripts, scope env overrides to that process only
+PRIME_API_KEY="your-api-key-here" python script.py
 ```
 
-Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect.ai).
+Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect.ai). Avoid exporting `PRIME_API_KEY` globally unless you want it to override your active Prime config in every project.
 
 ### Basic Usage
 
@@ -228,20 +228,20 @@ prime pods list
 
 ### API Key
 
-Multiple ways to configure your API key:
+Recommended setup:
 
 ```bash
-# Option 1: Interactive (hides input)
+# Option 1: Interactive login (recommended)
+prime login
+
+# Option 2: Store a key in the active Prime config
 prime config set-api-key
 
-# Option 2: Direct
-prime config set-api-key YOUR_API_KEY
-
-# Option 3: Environment variable
-export PRIME_API_KEY="your-api-key"
+# Option 3: Process-scoped override for one command
+PRIME_API_KEY="your-api-key" python script.py
 ```
 
-Configuration priority: CLI config > Environment variable
+Resolution priority is: explicit SDK/client argument > `PRIME_*` environment override > active Prime config. Because environment variables override the active config, prefer `prime login`, `prime switch`, and project-scoped `.env` files over globally exporting `PRIME_API_KEY`.
 
 ### SSH Key
 
@@ -259,13 +259,39 @@ prime config view
 
 ## Python SDK
 
-Prime also provides a Python SDK for programmatic access:
+Prime also provides a Python SDK for programmatic access. SDK clients use the active Prime config created by `prime login`, so library code should not read `PRIME_API_KEY` directly.
+
+### Prime Inference
+
+Prime Inference is OpenAI-compatible. Configure the standard OpenAI client from the active Prime context instead of reading `PRIME_API_KEY` directly:
+
+```python
+from openai import OpenAI
+from prime_cli import Config
+
+prime = Config()
+client_kwargs = {
+    "base_url": prime.inference_url,
+    "api_key": prime.api_key,
+}
+if prime.team_id:
+    client_kwargs["default_headers"] = {"X-Prime-Team-ID": prime.team_id}
+
+client = OpenAI(**client_kwargs)
+response = client.chat.completions.create(
+    model="qwen/qwen3-30b-a3b-instruct-2507",
+    messages=[{"role": "user", "content": "Say hi."}],
+)
+print(response.choices[0].message.content)
+```
+
+### Sandboxes
 
 ```python
 from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest
 
-# Initialize client
-client = APIClient(api_key="your-api-key")
+# Initialize client from prime login / active config
+client = APIClient()
 sandbox_client = SandboxClient(client)
 
 # Create a sandbox
@@ -294,7 +320,7 @@ import asyncio
 from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
 async def main():
-    async with AsyncSandboxClient(api_key="your-api-key") as client:
+    async with AsyncSandboxClient() as client:
         sandbox = await client.create(CreateSandboxRequest(
             name="async-sandbox",
             docker_image="python:3.11-slim",

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -77,7 +77,7 @@ allow-direct-references = true
 path = "src/prime_cli/__init__.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/prime_cli", "src/prime_lab_app"]
+packages = ["src/prime", "src/prime_cli", "src/prime_lab_app"]
 
 [tool.ruff]
 src = ["."]

--- a/packages/prime/src/prime/__init__.py
+++ b/packages/prime/src/prime/__init__.py
@@ -1,0 +1,5 @@
+"""Prime Intellect Python SDK."""
+
+from prime_cli import Config, __version__
+
+__all__ = ["Config", "__version__"]

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -178,6 +178,14 @@ class Config:
         self._save_config(self.config)
 
     @property
+    def inference_headers(self) -> dict[str, str]:
+        """Headers for OpenAI-compatible Prime Inference clients."""
+        team_id = self.team_id
+        if team_id:
+            return {"X-Prime-Team-ID": team_id}
+        return {}
+
+    @property
     def ssh_key_path(self) -> str:
         """Get SSH private key path with precedence: env > file > default."""
         env_val = os.getenv("PRIME_SSH_KEY_PATH")

--- a/packages/prime/tests/test_inference_config.py
+++ b/packages/prime/tests/test_inference_config.py
@@ -10,6 +10,7 @@ from prime_cli import Config as CliConfig
 @pytest.fixture
 def temp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
 
 
 def test_prime_exports_config() -> None:

--- a/packages/prime/tests/test_inference_config.py
+++ b/packages/prime/tests/test_inference_config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from prime import Config
+from prime_cli import Config as CliConfig
+
+
+@pytest.fixture
+def temp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+def test_prime_exports_config() -> None:
+    assert Config is CliConfig
+
+
+def test_inference_headers_empty_without_team(temp_home: None) -> None:
+    config = Config()
+
+    assert config.inference_headers == {}
+
+
+def test_inference_headers_use_active_team(temp_home: None) -> None:
+    config = Config()
+    config.set_team("cmf0ohr9s0026ilerf3w68s6n")
+
+    assert config.inference_headers == {"X-Prime-Team-ID": "cmf0ohr9s0026ilerf3w68s6n"}
+
+
+def test_inference_headers_respect_team_env_override(
+    temp_home: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PRIME_TEAM_ID", "cmf0ohr9s0026ilerf3w68s6m")
+
+    assert Config().inference_headers == {"X-Prime-Team-ID": "cmf0ohr9s0026ilerf3w68s6m"}


### PR DESCRIPTION
## Summary
- add a tiny `prime` package export so examples can use `from prime import Config`
- expose `Config.inference_headers` for OpenAI `default_headers`, including active team context via `X-Prime-Team-ID`
- update docs/examples to prefer `prime login` / active config and process-scoped `PRIME_API_KEY` overrides

## Tests
- exact OpenAI snippet with `from prime import Config`
- exact OpenAI snippet with `default_headers=prime.inference_headers`
- built wheel install + exact OpenAI snippet with process-scoped `PRIME_API_KEY`
- built wheel install + team-header snippet with process-scoped `PRIME_TEAM_ID`
- `PRIME_TEAM_ID=ci-team uv run pytest packages/prime/tests/test_inference_config.py -q`
- `uv run ruff check packages/prime/src/prime packages/prime/src/prime_cli/core/config.py packages/prime/tests/test_inference_config.py packages/prime-evals/examples/basic_usage.py packages/prime-sandboxes/examples/basic_usage.py packages/prime-sandboxes/examples/async_background.py`

## How it works now
Library code can use Prime Inference with the standard OpenAI client and the active `prime login` context:

```python
from openai import OpenAI
from prime import Config

prime = Config()
client = OpenAI(
    base_url=prime.inference_url,
    api_key=prime.api_key,
    default_headers=prime.inference_headers,
)
```

`prime.inference_headers` exposes the active team context as OpenAI `default_headers` (`X-Prime-Team-ID`) when a team is selected via `prime switch` or `PRIME_TEAM_ID`. `PRIME_API_KEY` still works, but as an explicit per-process/project override rather than something users need to export globally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive SDK surface and documentation; inference headers only attach team context when configured, with unit tests.
> 
> **Overview**
> Adds a **`prime`** Python package that re-exports **`Config`** so apps can use `from prime import Config`, and adds **`Config.inference_headers`** for OpenAI-compatible Prime Inference clients ( **`X-Prime-Team-ID`** from active team / `PRIME_TEAM_ID` ).
> 
> Docs and examples now steer users toward **`prime login`** / active config and **process-scoped** `PRIME_API_KEY` instead of global exports or inline API keys, including new **OpenAI + `Config`** snippets in the root and `packages/prime` READMEs. **`pyproject.toml`** includes `src/prime` in the wheel; tests cover the export and inference header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e967f2b11dec6c4ad509efd66a4db2e10d61da5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->