### PR TITLE
[ENG-4030] config updates to support orch v2

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -90,6 +90,7 @@ class RLRun(BaseModel):
     run_config: Optional[Dict[str, Any]] = Field(None, alias="runConfig")
     eval_config: Optional[Dict[str, Any]] = Field(None, alias="evalConfig")
     val_config: Optional[Dict[str, Any]] = Field(None, alias="valConfig")
+    # DEPRECATED: buffer removed in prime-rl orch v2; populated only on historical runs
     buffer_config: Optional[Dict[str, Any]] = Field(None, alias="bufferConfig")
     learning_rate: Optional[float] = Field(None, alias="learningRate")
     lora_alpha: Optional[int] = Field(None, alias="loraAlpha")
@@ -200,7 +201,6 @@ class RLClient:
         team_id: Optional[str] = None,
         eval_config: Optional[Dict[str, Any]] = None,
         val_config: Optional[Dict[str, Any]] = None,
-        buffer_config: Optional[Dict[str, Any]] = None,
         learning_rate: Optional[float] = None,
         lora_alpha: Optional[int] = None,
         max_inflight_rollouts: Optional[int] = None,
@@ -273,9 +273,6 @@ class RLClient:
 
             if val_config:
                 payload["val"] = val_config
-
-            if buffer_config:
-                payload["buffer"] = buffer_config
 
             if learning_rate is not None:
                 payload["learning_rate"] = learning_rate

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -265,7 +265,7 @@ id = "{env_value}"
 # # optional: default for all environments
 # num_examples = -1
 # rollouts_per_example = 1
-# eval_base_model = true
+# skip_first_step = false # set true to skip the pre-training eval of the base model
 #
 # [[eval.env]]
 # id = "primeintellect/eval-env"
@@ -458,7 +458,11 @@ class EvalConfig(BaseModel):
     interval: int | None = None
     num_examples: int | None = None
     rollouts_per_example: int | None = None
-    eval_base_model: bool | None = None
+    skip_first_step: bool | None = None
+    """Skip the eval of the base model that otherwise runs before training
+    starts. Replaces the deprecated ``eval_base_model`` with inverted meaning
+    (``eval_base_model = false`` ≡ ``skip_first_step = true``), matching the
+    prime-rl orch v2 rename."""
     env: List[EvalEnvConfig] = Field(default_factory=list)
     sampling: EvalSamplingConfig | None = None
 
@@ -472,8 +476,8 @@ class EvalConfig(BaseModel):
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:
             result["rollouts_per_example"] = self.rollouts_per_example
-        if self.eval_base_model is not None:
-            result["eval_base_model"] = self.eval_base_model
+        if self.skip_first_step is not None:
+            result["skip_first_step"] = self.skip_first_step
         if self.sampling is not None:
             sampling_dict = self.sampling.model_dump(exclude_none=True)
             if sampling_dict:
@@ -703,6 +707,26 @@ def _remove_deprecated_config_keys(data: Dict[str, Any]) -> None:
             "[yellow]Warning:[/yellow] `[buffer]` is deprecated and ignored: "
             "the difficulty-filtering buffer was removed from the trainer."
         )
+
+    eval_section = data.get("eval")
+    if isinstance(eval_section, dict) and "eval_base_model" in eval_section:
+        legacy = eval_section.pop("eval_base_model")
+        if "skip_first_step" in eval_section:
+            console.print(
+                "[yellow]Warning:[/yellow] `eval.eval_base_model` is deprecated and "
+                "ignored because `eval.skip_first_step` is also set. Remove "
+                "`eval_base_model` from your config."
+            )
+        else:
+            translated = (not legacy) if isinstance(legacy, bool) else legacy
+            eval_section["skip_first_step"] = translated
+            console.print(
+                "[yellow]Warning:[/yellow] `eval.eval_base_model` is deprecated: "
+                "prime-rl renamed it to `skip_first_step` with inverted meaning "
+                "(`eval_base_model = false` ≡ `skip_first_step = true`). "
+                f"Translating to `skip_first_step = {str(translated).lower()}` — "
+                "update your config to use `skip_first_step` directly."
+            )
 
 
 def _peek_toml(config_path: str) -> Dict[str, Any]:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -280,16 +280,6 @@ id = "{env_value}"
 # rollouts_per_example = 1
 # interval = 5
 
-# Optional: buffer configuration for difficulty filtering
-# [buffer]
-# easy_threshold = 1.0
-# hard_threshold = 0.0
-# easy_fraction = 0.0
-# hard_fraction = 0.0
-# online_difficulty_filtering = false
-# env_ratios = [0.5, 0.5]
-# skip_verification = false
-
 # Optional: checkpoint configuration
 # [checkpoints]
 # interval = 100              # Save checkpoint every N steps
@@ -509,39 +499,6 @@ class ValConfig(BaseModel):
         return result if result else None
 
 
