### PR TITLE
fix: use eval config model in job id

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -25,7 +25,7 @@ from ..utils import (
 )
 from ..utils.display import get_eval_viewer_url
 from ..utils.env_metadata import find_environment_metadata
-from ..utils.eval_push import load_results_jsonl
+from ..utils.eval_push import convert_eval_results, load_results_jsonl
 from ..utils.hosted_eval import (
     EvalStatus,
     HostedEvalConfig,
@@ -84,7 +84,7 @@ HOSTED_LOGS_RATE_LIMIT_WAIT_SECONDS = 30
 HOSTED_LOGS_RETRY_WAIT_SECONDS = 10
 HOSTED_LOGS_STATUS_UPDATE_EVERY_POLLS = 6
 EVAL_TABLE_MAX_TEXT_WIDTH = 30
-EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k -n 10"
+EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k-v1 -n 10"
 EVAL_HOSTED_LABEL = "HOSTED"
 EVAL_LOCAL_LABEL = "LOCAL"
 # Legacy verifiers config fields/flags are accepted through the parser only so
@@ -924,11 +924,7 @@ def _load_eval_directory(directory: Path) -> dict:
             f"Missing required 'env_id' or 'model' field in {directory / 'metadata.json'}"
         )
 
-    results = load_results_jsonl(directory / "results.jsonl")
-
-    for sample in results:
-        if "id" in sample and "example_id" not in sample:
-            sample["example_id"] = sample["id"]
+    results = convert_eval_results(load_results_jsonl(directory / "results.jsonl"))
 
     avg_pattern = re.compile(r"^avg_(.+)$")
     metrics = {}
@@ -1474,6 +1470,22 @@ def run_eval_cmd(
 ) -> None:
     """Run an evaluation with local-first environment resolution."""
     passthrough_args = list(ctx.args)
+    if environment == "@":
+        if not passthrough_args:
+            console.print("[red]Error:[/red] @ must be followed by a config path.")
+            raise typer.Exit(2)
+        environment = passthrough_args.pop(0)
+    elif environment == "--resume":
+        if not passthrough_args:
+            console.print("[red]Error:[/red] --resume must be followed by an output directory.")
+            raise typer.Exit(2)
+        resume_dir = passthrough_args.pop(0)
+        environment = resume_dir
+        passthrough_args = ["--resume", resume_dir, *passthrough_args]
+    elif environment and environment.startswith("--resume="):
+        resume_dir = environment.split("=", 1)[1]
+        environment = resume_dir
+        passthrough_args = [f"--resume={resume_dir}", *passthrough_args]
 
     if is_help_request(environment or "", passthrough_args):
         print_eval_run_help()
@@ -1494,10 +1506,17 @@ def run_eval_cmd(
         ctx.get_parameter_source("poll_interval") == ParameterSource.COMMANDLINE
     )
     local_passthrough_args = list(passthrough_args)
-    if sampling_args is not None:
-        local_passthrough_args.extend(["--sampling-args", sampling_args])
 
     if not hosted:
