### PR TITLE
improvement: drop auto-picked cluster prompt, add dispatch spinner

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -936,14 +936,15 @@ def _dispatch_full_finetune_run(
     # so the JSON output path doesn't accidentally launch an expensive
     # training job without an explicit ack — matches confirm_or_skip
     # in the LoRA path.
-    if not yes:
-        if not typer.confirm("Dispatch full_finetune run on auto-picked PrimeCluster?"):
-            raise typer.Exit(0)
+    if not confirm_or_skip("Launch this Hosted Training run?", yes, default=True):
+        console.print("\nRun cancelled")
+        raise typer.Exit(0)
 
     api_client = APIClient()
     client = HostedTrainingClient(api_client)
     try:
-        result = client.create_run(payload)
+        with console.status("[bold blue]Creating Hosted Training run...", spinner="dots"):
+            result = client.create_run(payload)
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import time
+from contextlib import nullcontext
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
@@ -942,8 +943,17 @@ def _dispatch_full_finetune_run(
 
     api_client = APIClient()
     client = HostedTrainingClient(api_client)
+    # Skip the spinner for --output json: PrimeConsole.status() falls back
+    # to a plain print in --plain mode, which would emit "Creating Hosted
+    # Training run..." on stdout ahead of the JSON payload and break
+    # automation parsing of run_id.
+    status_ctx = (
+        console.status("[bold blue]Creating Hosted Training run...", spinner="dots")
+        if output != "json"
+        else nullcontext()
+    )
     try:
-        with console.status("[bold blue]Creating Hosted Training run...", spinner="dots"):
+        with status_ctx:
             result = client.create_run(payload)
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")


### PR DESCRIPTION
- Replace `Dispatch full_finetune run on auto-picked PrimeCluster?` with `Launch this Hosted Training run?` to match the LoRA path framing
- Add `console.status` spinner around `create_run` so dispatch shows a loading animation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX changes on the full-FT dispatch path; JSON automation behavior is explicitly preserved by disabling the spinner.
> 
> **Overview**
> For **full fine-tune** hosted training dispatch (`_dispatch_full_finetune_run`), confirmation now uses shared **`confirm_or_skip`** with **"Launch this Hosted Training run?"** (same as the LoRA path) instead of a separate **auto-picked PrimeCluster** prompt, including a **"Run cancelled"** message on decline.
> 
> **`create_run`** is wrapped in **`console.status`** while the API call runs for interactive output; **`--output json`** uses **`nullcontext`** so no status text is printed on stdout before the JSON payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9812ceea683da54f881011f7054f299f8e791456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->