### PR TITLE
prime image build vm

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/images.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/images.py
@@ -55,6 +55,21 @@ class ImageClient:
             json={"context_uploaded": True},
         )
 
+    def build_vm_image(
+        self,
+        image_name: str,
+        image_tag: str,
+        *,
+        team_id: Optional[str] = None,
+    ) -> dict:
+        """Build a VM image from an existing container image."""
+        payload = {"teamId": team_id} if team_id else {}
+        return self.client.request(
+            "POST",
+            f"/images/{image_name}/{image_tag}/vm-build",
+            json=payload,
+        )
+
     def get_build_status(self, build_id: str) -> dict:
         """Fetch the status of a build group."""
         return self.client.request("GET", f"/images/build/{build_id}")
@@ -102,6 +117,21 @@ class AsyncImageClient:
             "POST",
             f"/images/build/{build_id}/start",
             json={"context_uploaded": True},
+        )
+
+    async def build_vm_image(
+        self,
+        image_name: str,
+        image_tag: str,
+        *,
+        team_id: Optional[str] = None,
+    ) -> dict:
+        """Build a VM image from an existing container image."""
+        payload = {"teamId": team_id} if team_id else {}
+        return await self.client.request(
+            "POST",
+            f"/images/{image_name}/{image_tag}/vm-build",
+            json=payload,
         )
 
     async def get_build_status(self, build_id: str) -> dict:

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -62,6 +62,7 @@ class Sandbox(BaseModel):
     kubernetes_job_id: Optional[str] = Field(None, alias="kubernetesJobId")
     region: Optional[str] = None
     registry_credentials_id: Optional[str] = Field(default=None, alias="registryCredentialsId")
+    pending_image_build_id: Optional[str] = Field(default=None, alias="pendingImageBuildId")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -488,15 +488,6 @@ class AsyncSandboxAuthCache:
             await self._save_cache()
 
 
-# First VM use of an image: the platform builds the VM image automatically
-# and the sandbox stays PENDING (pending_image_build_id set) until the build
-# completes. That phase is bounded server-side (~45 minutes), far beyond the
-# normal creation budget, so waits poll it on a separate slower budget that
-# does not consume the regular attempts.
-IMAGE_BUILD_WAIT_POLL_SECONDS = 10
-IMAGE_BUILD_WAIT_TIMEOUT_SECONDS = 50 * 60
-
-
 def _is_waiting_for_image_build(sandbox: Sandbox) -> bool:
     return sandbox.status == "PENDING" and bool(
         getattr(sandbox, "pending_image_build_id", None)
@@ -1108,7 +1099,7 @@ class SandboxClient:
         sandbox_id: str,
         max_attempts: int = 60,
         stability_checks: int = 1,
-        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
+        image_build_timeout_seconds: int = 3000,
     ) -> None:
         """Wait for sandbox to be running and stable.
 
@@ -1154,7 +1145,7 @@ class SandboxClient:
                     raise SandboxNotRunningError(
                         sandbox_id, "Timeout waiting for the VM image build"
                     )
-                time.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                time.sleep(10)
                 continue
 
             attempt += 1
@@ -1167,7 +1158,7 @@ class SandboxClient:
         self,
         sandbox_ids: List[str],
         max_attempts: int = 60,
-        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
+        image_build_timeout_seconds: int = 3000,
     ) -> Dict[str, str]:
         """Wait for multiple sandboxes to be running using list endpoint to avoid rate limits.
 
@@ -1231,7 +1222,7 @@ class SandboxClient:
                 if image_build_deadline is None:
                     image_build_deadline = time.monotonic() + image_build_timeout_seconds
                 if time.monotonic() < image_build_deadline:
-                    time.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                    time.sleep(10)
                     continue
                 break
 
@@ -2131,7 +2122,7 @@ class AsyncSandboxClient:
         sandbox_id: str,
         max_attempts: int = 60,
         stability_checks: int = 1,
