### PR TITLE
Fix config reset for inference URL

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -383,6 +383,7 @@ def reset(
         config.set_team(None)
         config.set_base_url(Config.DEFAULT_BASE_URL)
         config.set_frontend_url(Config.DEFAULT_FRONTEND_URL)
+        config.set_inference_url(Config.DEFAULT_INFERENCE_URL)
         config.set_ssh_key_path(Config.DEFAULT_SSH_KEY_PATH)
         config.set_current_environment("production")
         console.print("[green]Configuration reset to defaults![/green]")


### PR DESCRIPTION
## Summary
- reset the persisted Prime inference URL to its default in `prime config reset`

## Validation
- `ruff format --check packages/prime/src/prime_cli/commands/config.py`
- `ruff check packages/prime/src/prime_cli/commands/config.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CLI config change with no auth or API behavior changes.
> 
> **Overview**
> **`prime config reset`** now clears the persisted inference URL the same way it already resets base and frontend URLs, by calling **`config.set_inference_url(Config.DEFAULT_INFERENCE_URL)`** alongside the other default restorations.
> 
> Previously, a custom inference endpoint could survive a full config reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6090c1708aa3d92716b1e4d4acc6c6f547d9d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->