### PR TITLE
prime images list --platform-image

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -753,6 +753,11 @@ def list_images(
     all_images: bool = typer.Option(
         False, "--all", "-a", help="[Deprecated] Show all accessible images (personal + team)"
     ),
+    platform_image: bool = typer.Option(
+        False,
+        "--platform-image",
+        help="List org-less platform images (admins only)",
+    ),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
     num: int = typer.Option(50, "--num", "-n", help="Items per page (max 250)"),
 ):
@@ -772,6 +777,7 @@ def list_images(
         prime images list --num 100
         prime images list --page 2
         prime images list --output json
+        prime images list --platform-image
     """
     validate_output_format(output, console)
 
@@ -780,6 +786,9 @@ def list_images(
         raise typer.Exit(1)
     if num > 250:
         console.print("[red]Error:[/red] --num cannot exceed 250")
+        raise typer.Exit(1)
+    if platform_image and config.team_id:
+        console.print("[red]Error: Platform images cannot be listed in a team context[/red]")
         raise typer.Exit(1)
 
     if all_images and output != "json":
@@ -795,7 +804,9 @@ def list_images(
 
         # Build query params
         params: dict[str, str] = {"limit": str(num), "offset": str(offset)}
-        if config.team_id:
+        if platform_image:
+            params["ownerScope"] = "platform"
+        elif config.team_id:
             params["teamId"] = config.team_id
         if search:
             params["search"] = search
@@ -809,6 +820,11 @@ def list_images(
             output_data_as_json(response, console)
             return
 
+        push_hint: str = (
+            "Push an image with: [bold]prime images push <name>:<tag> --platform-image[/bold]"
+            if platform_image
+            else "Push an image with: [bold]prime images push <name>:<tag>[/bold]"
+        )
         if not images:
             if has_total_count and total_count == 0:
                 if search:
@@ -818,7 +834,7 @@ def list_images(
                     )
                 else:
                     console.print("[yellow]No images or builds found.[/yellow]")
-                    console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
+                    console.print(push_hint)
             elif has_total_count:
                 console.print(
                     f"[yellow]No images on page {page}. Total: {total_count} image(s).[/yellow]"
@@ -832,13 +848,16 @@ def list_images(
                 console.print("Try a different search term or run without [bold]--search[/bold].")
             else:
                 console.print("[yellow]No images or builds found.[/yellow]")
-                console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
+                console.print(push_hint)
             return
 
         # Table output
+        # Platform listings are never team-scoped (rejected above).
         is_team_listing: bool = bool(config.team_id)
         title: str
-        if is_team_listing:
+        if platform_image:
+            title = "Platform Docker Images"
+        elif is_team_listing:
             title = f"Team Docker Images (team: {config.team_id})"
         else:
             title = "Personal Docker Images"

--- a/packages/prime/tests/test_images_list.py
+++ b/packages/prime/tests/test_images_list.py
@@ -770,3 +770,60 @@ def test_list_cli_newest_group_first(run_images_list):
     new_idx = result.output.find("new-image")
     old_idx = result.output.find("old-image")
     assert 0 <= new_idx < old_idx
+
+
+# ---------------------------------------------------------------------------
+# --platform-image — org-less platform image listing (admins only)
+# ---------------------------------------------------------------------------
+
+
+def _platform_row(**kw: Any) -> ImageRow:
+    row = _container(**kw)
+    name = row["imageName"]
+    tag = row["imageTag"]
+    row.update({"ownerType": "platform", "displayRef": f"{name}:{tag}"})
+    return row
+
+
+def test_list_platform_image_forwards_owner_scope(monkeypatch):
+    result, captured = _run_list_capturing_params(
+        monkeypatch,
+        ["--platform-image"],
+        payload=[_platform_row(image="ubuntu:22.04", pushed_at="2026-04-16T22:24:07")],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["params"].get("ownerScope") == "platform"
+    assert "teamId" not in captured["params"]
+    assert "Platform Docker Images" in result.output
+
+
+def test_list_platform_image_rejected_in_team_context(monkeypatch):
+    result, captured = _run_list_capturing_params(
+        monkeypatch,
+        ["--platform-image"],
+        team_id=TEAM_ID,
+    )
+    assert result.exit_code == 1
+    assert "team context" in result.output
+    # Rejected client-side before any API request is made.
+    assert "params" not in captured
+
+
+def test_list_platform_image_empty_shows_platform_push_hint(monkeypatch):
+    result, _ = _run_list_capturing_params(
+        monkeypatch,
+        ["--platform-image"],
+        payload=[],
+    )
+    assert result.exit_code == 0, result.output
+    assert "--platform-image" in result.output
+
+
+def test_list_without_platform_flag_omits_owner_scope(monkeypatch):
+    result, captured = _run_list_capturing_params(
+        monkeypatch,
+        [],
+        payload=[_container(pushed_at="2026-04-16T22:24:07")],
+    )
+    assert result.exit_code == 0, result.output
+    assert "ownerScope" not in captured["params"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI-only listing and query-param changes with validation mirroring existing platform-image push; no auth or data-model changes in this diff.
> 
> **Overview**
> **`prime images list`** gains **`--platform-image`**, aligned with the existing push flag, so admins can list org-less platform images instead of personal or team scoped listings.
> 
> When the flag is set, the CLI sends **`ownerScope=platform`** on `GET /images` (and does not send `teamId`). Using **`--platform-image` with a team context** fails client-side before any API call, matching push behavior. Table output uses the title **Platform Docker Images**; empty results suggest **`prime images push … --platform-image`**.
> 
> Tests cover query param forwarding, team rejection, empty push hint, and that the default list omits `ownerScope`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d06fdf3c6b14aca2ca19985620e11d9bb62992b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->