-        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
+        image_build_timeout_seconds: int = 3000,
     ) -> None:
         """Wait for sandbox to be running and stable (async version).
 
@@ -2177,7 +2168,7 @@ class AsyncSandboxClient:
                     raise SandboxNotRunningError(
                         sandbox_id, "Timeout waiting for the VM image build"
                     )
-                await asyncio.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                await asyncio.sleep(10)
                 continue
 
             attempt += 1
@@ -2189,7 +2180,7 @@ class AsyncSandboxClient:
         self,
         sandbox_ids: List[str],
         max_attempts: int = 60,
-        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
+        image_build_timeout_seconds: int = 3000,
     ) -> Dict[str, str]:
         """Wait for multiple sandboxes to be running using list endpoint.
 
@@ -2254,7 +2245,7 @@ class AsyncSandboxClient:
                 if image_build_deadline is None:
                     image_build_deadline = time.monotonic() + image_build_timeout_seconds
                 if time.monotonic() < image_build_deadline:
-                    await asyncio.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                    await asyncio.sleep(10)
                     continue
                 break
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -488,17 +488,34 @@ class AsyncSandboxAuthCache:
             await self._save_cache()
 
 
+# First VM use of an image: the platform builds the VM image automatically
+# and the sandbox stays PENDING (pending_image_build_id set) until the build
+# completes. That phase is bounded server-side (~45 minutes), far beyond the
+# normal creation budget, so waits poll it on a separate slower budget that
+# does not consume the regular attempts.
+IMAGE_BUILD_WAIT_POLL_SECONDS = 10
+IMAGE_BUILD_WAIT_TIMEOUT_SECONDS = 50 * 60
+
+
+def _is_waiting_for_image_build(sandbox: Sandbox) -> bool:
+    return sandbox.status == "PENDING" and bool(
+        getattr(sandbox, "pending_image_build_id", None)
+    )
+
+
 def _check_sandbox_statuses(
     sandboxes: List[Sandbox], target_ids: set
-) -> tuple[int, List[tuple], Dict[str, str]]:
+) -> tuple[int, List[tuple], Dict[str, str], int]:
     """Helper function to check sandbox statuses
 
     Returns:
-        tuple of (running_count, failed_sandboxes, final_statuses)
+        tuple of (running_count, failed_sandboxes, final_statuses,
+        image_build_waiting_count)
     """
     running_count = 0
     failed_sandboxes = []
     final_statuses = {}
+    image_build_waiting = 0
 
     for sandbox in sandboxes:
         if sandbox.id in target_ids:
@@ -508,8 +525,10 @@ def _check_sandbox_statuses(
             elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
                 failed_sandboxes.append((sandbox.id, sandbox.status))
                 final_statuses[sandbox.id] = sandbox.status
+            elif _is_waiting_for_image_build(sandbox):
+                image_build_waiting += 1
 
-    return running_count, failed_sandboxes, final_statuses
+    return running_count, failed_sandboxes, final_statuses, image_build_waiting
 
 
 class SandboxClient:
@@ -1085,7 +1104,11 @@ class SandboxClient:
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     def wait_for_creation(
-        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
+        self,
+        sandbox_id: str,
+        max_attempts: int = 60,
+        stability_checks: int = 1,
+        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
     ) -> None:
         """Wait for sandbox to be running and stable.
 
@@ -1093,9 +1116,15 @@ class SandboxClient:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
             stability_checks: Number of consecutive successful reachability checks required
+            image_build_timeout_seconds: Separate wall-clock budget while the
+                platform auto-builds the VM image for a first-use image (the
+                sandbox stays PENDING with pending_image_build_id set). That
+                phase polls slowly and does not consume max_attempts.
         """
         consecutive_successes = 0
-        for attempt in range(max_attempts):
+        image_build_deadline: Optional[float] = None
+        attempt = 0
+        while attempt < max_attempts:
             sandbox = self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if self._is_sandbox_reachable(sandbox_id):
@@ -1104,6 +1133,7 @@ class SandboxClient:
                         return
                     # Small delay between stability checks
                     time.sleep(0.5)
+                    attempt += 1
                     continue
                 else:
                     # Reset counter if check fails
@@ -1115,22 +1145,45 @@ class SandboxClient:
                     "error_message": sandbox.error_message,
                 }
                 _raise_not_running_error(sandbox.id, ctx)
