### PR TITLE
improvement: add Damian as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @JannikSt @d42me @kcoopermiller @willccbb @burnpiro @JohannesHa
+* @JannikSt @d42me @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper


### PR DESCRIPTION
Add @DamianB-BitFlipper to CODEOWNERS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub metadata only; no application or runtime behavior changes.
> 
> **Overview**
> **CODEOWNERS:** The default `*` rule now includes **@DamianB-BitFlipper** alongside the existing reviewers, so they are requested on all repository changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463c1de26804d4c062d9e225fb76a0f860c65555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->