### PR TITLE
slug prefix for user sandbox images

### DIFF
--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -36,7 +36,7 @@ def test_image_client_transfer_image_payload_and_response():
                 "build_id": "build-123",
                 "buildIds": ["build-123"],
                 "upload_url": None,
-                "fullImagePath": "team-team1/ubuntu:22.04",
+                "fullImagePath": "research/ubuntu:22.04",
                 "visibility": "PUBLIC",
             },
             captured,
@@ -65,7 +65,7 @@ def test_image_client_transfer_image_payload_and_response():
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123"]
     assert response.upload_url is None
-    assert response.full_image_path == "team-team1/ubuntu:22.04"
+    assert response.full_image_path == "research/ubuntu:22.04"
 
 
 def test_build_image_response_allows_multi_transfer_without_full_image_path():
@@ -74,14 +74,14 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
             "build_id": "build-123",
             "buildIds": ["build-123", "build-456"],
             "upload_url": None,
-            "fullImagePath": "team-team1/ubuntu:22.04",
+            "fullImagePath": "research/ubuntu:22.04",
             "visibility": "PRIVATE",
         }
     )
 
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
-    assert response.full_image_path == "team-team1/ubuntu:22.04"
+    assert response.full_image_path == "research/ubuntu:22.04"
 
 
 def test_image_client_transfer_image_accepts_bulk_transfer_response():
@@ -93,7 +93,7 @@ def test_image_client_transfer_image_accepts_bulk_transfer_response():
                         "sourceImage": "ubuntu:22.04",
                         "success": True,
                         "buildId": "build-123",
-                        "fullImagePath": "team-team1/ubuntu:22.04",
+                        "fullImagePath": "research/ubuntu:22.04",
                         "visibility": "PRIVATE",
                     },
                     {
@@ -118,6 +118,6 @@ def test_image_client_transfer_image_accepts_bulk_transfer_response():
     assert isinstance(response, BulkImageTransferResponse)
     assert response.results[0].source_image == "ubuntu:22.04"
     assert response.results[0].build_id == "build-123"
-    assert response.results[0].full_image_path == "team-team1/ubuntu:22.04"
+    assert response.results[0].full_image_path == "research/ubuntu:22.04"
     assert response.failed[0].source_image == "missing:notfound"
     assert response.failed[0].error == "source image not found"

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -36,7 +36,7 @@ def test_image_client_transfer_image_payload_and_response():
                 "build_id": "build-123",
                 "buildIds": ["build-123"],
                 "upload_url": None,
-                "fullImagePath": "research/ubuntu:22.04",
+                "fullImagePath": "prime/research/ubuntu:22.04",
                 "visibility": "PUBLIC",
             },
             captured,
@@ -65,7 +65,7 @@ def test_image_client_transfer_image_payload_and_response():
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123"]
     assert response.upload_url is None
-    assert response.full_image_path == "research/ubuntu:22.04"
+    assert response.full_image_path == "prime/research/ubuntu:22.04"
 
 
 def test_build_image_response_allows_multi_transfer_without_full_image_path():
@@ -74,14 +74,14 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
             "build_id": "build-123",
             "buildIds": ["build-123", "build-456"],
             "upload_url": None,
-            "fullImagePath": "research/ubuntu:22.04",
+            "fullImagePath": "prime/research/ubuntu:22.04",
             "visibility": "PRIVATE",
         }
     )
 
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
-    assert response.full_image_path == "research/ubuntu:22.04"
+    assert response.full_image_path == "prime/research/ubuntu:22.04"
 
 
 def test_image_client_transfer_image_accepts_bulk_transfer_response():
@@ -93,7 +93,7 @@ def test_image_client_transfer_image_accepts_bulk_transfer_response():
                         "sourceImage": "ubuntu:22.04",
                         "success": True,
                         "buildId": "build-123",