+            elif _is_waiting_for_image_build(sandbox):
+                # The platform is building the VM image for this sandbox; it
+                # starts on its own once the build completes.
+                if image_build_deadline is None:
+                    image_build_deadline = time.monotonic() + image_build_timeout_seconds
+                if time.monotonic() >= image_build_deadline:
+                    raise SandboxNotRunningError(
+                        sandbox_id, "Timeout waiting for the VM image build"
+                    )
+                time.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                continue
 
+            attempt += 1
             # Aggressive polling for first 5 attempts (5 seconds), then back off
-            sleep_time = 1 if attempt < 5 else 2
+            sleep_time = 1 if attempt <= 5 else 2
             time.sleep(sleep_time)
         raise SandboxNotRunningError(sandbox_id, "Timeout during sandbox creation")
 
     def bulk_wait_for_creation(
-        self, sandbox_ids: List[str], max_attempts: int = 60
+        self,
+        sandbox_ids: List[str],
+        max_attempts: int = 60,
+        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
     ) -> Dict[str, str]:
-        """Wait for multiple sandboxes to be running using list endpoint to avoid rate limits"""
+        """Wait for multiple sandboxes to be running using list endpoint to avoid rate limits.
+
+        Sandboxes PENDING on an automatic VM image build (first use of an
+        image) are waited on a separate slower budget bounded by
+        image_build_timeout_seconds instead of consuming max_attempts.
+        """
         sandbox_id_set = set(sandbox_ids)
         final_statuses = {}
+        image_build_deadline: Optional[float] = None
 
-        for attempt in range(max_attempts):
+        attempt = 0
+        while attempt < max_attempts:
             total_running = 0
             all_failed = []
+            total_image_build_waiting = 0
             page = 1
 
             while True:
@@ -1143,13 +1196,14 @@ class SandboxClient:
                         continue
                     raise
 
-                running_count, failed_sandboxes, page_statuses = _check_sandbox_statuses(
-                    list_response.sandboxes, sandbox_id_set
+                running_count, failed_sandboxes, page_statuses, image_build_waiting = (
+                    _check_sandbox_statuses(list_response.sandboxes, sandbox_id_set)
                 )
 
                 total_running += running_count
                 all_failed.extend(failed_sandboxes)
                 final_statuses.update(page_statuses)
+                total_image_build_waiting += image_build_waiting
 
                 if len(final_statuses) == len(sandbox_ids) or not list_response.has_next:
                     break
@@ -1170,7 +1224,19 @@ class SandboxClient:
                 if all_reachable:
                     return final_statuses
 
-            sleep_time = 1 if attempt < 5 else 2
+            if total_image_build_waiting:
+                # At least one sandbox is waiting on an automatic VM image
+                # build; poll slowly on the image-build budget instead of
+                # consuming the normal attempts.
+                if image_build_deadline is None:
+                    image_build_deadline = time.monotonic() + image_build_timeout_seconds
+                if time.monotonic() < image_build_deadline:
+                    time.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                    continue
+                break
+
+            attempt += 1
+            sleep_time = 1 if attempt <= 5 else 2
             time.sleep(sleep_time)
 
         for sandbox_id in sandbox_id_set:
@@ -2061,7 +2127,11 @@ class AsyncSandboxClient:
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     async def wait_for_creation(
-        self, sandbox_id: str, max_attempts: int = 60, stability_checks: int = 1
+        self,
+        sandbox_id: str,
+        max_attempts: int = 60,
+        stability_checks: int = 1,
+        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
     ) -> None:
         """Wait for sandbox to be running and stable (async version).
 
@@ -2069,9 +2139,15 @@ class AsyncSandboxClient:
             sandbox_id: The sandbox ID to wait for
             max_attempts: Maximum polling attempts
             stability_checks: Number of consecutive successful reachability checks required
+            image_build_timeout_seconds: Separate wall-clock budget while the
+                platform auto-builds the VM image for a first-use image (the
+                sandbox stays PENDING with pending_image_build_id set). That
+                phase polls slowly and does not consume max_attempts.
         """
         consecutive_successes = 0
-        for attempt in range(max_attempts):
+        image_build_deadline: Optional[float] = None
+        attempt = 0
+        while attempt < max_attempts:
             sandbox = await self.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if await self._is_sandbox_reachable(sandbox_id):
@@ -2080,6 +2156,7 @@ class AsyncSandboxClient:
                         return
                     # Small delay between stability checks
                     await asyncio.sleep(0.5)
+                    attempt += 1
                     continue
                 else:
                     # Reset counter if check fails
@@ -2091,22 +2168,45 @@ class AsyncSandboxClient:
                     "error_message": sandbox.error_message,
                 }
                 _raise_not_running_error(sandbox.id, ctx)
