### PR TITLE
Fix: Image Build Response

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -30,6 +30,7 @@ from .models import (
     BackgroundJobStatus,
     BuildImageRequest,
     BuildImageResponse,
+    BuildImageResult,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
     CommandRequest,
@@ -87,6 +88,7 @@ __all__ = [
     "BackgroundJobStatus",
     "BuildImageRequest",
     "BuildImageResponse",
+    "BuildImageResult",
     "ImageVisibility",
     # Port Forwarding
     "ExposePortRequest",

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -30,9 +30,9 @@ from .models import (
     BackgroundJobStatus,
     BuildImageRequest,
     BuildImageResponse,
-    BuildImageResult,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
+    BulkImageTransferResponse,
     CommandRequest,
     CommandResponse,
     CreateSandboxRequest,
@@ -48,6 +48,7 @@ from .models import (
     SandboxListResponse,
     SandboxStatus,
     SSHSession,
+    TransferImageResult,
     UpdateSandboxRequest,
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
@@ -88,7 +89,8 @@ __all__ = [
     "BackgroundJobStatus",
     "BuildImageRequest",
     "BuildImageResponse",
-    "BuildImageResult",
+    "BulkImageTransferResponse",
+    "TransferImageResult",
     "ImageVisibility",
     # Port Forwarding
     "ExposePortRequest",

--- a/packages/prime-sandboxes/src/prime_sandboxes/images.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/images.py
@@ -3,7 +3,12 @@
 from typing import Optional
 
 from .core import APIClient, AsyncAPIClient
-from .models import BuildImageRequest, BuildImageResponse, ImageVisibility
+from .models import (
+    BuildImageRequest,
+    BuildImageResponse,
+    BulkImageTransferResponse,
+    ImageVisibility,
+)
 
 
 class ImageClient:
@@ -12,9 +17,13 @@ class ImageClient:
     def __init__(self, api_client: Optional[APIClient] = None):
         self.client = api_client or APIClient()
 
-    def initiate_build(self, request: BuildImageRequest) -> BuildImageResponse:
+    def initiate_build(
+        self, request: BuildImageRequest
+    ) -> BuildImageResponse | BulkImageTransferResponse:
         payload = request.model_dump(by_alias=False, exclude_none=True)
         response = self.client.request("POST", "/images/build", json=payload)
+        if "results" in response:
+            return BulkImageTransferResponse.model_validate(response)
         return BuildImageResponse.model_validate(response)
 
     def transfer_image(
@@ -26,7 +35,7 @@ class ImageClient:
         platform: str = "linux/amd64",
         team_id: Optional[str] = None,
         visibility: Optional[ImageVisibility] = None,
-    ) -> BuildImageResponse:
+    ) -> BuildImageResponse | BulkImageTransferResponse:
         request = BuildImageRequest(
             image_name=image_name,
             image_tag=image_tag,
@@ -51,9 +60,13 @@ class AsyncImageClient:
     def __init__(self, api_client: Optional[AsyncAPIClient] = None):
         self.client = api_client or AsyncAPIClient()
 
-    async def initiate_build(self, request: BuildImageRequest) -> BuildImageResponse:
+    async def initiate_build(
+        self, request: BuildImageRequest
+    ) -> BuildImageResponse | BulkImageTransferResponse:
         payload = request.model_dump(by_alias=False, exclude_none=True)
         response = await self.client.request("POST", "/images/build", json=payload)
+        if "results" in response:
+            return BulkImageTransferResponse.model_validate(response)
         return BuildImageResponse.model_validate(response)
 
     async def transfer_image(
@@ -65,7 +78,7 @@ class AsyncImageClient:
         platform: str = "linux/amd64",
         team_id: Optional[str] = None,
         visibility: Optional[ImageVisibility] = None,
-    ) -> BuildImageResponse:
+    ) -> BuildImageResponse | BulkImageTransferResponse:
         request = BuildImageRequest(
             image_name=image_name,
             image_tag=image_tag,

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -271,7 +271,7 @@ class BuildImageResponse(BaseModel):
     build_ids: List[str] = Field(default_factory=list, alias="buildIds")
     upload_url: Optional[str] = None
     expires_in: Optional[int] = None
-    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
+    full_image_path: str = Field(..., alias="fullImagePath")
     visibility: Optional[ImageVisibility] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -262,9 +262,26 @@ class BuildImageRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class BuildImageResult(BaseModel):
+    """Per-source result returned by multi-image transfer requests."""
+
+    source_image: Optional[str] = Field(default=None, alias="sourceImage")
+    build_id: Optional[str] = Field(
+        default=None,
+        alias="build_id",
+        validation_alias=AliasChoices("build_id", "buildId"),
+    )
+    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
+    error: Optional[str] = None
+    retryable: Optional[bool] = None
+    success: Optional[bool] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class BuildImageResponse(BaseModel):
-    build_id: str = Field(
-        ...,
+    build_id: Optional[str] = Field(
+        default=None,
         alias="build_id",
         validation_alias=AliasChoices("build_id", "buildId"),
     )
@@ -273,8 +290,18 @@ class BuildImageResponse(BaseModel):
     expires_in: Optional[int] = None
     full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
     visibility: Optional[ImageVisibility] = None
+    results: List[BuildImageResult] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def populate_build_ids_from_results(self) -> "BuildImageResponse":
+        """Support API responses shaped as {"results": [...]} for batch transfers."""
+        if not self.build_ids and self.results:
+            self.build_ids = [result.build_id for result in self.results if result.build_id]
+        if self.build_id is None and self.build_ids:
+            self.build_id = self.build_ids[0]
+        return self
 
 
 class ExposePortRequest(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -262,46 +262,42 @@ class BuildImageRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-class BuildImageResult(BaseModel):
-    """Per-source result returned by multi-image transfer requests."""
-
-    source_image: Optional[str] = Field(default=None, alias="sourceImage")
-    build_id: Optional[str] = Field(
-        default=None,
-        alias="build_id",
-        validation_alias=AliasChoices("build_id", "buildId"),
-    )
-    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
-    error: Optional[str] = None
-    retryable: Optional[bool] = None
-    success: Optional[bool] = None
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
 class BuildImageResponse(BaseModel):
-    build_id: Optional[str] = Field(
-        default=None,
+    build_id: str = Field(
+        ...,
         alias="build_id",
         validation_alias=AliasChoices("build_id", "buildId"),
     )
     build_ids: List[str] = Field(default_factory=list, alias="buildIds")
     upload_url: Optional[str] = None
     expires_in: Optional[int] = None
-    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
+    full_image_path: str = Field(..., alias="fullImagePath")
     visibility: Optional[ImageVisibility] = None
-    results: List[BuildImageResult] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
 
-    @model_validator(mode="after")
-    def populate_build_ids_from_results(self) -> "BuildImageResponse":
-        """Support API responses shaped as {"results": [...]} for batch transfers."""
-        if not self.build_ids and self.results:
-            self.build_ids = [result.build_id for result in self.results if result.build_id]
-        if self.build_id is None and self.build_ids:
-            self.build_id = self.build_ids[0]
-        return self
+
+class TransferImageResult(BaseModel):
+    """Per-source result returned by bulk image transfer requests."""
+
+    source_image: str = Field(..., alias="sourceImage")
+    success: bool
+    build_id: Optional[str] = Field(default=None, alias="buildId")
+    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
+    visibility: Optional[ImageVisibility] = None
+    error: Optional[str] = None
+    retryable: bool = False
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class BulkImageTransferResponse(BaseModel):
+    """Response returned for comma-separated image transfer requests."""
+
+    results: List[TransferImageResult] = Field(default_factory=list)
+    failed: List[TransferImageResult] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ExposePortRequest(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -271,7 +271,7 @@ class BuildImageResponse(BaseModel):
     build_ids: List[str] = Field(default_factory=list, alias="buildIds")
     upload_url: Optional[str] = None
     expires_in: Optional[int] = None
-    full_image_path: str = Field(..., alias="fullImagePath")
+    full_image_path: Optional[str] = Field(default=None, alias="fullImagePath")
     visibility: Optional[ImageVisibility] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -1,34 +1,47 @@
 from typing import Any
 
-from prime_sandboxes import APIClient, BuildImageResponse, ImageClient, ImageVisibility
+from prime_sandboxes import (
+    APIClient,
+    BuildImageResponse,
+    BulkImageTransferResponse,
+    ImageClient,
+    ImageVisibility,
+)
+
+
+class DummyAPIClient(APIClient):
+    def __init__(self, response: dict[str, Any], captured: dict[str, Any] | None = None) -> None:
+        self.response = response
+        self.captured = captured
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if self.captured is not None:
+            self.captured["method"] = method
+            self.captured["path"] = path
+            self.captured["json"] = json
+        return self.response
 
 
 def test_image_client_transfer_image_payload_and_response():
-    captured = {}
-
-    class DummyAPIClient(APIClient):
-        def __init__(self) -> None:
-            pass
-
-        def request(
-            self,
-            method: str,
-            path: str,
-            json: dict[str, Any] | None = None,
-            params: dict[str, Any] | None = None,
-        ) -> dict[str, Any]:
-            captured["method"] = method
-            captured["path"] = path
-            captured["json"] = json
-            return {
+    captured: dict[str, Any] = {}
+    client = ImageClient(
+        DummyAPIClient(
+            {
                 "build_id": "build-123",
                 "buildIds": ["build-123"],
                 "upload_url": None,
                 "fullImagePath": "team-team1/ubuntu:22.04",
                 "visibility": "PUBLIC",
-            }
-
-    client = ImageClient(DummyAPIClient())
+            },
+            captured,
+        )
+    )
     response = client.transfer_image(
         "ubuntu:22.04",
         image_name="ubuntu",
@@ -61,64 +74,50 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
             "build_id": "build-123",
             "buildIds": ["build-123", "build-456"],
             "upload_url": None,
+            "fullImagePath": "team-team1/ubuntu:22.04",
             "visibility": "PRIVATE",
         }
     )
 
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
-    assert response.full_image_path is None
+    assert response.full_image_path == "team-team1/ubuntu:22.04"
 
 
-def test_build_image_response_accepts_batch_transfer_results():
-    response = BuildImageResponse.model_validate(
-        {
-            "results": [
-                {
-                    "sourceImage": "ubuntu:22.04",
-                    "buildId": "build-123",
-                    "fullImagePath": "team-team1/ubuntu:22.04",
-                },
-                {
-                    "sourceImage": "missing:notfound",
-                    "error": "source image not found",
-                    "retryable": False,
-                },
-            ]
-        }
-    )
-
-    assert response.build_id == "build-123"
-    assert response.build_ids == ["build-123"]
-    assert response.results[0].source_image == "ubuntu:22.04"
-    assert response.results[0].build_id == "build-123"
-    assert response.results[1].error == "source image not found"
-    assert response.results[1].retryable is False
-
-
-def test_image_client_transfer_image_accepts_batch_transfer_results_response():
-    class DummyAPIClient(APIClient):
-        def __init__(self) -> None:
-            pass
-
-        def request(
-            self,
-            method: str,
-            path: str,
-            json: dict[str, Any] | None = None,
-            params: dict[str, Any] | None = None,
-        ) -> dict[str, Any]:
-            return {
+def test_image_client_transfer_image_accepts_bulk_transfer_response():
+    response = ImageClient(
+        DummyAPIClient(
+            {
                 "results": [
                     {
                         "sourceImage": "ubuntu:22.04",
+                        "success": True,
                         "buildId": "build-123",
+                        "fullImagePath": "team-team1/ubuntu:22.04",
+                        "visibility": "PRIVATE",
+                    },
+                    {
+                        "sourceImage": "missing:notfound",
+                        "success": False,
+                        "error": "source image not found",
+                        "retryable": False,
+                    },
+                ],
+                "failed": [
+                    {
+                        "sourceImage": "missing:notfound",
+                        "success": False,
+                        "error": "source image not found",
+                        "retryable": False,
                     }
-                ]
+                ],
             }
+        )
+    ).transfer_image("ubuntu:22.04,missing:notfound")
 
-    response = ImageClient(DummyAPIClient()).transfer_image("ubuntu:22.04")
-
-    assert response.build_id == "build-123"
-    assert response.build_ids == ["build-123"]
+    assert isinstance(response, BulkImageTransferResponse)
     assert response.results[0].source_image == "ubuntu:22.04"
+    assert response.results[0].build_id == "build-123"
+    assert response.results[0].full_image_path == "team-team1/ubuntu:22.04"
+    assert response.failed[0].source_image == "missing:notfound"
+    assert response.failed[0].error == "source image not found"

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -57,3 +57,48 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
     assert response.full_image_path is None
+
+
+def test_build_image_response_accepts_batch_transfer_results():
+    response = BuildImageResponse.model_validate(
+        {
+            "results": [
+                {
+                    "sourceImage": "ubuntu:22.04",
+                    "buildId": "build-123",
+                    "fullImagePath": "team-team1/ubuntu:22.04",
+                },
+                {
+                    "sourceImage": "missing:notfound",
+                    "error": "source image not found",
+                    "retryable": False,
+                },
+            ]
+        }
+    )
+
+    assert response.build_id == "build-123"
+    assert response.build_ids == ["build-123"]
+    assert response.results[0].source_image == "ubuntu:22.04"
+    assert response.results[0].build_id == "build-123"
+    assert response.results[1].error == "source image not found"
+    assert response.results[1].retryable is False
+
+
+def test_image_client_transfer_image_accepts_batch_transfer_results_response():
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            return {
+                "results": [
+                    {
+                        "sourceImage": "ubuntu:22.04",
+                        "buildId": "build-123",
+                    }
+                ]
+            }
+
+    response = ImageClient(DummyAPIClient()).transfer_image("ubuntu:22.04")
+
+    assert response.build_id == "build-123"
+    assert response.build_ids == ["build-123"]
+    assert response.results[0].source_image == "ubuntu:22.04"

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -1,11 +1,22 @@
-from prime_sandboxes import BuildImageResponse, ImageClient, ImageVisibility
+from typing import Any
+
+from prime_sandboxes import APIClient, BuildImageResponse, ImageClient, ImageVisibility
 
 
 def test_image_client_transfer_image_payload_and_response():
     captured = {}
 
-    class DummyAPIClient:
-        def request(self, method, path, json=None, params=None):
+    class DummyAPIClient(APIClient):
+        def __init__(self) -> None:
+            pass
+
+        def request(
+            self,
+            method: str,
+            path: str,
+            json: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
             captured["method"] = method
             captured["path"] = path
             captured["json"] = json
@@ -86,8 +97,17 @@ def test_build_image_response_accepts_batch_transfer_results():
 
 
 def test_image_client_transfer_image_accepts_batch_transfer_results_response():
-    class DummyAPIClient:
-        def request(self, method, path, json=None, params=None):
+    class DummyAPIClient(APIClient):
+        def __init__(self) -> None:
+            pass
+
+        def request(
+            self,
+            method: str,
+            path: str,
+            json: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
             return {
                 "results": [
                     {

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -74,14 +74,13 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
             "build_id": "build-123",
             "buildIds": ["build-123", "build-456"],
             "upload_url": None,
-            "fullImagePath": "team-team1/ubuntu:22.04",
             "visibility": "PRIVATE",
         }
     )
 
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
-    assert response.full_image_path == "team-team1/ubuntu:22.04"
+    assert response.full_image_path is None
 
 
 def test_image_client_transfer_image_accepts_bulk_transfer_response():

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -74,13 +74,14 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
             "build_id": "build-123",
             "buildIds": ["build-123", "build-456"],
             "upload_url": None,
+            "fullImagePath": "team-team1/ubuntu:22.04",
             "visibility": "PRIVATE",
         }
     )
 
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
-    assert response.full_image_path is None
+    assert response.full_image_path == "team-team1/ubuntu:22.04"
 
 
 def test_image_client_transfer_image_accepts_bulk_transfer_response():

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -14,6 +14,7 @@ from gitignore_parser import parse_gitignore
 from prime_sandboxes import (
     APIClient,
     APIError,
+    BulkImageTransferResponse,
     Config,
     ImageClient,
     ImageVisibility,
@@ -494,19 +495,43 @@ def push_image(
                 console.print(f"[red]Error: Failed to initiate transfer: {e}[/red]")
                 raise typer.Exit(1)
 
-            build_ids = response.build_ids or ([response.build_id] if response.build_id else [])
+            if isinstance(response, BulkImageTransferResponse):
+                successful_results = [result for result in response.results if result.build_id]
+                build_ids = [result.build_id for result in successful_results if result.build_id]
+                failed_results = response.failed
+                image_path = (
+                    successful_results[0].full_image_path if len(successful_results) == 1 else None
+                )
+            else:
+                build_ids = response.build_ids or [response.build_id]
+                failed_results = []
+                image_path = response.full_image_path
+
+            if not build_ids:
+                console.print("[red]Error: Failed to initiate image transfer[/red]")
+                for result in failed_results:
+                    console.print(f"[red]- {result.source_image}: {result.error}[/red]")
+                raise typer.Exit(1)
+
             console.print("[green]✓[/green] Transfer queued")
             console.print()
             if len(build_ids) == 1:
                 console.print("[bold green]Image transfer queued successfully![/bold green]")
                 console.print()
                 console.print(f"[bold]Build ID:[/bold] {build_ids[0]}")
-                console.print(f"[bold]Image:[/bold] {response.full_image_path}")
+                console.print(f"[bold]Image:[/bold] {image_path}")
             else:
                 console.print("[bold green]Image transfers queued successfully![/bold green]")
                 console.print()
                 console.print(f"[bold]Builds:[/bold] {len(build_ids)}")
                 console.print(f"[bold]Build IDs:[/bold] {', '.join(build_ids)}")
+            if failed_results:
+                console.print()
+                console.print(
+                    f"[yellow]Warning: {len(failed_results)} image transfer(s) failed:[/yellow]"
+                )
+                for result in failed_results:
+                    console.print(f"[yellow]- {result.source_image}: {result.error}[/yellow]")
             if public or private:
                 requested_visibility = ImageVisibility.PUBLIC if public else ImageVisibility.PRIVATE
                 console.print(f"[bold]Visibility:[/bold] {requested_visibility.value}")
@@ -521,6 +546,8 @@ def push_image(
             console.print("[bold]Check transfer status:[/bold]")
             console.print("  prime images list")
             console.print()
+            if failed_results:
+                raise typer.Exit(1)
             return
 
         console.print(

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -494,7 +494,7 @@ def push_image(
                 console.print(f"[red]Error: Failed to initiate transfer: {e}[/red]")
                 raise typer.Exit(1)
 
-            build_ids = response.build_ids or [response.build_id]
+            build_ids = response.build_ids or ([response.build_id] if response.build_id else [])
             console.print("[green]✓[/green] Transfer queued")
             console.print()
             if len(build_ids) == 1:

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -382,3 +382,114 @@ def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):
         dockerfile_member = tar.extractfile(PACKAGED_DOCKERFILE_PATH)
         assert dockerfile_member is not None
         assert dockerfile_member.read().decode() == dockerfile_path.read_text()
+
+
+def test_push_image_source_image_result_shape_uses_full_image_path(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            return {
+                "results": [
+                    {
+                        "sourceImage": "ubuntu:jammy",
+                        "success": True,
+                        "buildId": "buildabc",
+                        "fullImagePath": "cmkabc/ubuntu:jammy",
+                    }
+                ],
+                "failed": [],
+            }
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "--source-image", "ubuntu:jammy"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmkabc"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "buildabc" in result.output
+    assert "cmkabc/ubuntu:jammy" in result.output
+
+
+def test_push_image_source_image_result_shape_reports_all_failures(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            return {
+                "results": [
+                    {
+                        "sourceImage": "missing:notfound",
+                        "success": False,
+                        "error": "source image not found",
+                        "retryable": False,
+                    }
+                ],
+                "failed": [
+                    {
+                        "sourceImage": "missing:notfound",
+                        "success": False,
+                        "error": "source image not found",
+                        "retryable": False,
+                    }
+                ],
+            }
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "--source-image", "missing:notfound"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmkabc"},
+    )
+
+    assert result.exit_code == 1
+    assert "Failed to initiate image transfer" in result.output
+    assert "missing:notfound: source image not found" in result.output
+    assert "Your image transfer is running" not in result.output
+
+
+def test_push_image_source_image_result_shape_reports_partial_failures(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
+    failed = {
+        "sourceImage": "missing:notfound",
+        "success": False,
+        "error": "source image not found",
+        "retryable": False,
+    }
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            return {
+                "results": [
+                    {
+                        "sourceImage": "ubuntu:jammy",
+                        "success": True,
+                        "buildId": "buildabc",
+                        "fullImagePath": "cmkabc/ubuntu:jammy",
+                    },
+                    failed,
+                ],
+                "failed": [failed],
+            }
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "--source-image", "ubuntu:jammy,missing:notfound"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmkabc"},
+    )
+
+    assert result.exit_code == 1
+    assert "buildabc" in result.output
+    assert "image transfer" in result.output
+    assert "failed" in result.output
+    assert "missing:notfound: source image not found" in result.output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> SDK typing change (`full_image_path` required, union return types) can break callers that assumed optional paths or always got `BuildImageResponse`; CLI exit behavior on partial bulk failures is stricter.
> 
> **Overview**
> Aligns **prime-sandboxes** and the **prime** CLI with the image build API when transfers return a bulk `{results, failed}` payload instead of a single `BuildImageResponse`.
> 
> The SDK adds **`TransferImageResult`** and **`BulkImageTransferResponse`**, exports them from the package, and updates **`ImageClient` / `AsyncImageClient`** so `initiate_build` and `transfer_image` parse bulk responses when the JSON includes **`results`**. **`BuildImageResponse.full_image_path`** is now **required** (was optional), matching typical single-build/transfer responses.
> 
> **`prime images push --source-image`** branches on `BulkImageTransferResponse`: it collects build IDs from successful per-source results, prints **`fullImagePath`** for a single success, surfaces **`failed`** entries as errors or warnings, exits **1** when nothing queued or when any source failed, and skips the “transfer running” success path on total failure.
> 
> Tests cover SDK bulk parsing and CLI success, all-failure, and partial-failure transfer output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee057c302e6c62b17985b2d11205b7c53373b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->