### PR TITLE
sandbox read_file offset + limit

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -17,6 +17,7 @@ from .exceptions import (
     CommandTimeoutError,
     DownloadTimeoutError,
     SandboxFileNotFoundError,
+    SandboxFileTooLargeError,
     SandboxImagePullError,
     SandboxNotRunningError,
     SandboxOOMError,
@@ -102,6 +103,7 @@ __all__ = [
     "UnauthorizedError",
     "PaymentRequiredError",
     "SandboxFileNotFoundError",
+    "SandboxFileTooLargeError",
     "APITimeoutError",
     "TimeoutError",  # Deprecated alias
     "SandboxOOMError",

--- a/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
@@ -9,6 +9,16 @@ class SandboxFileNotFoundError(APIError):
     pass
 
 
+class SandboxFileTooLargeError(APIError):
+    """Raised when a file exceeds the sandbox read size limit (413).
+
+    Read a bounded window via read_file(offset=..., length=...) or use
+    download_file() for the full content.
+    """
+
+    pass
+
+
 class SandboxNotRunningError(RuntimeError):
     """Raised when an operation requires a RUNNING sandbox but it is not running."""
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -200,6 +200,9 @@ class ReadFileResponse(BaseModel):
 
     content: str
     size: int
+    total_size: int
+    offset: int
+    truncated: bool
 
 
 class SandboxLogsResponse(BaseModel):
@@ -365,3 +368,5 @@ class BackgroundJobStatus(BaseModel):
     exit_code: Optional[int] = None
     stdout: Optional[str] = None
     stderr: Optional[str] = None
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -200,9 +200,10 @@ class ReadFileResponse(BaseModel):
 
     content: str
     size: int
-    total_size: int
-    offset: int
-    truncated: bool
+    # VM sandboxes don't support windowed reads yet and omit them.
+    total_size: Optional[int] = None
+    offset: Optional[int] = None
+    truncated: Optional[bool] = None
 
 
 class SandboxLogsResponse(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -30,6 +30,7 @@ from .exceptions import (
     CommandTimeoutError,
     DownloadTimeoutError,
     SandboxFileNotFoundError,
+    SandboxFileTooLargeError,
     SandboxImagePullError,
     SandboxNotRunningError,
     SandboxOOMError,
@@ -95,6 +96,9 @@ RETRYABLE_5XX_STATUSES = frozenset({500, 502, 503, 504, 524})
 # Max retries for transient 409 errors
 MAX_409_RETRIES = 4
 RETRY_409_BASE_DELAY = 0.25  # 250ms, 500ms, 1000ms, 2000ms with exponential backoff
+
+# Max bytes of stdout/stderr returned per background-job status check
+JOB_OUTPUT_TAIL_BYTES = 10 * 1024 * 1024
 
 
 def _is_retryable_gateway_error(exc: BaseException) -> bool:
@@ -984,7 +988,9 @@ class SandboxClient:
                 applies.
 
         Returns:
-            BackgroundJobStatus with completed flag, and exit_code/stdout if done
+            BackgroundJobStatus with completed flag, and exit_code/stdout if
+            done. stdout/stderr hold at most the last JOB_OUTPUT_TAIL_BYTES
+            of each stream; the *_truncated flags report dropped output.
         """
 
         def read_or_empty(path: str) -> str:
@@ -992,6 +998,19 @@ class SandboxClient:
                 return self.read_file(sandbox_id, path, timeout=timeout).content
             except SandboxFileNotFoundError:
                 return ""
+
+        def read_output_tail(path: str) -> "tuple[str, bool]":
+            try:
+                response = self.read_file(
+                    sandbox_id,
+                    path,
+                    timeout=timeout,
+                    offset=-JOB_OUTPUT_TAIL_BYTES,
+                    length=JOB_OUTPUT_TAIL_BYTES,
+                )
+                return response.content, response.truncated
+            except SandboxFileNotFoundError:
+                return "", False
 
         exit_content = read_or_empty(job.exit_file)
         if not exit_content.strip():
@@ -1002,12 +1021,16 @@ class SandboxClient:
         except ValueError:
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
+        stdout, stdout_truncated = read_output_tail(job.stdout_log_file)
+        stderr, stderr_truncated = read_output_tail(job.stderr_log_file)
         return BackgroundJobStatus(
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=read_or_empty(job.stdout_log_file),
-            stderr=read_or_empty(job.stderr_log_file),
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
         )
 
     def run_background_job(
@@ -1296,14 +1319,20 @@ class SandboxClient:
         sandbox_id: str,
         file_path: str,
         timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
-        """Read a file from a sandbox via gateway."""
+        """Read a file (or a byte window of it) from a sandbox via gateway."""
         auth = self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/read-file"
         headers = {"Authorization": f"Bearer {auth['token']}"}
-        params = {"path": file_path}
+        params: Dict[str, Any] = {"path": file_path}
+        if offset is not None:
+            params["offset"] = offset
+        if length is not None:
+            params["length"] = length
 
         effective_timeout = timeout if timeout is not None else 30
 
@@ -1322,6 +1351,10 @@ class SandboxClient:
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:
                     raise SandboxFileNotFoundError(f"File not found: {file_path}") from e
+                if e.response.status_code == 413:
+                    raise SandboxFileTooLargeError(
+                        f"File too large to read: {file_path}: {e.response.text}"
+                    ) from e
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
@@ -1908,7 +1941,9 @@ class AsyncSandboxClient:
                 applies.
 
         Returns:
-            BackgroundJobStatus with completed flag, and exit_code/stdout if done
+            BackgroundJobStatus with completed flag, and exit_code/stdout if
+            done. stdout/stderr hold at most the last JOB_OUTPUT_TAIL_BYTES
+            of each stream; the *_truncated flags report dropped output.
         """
 
         async def read_or_empty(path: str) -> str:
@@ -1916,6 +1951,19 @@ class AsyncSandboxClient:
                 return (await self.read_file(sandbox_id, path, timeout=timeout)).content
             except SandboxFileNotFoundError:
                 return ""
+
+        async def read_output_tail(path: str) -> "tuple[str, bool]":
+            try:
+                response = await self.read_file(
+                    sandbox_id,
+                    path,
+                    timeout=timeout,
+                    offset=-JOB_OUTPUT_TAIL_BYTES,
+                    length=JOB_OUTPUT_TAIL_BYTES,
+                )
+                return response.content, response.truncated
+            except SandboxFileNotFoundError:
+                return "", False
 
         exit_content = await read_or_empty(job.exit_file)
         if not exit_content.strip():
@@ -1926,12 +1974,16 @@ class AsyncSandboxClient:
         except ValueError:
             return BackgroundJobStatus(job_id=job.job_id, completed=False)
 
+        stdout, stdout_truncated = await read_output_tail(job.stdout_log_file)
+        stderr, stderr_truncated = await read_output_tail(job.stderr_log_file)
         return BackgroundJobStatus(
             job_id=job.job_id,
             completed=True,
             exit_code=exit_code,
-            stdout=await read_or_empty(job.stdout_log_file),
-            stderr=await read_or_empty(job.stderr_log_file),
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
         )
 
     async def run_background_job(
@@ -2236,14 +2288,20 @@ class AsyncSandboxClient:
         sandbox_id: str,
         file_path: str,
         timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
-        """Read a file from a sandbox via gateway (async)"""
+        """Read a file (or a byte window of it) from a sandbox via gateway (async)."""
         auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
         url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/read-file"
         headers = {"Authorization": f"Bearer {auth['token']}"}
-        params = {"path": file_path}
+        params: Dict[str, Any] = {"path": file_path}
+        if offset is not None:
+            params["offset"] = offset
+        if length is not None:
+            params["length"] = length
 
         effective_timeout = timeout if timeout is not None else 30
 
@@ -2262,6 +2320,10 @@ class AsyncSandboxClient:
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:
                     raise SandboxFileNotFoundError(f"File not found: {file_path}") from e
+                if e.response.status_code == 413:
+                    raise SandboxFileTooLargeError(
+                        f"File too large to read: {file_path}: {e.response.text}"
+                    ) from e
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1008,7 +1008,8 @@ class SandboxClient:
                     offset=-JOB_OUTPUT_TAIL_BYTES,
                     length=JOB_OUTPUT_TAIL_BYTES,
                 )
-                return response.content, response.truncated
+                # Servers without windowed-read support omit `truncated`.
+                return response.content, bool(response.truncated)
             except SandboxFileNotFoundError:
                 return "", False
 
@@ -1322,7 +1323,13 @@ class SandboxClient:
         offset: Optional[int] = None,
         length: Optional[int] = None,
     ) -> ReadFileResponse:
-        """Read a file (or a byte window of it) from a sandbox via gateway."""
+        """Read a file (or a byte window of it) from a sandbox via gateway.
+
+        offset/length require server-side windowed-read support. VM sandboxes
+        don't support it yet: they ignore both params, return the whole file
+        (subject to the read size limit), and omit total_size/offset/truncated
+        from the response (detectable via ``response.offset is None``).
+        """
         auth = self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")
@@ -1961,7 +1968,8 @@ class AsyncSandboxClient:
                     offset=-JOB_OUTPUT_TAIL_BYTES,
                     length=JOB_OUTPUT_TAIL_BYTES,
                 )
-                return response.content, response.truncated
+                # Servers without windowed-read support omit `truncated`.
+                return response.content, bool(response.truncated)
             except SandboxFileNotFoundError:
                 return "", False
 
@@ -2291,7 +2299,13 @@ class AsyncSandboxClient:
         offset: Optional[int] = None,
         length: Optional[int] = None,
     ) -> ReadFileResponse:
-        """Read a file (or a byte window of it) from a sandbox via gateway (async)."""
+        """Read a file (or a byte window of it) from a sandbox via gateway (async).
+
+        offset/length require server-side windowed-read support. VM sandboxes
+        don't support it yet: they ignore both params, return the whole file
+        (subject to the read size limit), and omit total_size/offset/truncated
+        from the response (detectable via ``response.offset is None``).
+        """
         auth = await self._auth_cache.get_or_refresh(sandbox_id)
 
         gateway_url = auth["gateway_url"].rstrip("/")

--- a/packages/prime-sandboxes/tests/test_background_job_timeout.py
+++ b/packages/prime-sandboxes/tests/test_background_job_timeout.py
@@ -19,6 +19,13 @@ def _make_job() -> BackgroundJob:
     )
 
 