-                        "fullImagePath": "research/ubuntu:22.04",
+                        "fullImagePath": "prime/research/ubuntu:22.04",
                         "visibility": "PRIVATE",
                     },
                     {
@@ -118,6 +118,6 @@ def test_image_client_transfer_image_accepts_bulk_transfer_response():
     assert isinstance(response, BulkImageTransferResponse)
     assert response.results[0].source_image == "ubuntu:22.04"
     assert response.results[0].build_id == "build-123"
-    assert response.results[0].full_image_path == "research/ubuntu:22.04"
+    assert response.results[0].full_image_path == "prime/research/ubuntu:22.04"
     assert response.failed[0].source_image == "missing:notfound"
     assert response.failed[0].error == "source image not found"

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -463,7 +463,7 @@ def push_image(
             image_tag = "latest"
 
         # Validate image name doesn't contain slashes
-        if image_name is not None and "/" in image_name:
+        if image_name is not None and "/" in image_name and not platform_image:
             console.print(
                 "[red]Error: Image name cannot contain '/'. "
                 "Use simple names like 'myapp:v1.0.0'.[/red]"

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -260,10 +260,10 @@ def _render_status_column(partition: PartitionMap) -> str:
 def _render_image_reference(img: ImageRow, *, is_team_listing: bool) -> str:
     """Render the user-facing image reference.
 
-    The owner prefix (``{userId}/`` or ``team-{teamId}/``) is **always**
+    The owner prefix (``{ownerSlug}/``, ``{userId}/``, or ``team-{teamId}/``) is **always**
     preserved so the full string is a valid reference that can be pasted
     directly into downstream commands (e.g. ``prime sandbox create``),
-    which require the fully-qualified ``<userId>/<imageName>:<tag>`` form.
+    which require a fully-qualified ``<owner>/<imageName>:<tag>`` form.
 
     Visual truncation (if any) is applied separately by
     :func:`_truncate_ref_left` so that when the terminal is too narrow the
@@ -483,7 +483,7 @@ def push_image(
                     image_name=image_name,
                     image_tag=image_tag,
                     platform=platform,
-                    team_id=config.team_id,
+                    team_id=config.team_id or None,
                     visibility=visibility,
                 )
             except UnauthorizedError:
@@ -943,33 +943,25 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     """Parse refs accepted by mutating image commands.
 
     Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
-    either ``name:tag`` or ``{currentUserId}/name:tag``. Team image refs may
-    use ``team-{teamId}/name:tag``.
+    either ``name:tag``, ``{currentUserId}/name:tag``, or ``{userSlug}/name:tag``.
+    Team image refs may use ``team-{teamId}/name:tag`` or ``{teamSlug}/name:tag``.
+    Owner-prefixed refs are otherwise passed through for server-side resolution
+    because only the backend can distinguish user slugs from team slugs.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
         namespace, rest = image_reference.split("/", 1)
-        if namespace.startswith("team-"):
-            extracted_team_id = namespace[5:]
-            if not extracted_team_id:
-                console.print(
-                    "[red]Error: Invalid team image reference. "
-                    "Expected format: team-{teamId}/imagename:tag[/red]"
-                )
-                raise typer.Exit(1)
-            team_id = extracted_team_id
-            image_reference = rest
-        elif namespace == config.user_id:
+        if namespace == "team-":
+            console.print(
+                "[red]Error: Invalid team image reference. "
+                "Expected format: team-{teamId}/imagename:tag[/red]"
+            )
+            raise typer.Exit(1)
+        if namespace == config.user_id:
             team_id = None
             image_reference = rest
         else:
-            console.print(
-                f"[red]Error: Unrecognized image namespace '{namespace}'. "
-                "Use 'imagename:tag' for personal images, "
-                "'{userId}/imagename:tag' with your current user ID, or "
-                "'team-{teamId}/imagename:tag' for team images.[/red]"
-            )
-            raise typer.Exit(1)
+            team_id = None
 
     if ":" not in image_reference:
         console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")
@@ -1003,8 +995,8 @@ def publish_image(
         ...,
         help=(
             "Image reference to make public "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
+            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -1014,6 +1006,7 @@ def publish_image(
     \b
     Examples:
         prime images publish myapp:v1.0.0
+        prime images publish alice/myapp:v1.0.0
         prime images publish cmk123/myapp:v1.0.0
         prime images publish team-abc123/myapp:v1.0.0
     """
@@ -1033,8 +1026,8 @@ def unpublish_image(
         ...,
         help=(
             "Image reference to make private "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
+            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
 ):
@@ -1044,6 +1037,7 @@ def unpublish_image(
     \b
     Examples:
         prime images unpublish myapp:v1.0.0
+        prime images unpublish alice/myapp:v1.0.0
         prime images unpublish cmk123/myapp:v1.0.0
         prime images unpublish team-abc123/myapp:v1.0.0
     """
@@ -1063,8 +1057,8 @@ def delete_image(
         ...,
         help=(
             "Image reference to delete "
-            "(e.g., 'myapp:v1.0.0', '<currentUserId>/myapp:v1.0.0', "
-            "or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
+            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -1079,6 +1073,7 @@ def delete_image(
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes
+        prime images delete alice/myapp:v1.0.0
         prime images delete cmk123/myapp:v1.0.0
         prime images delete team-abc123/myapp:v1.0.0
     """

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -260,10 +260,11 @@ def _render_status_column(partition: PartitionMap) -> str:
 def _render_image_reference(img: ImageRow, *, is_team_listing: bool) -> str:
     """Render the user-facing image reference.
 
-    The owner prefix (``{ownerSlug}/``, ``{userId}/``, or ``team-{teamId}/``) is **always**
-    preserved so the full string is a valid reference that can be pasted
-    directly into downstream commands (e.g. ``prime sandbox create``),
-    which require a fully-qualified ``<owner>/<imageName>:<tag>`` form.
+    The Prime owner prefix (``prime/{ownerSlug}/``, ``prime/{userId}/``, or
+    ``prime/team-{teamId}/``) is **always** preserved so the full string is a
+    valid reference that can be pasted directly into downstream commands
+    (e.g. ``prime sandbox create``), which require a fully-qualified
+    ``prime/<owner>/<imageName>:<tag>`` form.
 
     Visual truncation (if any) is applied separately by
     :func:`_truncate_ref_left` so that when the terminal is too narrow the
@@ -942,26 +943,44 @@ def list_images(
 def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Optional[str]]:
     """Parse refs accepted by mutating image commands.
 
-    Returns ``(image_name, image_tag, team_id)``. Personal image refs may use
-    either ``name:tag``, ``{currentUserId}/name:tag``, or ``{userSlug}/name:tag``.
-    Team image refs may use ``team-{teamId}/name:tag`` or ``{teamSlug}/name:tag``.
-    Owner-prefixed refs are otherwise passed through for server-side resolution
-    because only the backend can distinguish user slugs from team slugs.
+    Returns ``(image_name, image_tag, team_id)``. ``name:tag`` uses the current
+    personal/team context. Owner-prefixed refs are passed through for
+    server-side resolution because only the backend can distinguish user slugs
+    from team slugs. New slug refs must use ``prime/<owner>/name:tag``; legacy
+    ``<userId>/name:tag`` and ``team-<teamId>/name:tag`` refs are still
+    accepted.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
-        namespace, rest = image_reference.split("/", 1)
+        parts = image_reference.split("/")
+        if len(parts) == 3 and parts[0] == "prime":
+            namespace = parts[1]
+            repo_and_tag = parts[2]
+        elif len(parts) == 2:
+            namespace = parts[0]
+            repo_and_tag = parts[1]
+        else:
+            console.print(
+                "[red]Error: Owner-prefixed image references must use "
+                "prime/<owner>/imagename:tag or legacy "
+                "<userId>/imagename:tag[/red]"
+            )
+            raise typer.Exit(1)
+        if not namespace or not repo_and_tag:
+            console.print(
+                "[red]Error: Owner-prefixed image references must use "
+                "prime/<owner>/imagename:tag or legacy "
+                "<userId>/imagename:tag[/red]"
+            )
+            raise typer.Exit(1)
         if namespace == "team-":
             console.print(
                 "[red]Error: Invalid team image reference. "
-                "Expected format: team-{teamId}/imagename:tag[/red]"
+                "Expected format: prime/team-{teamId}/imagename:tag or "
+                "team-{teamId}/imagename:tag[/red]"
             )
             raise typer.Exit(1)
-        elif namespace == config.user_id:
-            team_id = None
-            image_reference = rest
-        else:
-            team_id = None
+        team_id = None
 
     if ":" not in image_reference:
         console.print("[red]Error: Image reference must include a tag (e.g., myapp:latest)[/red]")
@@ -995,8 +1014,11 @@ def publish_image(
         ...,
         help=(
             "Image reference to make public "
-            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
-            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', 'prime/<ownerSlug>/myapp:v1.0.0', "
+            "'prime/<currentUserId>/myapp:v1.0.0', or "
+            "'prime/team-{teamId}/myapp:v1.0.0'; legacy "
+            "'<currentUserId>/myapp:v1.0.0' and "
+            "'team-{teamId}/myapp:v1.0.0' also work)"
         ),
     ),
 ):
@@ -1006,7 +1028,9 @@ def publish_image(
     \b
     Examples:
         prime images publish myapp:v1.0.0
-        prime images publish alice/myapp:v1.0.0
+        prime images publish prime/alice/myapp:v1.0.0
+        prime images publish prime/cmk123/myapp:v1.0.0
+        prime images publish prime/team-abc123/myapp:v1.0.0
         prime images publish cmk123/myapp:v1.0.0
         prime images publish team-abc123/myapp:v1.0.0
     """
@@ -1026,8 +1050,11 @@ def unpublish_image(
         ...,
         help=(
             "Image reference to make private "
-            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
-            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', 'prime/<ownerSlug>/myapp:v1.0.0', "
+            "'prime/<currentUserId>/myapp:v1.0.0', or "
+            "'prime/team-{teamId}/myapp:v1.0.0'; legacy "
+            "'<currentUserId>/myapp:v1.0.0' and "
+            "'team-{teamId}/myapp:v1.0.0' also work)"
         ),
     ),
 ):
@@ -1037,7 +1064,9 @@ def unpublish_image(
     \b
     Examples:
         prime images unpublish myapp:v1.0.0
-        prime images unpublish alice/myapp:v1.0.0
+        prime images unpublish prime/alice/myapp:v1.0.0
+        prime images unpublish prime/cmk123/myapp:v1.0.0
+        prime images unpublish prime/team-abc123/myapp:v1.0.0
         prime images unpublish cmk123/myapp:v1.0.0
         prime images unpublish team-abc123/myapp:v1.0.0
     """
@@ -1057,8 +1086,11 @@ def delete_image(
         ...,
         help=(
             "Image reference to delete "
-            "(e.g., 'myapp:v1.0.0', '<ownerSlug>/myapp:v1.0.0', "
-            "'<currentUserId>/myapp:v1.0.0', or 'team-{teamId}/myapp:v1.0.0')"
+            "(e.g., 'myapp:v1.0.0', 'prime/<ownerSlug>/myapp:v1.0.0', "
+            "'prime/<currentUserId>/myapp:v1.0.0', or "
+            "'prime/team-{teamId}/myapp:v1.0.0'; legacy "
+            "'<currentUserId>/myapp:v1.0.0' and "
+            "'team-{teamId}/myapp:v1.0.0' also work)"
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -1066,14 +1098,16 @@ def delete_image(
     """
     Delete an image from your registry.
 
-    For team images, you can use the team-prefixed format directly.
+    For team images, you can use the prime/team-{teamId}/... format directly.
     Only the image creator or team admins can delete team images.
 
     \b
     Examples:
         prime images delete myapp:v1.0.0
         prime images delete myapp:latest --yes
-        prime images delete alice/myapp:v1.0.0
+        prime images delete prime/alice/myapp:v1.0.0
+        prime images delete prime/cmk123/myapp:v1.0.0
+        prime images delete prime/team-abc123/myapp:v1.0.0
         prime images delete cmk123/myapp:v1.0.0
         prime images delete team-abc123/myapp:v1.0.0
     """

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -991,7 +991,14 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
         parts = image_reference.split("/")
-        if len(parts) >= 3 and parts[0] == "prime":
+        if parts[0] == "prime":
+            if len(parts) < 3:
+                console.print(
+                    "[red]Error: Owner-prefixed image references must use "
+                    "prime/<owner>/<imageName>:tag or legacy "
+                    "<userId>/<imageName>:tag[/red]"
+                )
+                raise typer.Exit(1)
             namespace = parts[1]
             repo_and_tag = "/".join(parts[2:])
         elif len(parts) >= 2 and not _looks_like_registry_host(parts[0]):

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -951,13 +951,16 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
         namespace, rest = image_reference.split("/", 1)
-        if namespace == "team-":
-            console.print(
-                "[red]Error: Invalid team image reference. "
-                "Expected format: team-{teamId}/imagename:tag[/red]"
-            )
-            raise typer.Exit(1)
-        if namespace == config.user_id:
+        if namespace.startswith("team-"):
+            team_id = namespace[5:]
+            if not team_id:
+                console.print(
+                    "[red]Error: Invalid team image reference. "
+                    "Expected format: team-{teamId}/imagename:tag[/red]"
+                )
+                raise typer.Exit(1)
+            image_reference = rest
+        elif namespace == config.user_id:
             team_id = None
             image_reference = rest
         else:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -973,6 +973,11 @@ def list_images(
         raise typer.Exit(1)
 
 
+def _looks_like_registry_host(value: str) -> bool:
+    # Docker treats localhost as a registry host even without a dot or port.
+    return "." in value or ":" in value or value == "localhost"
+
+
 def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Optional[str]]:
     """Parse refs accepted by mutating image commands.
 
@@ -980,30 +985,30 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     personal/team context. Owner-prefixed refs are passed through for
     server-side resolution because only the backend can distinguish user slugs
     from team slugs. New slug refs must use ``prime/<owner>/name:tag``; legacy
-    ``<userId>/name:tag`` and ``team-<teamId>/name:tag`` refs are still
+    ``<userId>/<imageName>:tag`` and ``team-<teamId>/<imageName>:tag`` refs are still
     accepted.
     """
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
         parts = image_reference.split("/")
-        if len(parts) == 3 and parts[0] == "prime":
+        if len(parts) >= 3 and parts[0] == "prime":
             namespace = parts[1]
-            repo_and_tag = parts[2]
-        elif len(parts) == 2:
+            repo_and_tag = "/".join(parts[2:])
+        elif len(parts) >= 2 and not _looks_like_registry_host(parts[0]):
             namespace = parts[0]
-            repo_and_tag = parts[1]
+            repo_and_tag = "/".join(parts[1:])
         else:
             console.print(
                 "[red]Error: Owner-prefixed image references must use "
-                "prime/<owner>/imagename:tag or legacy "
-                "<userId>/imagename:tag[/red]"
+                "prime/<owner>/<imageName>:tag or legacy "
+                "<userId>/<imageName>:tag[/red]"
             )
             raise typer.Exit(1)
         if not namespace or not repo_and_tag:
             console.print(
                 "[red]Error: Owner-prefixed image references must use "
-                "prime/<owner>/imagename:tag or legacy "
-                "<userId>/imagename:tag[/red]"
+                "prime/<owner>/<imageName>:tag or legacy "
+                "<userId>/<imageName>:tag[/red]"
             )
             raise typer.Exit(1)
         if namespace == "team-":

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -951,15 +951,12 @@ def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Opti
     team_id: Optional[str] = config.team_id
     if "/" in image_reference:
         namespace, rest = image_reference.split("/", 1)
-        if namespace.startswith("team-"):
-            team_id = namespace[5:]
-            if not team_id:
-                console.print(
-                    "[red]Error: Invalid team image reference. "
-                    "Expected format: team-{teamId}/imagename:tag[/red]"
-                )
-                raise typer.Exit(1)
-            image_reference = rest
+        if namespace == "team-":
+            console.print(
+                "[red]Error: Invalid team image reference. "
+                "Expected format: team-{teamId}/imagename:tag[/red]"
+            )
+            raise typer.Exit(1)
         elif namespace == config.user_id:
             team_id = None
             image_reference = rest

--- a/packages/prime/tests/test_images_list.py
+++ b/packages/prime/tests/test_images_list.py
@@ -67,7 +67,7 @@ def _art(
         "pushedAt": pushed_at,
         "teamId": team_id,
         "ownerType": "team" if team_id else "personal",
-        "displayRef": f"{scope}/{name}:{tag}",
+        "displayRef": f"prime/{scope}/{name}:{tag}",
     }
 
 
@@ -205,7 +205,7 @@ def test_render_type_column_container_and_vm():
     assert text.index("Container") < text.index("VM")
 
 
-def test_render_type_column_container_only_legacy():
+def test_render_type_column_container_only():
     text = _render_type_column(_partition_group([_container(pushed_at="2026-04-16T22:24:07")]))
     assert "Container" in text
     assert "VM" not in text
@@ -238,7 +238,7 @@ def test_render_status_column_partial_failure_aligned():
     assert text == "[green]Ready[/green] / [red]Failed[/red]"
 
 
-def test_render_status_column_container_only_legacy():
+def test_render_status_column_container_only():
     text = _render_status_column(_partition_group([_container(pushed_at="2026-04-16T22:24:07")]))
     assert text == "[green]Ready[/green]"
     assert " / " not in text
@@ -308,21 +308,24 @@ def test_render_status_column_surfaces_unknown_status_alongside_known():
 def test_render_image_reference_always_shows_user_prefix_for_personal():
     assert (
         _render_image_reference(_container(image="myapp:v1"), is_team_listing=False)
-        == f"{USER_ID}/myapp:v1"
+        == f"prime/{USER_ID}/myapp:v1"
     )
 
 
 def test_render_image_reference_keeps_team_prefix_for_team_listing():
     assert (
         _render_image_reference(_container(image="myapp:v1", team_id=TEAM_ID), is_team_listing=True)
-        == f"team-{TEAM_ID}/myapp:v1"
+        == f"prime/team-{TEAM_ID}/myapp:v1"
     )
 
 
 def test_render_image_reference_falls_back_without_display_ref():
     assert (
-        _render_image_reference({"imageName": "legacy", "imageTag": "v2"}, is_team_listing=False)
-        == "legacy:v2"
+        _render_image_reference(
+            {"imageName": "fallback-image", "imageTag": "v2"},
+            is_team_listing=False,
+        )
+        == "fallback-image:v2"
     )
 
 
@@ -336,7 +339,7 @@ def test_truncate_ref_left_returns_unchanged_when_within_width():
 
 
 def test_truncate_ref_left_clips_head_and_preserves_name_tag():
-    ref = f"{USER_ID}/nvidia-basic-dev:latest"
+    ref = f"prime/{USER_ID}/nvidia-basic-dev:latest"
     out = _truncate_ref_left(ref, 30)
     assert out.endswith("nvidia-basic-dev:latest")
     assert out.startswith("…")
@@ -345,7 +348,7 @@ def test_truncate_ref_left_clips_head_and_preserves_name_tag():
 
 @pytest.mark.parametrize("budget", [0, -5])
 def test_truncate_ref_left_handles_zero_or_negative_budget(budget):
-    ref = f"{USER_ID}/x:y"
+    ref = f"prime/{USER_ID}/x:y"
     assert _truncate_ref_left(ref, budget) == ref
 
 
@@ -522,7 +525,7 @@ def test_list_cli_shows_type_and_positional_status(run_images_list):
     assert "Container / VM" in result.output
     assert "Ready / Ready" in result.output
     assert "Failed" not in result.output  # stale, hidden by newer COMPLETED
-    assert f"{USER_ID}/nvidia-basic-dev:latest" in result.output
+    assert f"prime/{USER_ID}/nvidia-basic-dev:latest" in result.output
     assert "300.0 MB" in result.output
 
 
@@ -586,14 +589,16 @@ def test_list_cli_team_listing_keeps_owner_column_and_prefix(run_images_list):
     )
     assert result.exit_code == 0, result.output
     assert "Owner" in result.output
-    assert f"team-{TEAM_ID}/teamapp:latest" in result.output
+    assert f"prime/team-{TEAM_ID}/teamapp:latest" in result.output
 
 
-def test_list_cli_container_only_legacy_image(run_images_list):
+def test_list_cli_container_only_image(run_images_list):
     result = run_images_list(
         [
             _container(
-                image="legacy:latest", pushed_at="2026-04-16T22:24:07", size_bytes=10 * 1024 * 1024
+                image="container-only:latest",
+                pushed_at="2026-04-16T22:24:07",
+                size_bytes=10 * 1024 * 1024,
             ),
         ]
     )
@@ -632,7 +637,7 @@ def test_list_cli_truncates_owner_prefix_on_narrow_terminal(run_images_list):
     assert result.exit_code == 0, result.output
     assert "nvidia-basic-dev:latest" in result.output
     assert "…" in result.output
-    assert f"{USER_ID}/nvidia-basic-dev" not in result.output
+    assert f"prime/{USER_ID}/nvidia-basic-dev" not in result.output
 
 
 def _run_list_capturing_params(

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -241,8 +241,33 @@ def test_publish_image_calls_visibility_endpoint(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
-    assert captured["json"] == {"visibility": "PUBLIC"}
+    assert captured["path"] == "/images/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC", "teamId": "abc123"}
+
+
+def test_unpublish_image_parses_team_id_prefix(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PRIVATE", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "unpublish", "team-abc123/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PRIVATE", "teamId": "abc123"}
 
 
 def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
@@ -343,6 +368,31 @@ def test_delete_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
     assert captured["method"] == "DELETE"
     assert captured["path"] == "/images/research/rehl/latest"
     assert captured["params"] is None
+
+
+def test_delete_image_parses_team_id_prefix(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["params"] = params
+            return {"success": True, "message": "ok"}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "delete", "team-abc123/rehl:latest", "--yes"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/images/rehl/latest"
+    assert captured["params"] == {"teamId": "abc123"}
 
 
 def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -175,6 +175,66 @@ def test_push_platform_image_forces_public_owner_scope(tmp_path, monkeypatch):
     assert "Platform" in result.output
 
 
+def test_push_platform_image_allows_namespaced_image_reference(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
+    context_path = tmp_path / "context"
+    context_path.mkdir()
+    (context_path / "Dockerfile").write_text("FROM ubuntu:22.04\n")
+
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            if method == "POST" and path == "/images/build":
+                captured["build_payload"] = json
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://example.test/upload",
+                    "fullImagePath": "namanjain12/orange3_final:tag",
+                }
+
+            if method == "POST" and path == "/images/build/build-123/start":
+                return {}
+
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    class DummyUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    def fake_put(url, content, headers, timeout):
+        return DummyUploadResponse()
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        [
+            "images",
+            "push",
+            "namanjain12/orange3_final:tag",
+            "--context",
+            "context",
+            "--platform-image",
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["build_payload"] == {
+        "image_name": "namanjain12/orange3_final",
+        "image_tag": "tag",
+        "dockerfile_path": PACKAGED_DOCKERFILE_PATH,
+        "platform": "linux/amd64",
+        "owner_scope": "platform",
+        "visibility": "PUBLIC",
+    }
+
+
 def test_push_platform_image_source_image_queues_platform_transfer(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     monkeypatch.delenv("PRIME_TEAM_ID", raising=False)

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -484,6 +484,25 @@ def test_publish_image_rejects_empty_team_prefix(monkeypatch):
     assert "Invalid team image reference" in result.output
 
 
+def test_publish_image_rejects_prime_ref_without_owner(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "prime/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "prime/<owner>/<imageName>:tag" in result.output
+
+
 def test_publish_image_passes_legacy_user_id_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -220,7 +220,7 @@ def test_push_image_source_image_multi_rejects_destination(monkeypatch):
     assert "single-image transfers" in result.output
 
 
-def test_publish_image_calls_visibility_endpoint(monkeypatch):
+def test_publish_image_passes_team_prefixed_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -241,11 +241,11 @@ def test_publish_image_calls_visibility_endpoint(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/rehl/latest/visibility"
-    assert captured["json"] == {"visibility": "PUBLIC", "teamId": "abc123"}
+    assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
 
 
-def test_unpublish_image_parses_team_id_prefix(monkeypatch):
+def test_unpublish_image_passes_team_prefixed_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -266,8 +266,21 @@ def test_unpublish_image_parses_team_id_prefix(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/rehl/latest/visibility"
-    assert captured["json"] == {"visibility": "PRIVATE", "teamId": "abc123"}
+    assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PRIVATE"}
+
+
+def test_publish_image_rejects_empty_team_prefix(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "team-/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid team image reference" in result.output
 
 
 def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
@@ -370,7 +383,7 @@ def test_delete_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
     assert captured["params"] is None
 
 
-def test_delete_image_parses_team_id_prefix(monkeypatch):
+def test_delete_image_passes_team_prefixed_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -391,8 +404,8 @@ def test_delete_image_parses_team_id_prefix(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "DELETE"
-    assert captured["path"] == "/images/rehl/latest"
-    assert captured["params"] == {"teamId": "abc123"}
+    assert captured["path"] == "/images/team-abc123/rehl/latest"
+    assert captured["params"] is None
 
 
 def test_push_image_accepts_dockerfile_outside_context(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -509,6 +509,31 @@ def test_publish_image_passes_legacy_user_id_ref_to_backend(monkeypatch):
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
+def test_publish_image_passes_legacy_user_id_nested_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "cmk123/nested/rehl:latest"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/cmk123/nested/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
 def test_publish_image_passes_legacy_team_id_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
@@ -531,6 +556,31 @@ def test_publish_image_passes_legacy_team_id_ref_to_backend(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
     assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_publish_image_passes_legacy_team_id_nested_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "team-abc123/nested/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/team-abc123/nested/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
@@ -582,6 +632,50 @@ def test_publish_image_passes_prime_slug_ref_to_backend(monkeypatch):
     assert captured["method"] == "PATCH"
     assert captured["path"] == "/images/prime/alice/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_publish_image_passes_prime_slug_nested_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "prime/alice/nested/rehl:latest"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/prime/alice/nested/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_publish_image_rejects_external_registry_ref(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "docker.io/org/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Owner-prefixed image references" in result.output
 
 
 def test_delete_image_passes_prime_user_id_ref_to_backend(monkeypatch):

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -11,6 +11,7 @@ TEST_ENV = {
     "COLUMNS": "200",
     "LINES": "50",
     "PRIME_DISABLE_VERSION_CHECK": "1",
+    "PRIME_TEAM_ID": "",
 }
 
 
@@ -240,8 +241,8 @@ def test_publish_image_calls_visibility_endpoint(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/rehl/latest/visibility"
-    assert captured["json"] == {"visibility": "PUBLIC", "teamId": "abc123"}
+    assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
 
 
 def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
@@ -269,23 +270,29 @@ def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
-def test_publish_image_rejects_other_user_prefixed_personal_ref(monkeypatch):
+def test_publish_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
 
     class DummyAPIClient:
         def request(self, method, path, json=None, params=None):
-            raise AssertionError(f"Unexpected request: {method} {path}")
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
 
     monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
 
     result = runner.invoke(
         app,
-        ["images", "publish", "other-user/rehl:latest"],
+        ["images", "publish", "alice/rehl:latest"],
         env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
     )
 
-    assert result.exit_code == 1
-    assert "Unrecognized image namespace 'other-user'" in result.output
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/alice/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
 
 
 def test_delete_image_accepts_owner_prefixed_personal_ref(monkeypatch):
@@ -310,6 +317,31 @@ def test_delete_image_accepts_owner_prefixed_personal_ref(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["method"] == "DELETE"
     assert captured["path"] == "/images/rehl/latest"
+    assert captured["params"] is None
+
+
+def test_delete_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["params"] = params
+            return {"success": True, "message": "ok"}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "delete", "research/rehl:latest", "--yes"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123", "PRIME_TEAM_ID": "team-1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/images/research/rehl/latest"
     assert captured["params"] is None
 
 

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -133,7 +133,7 @@ def test_push_image_source_image_queues_transfer_without_upload(monkeypatch):
                 "build_id": "build-123",
                 "buildIds": ["build-123"],
                 "upload_url": None,
-                "fullImagePath": "cmk123/ubuntu:22.04",
+                "fullImagePath": "prime/cmk123/ubuntu:22.04",
                 "visibility": "PRIVATE",
             }
 
@@ -172,7 +172,7 @@ def test_push_image_source_image_with_destination_override(monkeypatch):
             return {
                 "build_id": "build-123",
                 "buildIds": ["build-123"],
-                "fullImagePath": "cmk123/myubuntu:22.04",
+                "fullImagePath": "prime/cmk123/myubuntu:22.04",
                 "visibility": "PUBLIC",
             }
 
@@ -220,7 +220,95 @@ def test_push_image_source_image_multi_rejects_destination(monkeypatch):
     assert "single-image transfers" in result.output
 
 
-def test_publish_image_passes_team_prefixed_ref_to_backend(monkeypatch):
+def test_publish_image_passes_prime_team_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "prime/team-abc123/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/prime/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_unpublish_image_passes_prime_team_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PRIVATE", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "unpublish", "prime/team-abc123/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/prime/team-abc123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PRIVATE"}
+
+
+def test_publish_image_rejects_empty_team_prefix(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "prime/team-/rehl:latest"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid team image reference" in result.output
+
+
+def test_publish_image_passes_legacy_user_id_ref_to_backend(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"success": True, "message": "ok", "visibility": "PUBLIC", "images": []}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "publish", "cmk123/rehl:latest"],
+        env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/images/cmk123/rehl/latest/visibility"
+    assert captured["json"] == {"visibility": "PUBLIC"}
+
+
+def test_publish_image_passes_legacy_team_id_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -245,45 +333,7 @@ def test_publish_image_passes_team_prefixed_ref_to_backend(monkeypatch):
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
-def test_unpublish_image_passes_team_prefixed_ref_to_backend(monkeypatch):
-    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
-    captured = {}
-
-    class DummyAPIClient:
-        def request(self, method, path, json=None, params=None):
-            captured["method"] = method
-            captured["path"] = path
-            captured["json"] = json
-            return {"success": True, "message": "ok", "visibility": "PRIVATE", "images": []}
-
-    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
-
-    result = runner.invoke(
-        app,
-        ["images", "unpublish", "team-abc123/rehl:latest"],
-        env=TEST_ENV,
-    )
-
-    assert result.exit_code == 0, result.output
-    assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/team-abc123/rehl/latest/visibility"
-    assert captured["json"] == {"visibility": "PRIVATE"}
-
-
-def test_publish_image_rejects_empty_team_prefix(monkeypatch):
-    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
-
-    result = runner.invoke(
-        app,
-        ["images", "publish", "team-/rehl:latest"],
-        env=TEST_ENV,
-    )
-
-    assert result.exit_code == 1
-    assert "Invalid team image reference" in result.output
-
-
-def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
+def test_publish_image_passes_prime_user_id_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -298,17 +348,17 @@ def test_publish_image_accepts_owner_prefixed_personal_ref(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["images", "publish", "cmk123/rehl:latest"],
+        ["images", "publish", "prime/cmk123/rehl:latest"],
         env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/rehl/latest/visibility"
+    assert captured["path"] == "/images/prime/cmk123/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
-def test_publish_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
+def test_publish_image_passes_prime_slug_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -323,17 +373,17 @@ def test_publish_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["images", "publish", "alice/rehl:latest"],
+        ["images", "publish", "prime/alice/rehl:latest"],
         env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "PATCH"
-    assert captured["path"] == "/images/alice/rehl/latest/visibility"
+    assert captured["path"] == "/images/prime/alice/rehl/latest/visibility"
     assert captured["json"] == {"visibility": "PUBLIC"}
 
 
-def test_delete_image_accepts_owner_prefixed_personal_ref(monkeypatch):
+def test_delete_image_passes_prime_user_id_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -348,17 +398,17 @@ def test_delete_image_accepts_owner_prefixed_personal_ref(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["images", "delete", "cmk123/rehl:latest", "--yes"],
+        ["images", "delete", "prime/cmk123/rehl:latest", "--yes"],
         env={**TEST_ENV, "PRIME_USER_ID": "cmk123"},
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "DELETE"
-    assert captured["path"] == "/images/rehl/latest"
+    assert captured["path"] == "/images/prime/cmk123/rehl/latest"
     assert captured["params"] is None
 
 
-def test_delete_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
+def test_delete_image_passes_prime_slug_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -373,17 +423,17 @@ def test_delete_image_passes_slug_prefixed_ref_to_backend(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["images", "delete", "research/rehl:latest", "--yes"],
+        ["images", "delete", "prime/research/rehl:latest", "--yes"],
         env={**TEST_ENV, "PRIME_USER_ID": "cmk123", "PRIME_TEAM_ID": "team-1"},
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "DELETE"
-    assert captured["path"] == "/images/research/rehl/latest"
+    assert captured["path"] == "/images/prime/research/rehl/latest"
     assert captured["params"] is None
 
 
-def test_delete_image_passes_team_prefixed_ref_to_backend(monkeypatch):
+def test_delete_image_passes_prime_team_ref_to_backend(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     captured = {}
 
@@ -398,13 +448,13 @@ def test_delete_image_passes_team_prefixed_ref_to_backend(monkeypatch):
 
     result = runner.invoke(
         app,
-        ["images", "delete", "team-abc123/rehl:latest", "--yes"],
+        ["images", "delete", "prime/team-abc123/rehl:latest", "--yes"],
         env=TEST_ENV,
     )
 
     assert result.exit_code == 0, result.output
     assert captured["method"] == "DELETE"
-    assert captured["path"] == "/images/team-abc123/rehl/latest"
+    assert captured["path"] == "/images/prime/team-abc123/rehl/latest"
     assert captured["params"] is None
 
 
@@ -491,7 +541,7 @@ def test_push_image_source_image_result_shape_uses_full_image_path(monkeypatch):
                         "sourceImage": "ubuntu:jammy",
                         "success": True,
                         "buildId": "buildabc",
-                        "fullImagePath": "cmkabc/ubuntu:jammy",
+                        "fullImagePath": "prime/cmkabc/ubuntu:jammy",
                     }
                 ],
                 "failed": [],
@@ -507,7 +557,7 @@ def test_push_image_source_image_result_shape_uses_full_image_path(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "buildabc" in result.output
-    assert "cmkabc/ubuntu:jammy" in result.output
+    assert "prime/cmkabc/ubuntu:jammy" in result.output
 
 
 def test_push_image_source_image_result_shape_reports_all_failures(monkeypatch):
@@ -568,7 +618,7 @@ def test_push_image_source_image_result_shape_reports_partial_failures(monkeypat
                         "sourceImage": "ubuntu:jammy",
                         "success": True,
                         "buildId": "buildabc",
-                        "fullImagePath": "cmkabc/ubuntu:jammy",
+                        "fullImagePath": "prime/cmkabc/ubuntu:jammy",
                     },
                     failed,
                 ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how CLI builds image API paths and validates references; mistakes could target the wrong image, though legacy ref formats remain supported and coverage is broad in tests.
> 
> **Overview**
> User-facing sandbox image refs now use a **`prime/<owner>/...`** prefix (slug, user id, or `team-{id}`) instead of bare `team-*` / user-id paths, including **`prime images list`** output and transfer **`fullImagePath`** expectations.
> 
> **`prime images`** parsing and mutating commands (**publish**, **unpublish**, **delete**) were reworked: owner-prefixed refs are forwarded to the API for server-side resolution (legacy `userId/...` and `team-.../...` still accepted); external registry refs are rejected unless they look like registry hosts. **Push/transfer** tweaks include allowing slashes in image names for **`--platform-image`**, and sending **`team_id`** only when set.
> 
> Tests across **`prime`**, **`prime-sandboxes`**, list/push suites were updated to match the new reference shape and API paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c4cb371a0372b09d4d64b866907e7a77b0e256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->