### PR TITLE
release: cli 0.6.16

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.27",
+    "prime-sandboxes>=0.2.28",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.15"
+__version__ = "0.6.16"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and dependency floor bump only; no application logic changes in this diff.
> 
> **Overview**
> **Release 0.6.16** bumps the published `prime` package version from **0.6.15** to **0.6.16** in `prime_cli/__init__.py` (Hatch’s single source of truth for the wheel).
> 
> The only functional dependency change is raising the minimum **`prime-sandboxes`** requirement from **>=0.2.27** to **>=0.2.28** in `pyproject.toml`, so installs of this CLI release pull in the newer sandboxes SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c70ba12a27c98ec4a056a6f6e59f273cdb518cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->