### PR TITLE
retry sandbox uploads

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -605,9 +605,10 @@ class SandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    def _should_retry_upload_5xx(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
-        """Check if a transient gateway 5xx on an upload should be retried."""
-        if error.response.status_code not in RETRYABLE_5XX_STATUSES:
+    def _should_retry_upload_error(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
+        """Check if a transient error (408/5xx) on an idempotent upload should be retried."""
+        status = error.response.status_code
+        if status != 408 and status not in RETRYABLE_5XX_STATUSES:
             return False
         if _is_gateway_sandbox_not_found(error.response):
             return False
@@ -1190,7 +1191,7 @@ class SandboxClient:
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
-                elif self._should_retry_upload_5xx(e, attempt):
+                elif self._should_retry_upload_error(e, attempt):
                     continue
                 error_details = (
                     f"HTTP {e.response.status_code} {e.request.method} "
@@ -1246,7 +1247,7 @@ class SandboxClient:
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
-                elif self._should_retry_upload_5xx(e, attempt):
+                elif self._should_retry_upload_error(e, attempt):
                     continue
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")
@@ -1546,9 +1547,10 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    async def _should_retry_upload_5xx(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
-        """Check if a transient gateway 5xx on an upload should be retried (async)."""
-        if error.response.status_code not in RETRYABLE_5XX_STATUSES:
+    async def _should_retry_upload_error(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
+        """Check if a transient 408/5xx on an idempotent upload should be retried (async)."""
+        status = error.response.status_code
+        if status != 408 and status not in RETRYABLE_5XX_STATUSES:
             return False
         if _is_gateway_sandbox_not_found(error.response):
             return False
@@ -2141,7 +2143,7 @@ class AsyncSandboxClient:
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue
-                elif await self._should_retry_upload_5xx(e, attempt):
+                elif await self._should_retry_upload_error(e, attempt):
                     continue
                 error_details = (
                     f"HTTP {e.response.status_code} {e.request.method} "
@@ -2198,7 +2200,7 @@ class AsyncSandboxClient:
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue
-                elif await self._should_retry_upload_5xx(e, attempt):
+                elif await self._should_retry_upload_error(e, attempt):
                     continue
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -605,6 +605,17 @@ class SandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
+    def _should_retry_upload_5xx(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
+        """Check if a transient gateway 5xx on an upload should be retried."""
+        if error.response.status_code not in RETRYABLE_5XX_STATUSES:
+            return False
+        if _is_gateway_sandbox_not_found(error.response):
+            return False
+        if attempt < MAX_409_RETRIES - 1:
+            time.sleep(RETRY_409_BASE_DELAY * (2**attempt))
+            return True
+        return False
+
     def clear_auth_cache(self) -> None:
         """Clear all cached auth tokens"""
         self._auth_cache.clear()
@@ -1179,6 +1190,8 @@ class SandboxClient:
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
+                elif self._should_retry_upload_5xx(e, attempt):
+                    continue
                 error_details = (
                     f"HTTP {e.response.status_code} {e.request.method} "
                     f"{e.request.url}: {e.response.text}"
@@ -1233,6 +1246,8 @@ class SandboxClient:
                 if e.response.status_code == 409:
                     if self._should_retry_409(sandbox_id, e, attempt):
                         continue
+                elif self._should_retry_upload_5xx(e, attempt):
+                    continue
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")
             except Exception as e:
@@ -1530,6 +1545,17 @@ class AsyncSandboxClient:
             ) from error
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
+
+    async def _should_retry_upload_5xx(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
+        """Check if a transient gateway 5xx on an upload should be retried (async)."""
+        if error.response.status_code not in RETRYABLE_5XX_STATUSES:
+            return False
+        if _is_gateway_sandbox_not_found(error.response):
+            return False
+        if attempt < MAX_409_RETRIES - 1:
+            await asyncio.sleep(RETRY_409_BASE_DELAY * (2**attempt))
+            return True
+        return False
 
     async def clear_auth_cache(self) -> None:
         """Clear all cached auth tokens."""
@@ -2115,6 +2141,8 @@ class AsyncSandboxClient:
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue
+                elif await self._should_retry_upload_5xx(e, attempt):
+                    continue
                 error_details = (
                     f"HTTP {e.response.status_code} {e.request.method} "
                     f"{e.request.url}: {e.response.text}"
@@ -2170,6 +2198,8 @@ class AsyncSandboxClient:
                 if e.response.status_code == 409:
                     if await self._should_retry_409(sandbox_id, e, attempt):
                         continue
+                elif await self._should_retry_upload_5xx(e, attempt):
+                    continue
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")
             except Exception as e:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upload POST retries assume idempotent gateway uploads; a misclassified success could duplicate writes, though behavior matches existing read-file retry semantics.
> 
> **Overview**
> **Sandbox file uploads** (`upload_file` / `upload_bytes`) now retry on transient gateway **408** and **5xx** responses, in addition to the existing **409** handling.
> 
> Sync and async clients each gain `_should_retry_upload_error`, which reuses `MAX_409_RETRIES` and the same exponential backoff as 409 retries. Retries are skipped when the gateway returns a **502** `sandbox_not_found` body, so missing sandboxes still fail fast.
> 
> This aligns upload behavior with the idempotent read-file retry path (`RETRYABLE_5XX_STATUSES` / 408) and is intended to reduce flaky failures during gateway or proxy timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013b311bde2039a4b29f7067214a09bcb52f7e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->