### PR TITLE
Orgless Images

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/images.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/images.py
@@ -1,6 +1,6 @@
 """Image build and transfer SDK client."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from .core import APIClient, AsyncAPIClient
 from .models import (
@@ -35,6 +35,7 @@ class ImageClient:
         platform: str = "linux/amd64",
         team_id: Optional[str] = None,
         visibility: Optional[ImageVisibility] = None,
+        owner_scope: Optional[Literal["platform"]] = None,
     ) -> BuildImageResponse | BulkImageTransferResponse:
         request = BuildImageRequest(
             image_name=image_name,
@@ -43,6 +44,7 @@ class ImageClient:
             platform=platform,
             team_id=team_id,
             visibility=visibility,
+            owner_scope=owner_scope,
         )
         return self.initiate_build(request)
 
@@ -78,6 +80,7 @@ class AsyncImageClient:
         platform: str = "linux/amd64",
         team_id: Optional[str] = None,
         visibility: Optional[ImageVisibility] = None,
+        owner_scope: Optional[Literal["platform"]] = None,
     ) -> BuildImageResponse | BulkImageTransferResponse:
         request = BuildImageRequest(
             image_name=image_name,
@@ -86,6 +89,7 @@ class AsyncImageClient:
             platform=platform,
             team_id=team_id,
             visibility=visibility,
+            owner_scope=owner_scope,
         )
         return await self.initiate_build(request)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
@@ -258,6 +258,7 @@ class BuildImageRequest(BaseModel):
     platform: str = "linux/amd64"
     team_id: Optional[str] = Field(default=None, alias="teamId")
     visibility: Optional[ImageVisibility] = None
+    owner_scope: Optional[Literal["platform"]] = Field(default=None, alias="ownerScope")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from prime_sandboxes import (
     APIClient,
+    BuildImageRequest,
     BuildImageResponse,
     BulkImageTransferResponse,
     ImageClient,
@@ -82,6 +83,78 @@ def test_build_image_response_allows_multi_transfer_without_full_image_path():
     assert response.build_id == "build-123"
     assert response.build_ids == ["build-123", "build-456"]
     assert response.full_image_path == "team-team1/ubuntu:22.04"
+
+
+def test_image_client_initiate_build_accepts_platform_owner_scope():
+    captured: dict[str, Any] = {}
+    client = ImageClient(
+        DummyAPIClient(
+            {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "upload_url": "https://example.test/upload",
+                "fullImagePath": "ubuntu:22.04",
+                "visibility": "PUBLIC",
+            },
+            captured,
+        )
+    )
+
+    response = client.initiate_build(
+        BuildImageRequest(
+            image_name="ubuntu",
+            image_tag="22.04",
+            visibility=ImageVisibility.PUBLIC,
+            owner_scope="platform",
+        )
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/images/build"
+    assert captured["json"] == {
+        "image_name": "ubuntu",
+        "image_tag": "22.04",
+        "dockerfile_path": "Dockerfile",
+        "platform": "linux/amd64",
+        "visibility": ImageVisibility.PUBLIC,
+        "owner_scope": "platform",
+    }
+    assert isinstance(response, BuildImageResponse)
+    assert response.build_id == "build-123"
+
+
+def test_image_client_transfer_image_accepts_platform_owner_scope():
+    captured: dict[str, Any] = {}
+    client = ImageClient(
+        DummyAPIClient(
+            {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "upload_url": None,
+                "fullImagePath": "ubuntu:22.04",
+                "visibility": "PUBLIC",
+            },
+            captured,
+        )
+    )
+
+    response = client.transfer_image(
+        "ubuntu:22.04",
+        visibility=ImageVisibility.PUBLIC,
+        owner_scope="platform",
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/images/build"
+    assert captured["json"] == {
+        "dockerfile_path": "Dockerfile",
+        "source_image": "ubuntu:22.04",
+        "platform": "linux/amd64",
+        "visibility": ImageVisibility.PUBLIC,
+        "owner_scope": "platform",
+    }
+    assert isinstance(response, BuildImageResponse)
+    assert response.full_image_path == "ubuntu:22.04"
 
 
 def test_image_client_transfer_image_accepts_bulk_transfer_response():

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -397,6 +397,11 @@ def push_image(
         "--source-image",
         help="Copy an existing public image into Prime instead of uploading a build context",
     ),
+    platform_image: bool = typer.Option(
+        False,
+        "--platform-image",
+        help="Build an org-less platform image (admins only)",
+    ),
 ):
     """
     Build and push a Docker image to Prime Intellect registry.