+        legacy_eval = "--save-results" in local_passthrough_args
+        if sampling_args is not None and legacy_eval:
+            local_passthrough_args.extend(["--sampling-args", sampling_args])
+        elif sampling_args is not None:
+            console.print(
+                "[red]Error:[/red] local v1 evals use --sampling.* options "
+                "(for example, --sampling.temperature 0.7)"
+            )
+            raise typer.Exit(2)
         hosted_only_args = {
             "--follow": follow,
             "--poll-interval": poll_interval_was_provided,

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -51,12 +51,98 @@ def load_results_jsonl(path: Path) -> list[dict]:
     return results
 
 
+def convert_eval_results(samples: list[dict]) -> list[dict]:
+    """Convert v1 traces to the sample schema while preserving legacy results."""
+    trace_type = None
+    trace_fields = {}
+    rollout_counts: dict[int, int] = {}
+    converted = []
+
+    for sample in samples:
+        if not (
+            isinstance(sample.get("nodes"), list)
+            and isinstance(sample.get("task"), dict)
+            and isinstance(sample.get("rewards"), dict)
+        ):
+            legacy_sample = dict(sample)
+            if "id" in legacy_sample and "example_id" not in legacy_sample:
+                legacy_sample["example_id"] = legacy_sample["id"]
+            converted.append(legacy_sample)
+            continue
+
+        if trace_type is None:
+            from verifiers.v1.task import WireTask
+            from verifiers.v1.trace import Trace
+
+            trace_type = Trace[WireTask]
+            trace_fields = trace_type.model_fields
+        trace = trace_type.model_validate(
+            {key: value for key, value in sample.items() if key in trace_fields}
+        )
+        task = trace.task.model_dump(mode="json", exclude_none=True)
+        branches = trace.branches
+        main_messages = (
+            [
+                message.model_dump(mode="json", exclude_none=True)
+                for message in branches[-1].messages
+            ]
+            if branches
+            else []
+        )
+        trajectory = [
+            {
+                "messages": [
+                    message.model_dump(mode="json", exclude_none=True)
+                    for message in branch.messages
+                ],
+                "reward": trace.reward,
+                "num_input_tokens": branch.prompt_len,
+                "num_output_tokens": branch.completion_len,
+            }
+            for branch in branches
+        ]
+        example_id = trace.task.idx
+        rollout_counts[example_id] = rollout_counts.get(example_id, 0) + 1
+        info = dict(trace.info)
+        info.update({key: value for key, value in sample.items() if key not in trace_fields})
+
+        converted.append(
+            {
+                "sample_id": trace.id,
+                "example_id": example_id,
+                "rollout_number": rollout_counts[example_id],
+                "task": task,
+                "prompt": [],
+                "completion": main_messages,
+                "answer": task.get("answer"),
+                "reward": trace.reward,
+                "timing": trace.timing.model_dump(mode="json", exclude_none=True),
+                "is_completed": trace.is_completed,
+                "is_truncated": trace.is_truncated,
+                "metrics": trace.metrics,
+                "error": (
+                    trace.error.model_dump(mode="json", exclude_none=True) if trace.error else None
+                ),
+                "stop_condition": trace.stop_condition,
+                "trajectory": trajectory,
+                "token_usage": (
+                    trace.usage.model_dump(mode="json", exclude_none=True) if trace.usage else None
+                ),
+                "num_steps": trace.num_turns,
+                "info": info or None,
+            }
+        )
+
+    return converted
+
+
 def push_eval_results_to_hub(
     env_name: str,
     model: str,
     job_id: str,
     env_path: Optional[Path] = None,
     upstream_slug: Optional[str] = None,
+    output_dir: Optional[Path] = None,
 ) -> None:
     """
     Push evaluation results to Prime Evals Hub after `prime eval run` completes.
@@ -78,23 +164,21 @@ def push_eval_results_to_hub(
     """
     # Step 1: Find the output directory
     module_name = env_name.replace("-", "_")
-    model_name = model.replace("/", "--")
-    env_model_str = f"{env_name}--{model_name}"
-
-    local_env_dir = Path("./environments") / module_name
-    if local_env_dir.exists():
-        base_evals_dir = local_env_dir / "outputs" / "evals" / env_model_str
-    else:
-        base_evals_dir = Path("./outputs") / "evals" / env_model_str
-
-    if not base_evals_dir.exists():
-        raise FileNotFoundError(f"Evaluation output directory not found: {base_evals_dir}")
-
-    subdirs = [d for d in base_evals_dir.iterdir() if d.is_dir()]
-    if not subdirs:
-        raise FileNotFoundError(f"No evaluation results found in {base_evals_dir}")
-
-    output_dir = max(subdirs, key=lambda d: d.stat().st_mtime)
+    if output_dir is None:
+        model_name = model.replace("/", "--")
+        env_model_str = f"{env_name}--{model_name}"
+        local_env_dir = Path("./environments") / module_name
+        base_evals_dir = (
+            local_env_dir / "outputs" / "evals" / env_model_str
+            if local_env_dir.exists()
+            else Path("./outputs") / "evals" / env_model_str
+        )
+        if not base_evals_dir.exists():
+            raise FileNotFoundError(f"Evaluation output directory not found: {base_evals_dir}")
+        subdirs = [d for d in base_evals_dir.iterdir() if d.is_dir()]
+        if not subdirs:
+            raise FileNotFoundError(f"No evaluation results found in {base_evals_dir}")
+        output_dir = max(subdirs, key=lambda d: d.stat().st_mtime)
 
     metadata_path = output_dir / "metadata.json"
     results_path = output_dir / "results.jsonl"
@@ -179,14 +263,7 @@ def push_eval_results_to_hub(
 
     eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
 
-    converted_results = [
-        {
-            "example_id": sample.get("id", 0),
-            "reward": sample.get("reward", 0.0),
-            **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
-        }
-        for sample in results_samples
-    ]
+    converted_results = convert_eval_results(results_samples)
 
     eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -992,6 +992,8 @@ def run_eval_passthrough(
         job_target = _env_name_from_reference(config_envs[0][0])
     if job_target is None:
         job_target = Path(environment).stem
+    if config_envs and _parse_value_option(passthrough_args, "--model", "-m") is None:
+        model = toml.load(environment).get("model") or model
     job_id = _build_job_id(job_target, model)
     args.extend(["--header", f"X-PI-Job-Id: {job_id}"])
 

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -21,7 +22,7 @@ from prime_cli.core import Config
 from .api.inference import InferenceAPIError, InferenceClient, InferencePaymentRequiredError
 from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
-from .utils.eval_push import push_eval_results_to_hub
+from .utils.eval_push import convert_eval_results, load_results_jsonl, push_eval_results_to_hub
 from .utils.plain import get_console
 from .verifiers_plugin import PrimeVerifiersPlugin, load_verifiers_prime_plugin
 
@@ -32,15 +33,23 @@ DEFAULT_ENV_DIR_PATH = "./environments"
 DEFAULT_ENDPOINTS_PATH = "./configs/endpoints.toml"
 PRIME_SLUG = "primeintellect"
 INTERNAL_ENV_DISPLAY_HEADER = "X-Prime-Eval-Env-Display"
+LEGACY_EVAL_MODULE = "verifiers.cli.commands.eval"
 EVAL_PREFLIGHT_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=60.0)
 MODULE_TO_PRIME_COMMAND = {
     "verifiers.cli.commands.eval": "prime eval run",
+    "verifiers.v1.cli.eval.main": "prime eval run",
     "verifiers.cli.commands.gepa": "prime gepa run",
     "verifiers.cli.commands.init": "prime env init",
+    "verifiers.v1.cli.init": "prime env init",
     "verifiers.cli.commands.install": "prime env install",
     "verifiers.cli.commands.build": "prime env build",
     "verifiers.cli.commands.setup": "prime lab setup",
     "verifiers.cli.tui": "prime eval view",
+}
+
+MODULE_TO_CONSOLE_SCRIPT = {
+    "verifiers.v1.cli.eval.main": "eval",
+    "verifiers.v1.cli.init": "init",
 }
 
 
@@ -73,6 +82,7 @@ def is_help_request(primary_arg: str, passthrough_args: list[str]) -> bool:
 
 def _sanitize_help_text(help_text: str, module_name: str, prime_command: str) -> str:
     lines = help_text.splitlines()
+    console_script = MODULE_TO_CONSOLE_SCRIPT.get(module_name)
     for idx, line in enumerate(lines):
         if line.lower().startswith("usage:"):
             suffix = line.split(":", 1)[1].strip()
@@ -80,8 +90,11 @@ def _sanitize_help_text(help_text: str, module_name: str, prime_command: str) ->
                 rf"^python(?:\d+(?:\.\d+)?)?\s+-m\s+{re.escape(module_name)}(?:\s+|$)"
             )
             module_prefix = re.compile(rf"^{re.escape(module_name)}(?:\s+|$)")
+            console_prefix = f"uv run {console_script}" if console_script else None
             match = python_module_prefix.match(suffix) or module_prefix.match(suffix)
-            if match is not None:
+            if console_prefix and suffix.startswith(console_prefix):
+                suffix = suffix[len(console_prefix) :].lstrip()
+            elif match is not None:
                 suffix = suffix[match.end() :].lstrip()
             else:
                 parts = suffix.split(maxsplit=1)
@@ -97,6 +110,15 @@ def _sanitize_help_text(help_text: str, module_name: str, prime_command: str) ->
     ):
         sanitized = sanitized.replace(f"python -m {module_alias}", command_alias)
         sanitized = sanitized.replace(module_alias, command_alias)
