### PR TITLE
release: sandbox 0.2.28

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -53,7 +53,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.27"
+__version__ = "0.2.28"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.15"
+__version__ = "0.6.16"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.16"
+__version__ = "0.6.15"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single version string change with no runtime or behavioral code modifications.
> 
> **Overview**
> Bumps the published **`prime-sandboxes`** package version from **0.2.27** to **0.2.28** in `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`. No API, client, or model changes accompany this release marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef9a6a031a9b0e85d8d8dde66b7ff24d6940349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->