### PR TITLE
[ENG-4231] Add CLI support for verifiers v1 env configs

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -42,6 +42,22 @@ from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
 console = get_console()
 
+V1_ENV_CONFIG_FIELDS = (
+    "taskset",
+    "harness",
+    "pool",
+    "timeout",
+    "retries",
+    "sampling",
+    "ratio",
+    "group_size",
+    "max_turns",
+    "max_input_tokens",
+    "max_output_tokens",
+    "max_total_tokens",
+    "multiplex",
+)
+
 RL_RUN_JSON_HELP = json_output_help(
     ".run = {id, name?, status, base_model, environments[], "
     "rollouts_per_example, max_steps, batch_size, created_at, updated_at, ...}",
@@ -258,6 +274,12 @@ id = "{env_value}"
 # [[env]] # add multiple [[env]] sections for multi-env training
 # id = "primeintellect/another-env"
 # args = {{ split = "train", max_examples = 1000 }}
+#
+# v1 environment shape: use taskset/harness instead of legacy id.
+# [[env]]
+# name = "alphabet-sort"
+# taskset = {{ id = "alphabet-sort-v1", min_turns = 3, max_turns = 5, power_per_turn = false }}
+# harness = {{ id = "default", runtime = {{ type = "subprocess" }} }}
 
 # Optional: online evaluation
 # [eval]
@@ -298,29 +320,125 @@ id = "{env_value}"
 '''
 
 
+def _validate_env_id_value(v: str, *, field_name: str) -> str:
+    """Validate a legacy env id or v1 plugin id.
+
+    Bare ids are importable runtime ids. Slash-shaped ids are Hub refs and
+    must include both owner and name.
+    """
+    v = v.strip()
+    if not v:
+        raise ValueError(f"{field_name} cannot be empty")
+    if "/" in v:
+        owner, name = v.split("/", 1)
+        if not owner.strip() or not name.strip():
+            raise ValueError(
+                f"{field_name} must have both owner and name (e.g., 'primeintellect/vf-math')"
+            )
+    return v
+
+
+def _dict_id(config: Dict[str, Any] | None) -> Any:
+    return config.get("id") if isinstance(config, dict) else None
+
+
+def _is_hub_env_id(value: Any) -> bool:
+    return isinstance(value, str) and "/" in value
+
+
+def _split_hub_env_id(env_id: str) -> str:
+    return env_id.rsplit("@", 1)[0]
+
+
+def _env_display_name(env: Dict[str, Any], index: int | None = None) -> str:
+    taskset_id = _dict_id(env.get("taskset") if isinstance(env.get("taskset"), dict) else None)
+    value = env.get("slug") or env.get("name") or env.get("id") or taskset_id
+    if value:
+        return str(value)
+    return f"env-{index}" if index is not None else "?"
+
+
 class EnvConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    id: str
+    id: str | None = None
     name: str | None = None
+    taskset: Dict[str, Any] | None = None
+    harness: Dict[str, Any] | None = None
+    pool: Dict[str, Any] | None = None
+    timeout: Dict[str, Any] | None = None
+    retries: Dict[str, Any] | None = None
+    sampling: Dict[str, Any] | None = None
+    ratio: float | None = Field(default=None, gt=0)
+    group_size: int | None = Field(default=None, ge=1)
+    max_turns: int | None = Field(default=None, ge=1)
+    max_input_tokens: int | None = Field(default=None, ge=1)
+    max_output_tokens: int | None = Field(default=None, ge=1)
+    max_total_tokens: int | None = Field(default=None, ge=1)
+    multiplex: int | None = Field(default=None, ge=1)
     args: Dict[str, Any] = Field(default_factory=dict)
     max_retries: int | None = Field(default=None, ge=0)
     version: str | None = None
 
+    @field_validator("id")
+    @classmethod
+    def validate_environment_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _validate_env_id_value(v, field_name="Environment ID")
+
     @model_validator(mode="after")
     def parse_version_from_id(self) -> "EnvConfig":
         """Extract version from id if specified as 'owner/name@version'."""
-        if "@" in self.id:
+        if self.id and "@" in self.id:
             id_part, version_part = self.id.rsplit("@", 1)
-            self.id = id_part
+            self.id = _validate_env_id_value(id_part, field_name="Environment ID")
             if self.version is None and version_part:
                 self.version = version_part
         return self
 
+    @model_validator(mode="after")
+    def validate_env_selector(self) -> "EnvConfig":
+        taskset_id = _dict_id(self.taskset)
+        if self.id is None and not taskset_id:
+            raise ValueError("Environment config requires either legacy id or v1 taskset.id")
+        if taskset_id is not None:
+            assert self.taskset is not None
+            self.taskset["id"] = _validate_env_id_value(str(taskset_id), field_name="taskset.id")
+        harness_id = _dict_id(self.harness)
+        if harness_id is not None:
+            assert self.harness is not None
+            self.harness["id"] = _validate_env_id_value(str(harness_id), field_name="harness.id")
+        return self
+
+    @property
+    def is_v1(self) -> bool:
+        return bool(_dict_id(self.taskset))
+
+    @property
+    def display_name(self) -> str:
+        return _env_display_name(self.to_api_dict())
+
+    def hub_env_ids(self) -> list[str]:
+        refs: list[str] = []
+        if _is_hub_env_id(self.id):
+            refs.append(str(self.id))
+        for config in (self.taskset, self.harness):
+            plugin_id = _dict_id(config)
+            if _is_hub_env_id(plugin_id):
+                refs.append(str(plugin_id))
+        return refs
+
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {"id": self.id}
+        result: Dict[str, Any] = {}
+        if self.id is not None:
+            result["id"] = self.id
         if self.name is not None:
             result["name"] = self.name
+        for field_name in V1_ENV_CONFIG_FIELDS:
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
         if self.args:
             result["args"] = self.args
         if self.max_retries is not None:
@@ -330,41 +448,34 @@ class EnvConfig(BaseModel):
         return result
 
 
-class EvalEnvConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    id: str
-    name: str | None = None
-    args: Dict[str, Any] = Field(default_factory=dict)
+class EvalEnvConfig(EnvConfig):
     num_examples: int | None = None
-    rollouts_per_example: int | None = None
-    max_retries: int | None = Field(default=None, ge=0)
-    version: str | None = None
+    rollouts_per_example: int | None = Field(default=None, ge=1)
+
+    @field_validator("num_examples")
+    @classmethod
+    def validate_num_examples(cls, v: int | None) -> int | None:
+        if v is not None and v != -1 and v < 1:
+            raise ValueError("num_examples must be -1 (all) or a positive integer")
+        return v
 
     @model_validator(mode="after")
-    def parse_version_from_id(self) -> "EvalEnvConfig":
-        """Extract version from id if specified as 'owner/name@version'."""
-        if "@" in self.id:
-            id_part, version_part = self.id.rsplit("@", 1)
-            self.id = id_part
-            if self.version is None and version_part:
-                self.version = version_part
+    def validate_eval_group_size_aliases(self) -> "EvalEnvConfig":
+        if (
+            self.group_size is not None
+            and self.rollouts_per_example is not None
+            and self.group_size != self.rollouts_per_example
+        ):
+            raise ValueError("group_size and rollouts_per_example cannot differ")
         return self
 
     def to_api_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {"id": self.id}
-        if self.name is not None:
-            result["name"] = self.name
-        if self.args:
-            result["args"] = self.args
+        result = super().to_api_dict()
         if self.num_examples is not None:
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:
-            result["rollouts_per_example"] = self.rollouts_per_example
-        if self.max_retries is not None:
-            result["max_retries"] = self.max_retries
-        if self.version is not None:
-            result["version"] = self.version
+            key = "group_size" if self.is_v1 else "rollouts_per_example"
+            result.setdefault(key, self.rollouts_per_example)
         return result
 
 
@@ -1034,7 +1145,8 @@ def _render_failure_analysis(analysis: Dict[str, Any]) -> None:
 def _format_run_for_display(run: RLRun) -> Dict[str, Any]:
     created_at = run.created_at.strftime("%Y-%m-%d %H:%M") if run.created_at else ""
     env_names = [
-        env.get("slug") or env.get("name") or env.get("id") or "?" for env in run.environments
+        _env_display_name(env, index=index) if isinstance(env, dict) else str(env)
+        for index, env in enumerate(run.environments)
     ]
     envs_display = ", ".join(env_names[:3])
     if len(env_names) > 3:
@@ -1240,7 +1352,7 @@ def create_run(
         console.print(f"  Loss:         {cfg.loss}")
         if cfg.teacher is not None:
             console.print(f"  Teacher:      {cfg.teacher.model}")
-        console.print(f"  Environments: {', '.join(e.id for e in cfg.env)}")
+        console.print(f"  Environments: {', '.join(e.display_name for e in cfg.env)}")
         if app_config.team_id:
             console.print(f"  Team:         {app_config.team_id}")
 
@@ -1296,7 +1408,7 @@ def create_run(
         # Eval
         if cfg.eval.env:
             console.print("\n[cyan]Evaluation[/cyan]")
-            console.print(f"  Environments: {', '.join(e.id for e in cfg.eval.env)}")
+            console.print(f"  Environments: {', '.join(e.display_name for e in cfg.eval.env)}")
             if cfg.eval.interval:
                 console.print(f"  Interval:     {cfg.eval.interval}")
 
@@ -1355,14 +1467,21 @@ def create_run(
 
         console.print()
 
-        # Check action status for hub environments
-        hub_envs = [e for e in cfg.env if "/" in e.id]
-        if hub_envs and not skip_action_check:
+        # Check action status for Hub-backed environment refs. Bare v1 ids
+        # like taskset.id="alphabet-sort-v1" are runtime-importable names and
+        # intentionally do not resolve through the Hub.
+        hub_env_ids: list[str] = []
+        for env_config in cfg.env:
+            for env_id in env_config.hub_env_ids():
+                if env_id not in hub_env_ids:
+                    hub_env_ids.append(env_id)
+
+        if hub_env_ids and not skip_action_check:
             console.print("[dim]Checking Environment Actions...[/dim]")
             failed_envs = []
 
-            for env_config in hub_envs:
-                env_id_base = env_config.id.split("@")[0]
+            for env_id in hub_env_ids:
+                env_id_base = _split_hub_env_id(env_id)
                 owner, name = env_id_base.split("/", 1)
                 try:
                     status_resp = rl_client.get_environment_status(owner, name)
@@ -1370,23 +1489,21 @@ def create_run(
                     action_status = action.get("status")
 
                     if action_status == "FAILED":
-                        console.print(f"  [red]✗[/red] {env_config.id} [dim](failed)[/dim]")
-                        failed_envs.append(env_config.id)
+                        console.print(f"  [red]✗[/red] {env_id} [dim](failed)[/dim]")
+                        failed_envs.append(env_id)
                     elif action_status == "SUCCESS":
-                        console.print(f"  [green]✓[/green] {env_config.id} [dim](success)[/dim]")
+                        console.print(f"  [green]✓[/green] {env_id} [dim](success)[/dim]")
                     elif action_status in ("RUNNING", "PENDING"):
-                        console.print(
-                            f"  [yellow]○[/yellow] {env_config.id} [dim](in progress)[/dim]"
-                        )
+                        console.print(f"  [yellow]○[/yellow] {env_id} [dim](in progress)[/dim]")
                     else:
-                        console.print(f"  [dim]-[/dim] {env_config.id} [dim](no action)[/dim]")
+                        console.print(f"  [dim]-[/dim] {env_id} [dim](no action)[/dim]")
                 except APIError:
-                    console.print(f"  [dim]-[/dim] {env_config.id} [dim](could not check)[/dim]")
+                    console.print(f"  [dim]-[/dim] {env_id} [dim](could not check)[/dim]")
 
             if failed_envs:
                 console.print("\n[red]Error: Action failed for environments:[/red]\n")
                 for env_id in failed_envs:
-                    env_id_base = env_id.split("@")[0]
+                    env_id_base = _split_hub_env_id(env_id)
                     owner, name = env_id_base.split("/", 1)
                     url = f"{app_config.frontend_url}/dashboard/environments/{owner}/{name}/actions"
                     console.print(f"  [red]✗[/red] {env_id}")

--- a/packages/prime/tests/test_rl_api.py
+++ b/packages/prime/tests/test_rl_api.py
@@ -104,6 +104,37 @@ def test_create_run_sends_max_inflight_rollouts() -> None:
     assert run.max_inflight_rollouts == 96
 
 
+def test_create_run_sends_v1_env_payload_unchanged() -> None:
+    api_client = FakeAPIClient()
+    client = RLClient(api_client)  # type: ignore[arg-type]
+    v1_env = {
+        "name": "alphabet-sort",
+        "taskset": {"id": "alphabet-sort-v1", "min_turns": 3},
+        "harness": {"id": "default", "runtime": {"type": "subprocess"}},
+        "group_size": 8,
+    }
+    eval_config = {
+        "environments": [
+            {
+                "taskset": {"id": "alphabet-sort-v1", "split": "test"},
+                "harness": {"id": "default"},
+                "group_size": 4,
+            }
+        ]
+    }
+
+    client.create_run(
+        model_name="Qwen/Qwen3.5-0.8B",
+        environments=[v1_env],
+        eval_config=eval_config,
+    )
+
+    assert api_client.posts[0][0] == "/rft/runs"
+    payload = api_client.posts[0][1]
+    assert payload["environments"] == [v1_env]
+    assert payload["eval"] == eval_config
+
+
 def test_create_run_sends_sft_loss_and_teacher_config() -> None:
     api_client = FakeAPIClient()
     client = RLClient(api_client)  # type: ignore[arg-type]

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -4,6 +4,7 @@ from typing import List
 import pytest
 import typer
 from prime_cli.commands.rl import (
+    EnvConfig,
     RLConfig,
     _flatten_config_schema,
     _is_full_finetune,
@@ -189,6 +190,99 @@ def test_load_config_accepts_eval_sampling_reasoning_effort(tmp_path: Path) -> N
             "max_tokens": 2048,
         },
     }
+
+
+def test_load_config_accepts_v1_train_env_without_legacy_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-0.8B"\n'
+        "[[env]]\n"
+        'name = "alphabet-sort"\n'
+        'taskset = { id = "alphabet-sort-v1", min_turns = 3, '
+        "max_turns = 5, power_per_turn = false }\n"
+        'harness = { id = "default", runtime = { type = "subprocess" } }\n'
+        "group_size = 8\n"
+        "ratio = 0.5\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    env = cfg.env[0]
+    assert env.id is None
+    assert env.display_name == "alphabet-sort"
+    assert env.to_api_dict() == {
+        "name": "alphabet-sort",
+        "taskset": {
+            "id": "alphabet-sort-v1",
+            "min_turns": 3,
+            "max_turns": 5,
+            "power_per_turn": False,
+        },
+        "harness": {"id": "default", "runtime": {"type": "subprocess"}},
+        "ratio": 0.5,
+        "group_size": 8,
+    }
+
+
+def test_load_config_rejects_env_without_legacy_id_or_taskset_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "Qwen/Qwen3.5-0.8B"\n[[env]]\nname = "missing-selector"\n')
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_eval_env_accepts_v1_group_size_alias(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-0.8B"\n'
+        "[[eval.env]]\n"
+        'taskset = { id = "alphabet-sort-v1", split = "test" }\n'
+        'harness = { id = "default" }\n'
+        "num_examples = 32\n"
+        "group_size = 4\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.eval.to_api_dict() == {
+        "environments": [
+            {
+                "taskset": {"id": "alphabet-sort-v1", "split": "test"},
+                "harness": {"id": "default"},
+                "group_size": 4,
+                "num_examples": 32,
+            }
+        ]
+    }
+
+
+def test_eval_env_emits_group_size_for_v1_rollouts_alias(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-0.8B"\n'
+        "[[eval.env]]\n"
+        'taskset = { id = "alphabet-sort-v1" }\n'
+        "rollouts_per_example = 4\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    env_payload = cfg.eval.to_api_dict()["environments"][0]
+    assert env_payload["group_size"] == 4
+    assert "rollouts_per_example" not in env_payload
+
+
+def test_env_config_hub_refs_include_only_slash_shaped_ids() -> None:
+    env = EnvConfig.model_validate(
+        {
+            "taskset": {"id": "dev/alphabet-sort-taskset@0.1.0"},
+            "harness": {"id": "default"},
+        }
+    )
+
+    assert env.display_name == "dev/alphabet-sort-taskset@0.1.0"
+    assert env.hub_env_ids() == ["dev/alphabet-sort-taskset@0.1.0"]
 
 
 def test_load_config_rejects_eval_sampling_with_both_reasoning_controls(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how training/eval environment payloads are validated and serialized before run creation; mistakes could reject valid configs or send wrong API shapes, but scope is CLI config parsing with new tests covering v1 paths.
> 
> **Overview**
> Adds **verifiers v1** environment blocks to `prime train` TOML parsing and API payloads while keeping legacy `[[env]].id` configs working.
> 
> Training and eval `[[env]]` / `[[eval.env]]` entries can use **`taskset` + `harness`** (and related v1 fields like `group_size`, `ratio`, pool/timeouts, token caps) without a top-level `id`. Config validation requires either legacy `id` or `taskset.id`, validates Hub-style `owner/name` refs, and maps eval **`rollouts_per_example` → `group_size`** for v1 envs.
> 
> The init template documents the v1 shape. Pre-run **Hub action checks** run only for slash-shaped refs (`legacy id`, `taskset.id`, `harness.id`), not bare runtime ids like `alphabet-sort-v1`. Run summaries and lists use clearer **display names** for v1 configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc15bb7da7cec1820a7d3b29653b35b00fb9bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->