### PR TITLE
delete tunnels by status

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -299,6 +299,7 @@ class TunnelClient:
         self,
         tunnel_ids: Optional[list[str]] = None,
         labels: Optional[list[str]] = None,
+        status: Optional[str] = None,
         team_id: Optional[str] = None,
         user_id: Optional[str] = None,
         all_users: bool = False,
@@ -308,6 +309,8 @@ class TunnelClient:
 
         if all_users and not team_id:
             raise TunnelError("all_users requires a team ID")
+        if status and tunnel_ids:
+            raise TunnelError("status cannot be combined with tunnel_ids")
 
         url = f"{self.base_url}/api/v1/tunnel"
         payload: Dict[str, Any] = {"all_users": all_users}
@@ -315,6 +318,8 @@ class TunnelClient:
             payload["tunnel_ids"] = tunnel_ids
         if labels:
             payload["labels"] = labels
+        if status:
+            payload["status"] = status
         if team_id:
             payload["teamId"] = team_id
         if user_id:

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -348,3 +348,35 @@ async def test_client_bulk_delete_all_users_requires_team_id(monkeypatch):
 
     with pytest.raises(TunnelError, match="all_users requires a team ID"):
         await client.bulk_delete_tunnels(labels=["dev"], all_users=True)
+
+
+@pytest.mark.asyncio
+async def test_client_bulk_delete_by_status(monkeypatch):
+    client = TunnelClient(api_key="test-key")
+    captured = {}
+
+    async def fake_request(method, url, json=None, params=None):
+        captured["method"] = method
+        captured["json"] = json
+        return MagicMock(status_code=200)
+
+    async def fake_handle_response(response, operation):
+        return {"succeeded": ["t-test123"], "failed": [], "message": "ok"}
+
+    monkeypatch.setattr(client, "_idempotent_request_with_retry", fake_request)
+    monkeypatch.setattr(client, "_handle_response", fake_handle_response)
+
+    result = await client.bulk_delete_tunnels(status="disconnected", user_id="user-1")
+
+    assert captured["json"]["status"] == "disconnected"
+    assert captured["json"]["userId"] == "user-1"
+    assert "tunnel_ids" not in captured["json"]
+    assert result["succeeded"] == ["t-test123"]
+
+
+@pytest.mark.asyncio
+async def test_client_bulk_delete_status_rejects_tunnel_ids():
+    client = TunnelClient(api_key="test-key")
+
+    with pytest.raises(TunnelError, match="status cannot be combined with tunnel_ids"):
+        await client.bulk_delete_tunnels(tunnel_ids=["t-1"], status="disconnected")

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -317,40 +317,71 @@ def tunnel_status(
 @app.command("stop")
 def stop_tunnel(
     tunnel_ids: Optional[List[str]] = typer.Argument(
-        None, help="Tunnel ID(s) to stop (space or comma-separated)"
+        None,
+        help=(
+            "Explicit tunnel ID(s) to stop, space- or comma-separated. "
+            "Cannot be combined with --all, --label, or --status (those select "
+            "tunnels by filter instead)."
+        ),
     ),
-    all: bool = typer.Option(False, "--all", "-a", help="Stop all tunnels"),
+    all: bool = typer.Option(
+        False,
+        "--all",
+        "-a",
+        help=(
+            "Stop every tunnel in scope (your own by default; add --all-users "
+            "for all members of a team). Cannot be combined with tunnel IDs or "
+            "--label; may be narrowed with --status."
+        ),
+    ),
     labels: Optional[List[str]] = typer.Option(
         None,
         "--label",
         "-l",
-        help="Stop tunnels matching labels. Can be specified multiple times.",
+        help=(
+            "Stop tunnels carrying ALL of the given labels (AND match, not OR). "
+            "Repeatable, e.g. -l dev -l preview. Cannot be combined with tunnel "
+            "IDs or --all; may be narrowed with --status."
+        ),
     ),
     status: Optional[str] = typer.Option(
         None,
         "--status",
         help=(
-            "Stop only tunnels currently in this status "
-            "(pending, connected, disconnected). Combines with --label/--all."
+            "Stop only tunnels currently in this status: pending, connected, or "
+            "disconnected (case-insensitive). Use alone to stop all tunnels in "
+            "that status, or combine with --all/--label to narrow further. "
+            "Cannot be combined with explicit tunnel IDs."
         ),
     ),
     team_id: Optional[str] = typer.Option(
         None,
         "--team-id",
-        help="Team ID to include team tunnels for --all (uses config team_id if not specified)",
+        help=(
+            "Team whose tunnels to target for --all/--label/--status "
+            "(defaults to your configured team_id). Required when using "
+            "--all-users."
+        ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     only_mine: bool = typer.Option(
         True,
         "--only-mine/--all-users",
         "-m/-A",
-        help="Restrict '--all' deletes to only your tunnels",
+        help=(
+            "Scope for filter deletes (--all/--label/--status): --only-mine "
+            "(default) restricts to tunnels you own; --all-users targets every "
+            "team member's tunnels and requires a team."
+        ),
         show_default=True,
     ),
 ) -> None:
     """Stop and delete one or more tunnels.
 
-    --only-mine controls whether '--all' will restrict to your tunnels or delete for all users.
+    Select tunnels in exactly one of two ways: pass explicit tunnel IDs, or use
+    the filter flags --all/--label/--status (which can be combined with each
+    other but not with explicit IDs). --only-mine/--all-users controls whether
+    filter deletes apply to just your tunnels or all members of a team.
     """
 
     if tunnel_ids and (all or labels or status):

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -326,6 +326,14 @@ def stop_tunnel(
         "-l",
         help="Stop tunnels matching labels. Can be specified multiple times.",
     ),
+    status: Optional[str] = typer.Option(
+        None,
+        "--status",
+        help=(
+            "Stop only tunnels currently in this status "
+            "(pending, connected, disconnected). Combines with --label/--all."
+        ),
+    ),
     team_id: Optional[str] = typer.Option(
         None,
         "--team-id",
@@ -345,13 +353,28 @@ def stop_tunnel(
     --only-mine controls whether '--all' will restrict to your tunnels or delete for all users.
     """
 
-    if sum(bool(flag) for flag in (all, tunnel_ids, labels)) > 1:
-        console.print("[red]Error:[/red] Use only one of tunnel IDs, --all, or --label")
+    if tunnel_ids and (all or labels or status):
+        console.print(
+            "[red]Error:[/red] Tunnel IDs cannot be combined with --all, --label, or --status"
+        )
         raise typer.Exit(1)
 
-    if not all and not tunnel_ids and not labels:
-        console.print("[red]Error:[/red] Must specify tunnel IDs, --all, or --label")
+    if all and labels:
+        console.print("[red]Error:[/red] Use only one of --all or --label")
         raise typer.Exit(1)
+
+    if not all and not tunnel_ids and not labels and not status:
+        console.print("[red]Error:[/red] Must specify tunnel IDs, --all, --label, or --status")
+        raise typer.Exit(1)
+
+    if status is not None:
+        status = status.strip().lower()
+        allowed_statuses = {"pending", "connected", "disconnected"}
+        if status not in allowed_statuses:
+            console.print(
+                "[red]Error:[/red] --status must be one of: " + ", ".join(sorted(allowed_statuses))
+            )
+            raise typer.Exit(1)
 
     parsed_ids: List[str] = []
     if tunnel_ids:
@@ -372,9 +395,11 @@ def stop_tunnel(
             console.print("[red]Error:[/red] No valid tunnel IDs provided")
             raise typer.Exit(1)
 
-    if all:
+    is_filter_delete = bool(all or labels or status)
 
-        async def validate_all_scope() -> None:
+    if is_filter_delete:
+
+        async def validate_filter_scope() -> None:
             client = _create_tunnel_client()
             try:
                 scoped_user_id = client.config.user_id if only_mine else None
@@ -390,54 +415,29 @@ def stop_tunnel(
                 await client.close()
 
         try:
-            asyncio.run(validate_all_scope())
+            asyncio.run(validate_filter_scope())
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}", style="bold")
             raise typer.Exit(1)
 
-    if labels:
+        filter_parts: List[str] = []
+        if status:
+            filter_parts.append(f"status '{status}'")
+        if labels:
+            filter_parts.append(f"label(s) {', '.join(labels)}")
+        subject = f"tunnels matching {' and '.join(filter_parts)}" if filter_parts else "tunnels"
 
-        async def validate_label_scope() -> None:
-            client = _create_tunnel_client()
-            try:
-                scoped_user_id = client.config.user_id if only_mine else None
-                scoped_team_id = team_id if team_id is not None else client.config.team_id
-                if only_mine and not scoped_user_id:
-                    raise ValueError(
-                        "Cannot resolve current user ID for scoped bulk delete. "
-                        "Run `prime login`, set PRIME_USER_ID, or delete explicit tunnel IDs."
-                    )
-                if not only_mine and not scoped_team_id:
-                    raise ValueError("all_users requires a team ID")
-            finally:
-                await client.close()
-
-        try:
-            asyncio.run(validate_label_scope())
-        except Exception as e:
-            console.print(f"[red]Error:[/red] {e}", style="bold")
-            raise typer.Exit(1)
-
-        confirmation_msg = (
-            f"Are you sure you want to stop tunnels matching label(s): {', '.join(labels)}? "
-            "This action cannot be undone."
-        )
-        cancel_msg = "Stop by label cancelled"
-    elif all:
-        confirmation_msg = (
-            "Are you sure you want to stop all matching tunnel(s)? This action cannot be undone."
-        )
         if team_id and only_mine:
-            confirmation_msg = (
-                f"Are you sure you want to stop all of your tunnels in team {team_id}? "
-                "This action cannot be undone."
-            )
+            who = f"your {subject} in team {team_id}"
         elif team_id and not only_mine:
-            confirmation_msg = (
-                f"Are you sure you want to stop all tunnels in team {team_id}? "
-                "This action cannot be undone."
-            )
-        cancel_msg = "Stop all cancelled"
+            who = f"all {subject} in team {team_id}"
+        elif not only_mine:
+            who = f"all {subject} (all users)"
+        else:
+            who = f"your {subject}"
+
+        confirmation_msg = f"Are you sure you want to stop {who}? This action cannot be undone."
+        cancel_msg = "Stop cancelled"
     elif len(parsed_ids) == 1:
         confirmation_msg = f"Are you sure you want to stop tunnel {parsed_ids[0]}?"
         cancel_msg = "Stop cancelled"
@@ -455,32 +455,23 @@ def stop_tunnel(
         not_found: List[dict] = []
         failed: List[dict] = []
         try:
-            scoped_team_id = team_id
-            if labels and scoped_team_id is None:
-                scoped_team_id = client.config.team_id
-            scoped_user_id = client.config.user_id if only_mine else None
-            if labels and only_mine and not scoped_user_id:
-                raise ValueError(
-                    "Cannot resolve current user ID for scoped bulk delete. "
-                    "Run `prime login`, set PRIME_USER_ID, or delete explicit tunnel IDs."
-                )
-            if labels:
-                result = await client.bulk_delete_tunnels(
-                    labels=labels,
-                    team_id=scoped_team_id,
-                    user_id=scoped_user_id,
-                    all_users=not only_mine,
-                )
-            elif all:
-                if scoped_team_id is None:
-                    scoped_team_id = client.config.team_id
-                result = await client.bulk_delete_tunnels(
-                    team_id=scoped_team_id,
-                    user_id=scoped_user_id,
-                    all_users=not only_mine,
-                )
-            else:
+            if parsed_ids:
                 result = await client.bulk_delete_tunnels(parsed_ids)
+            else:
+                scoped_team_id = team_id if team_id is not None else client.config.team_id
+                scoped_user_id = client.config.user_id if only_mine else None
+                if only_mine and not scoped_user_id:
+                    raise ValueError(
+                        "Cannot resolve current user ID for scoped bulk delete. "
+                        "Run `prime login`, set PRIME_USER_ID, or delete explicit tunnel IDs."
+                    )
+                result = await client.bulk_delete_tunnels(
+                    labels=labels or None,
+                    status=status,
+                    team_id=scoped_team_id,
+                    user_id=scoped_user_id,
+                    all_users=not only_mine,
+                )
             succeeded = result.get("succeeded", [])
             for failure in result.get("failed", []):
                 tid = failure.get("tunnel_id", "")
@@ -533,7 +524,7 @@ def stop_tunnel(
     if total_failed > 0:
         raise typer.Exit(1)
 
-    if all:
-        console.print("[green]All tunnels deleted successfully[/green]")
-    else:
+    if parsed_ids:
         console.print("[green]All specified tunnels deleted successfully[/green]")
+    else:
+        console.print("[green]All matching tunnels deleted successfully[/green]")

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -361,6 +361,88 @@ def test_tunnel_stop_all_users_uses_configured_team_scope(
     assert captured.get("user_id") is None
 
 
+def test_tunnel_stop_by_status_uses_scoped_bulk_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    captured: dict[str, Any] = {}
+
+    class FakeTunnelClient:
+        config = SimpleNamespace(user_id="user-1", team_id=None)
+
+        async def list_tunnels_page(self, **kwargs: Any) -> Any:
+            raise AssertionError("--status must scope the delete, not pre-list tunnels")
+
+        async def bulk_delete_tunnels(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"succeeded": ["t-disc"], "failed": [], "message": "ok"}
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
+
+    # Mixed case is accepted and normalized to the lowercase API enum value.
+    result = runner.invoke(app, ["tunnel", "stop", "--status", "DISCONNECTED", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["status"] == "disconnected"
+    assert captured["user_id"] == "user-1"
+    assert captured["all_users"] is False
+    assert "tunnel_ids" not in captured
+
+
+def test_tunnel_stop_status_combines_with_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    captured: dict[str, Any] = {}
+
+    class FakeTunnelClient:
+        config = SimpleNamespace(user_id="user-1", team_id=None)
+
+        async def bulk_delete_tunnels(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"succeeded": ["t-disc"], "failed": [], "message": "ok"}
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
+
+    result = runner.invoke(
+        app,
+        ["tunnel", "stop", "--label", "dev", "--status", "disconnected", "--yes"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["labels"] == ["dev"]
+    assert captured["status"] == "disconnected"
+    assert captured["user_id"] == "user-1"
+
+
+def test_tunnel_stop_invalid_status_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    result = runner.invoke(app, ["tunnel", "stop", "--status", "expired", "--yes"])
+
+    assert result.exit_code == 1
+    assert "--status must be one of" in result.output
+
+
+def test_tunnel_stop_status_with_ids_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    result = runner.invoke(app, ["tunnel", "stop", "t-123", "--status", "disconnected", "--yes"])
+
+    assert result.exit_code == 1
+    assert "Tunnel IDs cannot be combined with --all, --label, or --status" in result.output
+
+
 def test_tunnel_stop_all_exits_cleanly_when_nothing_matches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands destructive bulk-delete surface area; mitigated by confirmations, mutual-exclusion checks, and server-side scoping rather than client-side listing.
> 
> **Overview**
> Adds **status-based bulk deletion** so users can stop tunnels matching `pending`, `connected`, or `disconnected` without listing IDs first.
> 
> `TunnelClient.bulk_delete_tunnels` accepts an optional `status` and sends it on the bulk DELETE request; it **rejects** using `status` together with `tunnel_ids`. The **`prime tunnel stop`** command gains **`--status`**, which can be used alone or combined with **`--label`** or **`--all`** (still not with explicit tunnel IDs). CLI validation and help text are tightened: IDs vs filter flags are separated, invalid statuses are rejected (case-normalized), and filter deletes share one scoped bulk-delete path with clearer confirmation wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db9417ff9939c359040cd6bdff2b0a7957a15be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->