### PR TITLE
improvement: drop jobId from hosted training run response

### DIFF
--- a/packages/prime/src/prime_cli/api/training.py
+++ b/packages/prime/src/prime_cli/api/training.py
@@ -17,7 +17,6 @@ class HostedTrainingRunResponse(BaseModel):
     """Response from POST /v1/training/runs."""
 
     run_id: str = Field(..., alias="runId")
-    job_id: str = Field(..., alias="jobId")
     token_value: str = Field(..., alias="tokenValue")
 
     model_config = ConfigDict(populate_by_name=True)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -953,7 +953,7 @@ def _dispatch_full_finetune_run(
         # binds it via secretKeyRef and printing it leaks credentials
         # into automation logs.
         output_data_as_json(
-            {"run": {"runId": result.run_id, "jobId": result.job_id}},
+            {"run": {"runId": result.run_id}},
             console,
         )
         return
@@ -962,10 +962,7 @@ def _dispatch_full_finetune_run(
     # per-run k8s Secret automatically (orchestrator's PRIME_API_KEY env
     # via secretKeyRef). Surfacing it on stdout makes it easy to leak into
     # shared shell history/CI logs without buying anything for the user.
-    console.print(
-        f"[green]Dispatched[/green] hosted run [bold]{result.run_id}[/bold] "
-        f"(job [dim]{result.job_id}[/dim])"
-    )
+    console.print(f"[green]Dispatched[/green] hosted run [bold]{result.run_id}[/bold]")
 
 
 def load_config(path: str) -> RLConfig:


### PR DESCRIPTION
- Removes `job_id` / `jobId` from `HostedTrainingRunResponse` and the `prime rl` dispatch surface (JSON output and human print).
- `job_id` is a platform-internal scheduling id; the backend is dropping it from `POST /api/v1/training/runs` so clients can't infer the cluster from it.
- Beta-gated, no compat shims needed. `run_id` and `token_value` remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI/API contract change for a beta-gated endpoint; automation that parsed `jobId` from dispatch JSON would break, but `runId` remains.
> 
> **Overview**
> Aligns the Prime CLI with the backend removing **`jobId`** from **`POST /v1/training/runs`**, so clients no longer see the platform-internal scheduling id (which could leak cluster inference).
> 
> **`HostedTrainingRunResponse`** no longer parses **`job_id`**; **`run_id`** and **`token_value`** are unchanged (and **`token_value`** is still withheld from stdout/JSON on dispatch).
> 
> Full-FT dispatch via **`_dispatch_full_finetune_run`** now returns JSON **`{"run": {"runId": ...}}`** only and prints a single **Dispatched** line with **`run_id`**, without the job id suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff0c1fc0e8e70f3b33affcc399d6dc6804c762e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->