### PR TITLE
fix(sandbox): retry idempotent requests on transient HTTP 500

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -28,7 +28,10 @@ IDEMPOTENT_RETRYABLE_EXCEPTIONS = POST_RETRYABLE_EXCEPTIONS + (
     httpx.ReadError,  # Connection broken while reading response (e.g., TCP reset)
 )
 
-IDEMPOTENT_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+# 500 is retried for idempotent methods only: under sandbox-service overload the API emits
+# transient 500s (e.g. on DELETE/GET) that succeed on retry, and retrying is safe because these
+# methods are idempotent. Non-idempotent POST/PATCH never retry on status code.
+IDEMPOTENT_RETRYABLE_STATUSES = frozenset({500, 502, 503, 504})
 IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
 
 

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -210,7 +210,7 @@ class TestSyncAPIClientRetry:
         assert result == {"success": True}
         assert transport.call_count == 2
 
-    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
     def test_get_retries_transient_gateway_statuses(self, status_code):
         """GET retries transient gateway failures from the public API/LB path."""
         transport = StatusThenSucceedTransport(status_code)
@@ -233,7 +233,7 @@ class TestSyncAPIClientRetry:
 
         assert transport.call_count == 1
 
-    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
     def test_patch_does_not_retry_transient_gateway_statuses(self, status_code):
         """PATCH does not retry transient gateway statuses without explicit idempotency."""
         transport = StatusThenSucceedTransport(status_code)
@@ -272,7 +272,7 @@ class TestSyncAPIClientRetry:
         assert result == {"success": True}
         assert transport.call_count == 2
 
-    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
     def test_idempotent_post_retries_transient_gateway_statuses(self, status_code):
         """Idempotency-keyed POST retries transient gateway failures."""
         transport = StatusThenSucceedTransport(status_code)
@@ -339,7 +339,7 @@ class TestAsyncAPIClientRetry:
 
         assert transport.call_count == 3
 
-    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
     @pytest.mark.asyncio
     async def test_get_retries_transient_gateway_statuses(self, status_code):
         """Async GET retries transient gateway failures from the public API/LB path."""
@@ -364,7 +364,7 @@ class TestAsyncAPIClientRetry:
 
         assert transport.call_count == 1
 
-    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
     @pytest.mark.asyncio
     async def test_patch_does_not_retry_transient_gateway_statuses(self, status_code):
         """Async PATCH does not retry transient gateway statuses without explicit idempotency."""


### PR DESCRIPTION
## What
Add `500` to `IDEMPOTENT_RETRYABLE_STATUSES` in the sandbox client so idempotent requests (`GET/HEAD/PUT/DELETE/OPTIONS`) retry transient HTTP 500s, alongside the existing `502/503/504`. Reuses the existing retry config (`wait_random_exponential` exp-backoff+jitter, `stop_after_attempt(3)`, `reraise=True`).

## Why
Under sandbox-service overload, idempotent calls — notably `DELETE /sandbox/{id}` — return transient `HTTP 500`s. Today 500 isn't in the retryable set, so `delete()` raises on the first attempt. Best-effort callers (e.g. the verifiers env's per-rollout sandbox cleanup, which swallows delete failures) then drop the sandbox, leaking it until its TTL — which under load compounds into thousands of orphaned sandboxes and further saturates the service. Retrying transient 500s lets these calls self-heal at the client layer.

Scoped to **idempotent** methods only; non-idempotent `POST`/`PATCH` are unaffected (they retry only connection-phase errors, never on status code).

## Tests
Extended the existing gateway-status retry parametrizations (`[502, 503, 504]` → `[500, 502, 503, 504]`), which assert: GET retries 500, idempotency-keyed POST retries 500, and PATCH/non-idempotent does **not** retry 500.

`uv run pytest tests/test_client_retry.py tests/test_gateway_error_mapping.py` → 64 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to idempotent methods only; non-idempotent POST/PATCH behavior is unchanged, limiting duplicate-side-effect risk.
> 
> **Overview**
> Extends **idempotent** sandbox API retries so transient **HTTP 500** responses are treated like existing gateway failures (**502/503/504**), using the same tenacity policy (up to 3 attempts with exponential backoff).
> 
> **GET**, **DELETE**, and other idempotent verbs—and **idempotency-keyed POST**—can recover when the service returns overload-related 500s (e.g. failed cleanup **DELETE**s). **PATCH** and ordinary **POST** still do not retry on status codes.
> 
> Tests widen the gateway-status parametrization to include **500** for sync and async clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c6b08002e766ae206f7c76c7f7118f851de75b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->