### PR TITLE
slug prefix for user sandbox images

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -57,6 +57,18 @@ class Config:
         return self.config.get("user_id") or None
 
     @property
+    def team_slug(self) -> Optional[str]:
+        """Get active team slug from config file (used to build image refs)."""
+        if os.getenv("PRIME_TEAM_ID") is not None:
+            return None
+        return self.config.get("team_slug") or None
+
+    @property
+    def user_slug(self) -> Optional[str]:
+        """Get user slug (username) from config file (used to build image refs)."""
+        return self.config.get("user_slug") or None
+
+    @property
     def base_url(self) -> str:
         """Get API base URL with precedence: env > file > default."""
         env_val = os.getenv("PRIME_API_BASE_URL") or os.getenv("PRIME_BASE_URL")

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -916,9 +916,9 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     """Parse refs accepted by mutating image commands.
 
     Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
-    ``name:tag``, ``{yourUsername}/name:tag`` (your user slug), or
-    ``{currentUserId}/name:tag``. Team image refs may use ``{teamSlug}/name:tag``
-    (your active team's slug) or ``team-{teamId}/name:tag``.
+    ``name:tag`` for the current context, ``{userSlug}/name:tag`` or
+    ``{userId}/name:tag`` for personal images, and ``{teamSlug}/name:tag``
+    (active team only) or ``team-{teamId}/name:tag`` for team images.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
@@ -943,9 +943,9 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
             console.print(
                 f"[red]Error: Unrecognized image namespace '{namespace}'. "
                 "Use 'imagename:tag' for the current context, "
-                "'<your-username>/imagename:tag' or '{userId}/imagename:tag' for "
-                "personal images, or '<team-slug>/imagename:tag' (your active team) "
-                "or 'team-{teamId}/imagename:tag' for team images.[/red]"
+                "'<user-slug>/imagename:tag' or '<user-id>/imagename:tag' for "
+                "personal images, and '<team-slug>/imagename:tag' (your active team) "
+                "or 'team-<team-id>/imagename:tag' for team images.[/red]"
             )
             raise typer.Exit(1)
 
@@ -981,20 +981,25 @@ def publish_image(
         ...,
         help=(
             "Image reference to make public "
-            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
-            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<user-slug>/myapp:v1.0.0', "
+            "'<user-id>/myapp:v1.0.0', '<team-slug>/myapp:v1.0.0', "
+            "or 'team-<team-id>/myapp:v1.0.0')"
         ),
     ),
 ):
     """
     Make an image public so other Prime users can run it.
 
+    Personal images can be referenced with your user slug or user ID. Team
+    images can be referenced with your active team slug or ``team-<team-id>``.
+
     \b
     Examples:
         prime images publish myapp:v1.0.0
         prime images publish alice/myapp:v1.0.0
+        prime images publish cmkrcib4x00004kjyxq48nltd/myapp:v1.0.0
         prime images publish acme/myapp:v1.0.0
-        prime images publish team-abc123/myapp:v1.0.0
+        prime images publish team-cmf0ohr9s0026ilerf3w68s6z/myapp:v1.0.0
     """
     try:
         _set_image_visibility(image_reference, ImageVisibility.PUBLIC)
@@ -1012,20 +1017,25 @@ def unpublish_image(
         ...,
         help=(
             "Image reference to make private "
-            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
-            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<user-slug>/myapp:v1.0.0', "
+            "'<user-id>/myapp:v1.0.0', '<team-slug>/myapp:v1.0.0', "
+            "or 'team-<team-id>/myapp:v1.0.0')"
         ),
     ),
 ):
     """
     Make a public image private again.
 
+    Personal images can be referenced with your user slug or user ID. Team
+    images can be referenced with your active team slug or ``team-<team-id>``.
+
     \b
     Examples:
         prime images unpublish myapp:v1.0.0
         prime images unpublish alice/myapp:v1.0.0
+        prime images unpublish cmkrcib4x00004kjyxq48nltd/myapp:v1.0.0
         prime images unpublish acme/myapp:v1.0.0