+
+    if console_script:
+        sanitized = sanitized.replace(f"uv run {console_script}", prime_command)
+        module_script = module_name.rsplit(".", 1)[-1] + ".py"
+        sanitized = re.sub(
+            rf"(?im)^usage: (?:{re.escape(console_script)}|{re.escape(module_script)})\b",
+            f"Usage: {prime_command}",
+            sanitized,
+        )
 
     sanitized = re.sub(r"\bvf-[a-z0-9-]+\b", prime_command, sanitized)
     if prime_command in {"prime eval run", "prime gepa run"}:
@@ -748,46 +770,6 @@ def _prepare_single_environment(
     return resolved
 
 
-def _collect_eval_config_envs(config_path: Path, fallback_env_dir: str) -> list[tuple[str, str]]:
-    try:
-        raw = toml.load(config_path)
-    except Exception as exc:
-        console.print(
-            f"[yellow]Warning:[/yellow] Could not parse eval config {config_path}: {exc}. "
-            "Skipping pre-install."
-        )
-        return []
-
-    if not isinstance(raw, dict):
-        return []
-
-    eval_entries = raw.get("eval")
-    if not isinstance(eval_entries, list):
-        return []
-
-    global_env_dir = raw.get("env_dir_path")
-    if not isinstance(global_env_dir, str):
-        global_env_dir = fallback_env_dir
-
-    resolved: list[tuple[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-    for entry in eval_entries:
-        if not isinstance(entry, dict):
-            continue
-        env_id = entry.get("env_id") or entry.get("id")
-        if not isinstance(env_id, str) or not env_id:
-            continue
-        env_dir_path = entry.get("env_dir_path")
-        if not isinstance(env_dir_path, str):
-            env_dir_path = global_env_dir
-        key = (env_id, env_dir_path)
-        if key in seen:
-            continue
-        seen.add(key)
-        resolved.append(key)
-    return resolved
-
-
 def _env_name_from_reference(env_reference: str) -> str:
     base_ref, _version = _split_version(env_reference)
     return base_ref.rsplit("/", 1)[-1]
@@ -958,58 +940,173 @@ def run_eval_passthrough(
         )
         raise typer.Exit(1)
 
-    args, env, model, base_url = _add_default_inference_and_key_args(passthrough_args, config)
-    configured_base_url = (config.inference_url or "").strip().rstrip("/")
-    _validate_model(model, base_url, configured_base_url)
-    _preflight_inference_billing(model, base_url, configured_base_url)
+    if any(arg == "--resume" or arg.startswith("--resume=") for arg in passthrough_args):
+        env = os.environ.copy()
+        env["PRIME_API_KEY"] = config.api_key
+        if config.team_id:
+            env["PRIME_TEAM_ID"] = config.team_id
+        command = plugin.build_module_command(plugin.eval_module, passthrough_args)
+        _run_command(command, env=env)
+        return
 
-    env_dir_path = _env_dir_path_arg(args)
-    run_target = environment
-    upstream_slug: Optional[str] = None
-    env_name_for_upload: Optional[str] = None
-    resolved_env: Optional[ResolvedEnvironment] = None
-    config_envs: list[tuple[str, str]] = []
+    # Hosted-eval sandboxes still emit the v0 CLI surface; v1 always saves results.
+    if "--save-results" in passthrough_args:
+        args, env, model, base_url = _add_default_inference_and_key_args(passthrough_args, config)
+        configured_base_url = (config.inference_url or "").strip().rstrip("/")
+        _validate_model(model, base_url, configured_base_url)
+        _preflight_inference_billing(model, base_url, configured_base_url)
 
-    if _is_config_target(environment):
-        config_envs = _collect_eval_config_envs(Path(environment), env_dir_path)
-        for env_ref, ref_env_dir in config_envs:
-            _prepare_single_environment(plugin, env_ref, ref_env_dir)
-    else:
+        env_dir_path = _env_dir_path_arg(args)
         resolved_env = _prepare_single_environment(plugin, environment, env_dir_path)
-        run_target = resolved_env.env_name
-        upstream_slug = resolved_env.upstream_slug
-        env_name_for_upload = resolved_env.env_name
         if resolved_env.env_display_id:
             args.extend(
                 ["--header", f"{INTERNAL_ENV_DISPLAY_HEADER}: {resolved_env.env_display_id}"]
             )
 
-    if not skip_upload and not _has_flag(args, "--save-results", "-s"):
-        args.append("-s")
+        job_id = _build_job_id(resolved_env.env_name, model)
+        args.extend(["--header", f"X-PI-Job-Id: {job_id}"])
+        if config.team_id:
+            args.extend(["--header", f"X-Prime-Team-ID: {config.team_id}"])
+
+        console.print(f"[dim]Eval job_id: {job_id}[/dim]")
+        command = plugin.build_module_command(LEGACY_EVAL_MODULE, [resolved_env.env_name, *args])
+        _run_command(command, env=env)
+
+        if skip_upload:
+            _print_environment_source_footer(resolved_env)
+            console.print("[dim]Skipped uploading evaluation results[/dim]")
+            return
+
+        push_eval_results_to_hub(
+            env_name=resolved_env.env_name,
+            model=model,
+            job_id=job_id,
+            env_path=Path(env_path) if env_path else None,
+            upstream_slug=resolved_env.upstream_slug,
+        )
+        _print_environment_source_footer(resolved_env)
+        return
+
+    target = environment.removeprefix("@")
+    is_config = _is_config_target(target)
+    args = list(passthrough_args)
+    env = os.environ.copy()
+    env["PRIME_API_KEY"] = config.api_key
+    if config.team_id:
+        env["PRIME_TEAM_ID"] = config.team_id
+
+    config_data = toml.load(target) if is_config else {}
+    config_model = config_data.get("model") if isinstance(config_data, dict) else None
+    model = _parse_value_option(args, "--model", "-m") or config_model or DEFAULT_MODEL
+    if _parse_value_option(args, "--model", "-m") is None and not config_model:
+        args.extend(["--model", model])
+
+    configured_base_url = (config.inference_url or "").strip().rstrip("/")
+    config_client = config_data.get("client") if isinstance(config_data, dict) else None
+    config_base_url = config_client.get("base_url") if isinstance(config_client, dict) else None
+    base_url = (
+        _parse_value_option(args, "--client.base-url", None)
+        or config_base_url
+        or configured_base_url
+    )
+    if not base_url:
+        console.print(
+            "[red]Inference URL not configured.[/red] Check [bold]prime config view[/bold]."
+        )
+        raise typer.Exit(1)
+    dry_run_arg = _parse_value_option(args, "--dry-run", None)
+    dry_run = config_data.get("dry_run") is True
+    if dry_run_arg is not None:
+        dry_run = dry_run_arg.lower() == "true"
+    if not dry_run:
+        _validate_model(model, base_url, configured_base_url)
+        _preflight_inference_billing(model, base_url, configured_base_url)
+
+    env_dir_path = DEFAULT_ENV_DIR_PATH
+    run_target = target
+    upstream_slug: Optional[str] = None
+    env_name_for_upload: Optional[str] = None
+    resolved_env: Optional[ResolvedEnvironment] = None
+    config_envs: list[tuple[str, str]] = []
+
+    if is_config:
+        taskset = config_data.get("taskset", {})
+        if isinstance(taskset, dict) and isinstance(taskset.get("id"), str):
+            config_envs = [(taskset["id"], env_dir_path)]
+        for env_ref, ref_env_dir in config_envs:
+            _prepare_single_environment(plugin, env_ref, ref_env_dir)
+        run_target = f"@{target}"
+    else:
+        resolved_env = _prepare_single_environment(plugin, target, env_dir_path)
+        run_target = resolved_env.env_name
+        upstream_slug = resolved_env.upstream_slug
+        env_name_for_upload = resolved_env.env_name
 
     job_target = env_name_for_upload
     if job_target is None and config_envs:
         job_target = _env_name_from_reference(config_envs[0][0])
     if job_target is None:
-        job_target = Path(environment).stem
-    if config_envs and _parse_value_option(passthrough_args, "--model", "-m") is None:
-        model = toml.load(environment).get("model") or model
+        job_target = Path(target).stem
     job_id = _build_job_id(job_target, model)
-    args.extend(["--header", f"X-PI-Job-Id: {job_id}"])
+    output_dir_arg = _parse_value_option(args, "--output-dir", "-o")
+    config_output_dir = config_data.get("output_dir") if isinstance(config_data, dict) else None
+    configured_output_dir = output_dir_arg or config_output_dir
+    output_dir = (
+        Path(configured_output_dir)
+        if configured_output_dir
+        else Path("outputs", "evals", f"{job_target}--{model.replace('/', '--')}", job_id)
+    )
+    if configured_output_dir is None:
+        args.extend(["--output-dir", str(output_dir)])
 
-    if config.team_id:
-        args.extend(["--header", f"X-Prime-Team-ID: {config.team_id}"])
+    headers = config_client.get("headers", {}) if isinstance(config_client, dict) else {}
+    if not isinstance(headers, dict):
+        console.print("[red]Error:[/red] client.headers must be a table")
+        raise typer.Exit(2)
+    cli_headers = _parse_value_option(args, "--client.headers", None)
+    if cli_headers:
+        try:
+            parsed_headers = json.loads(cli_headers)
+        except json.JSONDecodeError as exc:
+            console.print("[red]Error:[/red] --client.headers must be valid JSON")
+            raise typer.Exit(2) from exc
+        if not isinstance(parsed_headers, dict):
+            console.print("[red]Error:[/red] --client.headers must be a JSON object")
+            raise typer.Exit(2)
+        headers = {**headers, **parsed_headers}
+    headers["X-PI-Job-Id"] = job_id
+    if resolved_env is not None and resolved_env.env_display_id:
+        headers[INTERNAL_ENV_DISPLAY_HEADER] = resolved_env.env_display_id
+    args.extend(["--client.headers", json.dumps(headers)])
 
     console.print(f"[dim]Eval job_id: {job_id}[/dim]")
     command = plugin.build_module_command(plugin.eval_module, [run_target, *args])
     _run_command(command, env=env)
+
+    results_path = output_dir / "results.jsonl"
+    if not results_path.exists():
+        console.print("[dim]No rollout results produced.[/dim]")
+        return
+    results = convert_eval_results(load_results_jsonl(results_path))
+    task_ids = {row["example_id"] for row in results if "example_id" in row}
+    rewards = [row["reward"] for row in results if isinstance(row.get("reward"), (int, float))]
+    metadata = {
+        "env": job_target,
+        "model": model,
+        "num_examples": len(task_ids),
+        "rollouts_per_example": len(results) // len(task_ids) if task_ids else 0,
+        "avg_reward": sum(rewards) / len(rewards) if rewards else 0.0,
+    }
+    (output_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+    )
 
     if skip_upload:
         _print_environment_source_footer(resolved_env)
         console.print("[dim]Skipped uploading evaluation results[/dim]")
         return
 
-    if _is_config_target(environment):
+    if is_config:
         console.print(
             "[yellow]Evaluation completed. Automatic upload is skipped for "
             "config-driven runs.[/yellow]"
@@ -1056,6 +1153,7 @@ def run_eval_passthrough(
             job_id=job_id,
             env_path=Path(env_path) if env_path else None,
             upstream_slug=upstream_slug,
+            output_dir=output_dir,
         )
     except Exception as exc:
         console.print(f"[red]Failed to push results to hub:[/red] {exc}")

--- a/packages/prime/src/prime_cli/verifiers_plugin.py
+++ b/packages/prime/src/prime_cli/verifiers_plugin.py
@@ -16,6 +16,12 @@ from rich.console import Console
 from .utils.plain import get_console
 
 EXPECTED_PLUGIN_API_VERSION = 1
+V1_EVAL_MODULE = "verifiers.v1.cli.eval.main"
+V1_INIT_MODULE = "verifiers.v1.cli.init"
+V1_ENTRYPOINTS = {
+    V1_EVAL_MODULE: f"import sys; sys.argv[0] = 'eval'; from {V1_EVAL_MODULE} import main; main()",
+    V1_INIT_MODULE: f"import sys; sys.argv[0] = 'init'; from {V1_INIT_MODULE} import main; main()",
+}
 
 
 def _venv_python(venv_root: Path) -> Path:
@@ -47,7 +53,7 @@ def resolve_workspace_python(cwd: Path | None = None) -> str:
     """Prefer workspace Python only when it can run verifiers command modules."""
     workspace = (cwd or Path.cwd()).resolve()
     workspace_str = str(workspace)
-    module = "verifiers.cli.commands.eval"
+    module = V1_EVAL_MODULE
 
     def _usable(candidate: Path) -> bool:
         return candidate.exists() and _python_can_import_module(
@@ -80,10 +86,10 @@ class PrimeVerifiersPlugin:
     """Local fallback contract used when verifiers plugin loading fails."""
 
     api_version: int = EXPECTED_PLUGIN_API_VERSION
-    eval_module: str = "verifiers.cli.commands.eval"
+    eval_module: str = V1_EVAL_MODULE
     gepa_module: str = "verifiers.cli.commands.gepa"
     install_module: str = "verifiers.cli.commands.install"
-    init_module: str = "verifiers.cli.commands.init"
+    init_module: str = V1_INIT_MODULE
     setup_module: str = "verifiers.cli.commands.setup"
     build_module: str = "verifiers.cli.commands.build"
     tui_module: str = "verifiers.cli.tui"
@@ -91,7 +97,9 @@ class PrimeVerifiersPlugin:
     def build_module_command(
         self, module_name: str, args: Sequence[str] | None = None
     ) -> list[str]:
-        command = [resolve_workspace_python(), "-m", module_name]
+        python = resolve_workspace_python()
+        entrypoint = V1_ENTRYPOINTS.get(module_name)
+        command = [python, "-c", entrypoint] if entrypoint else [python, "-m", module_name]
         if args:
             command.extend(args)
         return command
@@ -136,10 +144,10 @@ def load_verifiers_prime_plugin(console: Console | None = None) -> PrimeVerifier
 
     return PrimeVerifiersPlugin(
         api_version=int(api_version or EXPECTED_PLUGIN_API_VERSION),
-        eval_module=getattr(plugin, "eval_module", "verifiers.cli.commands.eval"),
+        eval_module=V1_EVAL_MODULE,
         gepa_module=getattr(plugin, "gepa_module", "verifiers.cli.commands.gepa"),
         install_module=getattr(plugin, "install_module", "verifiers.cli.commands.install"),
-        init_module=getattr(plugin, "init_module", "verifiers.cli.commands.init"),
+        init_module=V1_INIT_MODULE,
         setup_module=getattr(plugin, "setup_module", "verifiers.cli.commands.setup"),
         build_module=getattr(plugin, "build_module", "verifiers.cli.commands.build"),
         tui_module=getattr(plugin, "tui_module", "verifiers.cli.tui"),

--- a/packages/prime/src/prime_lab_app/agent_runtime.py
+++ b/packages/prime/src/prime_lab_app/agent_runtime.py
@@ -643,6 +643,7 @@ class AgentRuntime:
                 },
                 timeout=12,
             )
+            self._record_codex_account_status()
             thread = self._request(
                 "thread/start",
                 {
@@ -668,6 +669,71 @@ class AgentRuntime:
         thread_payload = thread.get("thread")
         thread_id = str(thread_payload.get("id") or "") if isinstance(thread_payload, dict) else ""
         self._set_connected(message="Connected", session_id=thread_id)
+
+    def _record_codex_account_status(self) -> None:
+        """Read Codex account metadata, including ChatGPT subscription plan, when available."""
+
+        try:
+            auth_status = self._request(
+                "getAuthStatus",
+                {"includeToken": False, "refreshToken": False},
+                timeout=5,
+            )
+        except Exception:
+            auth_status = {}
+        try:
+            account_status = self._request(
+                "account/read",
+                {"refreshToken": False},
+                timeout=5,
+            )
+        except Exception:
+            account_status = {}
+
+        auth_method = str(auth_status.get("authMethod") or "")
+        requires_openai_auth = bool(
+            auth_status.get("requiresOpenaiAuth") or account_status.get("requiresOpenaiAuth")
+        )
+        account = account_status.get("account")
+        account_type = ""
+        email = ""
+        plan_type = ""
+        if isinstance(account, dict):
+            account_type = str(account.get("type") or "")
+            email = str(account.get("email") or "")
+            plan_type = str(account.get("planType") or "")
+
+        content = _codex_account_status_text(
+            auth_method=auth_method,
+            account_type=account_type,
+            email=email,
+            plan_type=plan_type,
+            requires_openai_auth=requires_openai_auth,
+        )
+        if not content:
+            return
+        with self._lock:
+            self._messages = [
+                message
+                for message in self._messages
+                if message.metadata.get("title") != "Codex account"
+            ]
+            self._messages.append(
+                AgentChatMessage(
+                    "system",
+                    content,
+                    "tool",
+                    {
+                        "title": "Codex account",
+                        "auth_method": auth_method,
+                        "account_type": account_type,
+                        "email": email,
+                        "plan_type": plan_type,
+                        "requires_openai_auth": requires_openai_auth,
+                    },
+                )
+            )
+            self._emit_messages_locked()
 
     def _wait_for_endpoint_or_alive(self) -> None:
         deadline = time.monotonic() + 2.0
@@ -860,6 +926,11 @@ class AgentRuntime:
             if request_id is not None:
                 self._respond(request_id, None)
             return
+        if method == "account/updated":
+            self._handle_codex_account_updated(params)
+            if request_id is not None:
+                self._respond(request_id, None)
+            return
         if method == "item/agentMessage/delta":
             self._handle_codex_agent_delta(params)
             if request_id is not None:
@@ -951,6 +1022,33 @@ class AgentRuntime:
                         {"title": label, "tool_status": status},
                     )
                 )
+            self._emit_messages_locked()
+
+    def _handle_codex_account_updated(self, params: dict[str, Any]) -> None:
+        content = _codex_account_status_text(
+            auth_method=_string_or_empty(params.get("authMode")),
+            plan_type=_string_or_empty(params.get("planType")),
+        )
+        if not content:
+            return
+        with self._lock:
+            self._messages = [
+                message
+                for message in self._messages
+                if message.metadata.get("title") != "Codex account"
+            ]
+            self._messages.append(
+                AgentChatMessage(
+                    "system",
+                    content,
+                    "tool",
+                    {
+                        "title": "Codex account",
+                        "auth_method": _string_or_empty(params.get("authMode")),
+                        "plan_type": _string_or_empty(params.get("planType")),
+                    },
+                )
+            )
             self._emit_messages_locked()
 
     def _handle_codex_agent_delta(self, params: dict[str, Any]) -> None:
@@ -1522,6 +1620,52 @@ def _suffix_prefix_overlap(existing: str, delta: str) -> int:
         if existing.endswith(delta[:size]):
             return size
     return 0
+
+
+def _codex_account_status_text(
+    *,
+    auth_method: str = "",
+    account_type: str = "",
+    email: str = "",
+    plan_type: str = "",
+    requires_openai_auth: bool = False,
+) -> str:
+    auth_method = auth_method.strip()
+    account_type = account_type.strip()
+    email = email.strip()
+    plan_type = plan_type.strip()
+    if requires_openai_auth:
+        return "Codex account requires OpenAI authentication. Run `codex login` to connect ChatGPT."
+    if account_type == "chatgpt" or auth_method in {"chatgpt", "chatgptAuthTokens"}:
+        plan_label = _chatgpt_plan_label(plan_type)
+        account_label = email or "ChatGPT account"
+        return f"Codex is authenticated with {account_label} ({plan_label})."
+    if auth_method == "apikey" or account_type == "apiKey":
+        return "Codex is authenticated with an OpenAI API key."
+    return ""
+
+
+def _chatgpt_plan_label(plan_type: str) -> str:
+    normalized = plan_type.strip().lower()
+    labels = {
+        "free": "ChatGPT Free",
+        "go": "ChatGPT Go",
+        "plus": "ChatGPT Plus",
+        "pro": "ChatGPT Pro",
+        "prolite": "ChatGPT Pro",
+        "team": "ChatGPT Team",
+        "self_serve_business_usage_based": "ChatGPT Business",
+        "business": "ChatGPT Business",
+        "enterprise_cbp_usage_based": "ChatGPT Enterprise",
+        "enterprise": "ChatGPT Enterprise",
+        "edu": "ChatGPT Edu",
+        "unknown": "ChatGPT subscription",
+    }
+    return labels.get(normalized, "ChatGPT subscription")
+
+
+def _string_or_empty(value: Any) -> str:
+    return value if isinstance(value, str) else ""
 
 
 def _jsonrpc_response_id(value: Any) -> int | None:


### PR DESCRIPTION
## Summary
when you don't specify the model name in the CLI (but rather in the TOML), the prime CLI used the DEFAULT_MODEL (gpt-4.1 mini) instead of the TOML value. this fixes it


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main local eval execution and hub upload pipeline (model resolution, output layout, sample schema); legacy `--save-results` limits blast radius but v1 is now the default path.
> 
> **Overview**
> **Local eval runs now default to the verifiers v1 eval CLI** (`verifiers.v1.cli.eval.main`), including plugin command building and help text sanitization for `uv run eval`. The **legacy v0 path remains** when `--save-results` is passed (hosted sandboxes).
> 
> For v1 runs, **`run_eval_passthrough` resolves `model` from the eval TOML** when `--model` is not set—fixing job IDs, default `--model` injection, output paths, and post-run `metadata.json` that previously fell back to `DEFAULT_MODEL`. It also sets **`--output-dir`**, merges **`client.headers`** (job id, env display), supports **`--resume`** without the full wrapper, and reads **`taskset.id`** from config instead of the old `[[eval]]` table.
> 
> **`convert_eval_results`** maps v1 trace JSONL lines into the hub/viewer sample shape while leaving legacy rows intact (including `id` → `example_id`). Push/load paths use it; **`push_eval_results_to_hub`** can take an explicit **`output_dir`**.
> 
> **`prime eval run`** gains **`@config`** and **`--resume`** parsing, rejects **`--sampling-args`** for v1 local runs (points users at `--sampling.*`), and only forwards sampling JSON for legacy runs.
> 
> **Prime Lab** separately surfaces **Codex account / ChatGPT plan** status after connect and on `account/updated` notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefdf9220ed7cf448ec8bdc5f112695a3d8b4dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->