### PR TITLE
Ignore .grok/skills in Lab workspaces

### DIFF
--- a/packages/prime/src/prime_cli/lab_hygiene.py
+++ b/packages/prime/src/prime_cli/lab_hygiene.py
@@ -8,18 +8,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+LAB_AGENT_SKILL_DIRS = (
+    ".agents/skills",
+    ".claude/skills",
+    ".cursor/skills",
+    ".factory/skills",
+    ".grok/skills",
+    ".opencode/skills",
+    ".pi/skills",
+)
 LAB_GITIGNORE_PATTERNS = (
     ".env",
     "/AGENTS.md",
     "/CLAUDE.md",
     "/CLAUDE.local.md",
     "/.prime/",
-    "/.agents/skills/",
-    "/.claude/skills/",
-    "/.cursor/skills/",
-    "/.factory/skills/",
-    "/.opencode/skills/",
-    "/.pi/skills/",
+    *(f"/{skill_dir}/" for skill_dir in LAB_AGENT_SKILL_DIRS),
     "/outputs/",
     "/prime-rl/",
     "/environments/AGENTS.md",
@@ -60,12 +64,7 @@ LAB_TRACKED_EXACT_PATHS = {
 }
 LAB_TRACKED_PREFIXES = (
     ".prime/",
-    ".agents/skills/",
-    ".claude/skills/",
-    ".cursor/skills/",
-    ".factory/skills/",
-    ".opencode/skills/",
-    ".pi/skills/",
+    *(f"{skill_dir}/" for skill_dir in LAB_AGENT_SKILL_DIRS),
     "outputs/",
     "prime-rl/",
     ".pytest_cache/",

--- a/packages/prime/tests/test_lab_hygiene.py
+++ b/packages/prime/tests/test_lab_hygiene.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from prime_cli.lab_agents import agent_project_skills_dirs, known_agent_names
+from prime_cli.lab_hygiene import LAB_GITIGNORE_PATTERNS, LAB_TRACKED_PREFIXES
+
+
+def test_every_agent_project_skill_dir_is_covered_by_hygiene(tmp_path: Path) -> None:
+    base = tmp_path.resolve()
+    gitignore = set(LAB_GITIGNORE_PATTERNS)
+    tracked = set(LAB_TRACKED_PREFIXES)
+
+    for agent in known_agent_names():
+        for skill_dir in agent_project_skills_dirs(agent, base):
+            relative = skill_dir.relative_to(base).as_posix()
+            assert f"/{relative}/" in gitignore, (
+                f"{agent}: {relative} is created by setup but not in LAB_GITIGNORE_PATTERNS"
+            )
+            assert f"{relative}/" in tracked, (
+                f"{agent}: {relative} is created by setup but not in LAB_TRACKED_PREFIXES"
+            )


### PR DESCRIPTION
Closes #790.

When `grok` is selected during `prime lab setup`, the workspace gets a `.grok/skills/` directory, but that path was never added to `.gitignore` and wasn't flagged by `prime lab hygiene` / `prime lab doctor`. Every other agent's skills directory is ignored, so grok's generated files could be committed by accident.

The two lists in `lab_hygiene.py` (`LAB_GITIGNORE_PATTERNS` and `LAB_TRACKED_PREFIXES`) were hand-maintained copies of the per-agent skills directories, and grok was missing from both. Rather than just add the one line, I pulled the skill directories into a single `LAB_AGENT_SKILL_DIRS` tuple and derive both lists from it, so they can't drift apart again.

Added `tests/test_lab_hygiene.py`, which walks every agent from the registry and asserts its project skill directory is covered by both lists. Without the fix it fails on grok; with it, it passes.

### Testing

```
uv run pytest tests/test_lab_hygiene.py
```

The rest of the Lab test suite is unchanged by this PR. A handful of pre-existing failures in `tests/test_lab_setup.py` reproduce on `main` as well — they're unrelated (Windows path-separator assertions and symlink behaviour in the download/skill-sync tests).
