### PR TITLE
[ENG-4068] Support pre/post_batch_filters

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -276,10 +276,12 @@ class RLClient:
             if val_config:
                 payload["val"] = val_config
 
-            if pre_batch_filters:
+            # `is not None` rather than truthiness: an explicit empty list
+            # overrides prime-rl's default filters and must be sent.
+            if pre_batch_filters is not None:
                 payload["pre_batch_filters"] = pre_batch_filters
 
-            if post_batch_filters:
+            if post_batch_filters is not None:
                 payload["post_batch_filters"] = post_batch_filters
 
             if learning_rate is not None:

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -201,6 +201,8 @@ class RLClient:
         team_id: Optional[str] = None,
         eval_config: Optional[Dict[str, Any]] = None,
         val_config: Optional[Dict[str, Any]] = None,
+        pre_batch_filters: Optional[List[Dict[str, Any]]] = None,
+        post_batch_filters: Optional[List[Dict[str, Any]]] = None,
         learning_rate: Optional[float] = None,
         lora_alpha: Optional[int] = None,
         max_inflight_rollouts: Optional[int] = None,
@@ -273,6 +275,12 @@ class RLClient:
 
             if val_config:
                 payload["val"] = val_config
+
+            if pre_batch_filters:
+                payload["pre_batch_filters"] = pre_batch_filters
+
+            if post_batch_filters:
+                payload["post_batch_filters"] = post_batch_filters
 
             if learning_rate is not None:
                 payload["learning_rate"] = learning_rate

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1433,11 +1433,14 @@ def create_run(
             team_id=app_config.team_id,
             eval_config=cfg.eval.to_api_dict(),
             val_config=cfg.val.to_api_dict(),
+            # `is not None` rather than truthiness: an explicit `= []` means
+            # "replace prime-rl's default filter list with no filters" and
+            # must reach the API as an empty list, not be omitted.
             pre_batch_filters=[f.model_dump(exclude_none=True) for f in cfg.pre_batch_filters]
-            if cfg.pre_batch_filters
+            if cfg.pre_batch_filters is not None
             else None,
             post_batch_filters=[f.model_dump(exclude_none=True) for f in cfg.post_batch_filters]
-            if cfg.post_batch_filters
+            if cfg.post_batch_filters is not None
             else None,
             learning_rate=cfg.learning_rate,
             lora_alpha=cfg.lora_alpha,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -280,6 +280,12 @@ id = "{env_value}"
 # rollouts_per_example = 1
 # interval = 5
 
+# Optional: rollout filters (replaces the removed difficulty buffer).
+# Setting a slot overrides prime-rl's default filter list for that slot.
+# [[pre_batch_filters]]
+# type = "zero_advantage" # "gibberish" | "repetition" | "zero_advantage"
+# enforce = true          # drop flagged rollouts before they fill a batch slot
+
 # Optional: checkpoint configuration
 # [checkpoints]
 # interval = 100              # Save checkpoint every N steps
@@ -503,6 +509,22 @@ class ValConfig(BaseModel):
         return result if result else None
 
 
+class BatchFilterConfig(BaseModel):
+    """A single prime-rl rollout filter (one ``[[pre_batch_filters]]`` /
+    ``[[post_batch_filters]]`` table).
+
+    Extra keys pass through verbatim so type-specific knobs (e.g.
+    repetition's ``window``) reach the trainer without a CLI release.
+    Enforcing ``zero_advantage`` pre-batch is the orch v2 replacement for
+    the removed ``buffer.online_difficulty_filtering``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    enforce: bool | None = None
+
+
 class WandbConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -647,6 +669,8 @@ class RLConfig(BaseModel):
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
     val: ValConfig = Field(default_factory=ValConfig)
+    pre_batch_filters: List[BatchFilterConfig] | None = None
+    post_batch_filters: List[BatchFilterConfig] | None = None
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
@@ -1409,6 +1433,12 @@ def create_run(
             team_id=app_config.team_id,
             eval_config=cfg.eval.to_api_dict(),
             val_config=cfg.val.to_api_dict(),
+            pre_batch_filters=[f.model_dump(exclude_none=True) for f in cfg.pre_batch_filters]
+            if cfg.pre_batch_filters
+            else None,
+            post_batch_filters=[f.model_dump(exclude_none=True) for f in cfg.post_batch_filters]
+            if cfg.post_batch_filters
+            else None,
             learning_rate=cfg.learning_rate,
             lora_alpha=cfg.lora_alpha,
             max_inflight_rollouts=cfg.max_inflight_rollouts,


### PR DESCRIPTION
prime-rl orch v2 replaced the difficulty buffer with rollout filter slots; enforcing the zero_advantage filter pre-batch is the successor to buffer.online_difficulty_filtering. Expose them in rl.toml:

- Add pre_batch_filters / post_batch_filters to RLConfig (BatchFilterConfig: required type, optional enforce; extra keys pass through so type-specific knobs like repetition's window reach the trainer without a CLI release)
- Send both slots in the create-run payload
- Document [[pre_batch_filters]] in the config template as the replacement for the removed buffer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how training batches are built (rollout filtering) and must stay aligned with backend/prime-rl semantics; empty-list override behavior affects default trainer filters.
> 
> **Overview**
> Exposes **prime-rl orch v2 rollout filter slots** in Hosted Training `rl.toml` and the create-run API path, replacing the removed difficulty buffer.
> 
> Adds **`pre_batch_filters` / `post_batch_filters`** to `RLConfig` via a new **`BatchFilterConfig`** (`type`, optional `enforce`, plus passthrough extra keys for type-specific options). Values are serialized into the **`/rft/runs`** payload; both client and CLI use **`is not None`** so an explicit empty list is sent and overrides trainer defaults instead of being dropped.
> 
> The **`rl.toml` template** documents optional `[[pre_batch_filters]]` (e.g. `zero_advantage` with `enforce`) as the successor to `buffer.online_difficulty_filtering`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6324c9e265fcd7aa08f03ebeb7576acef19ce68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->