+            elif _is_waiting_for_image_build(sandbox):
+                # The platform is building the VM image for this sandbox; it
+                # starts on its own once the build completes.
+                if image_build_deadline is None:
+                    image_build_deadline = time.monotonic() + image_build_timeout_seconds
+                if time.monotonic() >= image_build_deadline:
+                    raise SandboxNotRunningError(
+                        sandbox_id, "Timeout waiting for the VM image build"
+                    )
+                await asyncio.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                continue
 
-            sleep_time = 1 if attempt < 5 else 2
+            attempt += 1
+            sleep_time = 1 if attempt <= 5 else 2
             await asyncio.sleep(sleep_time)
         raise SandboxNotRunningError(sandbox_id, "Timeout during sandbox creation")
 
     async def bulk_wait_for_creation(
-        self, sandbox_ids: List[str], max_attempts: int = 60
+        self,
+        sandbox_ids: List[str],
+        max_attempts: int = 60,
+        image_build_timeout_seconds: int = IMAGE_BUILD_WAIT_TIMEOUT_SECONDS,
     ) -> Dict[str, str]:
-        """Wait for multiple sandboxes to be running using list endpoint"""
+        """Wait for multiple sandboxes to be running using list endpoint.
+
+        Sandboxes PENDING on an automatic VM image build (first use of an
+        image) are waited on a separate slower budget bounded by
+        image_build_timeout_seconds instead of consuming max_attempts.
+        """
 
         sandbox_id_set = set(sandbox_ids)
         final_statuses = {}
+        image_build_deadline: Optional[float] = None
 
-        for attempt in range(max_attempts):
+        attempt = 0
+        while attempt < max_attempts:
             total_running = 0
             all_failed = []
+            total_image_build_waiting = 0
             page = 1
 
             while True:
@@ -2119,13 +2219,14 @@ class AsyncSandboxClient:
                         continue
                     raise
 