-class BufferConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    easy_threshold: float | None = None
-    hard_threshold: float | None = None
-    easy_fraction: float | None = None
-    hard_fraction: float | None = None
-    online_difficulty_filtering: bool | None = None
-    env_ratios: List[float] | None = None
-    skip_verification: bool | None = None
-    seed: int | None = None
-
-    def to_api_dict(self) -> Dict[str, Any] | None:
-        result: Dict[str, Any] = {}
-        if self.easy_threshold is not None:
-            result["easy_threshold"] = self.easy_threshold
-        if self.hard_threshold is not None:
-            result["hard_threshold"] = self.hard_threshold
-        if self.easy_fraction is not None:
-            result["easy_fraction"] = self.easy_fraction
-        if self.hard_fraction is not None:
-            result["hard_fraction"] = self.hard_fraction
-        if self.online_difficulty_filtering is not None:
-            result["online_difficulty_filtering"] = self.online_difficulty_filtering
-        if self.env_ratios is not None:
-            result["env_ratios"] = self.env_ratios
-        if self.skip_verification is not None:
-            result["skip_verification"] = self.skip_verification
-        if self.seed is not None:
-            result["seed"] = self.seed
-        return result if result else None
-
-
 class WandbConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -686,7 +643,6 @@ class RLConfig(BaseModel):
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
     val: ValConfig = Field(default_factory=ValConfig)
-    buffer: BufferConfig = Field(default_factory=BufferConfig)
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
@@ -740,6 +696,13 @@ def _remove_deprecated_config_keys(data: Dict[str, Any]) -> None:
 
     if removed:
         console.print("[yellow]Warning:[/yellow] `trajectory_strategy` is deprecated and ignored.")
+
+    if "buffer" in data:
+        data.pop("buffer", None)
+        console.print(
+            "[yellow]Warning:[/yellow] `[buffer]` is deprecated and ignored: "
+            "the difficulty-filtering buffer was removed from the trainer."
+        )
 
 
 def _peek_toml(config_path: str) -> Dict[str, Any]:
