### PR TITLE
Security: Sensitive Information Exposure in TunnelInfo Model

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
 class TunnelInfo(BaseModel):
@@ -11,8 +11,8 @@ class TunnelInfo(BaseModel):
     name: Optional[str] = Field(None, description="Friendly name")
     hostname: str = Field(..., description="Tunnel hostname")
     url: str = Field(..., description="Full HTTPS URL")
-    frp_token: str = Field(..., description="Authentication token for frpc")
-    binding_secret: str = Field("", description="Per-tunnel secret for frpc metadata")
+    frp_token: SecretStr = Field(..., description="Authentication token for frpc")
+    binding_secret: SecretStr = Field(default=SecretStr(""), description="Per-tunnel secret for frpc metadata")
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     local_port: Optional[int] = Field(None, description="Local port forwarded by the tunnel")
@@ -20,7 +20,7 @@ class TunnelInfo(BaseModel):
     http_user: Optional[str] = Field(
         None, description="HTTP basic auth username, if auth is enabled"
     )
-    http_password: Optional[str] = Field(
+    http_password: Optional[SecretStr] = Field(
         None,
         description=(
             "Auto-generated HTTP basic auth password. Only present in the "


### PR DESCRIPTION
## Summary

Security: Sensitive Information Exposure in TunnelInfo Model

## Problem

**Severity**: `High` | **File**: `packages/prime-tunnel/src/prime_tunnel/models.py:L1`

The `TunnelInfo` Pydantic model stores sensitive credentials including `frp_token`, `binding_secret`, and `http_password` as plain string fields. These credentials are exposed in the model without any encryption or masking. Additionally, the model includes a comment indicating that `http_password` is 'never retrievable afterwards' but it is still stored as a plain string field without any special handling.

## Solution

Implement secure handling for sensitive fields using Pydantic's `SecretStr` type to prevent accidental logging or serialization of credentials. Add proper access controls and consider encrypting these values at rest.

## Changes

- `packages/prime-tunnel/src/prime_tunnel/models.py` (modified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Credential fields change type, so any code that expects plain strings (e.g. f-string config generation) must use `.get_secret_value()` or serialization may break or leak masked placeholders.
> 
> **Overview**
> **`TunnelInfo`** now treats **`frp_token`**, **`binding_secret`**, and optional **`http_password`** as Pydantic **`SecretStr`** instead of plain strings, so default model dumps and logs mask secrets instead of exposing raw credentials.
> 
> **`binding_secret`** keeps an empty default via **`SecretStr("")`**; other tunnel metadata fields are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fa64545d94cb19f663e8e8c809194ba4b76eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->