### PR TITLE
Update Prime for Verifiers 0.2.0

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "textual>=6.1.0",
     "textual-plot>=0.10.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.14",
+    "verifiers>=0.2.0",
     "build>=1.0.0",
     "gitignore-parser>=0.1.13",
     "pyyaml>=6.0.0",
@@ -64,7 +64,7 @@ dev = [
 prime-sandboxes = { workspace = true }
 prime-evals = { workspace = true }
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.14" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.2.0" }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/prime/scripts/release_e2e.py
+++ b/packages/prime/scripts/release_e2e.py
@@ -279,7 +279,7 @@ def remote_script(config: RemoteConfig) -> str:
                 requires-python = ">=3.11"
                 dependencies = [
                   "datasets>=2.18.0",
-                  "verifiers>=0.1.14",
+                  "verifiers>=0.2.0",
                 ]
 
                 [build-system]

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.16"
+__version__ = "0.6.17"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -42,7 +42,7 @@ from .lab_hygiene import (
 )
 
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
-VERIFIERS_REF = "f43e42c1fabfe2604afc95b9ce62779a8f55d487"
+VERIFIERS_REF = "6c64ce6a3a01e8edde7c3c0e8e5315fb236e9faa"
 VERIFIERS_CONFIG_REF = "main"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ harnesses       = false
 
 [tool.uv.sources]
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.14" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.2.0" }
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
## Overview

Update Prime CLI and Lab integration for the Verifiers 0.2.0 release.

## Changes

- Pin Prime Lab skill and guidance downloads to the current Verifiers main commit.
- Raise Prime's Verifiers dependency and workspace source tag to 0.2.0.
- Update the release smoke environment to use Verifiers 0.2.0.
- Bump the Prime CLI version to 0.6.17.

This keeps Lab-managed skills reproducible while aligning the CLI package, workspace configuration, and release flow on the same Verifiers release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency and Lab asset pin changes can break eval/Lab workflows if Verifiers 0.2.0 introduces incompatible API changes; scope is limited to version alignment with no application logic edits in this diff.
> 
> **Overview**
> Aligns the Prime monorepo and CLI with **Verifiers 0.2.0** by bumping dependency floors and git pins from `0.1.14` / `v0.1.14` to **`>=0.2.0`** / **`v0.2.0`** in the root workspace `pyproject.toml`, `packages/prime/pyproject.toml`, and the temporary env stub in `release_e2e.py`.
> 
> **Lab setup** now downloads managed skills and workspace guidance (`AGENTS.md`, `CLAUDE.md`, etc.) from a new pinned Verifiers commit (`VERIFIERS_REF`), keeping Lab assets reproducible against the 0.2.0 line.
> 
> **Prime CLI** version is bumped to **0.6.17**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb3864e0a4e38f5d7fdf100989a821575247d146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->