### PR TITLE
release: prime-sandboxes 0.2.29

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -54,7 +54,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.28"
+__version__ = "0.2.29"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/transfer-bulk-failures.jsonl
+++ b/packages/prime/transfer-bulk-failures.jsonl
@@ -1,1 +1,0 @@
-{"source": "a/app-a:v1", "platform": "linux/amd64"}

--- a/packages/prime/transfer-bulk-failures.jsonl
+++ b/packages/prime/transfer-bulk-failures.jsonl
@@ -1,0 +1,1 @@
+{"source": "a/app-a:v1", "platform": "linux/amd64"}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> No runtime or API changes in the diff—only the package version string.
> 
> **Overview**
> Bumps the **prime-sandboxes** package release version from **0.2.28** to **0.2.29** by updating `__version__` in `prime_sandboxes/__init__.py` (the single source used by Hatch for the published wheel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab4c764228f7235a729d517fd4ea0b14c3dd9a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->