-        prime images unpublish team-abc123/myapp:v1.0.0
+        prime images unpublish team-cmf0ohr9s0026ilerf3w68s6z/myapp:v1.0.0
     """
     try:
         _set_image_visibility(image_reference, ImageVisibility.PRIVATE)
@@ -1043,8 +1053,9 @@ def delete_image(
         ...,
         help=(
             "Image reference to delete "
-            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
-            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<user-slug>/myapp:v1.0.0', "
+            "'<user-id>/myapp:v1.0.0', '<team-slug>/myapp:v1.0.0', "
+            "or 'team-<team-id>/myapp:v1.0.0')"
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -1052,17 +1063,18 @@ def delete_image(
     """
     Delete an image from your registry.
 
-    For team images, you can use the team slug (your active team) or the
-    team-prefixed id format directly. Only the image creator or team admins can
-    delete team images.
+    Personal images can be referenced with your user slug or user ID. Team
+    images can be referenced with your active team slug or ``team-<team-id>``.
+    Only the image creator or team admins can delete team images.
 
     \b
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes
         prime images delete alice/myapp:v1.0.0
+        prime images delete cmkrcib4x00004kjyxq48nltd/myapp:v1.0.0
         prime images delete acme/myapp:v1.0.0
-        prime images delete team-abc123/myapp:v1.0.0
+        prime images delete team-cmf0ohr9s0026ilerf3w68s6z/myapp:v1.0.0
     """
     # Store original input for error messages
     original_reference = image_reference

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -916,8 +916,9 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     """Parse refs accepted by mutating image commands.
 
     Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