@@ -1414,7 +1377,6 @@ def create_run(
             team_id=app_config.team_id,
             eval_config=cfg.eval.to_api_dict(),
             val_config=cfg.val.to_api_dict(),
-            buffer_config=cfg.buffer.to_api_dict(),
             learning_rate=cfg.learning_rate,
             lora_alpha=cfg.lora_alpha,
             max_inflight_rollouts=cfg.max_inflight_rollouts,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -876,6 +876,14 @@ def _dispatch_full_finetune_run(
         raise typer.Exit(1)
     resolved_image_tag = image_tag or config_image_tag
 
+    # Same deprecation pass as the LoRA path. In the prime-rl-native shape
+    # the deprecated keys live one level down, under `[orchestrator]` — and
+    # this config ships verbatim to the dedicated training endpoint, where
+    # orch v2 rejects the removed keys as "Extra inputs are not permitted".
+    orch_section = raw_cfg.get("orchestrator")
+    if isinstance(orch_section, dict):
+        _remove_deprecated_config_keys(orch_section)
+
     # Strip CLI-only secret-loading keys before shipping the TOML to the
     # backend. `env_file` / `env_files` only meaningfully exist on the
     # caller's filesystem — the hosted pod doesn't see them, and prime-rl

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -47,8 +47,6 @@ def training_config_toml(raw: dict[str, Any]) -> str:
         config["eval"] = _rl_eval_config(raw["eval_config"])
     if isinstance(raw.get("val_config"), dict):
         config["val"] = raw["val_config"]
-    if isinstance(raw.get("buffer_config"), dict):
-        config["buffer"] = raw["buffer_config"]
 
     filtered = _filter_empty_values(normalize_rl_config(config))
     return format_toml_blocks(toml.dumps(filtered)).rstrip() if filtered else ""
@@ -81,12 +79,10 @@ def normalize_rl_config(config: dict[str, Any]) -> dict[str, Any]:
             updated["val"] = val_config
     else:
         updated.pop("val_config", None)
-    if "buffer_config" in updated and "buffer" not in updated:
-        buffer_config = updated.pop("buffer_config")
-        if isinstance(buffer_config, dict):
-            updated["buffer"] = buffer_config
-    else:
-        updated.pop("buffer_config", None)
+    # The difficulty-filtering buffer was removed in prime-rl orch v2; strip it
+    # from regenerated configs so historical runs don't carry it forward.
+    updated.pop("buffer_config", None)
+    updated.pop("buffer", None)
     updated.pop("run_config", None)
     return updated
 

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -73,6 +73,18 @@ def normalize_rl_config(config: dict[str, Any]) -> dict[str, Any]:
             updated["eval"] = _rl_eval_config(eval_config)
     else:
         updated.pop("eval_config", None)
+    eval_table = updated.get("eval")
+    if isinstance(eval_table, dict) and "eval_base_model" in eval_table:
+        # eval_base_model was removed in prime-rl orch v2; translate to its
+        # replacement (inverted meaning) so saved workspace TOMLs keep
+        # validating against RLConfig. `eval_base_model = true` matches the
+        # `skip_first_step` default, so it is simply dropped instead of
+        # emitting a redundant `= false`.
+        eval_table = dict(eval_table)
+        legacy = eval_table.pop("eval_base_model")
+        if legacy is False and "skip_first_step" not in eval_table:
+            eval_table["skip_first_step"] = True
+        updated["eval"] = eval_table
     if "val_config" in updated and "val" not in updated:
         val_config = updated.pop("val_config")
         if isinstance(val_config, dict):
@@ -201,14 +213,6 @@ def _rl_eval_config(config: dict[str, Any]) -> dict[str, Any]:
         updated["env"] = _rl_env_configs(_list_value(updated["env"]))
     elif isinstance(environments, list) and environments:
         updated["env"] = _rl_env_configs(environments)
-    # Historical runs store the deprecated `eval_base_model`; regenerate
-    # configs with its prime-rl orch v2 replacement (inverted meaning).
-    # `eval_base_model = true` matches the `skip_first_step` default, so it
-    # is simply dropped instead of emitting a redundant `= false`.
-    if "eval_base_model" in updated:
-        legacy = updated.pop("eval_base_model")
-        if legacy is False and "skip_first_step" not in updated:
-            updated["skip_first_step"] = True
     return updated
 
 

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -201,6 +201,14 @@ def _rl_eval_config(config: dict[str, Any]) -> dict[str, Any]:
         updated["env"] = _rl_env_configs(_list_value(updated["env"]))
     elif isinstance(environments, list) and environments:
         updated["env"] = _rl_env_configs(environments)
+    # Historical runs store the deprecated `eval_base_model`; regenerate
+    # configs with its prime-rl orch v2 replacement (inverted meaning).
+    # `eval_base_model = true` matches the `skip_first_step` default, so it
+    # is simply dropped instead of emitting a redundant `= false`.
+    if "eval_base_model" in updated:
+        legacy = updated.pop("eval_base_model")
+        if legacy is False and "skip_first_step" not in updated:
+            updated["skip_first_step"] = True
     return updated
 
 

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 import pytest
 import typer
@@ -9,6 +10,7 @@ from prime_cli.commands.rl import (
     generate_rl_config_template,
     load_config,
 )
+from pydantic import BaseModel
 
 
 def test_load_config_warns_and_ignores_deprecated_trajectory_strategy(
@@ -42,13 +44,6 @@ def test_load_config_still_rejects_other_unknown_keys(tmp_path: Path) -> None:
 
     with pytest.raises(typer.Exit):
         load_config(str(config_path))
-
-
-def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> None:
-    template = generate_rl_config_template()
-
-    assert "# easy_threshold = 1.0" in template
-    assert "# hard_threshold = 0.0" in template
 
 
 def test_generate_rl_config_template_keeps_default_surface_minimal() -> None:
@@ -114,13 +109,16 @@ def test_flatten_config_schema_expands_optional_nested_models() -> None:
 
 
 def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
-    schema = RLConfig.model_json_schema()
+    class _OptionalArrayModel(BaseModel):
+        ratios: List[float] | None = None
+
+    schema = _OptionalArrayModel.model_json_schema()
     rows = {
         path: type_str
         for path, type_str, _ in _flatten_config_schema(schema, schema.get("$defs", {}))
     }
 
-    assert rows["buffer.env_ratios"] == "list[number]"
+    assert rows["ratios"] == "list[number]"
 
 
 def test_load_config_accepts_sampling_reasoning_effort(tmp_path: Path) -> None:


### PR DESCRIPTION
see: https://github.com/PrimeIntellect-ai/prime-rl/pull/2639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes training/eval config contracts and migration paths; mis-translated legacy eval flags could alter whether pre-training base-model eval runs, though warnings and inverted mapping are explicit.
> 
> **Overview**
> Aligns Hosted Training config with **prime-rl orchestrator v2**: removes the difficulty-filtering **buffer** from CLI schemas, API create payloads, and lab TOML regeneration, and renames eval’s **`eval_base_model`** to **`skip_first_step`** (inverted semantics).
> 
> **Buffer:** `BufferConfig` and `[buffer]` are dropped from `RLConfig`; `create_run` no longer sends `buffer` / `buffer_config`. Historical API runs may still expose `buffer_config` on read. Legacy TOMLs with `[buffer]` get a warning and the key is stripped before validation; full-FT dispatch also runs deprecation cleanup on `[orchestrator]` so orch v2 doesn’t reject extra fields.
> 
> **Eval:** `EvalConfig` uses `skip_first_step` in templates and API payloads. Load-time migration maps `eval_base_model = false` → `skip_first_step = true`, warns on conflicts, and `training_config.normalize_rl_config` does the same when exporting configs from past runs.
> 
> Tests drop buffer-template assertions and use a small helper model for optional-array schema flattening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae13c688bccca49cbb675ed03066c61ff330838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->