+def _whole_file(content: str) -> ReadFileResponse:
+    size = len(content.encode())
+    return ReadFileResponse(
+        content=content, size=size, total_size=size, offset=0, truncated=False
+    )
+
+
 def test_sync_get_background_job_forwards_timeout_to_read_file():
     client = SandboxClient(APIClient(api_key="test-key"))
     client_any = cast(Any, client)
@@ -26,11 +33,15 @@ def test_sync_get_background_job_forwards_timeout_to_read_file():
     seen_timeouts: List[Optional[int]] = []
 
     def fake_read_file(
-        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
         seen_timeouts.append(timeout)
         # Empty content => job not completed; single read_file invocation is enough.
-        return ReadFileResponse(content="", size=0)
+        return _whole_file("")
 
     client_any.read_file = fake_read_file
 
@@ -48,10 +59,14 @@ def test_sync_get_background_job_defaults_timeout_to_none():
     seen_timeouts: List[Optional[int]] = []
 
     def fake_read_file(
-        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
         seen_timeouts.append(timeout)
-        return ReadFileResponse(content="", size=0)
+        return _whole_file("")
 
     client_any.read_file = fake_read_file
 
@@ -71,12 +86,16 @@ def test_sync_get_background_job_forwards_timeout_on_completed_reads():
     seen_timeouts: List[Optional[int]] = []
 
     def fake_read_file(
-        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
         seen_timeouts.append(timeout)
         if file_path.endswith(".exit"):
-            return ReadFileResponse(content="0\n", size=2)
-        return ReadFileResponse(content="out", size=3)
+            return _whole_file("0\n")
+        return _whole_file("out")
 
     client_any.read_file = fake_read_file
 
@@ -97,10 +116,14 @@ async def test_async_get_background_job_forwards_timeout_to_read_file():
     seen_timeouts: List[Optional[int]] = []
 
     async def fake_read_file(
-        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
         seen_timeouts.append(timeout)
-        return ReadFileResponse(content="", size=0)
+        return _whole_file("")
 
     client_any.read_file = fake_read_file
 
@@ -119,10 +142,14 @@ async def test_async_get_background_job_defaults_timeout_to_none():
     seen_timeouts: List[Optional[int]] = []
 
     async def fake_read_file(
-        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
     ) -> ReadFileResponse:
         seen_timeouts.append(timeout)
-        return ReadFileResponse(content="", size=0)
+        return _whole_file("")
 
     client_any.read_file = fake_read_file
 

--- a/packages/prime-sandboxes/tests/test_background_job_timeout.py
+++ b/packages/prime-sandboxes/tests/test_background_job_timeout.py
@@ -21,9 +21,12 @@ def _make_job() -> BackgroundJob:
 
 def _whole_file(content: str) -> ReadFileResponse:
     size = len(content.encode())
-    return ReadFileResponse(
-        content=content, size=size, total_size=size, offset=0, truncated=False
-    )
+    return ReadFileResponse(content=content, size=size, total_size=size, offset=0, truncated=False)
+
+
+def _legacy_whole_file(content: str) -> ReadFileResponse:
+    """Response shape from servers without windowed-read support (VM sandboxes)."""
+    return ReadFileResponse.model_validate({"content": content, "size": len(content.encode())})
 
 
 def test_sync_get_background_job_forwards_timeout_to_read_file():
@@ -106,6 +109,63 @@ def test_sync_get_background_job_forwards_timeout_on_completed_reads():
     assert status.exit_code == 0
     # Exit file read, then stdout, then stderr.
     assert seen_timeouts == [45, 45, 45]
+
+
+def test_sync_get_background_job_handles_legacy_read_file_response():
+    """VM sandboxes ignore offset/length and omit the window metadata fields;
+    the truncated flags must default to False rather than fail validation."""
+
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client_any = cast(Any, client)
+
+    def fake_read_file(
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+    ) -> ReadFileResponse:
+        if file_path.endswith(".exit"):
+            return _legacy_whole_file("0\n")
+        return _legacy_whole_file("out")
+
+    client_any.read_file = fake_read_file
+
+    status = client.get_background_job("sbx-123", _make_job())
+
+    assert status.completed
+    assert status.exit_code == 0
+    assert status.stdout == "out"
+    assert status.stderr == "out"
+    assert status.stdout_truncated is False
+    assert status.stderr_truncated is False
+
+
+@pytest.mark.asyncio
+async def test_async_get_background_job_handles_legacy_read_file_response():
+    client = AsyncSandboxClient(api_key="test-key")
+    client_any = cast(Any, client)
+
+    async def fake_read_file(
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+    ) -> ReadFileResponse:
+        if file_path.endswith(".exit"):
+            return _legacy_whole_file("0\n")
+        return _legacy_whole_file("out")
+
+    client_any.read_file = fake_read_file
+
+    status = await client.get_background_job("sbx-123", _make_job())
+
+    assert status.completed
+    assert status.exit_code == 0
+    assert status.stdout == "out"
+    assert status.stdout_truncated is False
+    assert status.stderr_truncated is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches widely used `read_file` and `get_background_job` behavior; VM/legacy servers are handled via optional response fields, but callers may see truncated job output or new 413 errors on oversized reads.
> 
> **Overview**
> Adds **byte-window reads** to sync/async `read_file` via optional `offset` and `length` gateway query params, and extends `ReadFileResponse` with optional `total_size`, `offset`, and `truncated` (omitted on VM sandboxes that still return whole files).
> 
> HTTP **413** on read-file now raises **`SandboxFileTooLargeError`** (exported from the package), with guidance to use windowed reads or `download_file()`.
> 
> **`get_background_job`** no longer loads full stdout/stderr logs; it fetches at most the last **10 MiB** per stream using `offset=-JOB_OUTPUT_TAIL_BYTES` and sets **`stdout_truncated` / `stderr_truncated`** on `BackgroundJobStatus` when the server reports truncation (legacy responses default to not truncated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cf041d7eb3ea5fcf6117488eb16e5bf5e6bcda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->