-                running_count, failed_sandboxes, page_statuses = _check_sandbox_statuses(
-                    list_response.sandboxes, sandbox_id_set
+                running_count, failed_sandboxes, page_statuses, image_build_waiting = (
+                    _check_sandbox_statuses(list_response.sandboxes, sandbox_id_set)
                 )
 
                 total_running += running_count
                 all_failed.extend(failed_sandboxes)
                 final_statuses.update(page_statuses)
+                total_image_build_waiting += image_build_waiting
 
                 if len(final_statuses) == len(sandbox_ids) or not list_response.has_next:
                     break
@@ -2146,7 +2247,19 @@ class AsyncSandboxClient:
                 if all_reachable:
                     return final_statuses
 
-            sleep_time = 1 if attempt < 5 else 2
+            if total_image_build_waiting:
+                # At least one sandbox is waiting on an automatic VM image
+                # build; poll slowly on the image-build budget instead of
+                # consuming the normal attempts.
+                if image_build_deadline is None:
+                    image_build_deadline = time.monotonic() + image_build_timeout_seconds
+                if time.monotonic() < image_build_deadline:
+                    await asyncio.sleep(IMAGE_BUILD_WAIT_POLL_SECONDS)
+                    continue
+                break
+
+            attempt += 1
+            sleep_time = 1 if attempt <= 5 else 2
             await asyncio.sleep(sleep_time)
 
         for sandbox_id in sandbox_id_set:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -756,7 +756,8 @@ def build_vm_image(
     Build a VM image from an existing container image.
 
     Requires VM sandboxes to be enabled for your account and a linux/amd64
-    image. Track progress with 'prime images list'.
+    image. For team images, only the image creator or team admins can
+    trigger this. Track progress with 'prime images list'.
 
     \b
     Examples:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -741,6 +741,56 @@ def push_image(
 app.command("push-bulk")(push_bulk)
 
 
+@app.command("build")
+def build_vm_image(
+    image_reference: str = typer.Argument(
+        ...,
+        help=(
+            "Existing image to build a VM image for "
+            "(e.g., 'myapp:v1.0.0', 'prime/<ownerSlug>/myapp:v1.0.0', or "
+            "'prime/team-{teamId}/myapp:v1.0.0')"
+        ),
+    ),
+):
+    """
+    Build a VM image from an existing container image.
+
+    Requires VM sandboxes to be enabled for your account and a linux/amd64
+    image. Track progress with 'prime images list'.
+
+    \b
+    Examples:
+        prime images build myapp:v1.0.0
+        prime images build prime/alice/myapp:v1.0.0
+        prime images build prime/team-abc123/myapp:v1.0.0
+    """
+    try:
+        image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
+        payload: dict[str, str] = {"teamId": team_id} if team_id else {}
+
+        client = APIClient()
+        response = client.request(
+            "POST",
+            f"/images/{image_name}/{image_tag}/vm-build",
+            json=payload,
+        )
+
+        context = f" (team: {team_id})" if team_id else ""
+        console.print(
+            f"[green]✓[/green] VM image build queued for {image_name}:{image_tag}{context}"
+        )
+        build_id = response.get("buildId") if isinstance(response, dict) else None
+        if build_id:
+            console.print(f"[bold]Build ID:[/bold] {build_id}")
+        console.print("Track progress with: prime images list")
+    except UnauthorizedError:
+        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
 @app.command("list", epilog=LIST_IMAGES_JSON_HELP)
 def list_images(
     output: str = typer.Option("table", "--output", "-o", help="Output format (table or json)"),

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -741,7 +741,7 @@ def push_image(
 app.command("push-bulk")(push_bulk)
 
 
-@app.command("build")
+@app.command("build-vm")
 def build_vm_image(
     image_reference: str = typer.Argument(
         ...,
@@ -761,9 +761,9 @@ def build_vm_image(
 
     \b
     Examples:
-        prime images build myapp:v1.0.0
-        prime images build prime/alice/myapp:v1.0.0
-        prime images build prime/team-abc123/myapp:v1.0.0
+        prime images build-vm myapp:v1.0.0
+        prime images build-vm prime/alice/myapp:v1.0.0
+        prime images build-vm prime/team-abc123/myapp:v1.0.0
     """
     try:
         image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -710,6 +710,13 @@ def create(
                 sandbox = sandbox_client.create(request)
 
             console.print(f"\n[green]Successfully created sandbox {sandbox.id}[/green]")
+            if getattr(sandbox, "pending_image_build_id", None):
+                console.print(
+                    "[yellow]First VM use of this image: a VM image is being "
+                    "built automatically. The sandbox stays PENDING and starts "
+                    "on its own once the build completes (this can take "
+                    "several minutes).[/yellow]"
+                )
             console.print(
                 f"[blue]Use 'prime sandbox get {sandbox.id}' to check the sandbox status[/blue]"
             )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes sandbox readiness polling and timeout semantics for VM first-use images; incorrect handling could cause premature timeouts or long hangs, but changes are localized to wait helpers and new optional API fields.
> 
> **Overview**
> Adds **manual VM image builds** and **client support for sandboxes blocked on automatic first-use VM image conversion**.
> 
> The SDK exposes `build_vm_image` on sync/async `ImageClient` (POST `/images/{imageName}/{imageTag}/vm-build`, optional `teamId`). The CLI adds **`prime images build-vm`** with the same owner-prefixed reference parsing as other image commands.
> 
> The `Sandbox` model gains **`pendingImageBuildId`**. Sync and async **`wait_for_creation`** / **`bulk_wait_for_creation`** treat `PENDING` + that field as “waiting on VM image build”: they poll every 10s on a separate **`image_build_timeout_seconds`** (default 3000) that does **not** consume `max_attempts`, and fail with a dedicated timeout if the build never finishes. **`prime sandbox create`** prints a yellow notice when the create response includes a pending image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00825bef1fa39922966d9f4846ad8aae26a4323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->