### PR TITLE
Prime Image Transfer

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -23,10 +23,13 @@ from .exceptions import (
     SandboxTimeoutError,
     UploadTimeoutError,
 )
+from .images import AsyncImageClient, ImageClient
 from .models import (
     AdvancedConfigs,
     BackgroundJob,
     BackgroundJobStatus,
+    BuildImageRequest,
+    BuildImageResponse,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
     CommandRequest,
@@ -36,6 +39,7 @@ from .models import (
     ExposedPort,
     ExposePortRequest,
     FileUploadResponse,
+    ImageVisibility,
     ListExposedPortsResponse,
     ReadFileResponse,
     RegistryCredentialSummary,
@@ -62,6 +66,8 @@ __all__ = [
     "AsyncSandboxClient",
     "TemplateClient",
     "AsyncTemplateClient",
+    "ImageClient",
+    "AsyncImageClient",
     # Models
     "Sandbox",
     "SandboxStatus",
@@ -79,6 +85,9 @@ __all__ = [
     "AdvancedConfigs",
     "BackgroundJob",
     "BackgroundJobStatus",
+    "BuildImageRequest",
+    "BuildImageResponse",
+    "ImageVisibility",
     # Port Forwarding
     "ExposePortRequest",
     "ExposedPort",

--- a/packages/prime-sandboxes/src/prime_sandboxes/images.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/images.py
@@ -1,0 +1,93 @@
+"""Image build and transfer SDK client."""
+
+from typing import Optional
+
+from .core import APIClient, AsyncAPIClient
+from .models import BuildImageRequest, BuildImageResponse, ImageVisibility
+
+
+class ImageClient:
+    """Client for Prime image build and transfer APIs."""
+
+    def __init__(self, api_client: Optional[APIClient] = None):
+        self.client = api_client or APIClient()
+
+    def initiate_build(self, request: BuildImageRequest) -> BuildImageResponse:
+        payload = request.model_dump(by_alias=False, exclude_none=True)
+        response = self.client.request("POST", "/images/build", json=payload)
+        return BuildImageResponse.model_validate(response)
+
+    def transfer_image(
+        self,
+        source_image: str,
+        *,
+        image_name: Optional[str] = None,
+        image_tag: Optional[str] = None,
+        platform: str = "linux/amd64",
+        team_id: Optional[str] = None,
+        visibility: Optional[ImageVisibility] = None,
+    ) -> BuildImageResponse:
+        request = BuildImageRequest(
+            image_name=image_name,
+            image_tag=image_tag,
+            source_image=source_image,
+            platform=platform,
+            team_id=team_id,
+            visibility=visibility,
+        )
+        return self.initiate_build(request)
+
+    def start_build(self, build_id: str) -> dict:
+        return self.client.request(
+            "POST",
+            f"/images/build/{build_id}/start",
+            json={"context_uploaded": True},
+        )
+
+
+class AsyncImageClient:
+    """Async client for Prime image build and transfer APIs."""
+
+    def __init__(self, api_client: Optional[AsyncAPIClient] = None):
+        self.client = api_client or AsyncAPIClient()
+
+    async def initiate_build(self, request: BuildImageRequest) -> BuildImageResponse:
+        payload = request.model_dump(by_alias=False, exclude_none=True)
+        response = await self.client.request("POST", "/images/build", json=payload)
+        return BuildImageResponse.model_validate(response)
+
+    async def transfer_image(
+        self,
+        source_image: str,
+        *,
+        image_name: Optional[str] = None,
+        image_tag: Optional[str] = None,
+        platform: str = "linux/amd64",
+        team_id: Optional[str] = None,
+        visibility: Optional[ImageVisibility] = None,
+    ) -> BuildImageResponse:
+        request = BuildImageRequest(
+            image_name=image_name,
+            image_tag=image_tag,
+            source_image=source_image,
+            platform=platform,
+            team_id=team_id,
+            visibility=visibility,
+        )
+        return await self.initiate_build(request)
+
+    async def start_build(self, build_id: str) -> dict:
+        return await self.client.request(
+            "POST",
+            f"/images/build/{build_id}/start",
+            json={"context_uploaded": True},
+        )
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "AsyncImageClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.aclose()

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class SandboxStatus(str, Enum):
@@ -243,6 +243,38 @@ class RegistryCredentialSummary(BaseModel):
 class DockerImageCheckResponse(BaseModel):
     accessible: bool
     details: str
+
+
+class ImageVisibility(str, Enum):
+    PRIVATE = "PRIVATE"
+    PUBLIC = "PUBLIC"
+
+
+class BuildImageRequest(BaseModel):
+    image_name: Optional[str] = None
+    image_tag: Optional[str] = None
+    dockerfile_path: str = "Dockerfile"
+    source_image: Optional[str] = Field(default=None, alias="sourceImage")
+    platform: str = "linux/amd64"
+    team_id: Optional[str] = Field(default=None, alias="teamId")
+    visibility: Optional[ImageVisibility] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class BuildImageResponse(BaseModel):
+    build_id: str = Field(
+        ...,
+        alias="build_id",
+        validation_alias=AliasChoices("build_id", "buildId"),
+    )
+    build_ids: List[str] = Field(default_factory=list, alias="buildIds")
+    upload_url: Optional[str] = None
+    expires_in: Optional[int] = None
+    full_image_path: str = Field(..., alias="fullImagePath")
+    visibility: Optional[ImageVisibility] = None
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ExposePortRequest(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -271,7 +271,7 @@ class BuildImageResponse(BaseModel):
     build_ids: List[str] = Field(default_factory=list, alias="buildIds")
     upload_url: Optional[str] = None
     expires_in: Optional[int] = None
-    full_image_path: str = Field(..., alias="fullImagePath")
+    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
     visibility: Optional[ImageVisibility] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -42,3 +42,18 @@ def test_image_client_transfer_image_payload_and_response():
     assert response.build_ids == ["build-123"]
     assert response.upload_url is None
     assert response.full_image_path == "team-team1/ubuntu:22.04"
+
+
+def test_build_image_response_allows_multi_transfer_without_full_image_path():
+    response = BuildImageResponse.model_validate(
+        {
+            "build_id": "build-123",
+            "buildIds": ["build-123", "build-456"],
+            "upload_url": None,
+            "visibility": "PRIVATE",
+        }
+    )
+
+    assert response.build_id == "build-123"
+    assert response.build_ids == ["build-123", "build-456"]
+    assert response.full_image_path is None

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -1,0 +1,44 @@
+from prime_sandboxes import BuildImageResponse, ImageClient, ImageVisibility
+
+
+def test_image_client_transfer_image_payload_and_response():
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "upload_url": None,
+                "fullImagePath": "team-team1/ubuntu:22.04",
+                "visibility": "PUBLIC",
+            }
+
+    client = ImageClient(DummyAPIClient())
+    response = client.transfer_image(
+        "ubuntu:22.04",
+        image_name="ubuntu",
+        image_tag="22.04",
+        team_id="team1",
+        visibility=ImageVisibility.PUBLIC,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/images/build"
+    assert captured["json"] == {
+        "image_name": "ubuntu",
+        "image_tag": "22.04",
+        "dockerfile_path": "Dockerfile",
+        "source_image": "ubuntu:22.04",
+        "platform": "linux/amd64",
+        "team_id": "team1",
+        "visibility": ImageVisibility.PUBLIC,
+    }
+    assert isinstance(response, BuildImageResponse)
+    assert response.build_id == "build-123"
+    assert response.build_ids == ["build-123"]
+    assert response.upload_url is None
+    assert response.full_image_path == "team-team1/ubuntu:22.04"

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -4,7 +4,6 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
@@ -12,7 +11,14 @@ import click
 import httpx
 import typer
 from gitignore_parser import parse_gitignore
-from prime_sandboxes import APIClient, APIError, Config, UnauthorizedError
+from prime_sandboxes import (
+    APIClient,
+    APIError,
+    Config,
+    ImageClient,
+    ImageVisibility,
+    UnauthorizedError,
+)
 from rich.table import Table
 
 from ..utils import (
@@ -29,11 +35,6 @@ console = get_console()
 PACKAGED_DOCKERFILE_PATH = ".__prime_dockerfile__"
 
 config = Config()
-
-
-class ImageVisibility(str, Enum):
-    PRIVATE = "PRIVATE"
-    PUBLIC = "PUBLIC"
 
 
 LIST_IMAGES_JSON_HELP = json_output_help(
@@ -363,8 +364,8 @@ def _group_sort_key(partition: PartitionMap) -> datetime:
 
 @app.command("push")
 def push_image(
-    image_reference: str = typer.Argument(
-        ..., help="Image reference (e.g., 'myapp:v1.0.0' or 'myapp:latest')"
+    image_reference: Optional[str] = typer.Argument(
+        None, help="Image reference (e.g., 'myapp:v1.0.0' or 'myapp:latest')"
     ),
     context: str = typer.Option(".", "--context", "-c", help="Build context directory"),
     dockerfile: Optional[str] = typer.Option(
@@ -390,6 +391,11 @@ def push_image(
         "--private",
         help="Make the image private when the build completes",
     ),
+    source_image: Optional[str] = typer.Option(
+        None,
+        "--source-image",
+        help="Copy an existing public image into Prime instead of uploading a build context",
+    ),
 ):
     """
     Build and push a Docker image to Prime Intellect registry.
@@ -403,26 +409,119 @@ def push_image(
         prime images push myapp:latest --context ./app --dockerfile ../docker/Dockerfile.prod
         prime images push myapp:v1 --platform linux/arm64
         prime images push myapp:v1 --public
+        prime images push --source-image ubuntu:22.04
+        prime images push myubuntu:22.04 --source-image ubuntu:22.04
     """
     try:
         if public and private:
             console.print("[red]Error: --public and --private cannot be used together[/red]")
             raise typer.Exit(1)
 
+        is_transfer = source_image is not None
+        if not is_transfer and image_reference is None:
+            console.print(
+                "[red]Error: Image reference is required unless --source-image is used[/red]"
+            )
+            raise typer.Exit(1)
+
+        transfer_sources = [
+            source.strip() for source in (source_image or "").split(",") if source.strip()
+        ]
+        if is_transfer and not transfer_sources:
+            console.print(
+                "[red]Error: --source-image must include at least one image reference[/red]"
+            )
+            raise typer.Exit(1)
+        if is_transfer and image_reference is not None and len(transfer_sources) > 1:
+            console.print(
+                "[red]Error: Destination image reference can only be provided for "
+                "single-image transfers[/red]"
+            )
+            raise typer.Exit(1)
+
         # Parse image reference
-        if ":" in image_reference:
+        if image_reference is None:
+            image_name = None
+            image_tag = None
+        elif ":" in image_reference:
             image_name, image_tag = image_reference.rsplit(":", 1)
         else:
             image_name = image_reference
             image_tag = "latest"
 
         # Validate image name doesn't contain slashes
-        if "/" in image_name:
+        if image_name is not None and "/" in image_name:
             console.print(
                 "[red]Error: Image name cannot contain '/'. "
                 "Use simple names like 'myapp:v1.0.0'.[/red]"
             )
             raise typer.Exit(1)
+
+        if is_transfer:
+            source_display = ", ".join(transfer_sources)
+            destination_display = (
+                f"{image_name}:{image_tag}" if image_name and image_tag else "derived"
+            )
+            console.print("[bold blue]Transferring image into Prime:[/bold blue]")
+            console.print(f"[bold]Source:[/bold] {source_display}")
+            console.print(f"[bold]Destination:[/bold] {destination_display}")
+            if config.team_id:
+                console.print(f"[dim]Team: {config.team_id}[/dim]")
+            console.print()
+
+            client = ImageClient(APIClient())
+            visibility = None
+            if public:
+                visibility = ImageVisibility.PUBLIC
+            elif private:
+                visibility = ImageVisibility.PRIVATE
+
+            try:
+                response = client.transfer_image(
+                    ",".join(transfer_sources),
+                    image_name=image_name,
+                    image_tag=image_tag,
+                    platform=platform,
+                    team_id=config.team_id,
+                    visibility=visibility,
+                )
+            except UnauthorizedError:
+                console.print(
+                    "[red]Error: Not authenticated. Please run 'prime login' first.[/red]"
+                )
+                raise typer.Exit(1)
+            except APIError as e:
+                console.print(f"[red]Error: Failed to initiate transfer: {e}[/red]")
+                raise typer.Exit(1)
+
+            build_ids = response.build_ids or [response.build_id]
+            console.print("[green]✓[/green] Transfer queued")
+            console.print()
+            if len(build_ids) == 1:
+                console.print("[bold green]Image transfer queued successfully![/bold green]")
+                console.print()
+                console.print(f"[bold]Build ID:[/bold] {build_ids[0]}")
+                console.print(f"[bold]Image:[/bold] {response.full_image_path}")
+            else:
+                console.print("[bold green]Image transfers queued successfully![/bold green]")
+                console.print()
+                console.print(f"[bold]Builds:[/bold] {len(build_ids)}")
+                console.print(f"[bold]Build IDs:[/bold] {', '.join(build_ids)}")
+            if public or private:
+                requested_visibility = ImageVisibility.PUBLIC if public else ImageVisibility.PRIVATE
+                console.print(f"[bold]Visibility:[/bold] {requested_visibility.value}")
+            else:
+                console.print(
+                    "[bold]Visibility:[/bold] PRIVATE for new images "
+                    "(existing tags keep their current visibility)"
+                )
+            console.print()
+            console.print("[cyan]Your image transfer is running.[/cyan]")
+            console.print()
+            console.print("[bold]Check transfer status:[/bold]")
+            console.print("  prime images list")
+            console.print()
+            return
 
         console.print(
             f"[bold blue]Building and pushing image:[/bold blue] {image_name}:{image_tag}"

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -118,6 +118,105 @@ def test_push_image_public_sends_visibility(tmp_path, monkeypatch):
     assert "Visibility:" in result.output
 
 
+def test_push_image_source_image_queues_transfer_without_upload(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "upload_url": None,
+                "fullImagePath": "cmk123/ubuntu:22.04",
+                "visibility": "PRIVATE",
+            }
+
+    def fake_put(*args, **kwargs):
+        raise AssertionError("transfer should not upload a build context")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "--source-image", "ubuntu:22.04"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/images/build"
+    assert captured["json"] == {
+        "dockerfile_path": "Dockerfile",
+        "source_image": "ubuntu:22.04",
+        "platform": "linux/amd64",
+    }
+    assert "Transfer queued" in result.output
+    assert "build-123" in result.output
+
+
+def test_push_image_source_image_with_destination_override(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["json"] = json
+            return {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "fullImagePath": "cmk123/myubuntu:22.04",
+                "visibility": "PUBLIC",
+            }
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "myubuntu:22.04", "--source-image", "ubuntu:22.04", "--public"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["json"] == {
+        "image_name": "myubuntu",
+        "image_tag": "22.04",
+        "dockerfile_path": "Dockerfile",
+        "source_image": "ubuntu:22.04",
+        "platform": "linux/amd64",
+        "visibility": "PUBLIC",
+    }
+
+
+def test_push_image_source_image_multi_rejects_destination(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        [
+            "images",
+            "push",
+            "myubuntu:22.04",
+            "--source-image",
+            "ubuntu:22.04,ghcr.io/org/app:v1",
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "single-image transfers" in result.output
+
+
 def test_publish_image_calls_visibility_endpoint(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -120,6 +120,7 @@ def test_push_image_public_sends_visibility(tmp_path, monkeypatch):
 
 def test_push_image_source_image_queues_transfer_without_upload(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
     captured = {}
 
     class DummyAPIClient:
@@ -161,6 +162,7 @@ def test_push_image_source_image_queues_transfer_without_upload(monkeypatch):
 
 def test_push_image_source_image_with_destination_override(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
     captured = {}
 
     class DummyAPIClient:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are additive SDK/CLI surface and tests; transfer reuses the existing `/images/build` API without altering the context-upload build path.
> 
> **Overview**
> Adds **Prime image transfer** so users can copy external/public images into the registry without packaging a build context.
> 
> **prime-sandboxes** introduces `ImageClient` / `AsyncImageClient` with `initiate_build`, `transfer_image` (via `source_image` on `POST /images/build`), and `start_build`, plus `BuildImageRequest`, `BuildImageResponse`, and shared `ImageVisibility`. `BuildImageResponse` supports multiple `buildIds` and optional `fullImagePath` for multi-source transfers.
> 
> **prime CLI** extends `prime images push` with `--source-image` (comma-separated for multi-transfer). Transfer mode skips tar upload, makes the destination argument optional (derived names), and rejects a custom destination when multiple sources are given. `ImageVisibility` moves from the CLI into the SDK.
> 
> Tests cover the SDK client payloads and CLI transfer, destination override, and validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60aee633b55b7e8b65e6a0402ca4ab410911da18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->