@@ -419,6 +424,12 @@ def push_image(
             raise typer.Exit(1)
 
         is_transfer = source_image is not None
+        if platform_image and private:
+            console.print("[red]Error: Platform images must be public[/red]")
+            raise typer.Exit(1)
+        if platform_image and config.team_id:
+            console.print("[red]Error: Platform images cannot be pushed in a team context[/red]")
+            raise typer.Exit(1)
         if not is_transfer and image_reference is None:
             console.print(
                 "[red]Error: Image reference is required unless --source-image is used[/red]"
@@ -463,9 +474,14 @@ def push_image(
             destination_display = (
                 f"{image_name}:{image_tag}" if image_name and image_tag else "derived"
             )
-            console.print("[bold blue]Transferring image into Prime:[/bold blue]")
+            if platform_image:
+                console.print("[bold blue]Transferring platform image into Prime:[/bold blue]")
+            else:
+                console.print("[bold blue]Transferring image into Prime:[/bold blue]")
             console.print(f"[bold]Source:[/bold] {source_display}")
             console.print(f"[bold]Destination:[/bold] {destination_display}")
+            if platform_image:
+                console.print("[bold]Owner:[/bold] Platform")
             if config.team_id:
                 console.print(f"[dim]Team: {config.team_id}[/dim]")
             console.print()
@@ -476,6 +492,8 @@ def push_image(
                 visibility = ImageVisibility.PUBLIC
             elif private:
                 visibility = ImageVisibility.PRIVATE
+            if platform_image:
+                visibility = ImageVisibility.PUBLIC
 
             try:
                 response = client.transfer_image(
@@ -485,6 +503,7 @@ def push_image(
                     platform=platform,
                     team_id=config.team_id,
                     visibility=visibility,
+                    owner_scope="platform" if platform_image else None,
                 )
             except UnauthorizedError:
                 console.print(
@@ -532,7 +551,9 @@ def push_image(
                 )
                 for result in failed_results:
                     console.print(f"[yellow]- {result.source_image}: {result.error}[/yellow]")
-            if public or private:
+            if platform_image:
+                console.print(f"[bold]Visibility:[/bold] {ImageVisibility.PUBLIC.value}")
+            elif public or private:
                 requested_visibility = ImageVisibility.PUBLIC if public else ImageVisibility.PRIVATE
                 console.print(f"[bold]Visibility:[/bold] {requested_visibility.value}")
             else:
@@ -550,9 +571,15 @@ def push_image(
                 raise typer.Exit(1)
             return
 
-        console.print(
-            f"[bold blue]Building and pushing image:[/bold blue] {image_name}:{image_tag}"
-        )
+        if platform_image:
+            console.print(
+                f"[bold blue]Building and pushing platform image:[/bold blue] "
+                f"{image_name}:{image_tag}"
+            )
+        else:
+            console.print(
+                f"[bold blue]Building and pushing image:[/bold blue] {image_name}:{image_tag}"
+            )
         if config.team_id:
             console.print(f"[dim]Team: {config.team_id}[/dim]")
         console.print()
@@ -634,7 +661,10 @@ def push_image(
                 }
                 if config.team_id:
                     build_payload["team_id"] = config.team_id
-                if public:
+                if platform_image:
+                    build_payload["ownerScope"] = "platform"
+                    build_payload["visibility"] = ImageVisibility.PUBLIC.value
+                elif public:
                     build_payload["visibility"] = ImageVisibility.PUBLIC.value
                 elif private:
                     build_payload["visibility"] = ImageVisibility.PRIVATE.value
@@ -703,7 +733,10 @@ def push_image(
             console.print()
             console.print(f"[bold]Build ID:[/bold] {build_id}")
             console.print(f"[bold]Image:[/bold] {full_image_path}")
-            if public or private:
+            if platform_image:
+                console.print("[bold]Owner:[/bold] Platform")
+                console.print(f"[bold]Visibility:[/bold] {ImageVisibility.PUBLIC.value}")
+            elif public or private:
                 requested_visibility = ImageVisibility.PUBLIC if public else ImageVisibility.PRIVATE
                 console.print(f"[bold]Visibility:[/bold] {requested_visibility.value}")
             else:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -662,7 +662,7 @@ def push_image(
                 if config.team_id:
                     build_payload["team_id"] = config.team_id
                 if platform_image:
-                    build_payload["ownerScope"] = "platform"
+                    build_payload["owner_scope"] = "platform"
                     build_payload["visibility"] = ImageVisibility.PUBLIC.value
                 elif public:
                     build_payload["visibility"] = ImageVisibility.PUBLIC.value

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -118,6 +118,147 @@ def test_push_image_public_sends_visibility(tmp_path, monkeypatch):
     assert "Visibility:" in result.output
 
 
+def test_push_platform_image_forces_public_owner_scope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+
+    context_path = tmp_path / "context"
+    context_path.mkdir()
+    (context_path / "Dockerfile").write_text("FROM ubuntu:22.04\n")
+
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            if method == "POST" and path == "/images/build":
+                captured["build_payload"] = json
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://example.test/upload",
+                    "fullImagePath": "ubuntu:22.04",
+                }
+
+            if method == "POST" and path == "/images/build/build-123/start":
+                return {}
+
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    class DummyUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    def fake_put(url, content, headers, timeout):
+        return DummyUploadResponse()
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "ubuntu:22.04", "--context", "context", "--platform-image"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["build_payload"] == {
+        "image_name": "ubuntu",
+        "image_tag": "22.04",
+        "dockerfile_path": PACKAGED_DOCKERFILE_PATH,
+        "platform": "linux/amd64",
+        "ownerScope": "platform",
+        "visibility": "PUBLIC",
+    }
+    assert "Building and pushing platform image" in result.output
+    assert "Owner:" in result.output
+    assert "Platform" in result.output
+
+
+def test_push_platform_image_source_image_queues_platform_transfer(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+    captured = {}
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {
+                "build_id": "build-123",
+                "buildIds": ["build-123"],
+                "upload_url": None,
+                "fullImagePath": "ubuntu:22.04",
+                "visibility": "PUBLIC",
+            }
+
+    def fake_put(*args, **kwargs):
+        raise AssertionError("transfer should not upload a build context")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.commands.images.httpx.put", fake_put)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "--source-image", "ubuntu:22.04", "--platform-image"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/images/build"
+    assert captured["json"] == {
+        "dockerfile_path": "Dockerfile",
+        "source_image": "ubuntu:22.04",
+        "platform": "linux/amd64",
+        "visibility": "PUBLIC",
+        "owner_scope": "platform",
+    }
+    assert "Transferring platform image" in result.output
+    assert "Owner:" in result.output
+    assert "Platform" in result.output
+    assert "Visibility:" in result.output
+    assert "PUBLIC" in result.output
+
+
+def test_push_platform_image_rejects_private(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "ubuntu:22.04", "--platform-image", "--private"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Platform images must be public" in result.output
+
+
+def test_push_platform_image_rejects_team_context(monkeypatch):
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            raise AssertionError(f"Unexpected request: {method} {path}")
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["images", "push", "ubuntu:22.04", "--platform-image"],
+        env={**TEST_ENV, "PRIME_TEAM_ID": "team-123"},
+    )
+
+    assert result.exit_code == 1
+    assert "Platform images cannot be pushed in a team context" in result.output
+
+
 def test_push_image_source_image_queues_transfer_without_upload(monkeypatch):
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     monkeypatch.delenv("PRIME_TEAM_ID", raising=False)

--- a/packages/prime/tests/test_images_push.py
+++ b/packages/prime/tests/test_images_push.py
@@ -166,7 +166,7 @@ def test_push_platform_image_forces_public_owner_scope(tmp_path, monkeypatch):
         "image_tag": "22.04",
         "dockerfile_path": PACKAGED_DOCKERFILE_PATH,
         "platform": "linux/amd64",
-        "ownerScope": "platform",
+        "owner_scope": "platform",
         "visibility": "PUBLIC",
     }
     assert "Building and pushing platform image" in result.output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how images are owned and published in the registry (platform vs user/team); misuse could affect shared catalog if server-side admin checks are incomplete, though the CLI enforces public-only and no-team constraints.
> 
> **Overview**
> Adds support for **org-less platform images** by threading an optional `owner_scope: "platform"` through image build/transfer APIs in the **prime-sandboxes** SDK and exposing it via **`prime images push --platform-image`** (documented as admins only).
> 
> When `--platform-image` is set, build and source-image transfer flows send `owner_scope: "platform"` and force **PUBLIC** visibility. The CLI rejects combining platform images with **`--private`** or a **team context** (`PRIME_TEAM_ID`), and updates user-facing output to label owner as Platform.
> 
> SDK changes: `BuildImageRequest` gains `owner_scope`; sync/async `transfer_image` accept and forward it. Tests cover SDK payloads and CLI validation plus API payloads for context upload and transfer paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebb2d7e1960ed068f0cfe7ff3c97fde4d72578f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->