### PR TITLE
improvement: show cached input prices

### DIFF
--- a/packages/prime/src/prime_cli/api/billing.py
+++ b/packages/prime/src/prime_cli/api/billing.py
@@ -11,6 +11,9 @@ class RunUsageBreakdown(BaseModel):
     tokens: int = 0
     input_tokens: int = Field(0, alias="input_tokens")
     output_tokens: int = Field(0, alias="output_tokens")
+    # Prefix-cache hits — a subset of ``input_tokens`` billed at the discounted
+    # cached-input rate. Optional so old backends that don't emit it stay valid.
+    cached_input_tokens: Optional[int] = Field(None, alias="cached_input_tokens")
     cost_usd: float = Field(0.0, alias="cost_usd")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -20,6 +23,9 @@ class RunPricing(BaseModel):
     training_per_mtok: Optional[float] = Field(None, alias="training_per_mtok")
     inference_input_per_mtok: Optional[float] = Field(None, alias="inference_input_per_mtok")
     inference_output_per_mtok: Optional[float] = Field(None, alias="inference_output_per_mtok")
+    inference_cached_input_per_mtok: Optional[float] = Field(
+        None, alias="inference_cached_input_per_mtok"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -20,12 +20,16 @@ class RLModel(BaseModel):
     inference_output_price_per_mtok: Optional[float] = Field(
         None, alias="inferenceOutputPricePerMtok"
     )
+    cached_input_price_per_mtok: Optional[float] = Field(None, alias="cachedInputPricePerMtok")
     list_training_price_per_mtok: Optional[float] = Field(None, alias="listTrainingPricePerMtok")
     list_inference_input_price_per_mtok: Optional[float] = Field(
         None, alias="listInferenceInputPricePerMtok"
     )
     list_inference_output_price_per_mtok: Optional[float] = Field(
         None, alias="listInferenceOutputPricePerMtok"
+    )
+    list_cached_input_price_per_mtok: Optional[float] = Field(
+        None, alias="listCachedInputPricePerMtok"
     )
     effective_training_price_per_mtok: Optional[float] = Field(
         None, alias="effectiveTrainingPricePerMtok"
@@ -36,6 +40,9 @@ class RLModel(BaseModel):
     effective_inference_output_price_per_mtok: Optional[float] = Field(
         None, alias="effectiveInferenceOutputPricePerMtok"
     )
+    effective_cached_input_price_per_mtok: Optional[float] = Field(
+        None, alias="effectiveCachedInputPricePerMtok"
+    )
     promo_label: Optional[str] = Field(None, alias="promoLabel")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -43,13 +50,21 @@ class RLModel(BaseModel):
     def resolve_prices(self, category: str) -> tuple[Optional[float], Optional[float]]:
         """Return ``(list_price, effective_price)`` for ``category``.
 
-        Categories: ``training``, ``inference_input``, ``inference_output``.
+        Categories: ``training``, ``inference_input``, ``inference_output``,
+        ``inference_cached_input``.
 
         Post-swap backends populate ``list_*`` with the un-discounted price and
         the legacy ``*_price_per_mtok`` with the effective (charged) price.
         Pre-swap backends omit ``list_*`` and keep ``legacy = list``,
         ``effective = charged``.
         """
+        # `inference_cached_input` is a virtual category — the API exposes the
+        # prefix-cache discount rate under the shorter `cached_input_*` names.
+        if category == "inference_cached_input":
+            list_value = self.list_cached_input_price_per_mtok
+            if list_value is not None:
+                return list_value, self.cached_input_price_per_mtok
+            return self.cached_input_price_per_mtok, self.effective_cached_input_price_per_mtok
         list_attr = f"list_{category}_price_per_mtok"
         legacy_attr = f"{category}_price_per_mtok"
         effective_attr = f"effective_{category}_price_per_mtok"

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -51,9 +51,11 @@ RL_RUN_JSON_HELP = json_output_help(
 RL_MODELS_JSON_HELP = json_output_help(
     ".models[] = {name, at_capacity, training_price_per_mtok, "
     "inference_input_price_per_mtok, inference_output_price_per_mtok, "
+    "cached_input_price_per_mtok?, "
     "effective_training_price_per_mtok?, "
     "effective_inference_input_price_per_mtok?, "
-    "effective_inference_output_price_per_mtok?, promo_label?}",
+    "effective_inference_output_price_per_mtok?, "
+    "effective_cached_input_price_per_mtok?, promo_label?}",
 )
 
 RL_LIST_JSON_HELP = json_output_help(
@@ -1344,6 +1346,7 @@ def create_run(
             list_train, eff_train = priced.resolve_prices("training")
             list_input, eff_input = priced.resolve_prices("inference_input")
             list_output, eff_output = priced.resolve_prices("inference_output")
+            list_cached, eff_cached = priced.resolve_prices("inference_cached_input")
             console.print(
                 "\n[cyan]Pricing[/cyan] [dim](per 1M tokens, charged on actual usage)[/dim]"
             )
@@ -1358,9 +1361,13 @@ def create_run(
                     return "[bold green]Free[/bold green]"
                 return format_promo_price(list_p, eff_p) or "-"
 
-            console.print(f"  Training:         {_format(list_train, eff_train)}")
-            console.print(f"  Inference Input:  {_format(list_input, eff_input)}")
-            console.print(f"  Inference Output: {_format(list_output, eff_output)}")
+            console.print(f"  Training:                {_format(list_train, eff_train)}")
+            console.print(f"  Inference Input:         {_format(list_input, eff_input)}")
+            # Only show cached-input line when the backend advertises a rate —
+            # models without prefix-cache pricing shouldn't get an empty row.
+            if list_cached is not None or eff_cached is not None:
+                console.print(f"  Inference Cached Input:  {_format(list_cached, eff_cached)}")
+            console.print(f"  Inference Output:        {_format(list_output, eff_output)}")
             if priced.promo_label:
                 console.print(f"  [bold yellow]{rich_escape(priced.promo_label)}[/bold yellow]")
 
@@ -1542,6 +1549,7 @@ def list_models(
         table.add_column("Model", style="cyan")
         table.add_column("Status")
         table.add_column("Input", style="green", justify="right")
+        table.add_column("Cached", style="green", justify="right")
         table.add_column("Output", style="green", justify="right")
         table.add_column("Train", style="green", justify="right")
 
@@ -1554,10 +1562,12 @@ def list_models(
             list_train, eff_train = model.resolve_prices("training")
             list_input, eff_input = model.resolve_prices("inference_input")
             list_output, eff_output = model.resolve_prices("inference_output")
+            list_cached, eff_cached = model.resolve_prices("inference_cached_input")
             table.add_row(
                 model.name,
                 status,
                 format_promo_price(list_input, eff_input) or "-",
+                format_promo_price(list_cached, eff_cached) or "-",
                 format_promo_price(list_output, eff_output) or "-",
                 format_promo_price(list_train, eff_train) or "-",
             )

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -32,9 +32,9 @@ RUN_USAGE_JSON_HELP = json_output_help(
     ". = {run_id, run_name?, base_model?, status?, total_tokens, "
     "total_cost_usd, record_count, "
     "training: {tokens, input_tokens, output_tokens, cost_usd}, "
-    "inference: {tokens, input_tokens, output_tokens, cost_usd}, "
+    "inference: {tokens, input_tokens, output_tokens, cached_input_tokens?, cost_usd}, "
     "pricing: {training_per_mtok?, inference_input_per_mtok?, "
-    "inference_output_per_mtok?}}"
+    "inference_output_per_mtok?, inference_cached_input_per_mtok?}}"
 )
 
 
@@ -106,7 +106,20 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     # halves sum to the combined inference cost in the response (modulo a
     # cent of rounding). The Total row keeps using the backend's exact sum
     # so what we show as "Total" is what was actually billed.
-    in_cost = _derived_cost(usage.inference.input_tokens, usage.pricing.inference_input_per_mtok)
+    #
+    # Prefix-cache hits are a subset of input_tokens — the "Inference (input)"
+    # row shows the non-cached remainder so the two rows sum to total input
+    # tokens (and derived cost sums to combined inference cost). We fall back
+    # to the full input rate for cached tokens when the backend hasn't sent a
+    # discounted rate yet, so cost stays consistent with the billed total.
+    cached_tokens = usage.inference.cached_input_tokens or 0
+    cached_rate = usage.pricing.inference_cached_input_per_mtok
+    effective_cached_rate = (
+        cached_rate if cached_rate is not None else usage.pricing.inference_input_per_mtok
+    )
+    non_cached_input = max(0, usage.inference.input_tokens - cached_tokens)
+    in_cost = _derived_cost(non_cached_input, usage.pricing.inference_input_per_mtok)
+    cached_cost = _derived_cost(cached_tokens, effective_cached_rate)
     out_cost = _derived_cost(usage.inference.output_tokens, usage.pricing.inference_output_per_mtok)
 
     table.add_row(
@@ -117,10 +130,20 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     )
     table.add_row(
         "Inference (input)",
-        _format_tokens(usage.inference.input_tokens),
+        _format_tokens(non_cached_input),
         format_usd(in_cost) if in_cost is not None else "-",
         format_price_per_mtok(usage.pricing.inference_input_per_mtok) or "-",
     )
+    # Only show the cached row when there's a signal it's relevant: either
+    # the backend published a discounted rate, or the run actually consumed
+    # cached tokens. Otherwise stay quiet for models without prefix caching.
+    if cached_rate is not None or cached_tokens > 0:
+        table.add_row(
+            "Inference (cached input)",
+            _format_tokens(cached_tokens),
+            format_usd(cached_cost) if cached_cost is not None else "-",
+            format_price_per_mtok(effective_cached_rate) or "-",
+        )
     table.add_row(
         "Inference (output)",
         _format_tokens(usage.inference.output_tokens),

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -296,6 +296,63 @@ def test_models_json_includes_effective_fields(monkeypatch: pytest.MonkeyPatch) 
     assert data["models"][0]["promo_label"] == "Free RFT week"
 
 
+def test_models_table_renders_cached_input_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cached-input column shows the discounted rate when the backend emits it."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return {
+            "models": [
+                {
+                    "name": "qwen/qwen3-8b",
+                    "atCapacity": False,
+                    "trainingPricePerMtok": 0.5,
+                    "inferenceInputPricePerMtok": 1.0,
+                    "inferenceOutputPricePerMtok": 3.0,
+                    "cachedInputPricePerMtok": 0.1,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    # Header includes the new Cached column between Input and Output.
+    assert "Cached" in plain
+    # Discounted rate rendered.
+    assert "$0.1" in plain
+
+
+def test_models_json_includes_cached_input_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return {
+            "models": [
+                {
+                    "name": "qwen/qwen3-8b",
+                    "atCapacity": False,
+                    "trainingPricePerMtok": 0.5,
+                    "inferenceInputPricePerMtok": 1.0,
+                    "inferenceOutputPricePerMtok": 3.0,
+                    "cachedInputPricePerMtok": 0.1,
+                    "listCachedInputPricePerMtok": 0.2,
+                    "effectiveCachedInputPricePerMtok": 0.1,
+                }
+            ]
+        }
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["train", "models", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["models"][0]["cached_input_price_per_mtok"] == 0.1
+    assert data["models"][0]["list_cached_input_price_per_mtok"] == 0.2
+    assert data["models"][0]["effective_cached_input_price_per_mtok"] == 0.1
+
+
 def test_model_name_sort_key_orders_parameter_counts_numerically() -> None:
     models = [
         "Qwen/Qwen3-30B-A3B-Instruct-2507",

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -165,6 +165,71 @@ def test_format_tokens_promotes_to_M_at_rounding_boundary() -> None:
     assert _format_tokens(0) == "0"
 
 
+def test_train_usage_renders_cached_input_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the backend emits cached-input tokens+rate, they get their own row
+    and the plain input row shows the non-cached remainder so tokens sum right.
+    """
+    payload = _run_usage_payload()
+    # 1M input total split into 200K cached + 800K non-cached, cached rate $0.1/Mtok.
+    payload["inference"]["cached_input_tokens"] = 200_000
+    payload["pricing"]["inference_cached_input_per_mtok"] = 0.1
+
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": payload}, []),
+    )
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "Inference (cached input)" in plain
+    # 200K cached tokens rendered.
+    assert "200.00K" in plain
+    # Non-cached remainder rendered on the input row.
+    assert "800.00K" in plain
+    # Cached rate rendered.
+    assert "$0.1" in plain
+
+
+def test_train_usage_skips_cached_row_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-cache-pricing backends must render the same layout as today."""
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": _run_usage_payload()}, []),
+    )
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "cached input" not in plain.lower()
+
+
+def test_train_usage_cached_row_falls_back_to_input_rate_when_no_cached_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If cached tokens > 0 but no cached rate is set yet, cost falls back to
+    the full input rate so the totals still line up.
+    """
+    payload = _run_usage_payload()
+    payload["inference"]["cached_input_tokens"] = 100_000
+    # deliberately no inference_cached_input_per_mtok
+
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": payload}, []),
+    )
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "Inference (cached input)" in plain
+    # Fell back to input rate ($0.5/Mtok).
+    assert "$0.5" in plain
+
+
 def test_train_usage_wraps_response_shape_drift_as_api_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Surface the prefix-cache discount rate in the CLI now that RFT pricing carries it.

- `prime train models` gains a `Cached` column between `Input` and `Output`
- `prime train run` preview and `prime train usage` render an "Inference (cached input)" line/row when the model advertises a cached rate or the run consumed cached tokens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and optional schema fields only; no billing logic changes, with tests for legacy backends and cost fallback behavior.
> 
> **Overview**
> Adds **optional** API fields and CLI display for **prefix-cache (cached) inference input** pricing and usage, aligned with RFT backends that bill cached input tokens at a discounted rate.
> 
> **Models & API:** `RunUsageBreakdown` / `RunPricing` gain `cached_input_tokens` and `inference_cached_input_per_mtok`. `RLModel` gains `cached_input_*`, `list_cached_*`, and `effective_cached_*` fields; `resolve_prices` supports a virtual `inference_cached_input` category with the same list/effective semantics as other price types.
> 
> **CLI:** `prime train models` adds a **Cached** column; run confirmation **Pricing** shows **Inference Cached Input** when a rate exists; `prime train usage` splits inference input into non-cached vs **Inference (cached input)** rows (tokens and derived costs sum correctly, with fallback to the full input rate when cached tokens exist but no cached rate is sent). JSON help strings and `--output json` include the new fields.
> 
> **Tests:** Coverage for models table/JSON cached pricing and usage row visibility, absence on old backends, and rate fallback.
> 
> Backward compatible: missing fields keep prior layouts and parsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0280ab7bcd879317292899fd13925c77f8cd97bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->