-    either ``name:tag`` or ``{currentUserId}/name:tag``. Team image refs may
-    use ``team-{teamId}/name:tag``.
+    ``name:tag``, ``{yourUsername}/name:tag`` (your user slug), or
+    ``{currentUserId}/name:tag``. Team image refs may use ``{teamSlug}/name:tag``
+    (your active team's slug) or ``team-{teamId}/name:tag``.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
@@ -932,15 +933,19 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
                 raise typer.Exit(1)
             team_id = extracted_team_id
             image_reference = rest
-        elif namespace == config.user_id:
+        elif namespace == config.user_id or (config.user_slug and namespace == config.user_slug):
             team_id = None
+            image_reference = rest
+        elif config.team_slug and namespace == config.team_slug:
+            team_id = config.team_id
             image_reference = rest
         else:
             console.print(
                 f"[red]Error: Unrecognized image namespace '{namespace}'. "
-                "Use 'imagename:tag' for personal images, "
-                "'{userId}/imagename:tag' with your current user ID, or "
-                "'team-{teamId}/imagename:tag' for team images.[/red]"
+                "Use 'imagename:tag' for the current context, "
+                "'<your-username>/imagename:tag' or '{userId}/imagename:tag' for "
+                "personal images, or '<team-slug>/imagename:tag' (your active team) "
+                "or 'team-{teamId}/imagename:tag' for team images.[/red]"
             )
             raise typer.Exit(1)
 
@@ -976,8 +981,8 @@ def publish_image(
         ...,
         help=(
             "Image reference to make public "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
+            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -987,7 +992,8 @@ def publish_image(
     \b
     Examples:
         prime images publish myapp:v1.0.0
-        prime images publish cmk123/myapp:v1.0.0
+        prime images publish alice/myapp:v1.0.0
+        prime images publish acme/myapp:v1.0.0
         prime images publish team-abc123/myapp:v1.0.0
     """
     try:
@@ -1006,8 +1012,8 @@ def unpublish_image(
         ...,
         help=(
             "Image reference to make private "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
+            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -1017,7 +1023,8 @@ def unpublish_image(
     \b
     Examples:
         prime images unpublish myapp:v1.0.0
-        prime images unpublish cmk123/myapp:v1.0.0
+        prime images unpublish alice/myapp:v1.0.0
+        prime images unpublish acme/myapp:v1.0.0
         prime images unpublish team-abc123/myapp:v1.0.0
     """
     try:
@@ -1036,8 +1043,8 @@ def delete_image(
         ...,
         help=(
             "Image reference to delete "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<your-username>/myapp:v1.0.0', "
+            "'<team-slug>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -1045,14 +1052,16 @@ def delete_image(
     """
     Delete an image from your registry.
 
-    For team images, you can use the team-prefixed format directly.
-    Only the image creator or team admins can delete team images.
+    For team images, you can use the team slug (your active team) or the
+    team-prefixed id format directly. Only the image creator or team admins can
+    delete team images.
 
     \b
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes
-        prime images delete cmk123/myapp:v1.0.0
+        prime images delete alice/myapp:v1.0.0
+        prime images delete acme/myapp:v1.0.0
         prime images delete team-abc123/myapp:v1.0.0
     """
     # Store original input for error messages

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -59,6 +59,7 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                     team_id = selected_team.get("teamId")
                     team_name = selected_team.get("name", "Unknown")
                     team_role = selected_team.get("role", "member")
+                    team_slug = selected_team.get("slug")
 
                     if not team_id:
                         console.print("[yellow]Invalid team. Using personal account.[/yellow]")
@@ -66,7 +67,12 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                         config.update_current_environment_file()
                         return
 
-                    config.set_team(team_id, team_name=team_name, team_role=team_role)
+                    config.set_team(
+                        team_id,
+                        team_name=team_name,
+                        team_role=team_role,
+                        team_slug=team_slug,
+                    )
                     config.update_current_environment_file()
                     console.print(f"[green]Using team '{team_name}'.[/green]")
                     return
@@ -219,6 +225,7 @@ def login(
                                 user_id = data.get("id")
                                 if user_id:
                                     config.set_user_id(user_id)
+                                    config.set_user_slug(data.get("slug"))
                                     config.update_current_environment_file()
                         except (APIError, Exception):
                             console.print("[yellow]Logged in, but failed to fetch user id[/yellow]")

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -44,12 +44,13 @@ def _switch_to_team(config: Config, team: dict) -> None:
     team_id = team.get("teamId")
     team_name = team.get("name", "Unknown")
     team_role = team.get("role", "member")
+    team_slug = team.get("slug")
 
     if not team_id:
         console.print("[red]Error:[/red] Selected team is missing a team ID.")
         raise typer.Exit(1)
 
-    config.set_team(team_id, team_name=team_name, team_role=team_role)
+    config.set_team(team_id, team_name=team_name, team_role=team_role, team_slug=team_slug)
     config.update_current_environment_file()
     console.print(f"[green]Switched to team '{team_name}'.[/green]")
 

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -33,6 +33,7 @@ def whoami() -> None:
         config = Config()
         if user_id:
             config.set_user_id(user_id)
+            config.set_user_slug(slug)
             config.update_current_environment_file()
 
         # Display account info table

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -12,7 +12,9 @@ class ConfigModel(BaseModel):
     team_id: str | None = None
     team_name: str | None = None
     team_role: str | None = None
+    team_slug: str | None = None
     user_id: str | None = None
+    user_slug: str | None = None
     base_url: str = "https://api.primeintellect.ai"
     frontend_url: str = "https://app.primeintellect.ai"
     inference_url: str = "https://api.pinference.ai/api/v1"
@@ -111,13 +113,25 @@ class Config:
         """Get team role from config file (only valid if team_id not from env)."""
         return self.config.get("team_role") or None
 
+    @property
+    def team_slug(self) -> Optional[str]:
+        """Get active team slug from config file (only valid if team_id not from env)."""
+        if self.team_id_from_env:
+            return None
+        return self.config.get("team_slug") or None
+
     def set_team(
-        self, value: str | None, team_name: str | None = None, team_role: str | None = None
+        self,
+        value: str | None,
+        team_name: str | None = None,
+        team_role: str | None = None,
+        team_slug: str | None = None,
     ) -> None:
-        """Set team ID, name, and role in config file."""
+        """Set team ID, name, role, and slug in config file."""
         self.config["team_id"] = value or None
         self.config["team_name"] = team_name if value else None
         self.config["team_role"] = team_role if value else None
+        self.config["team_slug"] = team_slug if value else None
         self._save_config(self.config)
 
     @property
@@ -131,6 +145,16 @@ class Config:
     def set_user_id(self, value: str | None) -> None:
         """Set user ID in config file"""
         self.config["user_id"] = value if value else None
+        self._save_config(self.config)
+
+    @property
+    def user_slug(self) -> Optional[str]:
+        """Get user slug (username) from config file."""
+        return self.config.get("user_slug") or None
+
+    def set_user_slug(self, value: str | None) -> None:
+        """Set user slug (username) in config file."""
+        self.config["user_slug"] = value if value else None
         self._save_config(self.config)
 
     @property
@@ -253,7 +277,9 @@ class Config:
             "team_id": self.team_id,
             "team_name": None if self.team_id_from_env else self.team_name,
             "team_role": None if self.team_id_from_env else self.team_role,
+            "team_slug": None if self.team_id_from_env else self.team_slug,
             "user_id": self.user_id,
+            "user_slug": self.user_slug,
             "base_url": self.base_url,
             "frontend_url": self.frontend_url,
             "inference_url": self.inference_url,
@@ -303,6 +329,7 @@ class Config:
                 self.config["team_id"] = None
                 self.config["team_name"] = None
                 self.config["team_role"] = None
+                self.config["team_slug"] = None
                 self.config["current_environment"] = "production"
             return True
 
@@ -318,14 +345,16 @@ class Config:
                 if persist:
                     if "api_key" in env_config:
                         self.set_api_key(env_config["api_key"])
-                    # Set team_id, team_name, and team_role from environment
+                    # Set team_id, team_name, team_role, and team_slug from environment
                     self.set_team(
                         env_config.get("team_id", None),
                         team_name=env_config.get("team_name", None),
                         team_role=env_config.get("team_role", None),
+                        team_slug=env_config.get("team_slug", None),
                     )
-                    # Set user_id from environment
+                    # Set user_id and user_slug from environment
                     self.set_user_id(env_config.get("user_id", None))
+                    self.set_user_slug(env_config.get("user_slug", None))
                     self.set_base_url(env_config.get("base_url", self.DEFAULT_BASE_URL))
                     self.set_frontend_url(env_config.get("frontend_url", self.DEFAULT_FRONTEND_URL))
                     self.set_inference_url(
@@ -339,7 +368,9 @@ class Config:
                     self.config["team_id"] = env_config.get("team_id", None)
                     self.config["team_name"] = env_config.get("team_name", None)
                     self.config["team_role"] = env_config.get("team_role", None)
+                    self.config["team_slug"] = env_config.get("team_slug", None)
                     self.config["user_id"] = env_config.get("user_id", None)
+                    self.config["user_slug"] = env_config.get("user_slug", None)
                     # Normalize URLs the same way set_* methods do
                     base_url = env_config.get("base_url", self.DEFAULT_BASE_URL)
                     self.config["base_url"] = self._strip_api_v1(base_url)
@@ -367,7 +398,9 @@ class Config:
                         "team_id": self.team_id,
                         "team_name": None if self.team_id_from_env else self.team_name,
                         "team_role": None if self.team_id_from_env else self.team_role,
+                        "team_slug": None if self.team_id_from_env else self.team_slug,
                         "user_id": self.user_id,
+                        "user_slug": self.user_slug,
                         "base_url": self.base_url,
                         "frontend_url": self.frontend_url,
                         "inference_url": self.inference_url,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to local config persistence and client-side image reference parsing; existing `name:tag` and ID-prefixed refs remain supported.
> 
> **Overview**
> Adds **`user_slug`** and **`team_slug`** to CLI and SDK config, populated on login/`whoami` and when selecting or switching teams, and persisted in saved environments.
> 
> **`prime images`** mutating commands (`publish`, `unpublish`, `delete`) now parse namespaced refs using **user slug or user ID** for personal images and **active team slug** (in addition to `team-<team-id>`) for team images. Help text and error messages were updated to document the new forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68761fbe538ecdca4f5de945756fb475f86666b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->