### PR TITLE
Inline arrow-key prompts for interactive CLI commands

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "typer>=0.9.0,<0.26",
+    "questionary>=2.0.0",
     "rich>=13.3.1",
     "textual>=6.1.0",
     "textual-plot>=0.10.1",

--- a/packages/prime/src/prime_cli/agent_picker.py
+++ b/packages/prime/src/prime_cli/agent_picker.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-import questionary
-from questionary import Choice, Style
+from questionary import Choice
+
+from .utils.prompt import ask_checkbox
 
 AgentMenu = list[tuple[str, str, bool]]
-
-# Colour the checked marker (●) green and leave the label at its normal colour,
-# so selecting an agent does not highlight the whole row.
-_STYLE = Style([("selected", "fg:green noreverse")])
 
 
 def _choices(menu: AgentMenu, default_index: int) -> list[Choice]:
@@ -32,14 +29,13 @@ def select_agents(
 ) -> tuple[str, ...] | None:
     """Prompt for coding agents inline; return the picks in menu order (first is primary)."""
 
-    answer = questionary.checkbox(
+    answer = ask_checkbox(
         "Select coding agents (first is primary)",
-        choices=_choices(menu, default_index),
+        _choices(menu, default_index),
         instruction="↑/↓ move · space toggle · enter confirm",
         validate=_require_one,
-        style=_STYLE,
         **prompt_kwargs,
-    ).ask()
+    )
     if not answer:
         return None
     chosen = set(answer)

--- a/packages/prime/src/prime_cli/agent_picker.py
+++ b/packages/prime/src/prime_cli/agent_picker.py
@@ -1,0 +1,46 @@
+"""Interactive coding-agent picker used by prime lab setup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import questionary
+from questionary import Choice, Style
+
+AgentMenu = list[tuple[str, str, bool]]
+
+# Colour the checked marker (●) green and leave the label at its normal colour,
+# so selecting an agent does not highlight the whole row.
+_STYLE = Style([("selected", "fg:green noreverse")])
+
+
+def _choices(menu: AgentMenu, default_index: int) -> list[Choice]:
+    choices = []
+    for index, (name, label, installed) in enumerate(menu):
+        status = "installed" if installed else "not installed"
+        title = [("class:text", f"{label}  ({status})")]
+        choices.append(Choice(title=title, value=name, checked=index == default_index))
+    return choices
+
+
+def _require_one(selected: list[str]) -> bool | str:
+    return bool(selected) or "Select at least one agent (space to toggle)."
+
+
+def select_agents(
+    menu: AgentMenu, default_index: int, **prompt_kwargs: Any
+) -> tuple[str, ...] | None:
+    """Prompt for coding agents inline; return the picks in menu order (first is primary)."""
+
+    answer = questionary.checkbox(
+        "Select coding agents (first is primary)",
+        choices=_choices(menu, default_index),
+        instruction="↑/↓ move · space toggle · enter confirm",
+        validate=_require_one,
+        style=_STYLE,
+        **prompt_kwargs,
+    ).ask()
+    if not answer:
+        return None
+    chosen = set(answer)
+    return tuple(name for name, _, _ in menu if name in chosen)

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -2,13 +2,14 @@ import os
 import re
 from typing import Optional
 
+import questionary
 import typer
 from rich.table import Table
 
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, confirm, get_console
 from .teams import fetch_teams
 
 app = PlainTyper(help="Configure the CLI", no_args_is_help=True)
@@ -118,12 +119,12 @@ def set_api_key(
     """Set your API key (prompts securely if not provided)"""
     if api_key is None:
         # Interactive mode with secure prompt
-        api_key = typer.prompt(
-            "Enter your Prime Intellect API key (or press Enter to clear)",
-            hide_input=True,
-            confirmation_prompt=False,
-            default="",
-        )
+        answer = questionary.password(
+            "Enter your Prime Intellect API key (or press Enter to clear)"
+        ).ask()
+        if answer is None:
+            raise typer.Abort()
+        api_key = answer
 
     config = Config()
     config.set_api_key(api_key)
@@ -214,10 +215,12 @@ def set_base_url(
     """Set the API base URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = typer.prompt(
+        url = questionary.text(
             "Enter the base URL for the Prime Intellect API",
             default=config.base_url,
-        )
+        ).ask()
+        if not url:
+            raise typer.Abort()
         if not url:
             console.print("[red]Base URL is required[/red]")
             return
@@ -237,10 +240,12 @@ def set_frontend_url(
     """Set the frontend URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = typer.prompt(
+        url = questionary.text(
             "Enter the frontend URL for the Prime Intellect web app",
             default=config.frontend_url,
-        )
+        ).ask()
+        if not url:
+            raise typer.Abort()
         if not url:
             console.print("[red]Frontend URL is required[/red]")
             return
@@ -260,10 +265,12 @@ def set_inference_url(
     """Set the inference URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = typer.prompt(
+        url = questionary.text(
             "Enter the inference URL for Prime Inference API",
             default=config.inference_url,
-        )
+        ).ask()
+        if not url:
+            raise typer.Abort()
         if not url:
             console.print("[red]Inference URL is required[/red]")
             return
@@ -377,7 +384,7 @@ def reset(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Reset configuration to defaults"""
-    if yes or typer.confirm("Are you sure you want to reset all settings?"):
+    if yes or confirm("Are you sure you want to reset all settings?"):
         config = Config()
         config.set_api_key("")
         config.set_team(None)

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -2,14 +2,13 @@ import os
 import re
 from typing import Optional
 
-import questionary
 import typer
 from rich.table import Table
 
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, confirm, get_console
+from ..utils import PlainTyper, ask_password, ask_text, confirm, get_console
 from .teams import fetch_teams
 
 app = PlainTyper(help="Configure the CLI", no_args_is_help=True)
@@ -119,9 +118,7 @@ def set_api_key(
     """Set your API key (prompts securely if not provided)"""
     if api_key is None:
         # Interactive mode with secure prompt
-        answer = questionary.password(
-            "Enter your Prime Intellect API key (or press Enter to clear)"
-        ).ask()
+        answer = ask_password("Enter your Prime Intellect API key (or press Enter to clear)")
         if answer is None:
             raise typer.Abort()
         api_key = answer
@@ -215,10 +212,10 @@ def set_base_url(
     """Set the API base URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = questionary.text(
+        url = ask_text(
             "Enter the base URL for the Prime Intellect API",
             default=config.base_url,
-        ).ask()
+        )
         if not url:
             raise typer.Abort()
         if not url:
@@ -240,10 +237,10 @@ def set_frontend_url(
     """Set the frontend URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = questionary.text(
+        url = ask_text(
             "Enter the frontend URL for the Prime Intellect web app",
             default=config.frontend_url,
-        ).ask()
+        )
         if not url:
             raise typer.Abort()
         if not url:
@@ -265,10 +262,10 @@ def set_inference_url(
     """Set the inference URL (prompts if not provided)"""
     if not url:
         config = Config()
-        url = questionary.text(
+        url = ask_text(
             "Enter the inference URL for Prime Inference API",
             default=config.inference_url,
-        ).ask()
+        )
         if not url:
             raise typer.Abort()
         if not url:

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -10,6 +10,7 @@ from ..client import APIClient, APIError
 from ..core import Config
 from ..utils import (
     PlainTyper,
+    confirm,
     get_console,
     json_output_help,
     output_data_as_json,
@@ -240,8 +241,7 @@ def create_deployment(
             console.print()
 
             if not yes:
-                confirm = typer.confirm("Are you sure you want to deploy this checkpoint?")
-                if not confirm:
+                if not confirm("Are you sure you want to deploy this checkpoint?"):
                     console.print("Cancelled.")
                     raise typer.Exit(0)
 
@@ -298,8 +298,7 @@ def create_deployment(
         console.print()
 
         if not yes:
-            confirm = typer.confirm("Are you sure you want to deploy this model?")
-            if not confirm:
+            if not confirm("Are you sure you want to deploy this model?"):
                 console.print("Cancelled.")
                 raise typer.Exit(0)
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
+import questionary
 import toml
 import typer
 from gitignore_parser import parse_gitignore
@@ -38,6 +39,7 @@ from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
     any_provided,
+    confirm,
     prompt_for_value,
     require_selection,
     validate_env_var_name,
@@ -1255,17 +1257,11 @@ def push(
                     )
 
                     while True:
-                        try:
-                            chosen = (
-                                typer.prompt(
-                                    "Enter your desired username",
-                                )
-                                .strip()
-                                .lower()
-                            )
-                        except typer.Abort:
+                        answer = questionary.text("Enter your desired username").ask()
+                        if answer is None:
                             console.print("[red]Cancelled by user[/red]")
                             raise typer.Exit(1)
+                        chosen = answer.strip().lower()
 
                         if not chosen:
                             console.print("[red]Username cannot be empty[/red]")
@@ -2899,8 +2895,7 @@ def delete_version(
                     f"Are you sure you want to permanently delete version with content "
                     f"hash '{content_hash}' from '{env_id}' on the environments hub?"
                 )
-                confirm = typer.confirm(confirm_msg)
-                if not confirm:
+                if not confirm(confirm_msg):
                     console.print("Deletion cancelled.")
                     raise typer.Exit()
             except typer.Abort:
@@ -2954,8 +2949,7 @@ def delete(
                     f"Are you sure you want to permanently delete entire environment "
                     f"'{env_id}' and ALL its versions from the environments hub?"
                 )
-                confirm = typer.confirm(delete_msg)
-                if not confirm:
+                if not confirm(delete_msg):
                     console.print("Deletion cancelled.")
                     raise typer.Exit()
             except typer.Abort:
@@ -3661,8 +3655,7 @@ def env_secret_delete(
             secret_name = secret_data.get("name") if secret_data else secret_id
 
         if not yes:
-            confirm = typer.confirm(f"Delete secret '{secret_name}' from {owner}/{env_name}?")
-            if not confirm:
+            if not confirm(f"Delete secret '{secret_name}' from {owner}/{env_name}?"):
                 console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
@@ -3744,10 +3737,7 @@ def env_secret_unlink(
 
     try:
         if not yes:
-            confirm = typer.confirm(
-                f"Unlink global secret {global_secret_id} from {owner}/{env_name}?"
-            )
-            if not confirm:
+            if not confirm(f"Unlink global secret {global_secret_id} from {owner}/{env_name}?"):
                 console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 
@@ -3998,8 +3988,7 @@ def var_delete(
 
     try:
         if not yes:
-            confirm = typer.confirm(f"Delete variable {var_id} from {owner}/{env_name}?")
-            if not confirm:
+            if not confirm(f"Delete variable {var_id} from {owner}/{env_name}?"):
                 console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
-import questionary
 import toml
 import typer
 from gitignore_parser import parse_gitignore
@@ -39,6 +38,7 @@ from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
     any_provided,
+    ask_text,
     confirm,
     prompt_for_value,
     require_selection,
@@ -1257,7 +1257,7 @@ def push(
                     )
 
                     while True:
-                        answer = questionary.text("Enter your desired username").ask()
+                        answer = ask_text("Enter your desired username")
                         if answer is None:
                             console.print("[red]Cancelled by user[/red]")
                             raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/feedback.py
+++ b/packages/prime/src/prime_cli/commands/feedback.py
@@ -7,7 +7,7 @@ from click.exceptions import Abort
 from prime_cli import __version__
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, ask_select, ask_text, get_console
 
 app = PlainTyper(
     help="Submit feedback about Prime Intellect.",
@@ -27,11 +27,11 @@ _CATEGORY_CHOICES: tuple[tuple[FeedbackCategory, str], ...] = (
 
 
 def _prompt_category() -> FeedbackCategory:
-    selected = questionary.select(
+    selected = ask_select(
         "What are you sharing?",
-        choices=[questionary.Choice(label, value=cat) for cat, label in _CATEGORY_CHOICES],
+        [questionary.Choice(label, value=cat) for cat, label in _CATEGORY_CHOICES],
         default="general",
-    ).ask()
+    )
     if selected is None:
         raise Abort()
     return selected
@@ -39,7 +39,7 @@ def _prompt_category() -> FeedbackCategory:
 
 def _prompt_message() -> str:
     while True:
-        answer = questionary.text("Your feedback (required)").ask()
+        answer = ask_text("Your feedback (required)")
         if answer is None:
             raise Abort()
         message = answer.strip()
@@ -49,7 +49,7 @@ def _prompt_message() -> str:
 
 
 def _prompt_run_id() -> str | None:
-    answer = questionary.text("Related run ID (optional)").ask()
+    answer = ask_text("Related run ID (optional)")
     if answer is None:
         raise Abort()
     return answer.strip() or None

--- a/packages/prime/src/prime_cli/commands/feedback.py
+++ b/packages/prime/src/prime_cli/commands/feedback.py
@@ -30,7 +30,6 @@ def _prompt_category() -> FeedbackCategory:
     selected = ask_select(
         "What are you sharing?",
         [questionary.Choice(label, value=cat) for cat, label in _CATEGORY_CHOICES],
-        default="general",
     )
     if selected is None:
         raise Abort()

--- a/packages/prime/src/prime_cli/commands/feedback.py
+++ b/packages/prime/src/prime_cli/commands/feedback.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import questionary
 import typer
 from click.exceptions import Abort
 
@@ -26,33 +27,32 @@ _CATEGORY_CHOICES: tuple[tuple[FeedbackCategory, str], ...] = (
 
 
 def _prompt_category() -> FeedbackCategory:
-    console.print("\n[bold]What are you sharing?[/bold]")
-    for idx, (_, label) in enumerate(_CATEGORY_CHOICES, start=1):
-        console.print(f"  [cyan]({idx})[/cyan] {label}")
-
-    while True:
-        selection = typer.prompt("Select", type=int, default=3)
-        if 1 <= selection <= len(_CATEGORY_CHOICES):
-            return _CATEGORY_CHOICES[selection - 1][0]
-        console.print(f"[red]Invalid selection. Enter 1-{len(_CATEGORY_CHOICES)}.[/red]")
+    selected = questionary.select(
+        "What are you sharing?",
+        choices=[questionary.Choice(label, value=cat) for cat, label in _CATEGORY_CHOICES],
+        default="general",
+    ).ask()
+    if selected is None:
+        raise Abort()
+    return selected
 
 
 def _prompt_message() -> str:
-    console.print("\n[bold]Your feedback[/bold] [dim](required)[/dim]")
     while True:
-        message = typer.prompt("", prompt_suffix="> ").strip()
+        answer = questionary.text("Your feedback (required)").ask()
+        if answer is None:
+            raise Abort()
+        message = answer.strip()
         if message:
             return message
         console.print("[red]Feedback cannot be empty.[/red]")
 
 
 def _prompt_run_id() -> str | None:
-    run_id = typer.prompt(
-        "Related run ID (optional)",
-        default="",
-        show_default=False,
-    ).strip()
-    return run_id or None
+    answer = questionary.text("Related run ID (optional)").ask()
+    if answer is None:
+        raise Abort()
+    return answer.strip() or None
 
 
 def submit_feedback(

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -29,6 +29,7 @@ from rich.table import Table
 
 from ..utils import (
     PlainTyper,
+    confirm,
     confirm_or_skip,
     get_console,
     json_output_help,
@@ -1576,8 +1577,7 @@ def delete_image(
         context = f" (team: {team_id})" if team_id else ""
         if not yes:
             msg = f"Are you sure you want to delete {image_name}:{image_tag}{context}?"
-            confirm = typer.confirm(msg)
-            if not confirm:
+            if not confirm(msg):
                 console.print("[yellow]Cancelled[/yellow]")
                 raise typer.Exit(0)
 

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, ask_select, get_console
 from .teams import fetch_teams
 
 app = PlainTyper(help="Login to Prime Intellect")
@@ -37,11 +37,11 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
                 questionary.Choice(f"{team.get('name', 'Unknown')} (role: {role})", value=team)
             )
 
-        selected = questionary.select(
+        selected = ask_select(
             "Select account",
-            choices=choices,
+            choices,
             instruction="Change this any time by running 'prime login' again.",
-        ).ask()
+        )
 
         if selected is None or selected == "personal":
             config.set_team(None)

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -4,8 +4,8 @@ import webbrowser
 from typing import Optional
 
 import httpx
+import questionary
 import typer
-from click.exceptions import Abort
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -30,56 +30,39 @@ def fetch_and_select_team(client: APIClient, config: Config) -> None:
             config.update_current_environment_file()
             return
 
-        console.print("\n[bold]Select:[/bold]\n")
-        console.print("  [cyan](1)[/cyan] Personal")
-        for idx, team in enumerate(teams, start=2):
-            role = team.get("role", "member")
-            role_display = role.lower()
-            role_badge = (
-                f"[yellow](role: {role_display})[/yellow]"
-                if role == "admin"
-                else f"[dim](role: {role_display})[/dim]"
+        choices = [questionary.Choice("Personal", value="personal")]
+        for team in teams:
+            role = str(team.get("role", "member")).lower()
+            choices.append(
+                questionary.Choice(f"{team.get('name', 'Unknown')} (role: {role})", value=team)
             )
-            console.print(f"  [cyan]({idx})[/cyan] {team.get('name', 'Unknown')} {role_badge}")
 
-        console.print("\n[dim]You can always change this by running 'prime login' again.[/dim]")
+        selected = questionary.select(
+            "Select account",
+            choices=choices,
+            instruction="Change this any time by running 'prime login' again.",
+        ).ask()
 
-        while True:
-            try:
-                selection = typer.prompt("Select", type=int, default=1)
+        if selected is None or selected == "personal":
+            config.set_team(None)
+            config.update_current_environment_file()
+            if selected == "personal":
+                console.print("[green]Using personal account.[/green]")
+            return
 
-                if selection == 1:
-                    config.set_team(None)
-                    config.update_current_environment_file()
-                    console.print("[green]Using personal account.[/green]")
-                    return
+        team_id = selected.get("teamId")
+        team_name = selected.get("name", "Unknown")
+        team_role = selected.get("role", "member")
+        if not team_id:
+            console.print("[yellow]Invalid team. Using personal account.[/yellow]")
+            config.set_team(None)
+            config.update_current_environment_file()
+            return
 
-                if 2 <= selection <= len(teams) + 1:
-                    selected_team = teams[selection - 2]
-                    team_id = selected_team.get("teamId")
-                    team_name = selected_team.get("name", "Unknown")
-                    team_role = selected_team.get("role", "member")
-
-                    if not team_id:
-                        console.print("[yellow]Invalid team. Using personal account.[/yellow]")
-                        config.set_team(None)
-                        config.update_current_environment_file()
-                        return
-
-                    config.set_team(team_id, team_name=team_name, team_role=team_role)
-                    config.update_current_environment_file()
-                    console.print(f"[green]Using team '{team_name}'.[/green]")
-                    return
-
-                console.print(f"[red]Invalid selection. Enter 1-{len(teams) + 1}.[/red]")
-            except Abort:
-                config.set_team(None)
-                config.update_current_environment_file()
-                return
-
-    except Abort:
-        config.set_team(None)
+        config.set_team(team_id, team_name=team_name, team_role=team_role)
         config.update_current_environment_file()
+        console.print(f"[green]Using team '{team_name}'.[/green]")
+
     except (APIError, Exception):
         config.set_team(None)
         config.update_current_environment_file()

--- a/packages/prime/src/prime_cli/commands/logout.py
+++ b/packages/prime/src/prime_cli/commands/logout.py
@@ -5,7 +5,7 @@ import typer
 
 from prime_cli.core import Config
 
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, confirm, get_console
 
 app = PlainTyper(help="Log out of Prime Intellect", no_args_is_help=False)
 console = get_console()
@@ -66,7 +66,7 @@ def logout(
         raise typer.Exit(0)
 
     env_name = config.current_environment
-    if not yes and not typer.confirm(
+    if not yes and not confirm(
         f"Log out of '{env_name}' (clears API key, team, and user id)?",
         default=True,
     ):

--- a/packages/prime/src/prime_cli/commands/pods.py
+++ b/packages/prime/src/prime_cli/commands/pods.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
+import questionary
 import typer
 from rich.table import Table
 from rich.text import Text
@@ -34,6 +35,36 @@ from ..utils.display import POD_STATUS_COLORS
 
 app = PlainTyper(help="Manage compute pods", no_args_is_help=True)
 console = get_console()
+
+
+def _select_or_exit(message: str, choices: List[questionary.Choice]) -> Any:
+    answer = questionary.select(message, choices=choices).ask()
+    if answer is None:
+        raise typer.Exit(1)
+    return answer
+
+
+def _prompt_int(
+    message: str, default: Optional[int], minimum: Optional[int], maximum: Optional[int]
+) -> int:
+    def validate(text: str) -> object:
+        try:
+            value = int(text)
+        except ValueError:
+            return "Enter a whole number."
+        if minimum is not None and value < minimum:
+            return f"Must be at least {minimum}."
+        if maximum is not None and value > maximum:
+            return f"Must be at most {maximum}."
+        return True
+
+    answer = questionary.text(
+        message, default=str(default) if default is not None else "", validate=validate
+    ).ask()
+    if answer is None:
+        raise typer.Exit(1)
+    return int(answer)
+
 
 LIST_PODS_JSON_HELP = json_output_help(
     ".pods[] = {id, name, gpu, status, created_at}",
@@ -520,19 +551,13 @@ def create(
         else:
             # Interactive GPU selection if no ID provided
             if not gpu_type:
-                # Show available GPU types
-                console.print("\n[bold]Available GPU Types:[/bold]")
                 gpu_types = sorted(
                     [gpu_type for gpu_type, gpus in availabilities.items() if len(gpus) > 0]
                 )
-                for idx, gpu_type_option in enumerate(gpu_types, 1):
-                    console.print(f"{idx}. {gpu_type_option}")
-
-                gpu_type_idx = typer.prompt("Select GPU type number", type=int, default=1)
-                if gpu_type_idx < 1 or gpu_type_idx > len(gpu_types):
-                    console.print("[red]Invalid GPU type selection[/red]")
-                    raise typer.Exit(1)
-                gpu_type = gpu_types[gpu_type_idx - 1]
+                gpu_type = _select_or_exit(
+                    "Select GPU type",
+                    [questionary.Choice(option, value=option) for option in gpu_types],
+                )
 
             def select_provider_from_configs(
                 matching_configs: List[GPUAvailability],
@@ -553,25 +578,19 @@ def create(
                         unique_configs.append(gpu)
 
                 if len(unique_configs) > 1:
-                    console.print("\n[bold]Available Providers:[/bold]")
-                    for idx, gpu in enumerate(unique_configs, 1):
+                    provider_choices = []
+                    for gpu in unique_configs:
                         price = gpu.prices.price if gpu.prices else float("inf")
                         price_display = (
                             f"${round(float(price), 2)}/hr" if price != float("inf") else "N/A"
                         )
                         spot_display = " (spot)" if gpu.is_spot else ""
-                        console.print(f"{idx}. {gpu.provider}{spot_display} ({price_display})")
-
-                    provider_idx = typer.prompt(
-                        "Select provider number",
-                        type=int,
-                        default=1,
-                        show_default=False,
-                    )
-                    if provider_idx < 1 or provider_idx > len(unique_configs):
-                        console.print("[red]Invalid provider selection[/red]")
-                        raise typer.Exit(1)
-                    selected_gpu = unique_configs[provider_idx - 1]
+                        provider_choices.append(
+                            questionary.Choice(
+                                f"{gpu.provider}{spot_display} ({price_display})", value=gpu
+                            )
+                        )
+                    selected_gpu = _select_or_exit("Select provider", provider_choices)
                     if not isinstance(selected_gpu, GPUAvailability):
                         raise TypeError("Selected GPU is not of type GPUAvailability")
                     return selected_gpu
@@ -600,24 +619,17 @@ def create(
                     key=lambda x: x[0],
                 )
 
-                for idx, (count, gpu, price) in enumerate(config_list, 1):
+                config_choices = []
+                for count, gpu, price in config_list:
                     price_display = (
                         f"${round(float(price), 2)}/hr" if price != float("inf") else "N/A"
                     )
-                    console.print(f"{idx}. {count}x {gpu_type} ({price_display})")
-
-                config_idx = typer.prompt(
-                    "Select configuration number",
-                    type=int,
-                    default=1,
-                    show_default=False,
-                )
-                if config_idx < 1 or config_idx > len(config_list):
-                    console.print("[red]Invalid configuration selection[/red]")
-                    raise typer.Exit(1)
+                    config_choices.append(
+                        questionary.Choice(f"{count}x {gpu_type} ({price_display})", value=count)
+                    )
 
                 # Find all providers for selected configuration
-                selected_count = config_list[config_idx - 1][0]
+                selected_count = _select_or_exit("Select configuration", config_choices)
                 matching_configs = [gpu for gpu in gpu_configs if gpu.gpu_count == selected_count]
 
                 selected_gpu = select_provider_from_configs(matching_configs)
@@ -641,23 +653,25 @@ def create(
             raise typer.Exit(1)
 
         if not name:
-            while True:
-                gpu_name = selected_gpu.gpu_type.lower().split("_")[0]
-                default_name = f"{gpu_name}-{selected_gpu.gpu_count}"
-                name = typer.prompt(
-                    "Pod name (alphanumeric and dashes only, must contain at least 1 letter)",
-                    default=default_name,
-                )
+            gpu_name = selected_gpu.gpu_type.lower().split("_")[0]
+            default_name = f"{gpu_name}-{selected_gpu.gpu_count}"
+
+            def _valid_pod_name(text: str) -> object:
+                candidate = text.strip()
                 if (
-                    name
-                    and any(c.isalpha() for c in name)
-                    and all(c.isalnum() or c == "-" for c in name)
+                    candidate
+                    and any(c.isalpha() for c in candidate)
+                    and all(c.isalnum() or c == "-" for c in candidate)
                 ):
-                    break
-                console.print(
-                    "[red]Invalid name format. Use only letters, numbers and dashes. "
-                    "Must contain at least 1 letter.[/red]"
-                )
+                    return True
+                return "Use letters, numbers and dashes; must contain at least 1 letter."
+
+            answer = questionary.text(
+                "Pod name", default=default_name, validate=_valid_pod_name
+            ).ask()
+            if answer is None:
+                raise typer.Exit(1)
+            name = answer.strip()
 
         gpu_count = selected_gpu.gpu_count
 
@@ -669,17 +683,12 @@ def create(
             if min_disk is None or max_disk is None:
                 disk_size = default_disk
             else:
-                disk_size = typer.prompt(
+                disk_size = _prompt_int(
                     f"Disk size in GB (min: {min_disk}, max: {max_disk})",
-                    default=default_disk or min_disk,
-                    type=int,
+                    default_disk or min_disk,
+                    min_disk,
+                    max_disk,
                 )
-                if min_disk is not None and disk_size is not None and disk_size < min_disk:
-                    console.print(f"[red]Disk size must be at least {min_disk}GB[/red]")
-                    raise typer.Exit(1)
-                if max_disk is not None and disk_size is not None and disk_size > max_disk:
-                    console.print(f"[red]Disk size must be at most {max_disk}GB[/red]")
-                    raise typer.Exit(1)
 
         if not vcpus:
             min_vcpus = selected_gpu.vcpu.min_count
@@ -688,16 +697,12 @@ def create(
             if min_vcpus is None or max_vcpus is None or default_vcpus is None:
                 vcpus = default_vcpus
             else:
-                vcpus = typer.prompt(
+                vcpus = _prompt_int(
                     f"Number of vCPUs (min: {min_vcpus}, max: {max_vcpus})",
-                    default=default_vcpus,
-                    type=int,
+                    default_vcpus,
+                    min_vcpus,
+                    max_vcpus,
                 )
-                if vcpus is None or vcpus < min_vcpus or vcpus > max_vcpus:
-                    console.print(
-                        f"[red]vCPU count must be between {min_vcpus} and {max_vcpus}[/red]"
-                    )
-                    raise typer.Exit(1)
 
         if not memory:
             min_memory = selected_gpu.memory.min_count
@@ -707,16 +712,12 @@ def create(
             if min_memory is None or max_memory is None:
                 memory = default_memory
             else:
-                memory = typer.prompt(
+                memory = _prompt_int(
                     f"Memory in GB (min: {min_memory}, max: {max_memory})",
-                    default=default_memory,
-                    type=int,
+                    default_memory,
+                    min_memory,
+                    max_memory,
                 )
-                if memory is None or memory < min_memory or memory > max_memory:
-                    console.print(
-                        f"[red]Memory must be between {min_memory}GB and {max_memory}GB[/red]"
-                    )
-                    raise typer.Exit(1)
 
         available_images = selected_gpu.images
 
@@ -725,21 +726,10 @@ def create(
                 # If only one image available, use it directly
                 image = available_images[0]
             else:
-                # Show available images
-                console.print("\n[bold]Available Images:[/bold]")
-                for idx, img in enumerate(available_images):
-                    console.print(f"{idx + 1}. {img}")
-
-                # Prompt for image selection
-                image_idx = typer.prompt(
-                    "Select image number", type=int, default=1, show_default=False
+                image = _select_or_exit(
+                    "Select image",
+                    [questionary.Choice(img, value=img) for img in available_images],
                 )
-
-                if image_idx < 1 or image_idx > len(available_images):
-                    console.print("[red]Invalid image selection[/red]")
-                    raise typer.Exit(1)
-
-                image = available_images[image_idx - 1]
 
         # Determine sharing settings
         shared_with_team = share_with_team
@@ -757,43 +747,30 @@ def create(
             if not selectable_members:
                 console.print("[yellow]No other team members to share with.[/yellow]")
             else:
-                console.print("\n[bold]Team Members:[/bold]")
-                for idx, m in enumerate(selectable_members, 1):
+                member_choices = [
+                    questionary.Choice("Everyone (share with the whole team)", value="__all__")
+                ]
+                for m in selectable_members:
                     member_name = m.get("userName") or "N/A"
                     email = m.get("userEmail") or "N/A"
                     role = m.get("role", "")
-                    console.print(f"  {idx}. {member_name} ({email}) - {role}")
+                    member_choices.append(
+                        questionary.Choice(f"{member_name} ({email}) - {role}", value=m)
+                    )
 
-                selection = typer.prompt(
-                    "\nSelect members (comma-separated numbers, or 'all' for everyone)",
-                    default="all",
-                )
+                picked = questionary.checkbox(
+                    "Select members to share with",
+                    choices=member_choices,
+                ).ask()
+                if picked is None:
+                    raise typer.Exit(1)
 
-                if selection.strip().lower() == "all":
+                if any(item == "__all__" for item in picked):
                     shared_with_team = True
                     sharing_display = "All team members"
                 else:
-                    selected_indices = []
-                    for part in selection.split(","):
-                        part = part.strip()
-                        if part.isdigit():
-                            idx = int(part)
-                            if 1 <= idx <= len(selectable_members):
-                                selected_indices.append(idx - 1)
-                            else:
-                                console.print(
-                                    f"[red]Invalid selection: {idx}. "
-                                    f"Must be between 1 and "
-                                    f"{len(selectable_members)}[/red]"
-                                )
-                                raise typer.Exit(1)
-                        else:
-                            console.print(f"[red]Invalid input: {part}[/red]")
-                            raise typer.Exit(1)
-
-                    selected_members = [selectable_members[i] for i in selected_indices]
-                    team_member_ids = [m["userId"] for m in selected_members]
-                    names = [m.get("userName") or m["userId"] for m in selected_members]
+                    team_member_ids = [m["userId"] for m in picked]
+                    names = [m.get("userName") or m["userId"] for m in picked]
                     sharing_display = ", ".join(names)
 
         elif not share_with_team and not add_members:
@@ -1093,17 +1070,10 @@ def connect(pod_id: str) -> None:
         # If multiple connections available, let user choose
         connection_str: str
         if len(connections) > 1:
-            console.print("\nMultiple nodes available. Please select one:")
-            for idx, conn in enumerate(connections):
-                console.print(f"[blue]{idx + 1}[/blue]) {conn}")
-
-            choice = typer.prompt("Enter node number", type=int, default=1, show_default=False)
-
-            if choice < 1 or choice > len(connections):
-                console.print("[red]Invalid selection[/red]")
-                raise typer.Exit(1)
-
-            connection_str = connections[choice - 1]
+            connection_str = _select_or_exit(
+                "Multiple nodes available. Select one",
+                [questionary.Choice(conn, value=conn) for conn in connections],
+            )
         else:
             connection_str = connections[0]
 

--- a/packages/prime/src/prime_cli/commands/pods.py
+++ b/packages/prime/src/prime_cli/commands/pods.py
@@ -20,6 +20,9 @@ from ..commands.teams import fetch_team_members
 from ..helper.short_id import generate_short_id
 from ..utils import (
     PlainTyper,
+    ask_checkbox,
+    ask_select,
+    ask_text,
     confirm_or_skip,
     format_ip_display,
     get_console,
@@ -38,7 +41,7 @@ console = get_console()
 
 
 def _select_or_exit(message: str, choices: List[questionary.Choice]) -> Any:
-    answer = questionary.select(message, choices=choices).ask()
+    answer = ask_select(message, choices)
     if answer is None:
         raise typer.Exit(1)
     return answer
@@ -58,9 +61,9 @@ def _prompt_int(
             return f"Must be at most {maximum}."
         return True
 
-    answer = questionary.text(
+    answer = ask_text(
         message, default=str(default) if default is not None else "", validate=validate
-    ).ask()
+    )
     if answer is None:
         raise typer.Exit(1)
     return int(answer)
@@ -666,9 +669,7 @@ def create(
                     return True
                 return "Use letters, numbers and dashes; must contain at least 1 letter."
 
-            answer = questionary.text(
-                "Pod name", default=default_name, validate=_valid_pod_name
-            ).ask()
+            answer = ask_text("Pod name", default=default_name, validate=_valid_pod_name)
             if answer is None:
                 raise typer.Exit(1)
             name = answer.strip()
@@ -758,10 +759,7 @@ def create(
                         questionary.Choice(f"{member_name} ({email}) - {role}", value=m)
                     )
 
-                picked = questionary.checkbox(
-                    "Select members to share with",
-                    choices=member_choices,
-                ).ask()
+                picked = ask_checkbox("Select members to share with", member_choices)
                 if picked is None:
                     raise typer.Exit(1)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+import questionary
 import toml
 import typer
 from click.exceptions import Abort
@@ -37,7 +38,7 @@ from ..utils.formatters import (
     format_promo_price,
     strip_ansi,
 )
-from ..utils.prompt import confirm_or_skip
+from ..utils.prompt import confirm, confirm_or_skip
 from .feedback import submit_feedback
 from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
@@ -1877,20 +1878,23 @@ def list_gpus(
 
 
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
-    console.print(f"\n[bold]{label}[/bold] [dim](required)[/dim]")
     console.print(f"[dim]{help_text}[/dim]")
     while True:
-        value = typer.prompt("", prompt_suffix="> ").strip()
+        answer = questionary.text(f"{label} (required)").ask()
+        if answer is None:
+            raise typer.Abort()
+        value = answer.strip()
         if value:
             return value
         console.print(f"[red]{empty_error}[/red]")
 
 
 def _prompt_optional_text(label: str, help_text: str) -> str | None:
-    console.print(f"\n[bold]{label}[/bold] [dim](optional)[/dim]")
     console.print(f"[dim]{help_text}[/dim]")
-    value = typer.prompt("", default="", show_default=False, prompt_suffix="> ").strip()
-    return value or None
+    answer = questionary.text(f"{label} (optional)").ask()
+    if answer is None:
+        raise typer.Abort()
+    return answer.strip() or None
 
 
 def _format_model_request_feedback(models: str, context: str | None) -> str:
@@ -2250,8 +2254,7 @@ def stop_run(
     """Stop a run."""
     try:
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to stop run {run_id}?")
-            if not confirm:
+            if not confirm(f"Are you sure you want to stop run {run_id}?"):
                 console.print("Cancelled.")
                 raise typer.Exit(0)
 
@@ -2275,8 +2278,7 @@ def delete_run(
 ) -> None:
     """Delete a run."""
     if not force:
-        confirm = typer.confirm(f"Are you sure you want to permanently delete run {run_id}?")
-        if not confirm:
+        if not confirm(f"Are you sure you want to permanently delete run {run_id}?"):
             console.print("Cancelled.")
             raise typer.Exit(0)
 
@@ -2318,10 +2320,9 @@ def restart_run(
     """
     try:
         if not force:
-            confirm = typer.confirm(
+            if not confirm(
                 f"Are you sure you want to restart run {run_id} from its latest checkpoint?"
-            )
-            if not confirm:
+            ):
                 console.print("Cancelled.")
                 raise typer.Exit(0)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
-import questionary
 import toml
 import typer
 from click.exceptions import Abort
@@ -38,7 +37,7 @@ from ..utils.formatters import (
     format_promo_price,
     strip_ansi,
 )
-from ..utils.prompt import confirm, confirm_or_skip
+from ..utils.prompt import ask_text, confirm, confirm_or_skip
 from .feedback import submit_feedback
 from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
@@ -1880,7 +1879,7 @@ def list_gpus(
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
     console.print(f"[dim]{help_text}[/dim]")
     while True:
-        answer = questionary.text(f"{label} (required)").ask()
+        answer = ask_text(f"{label} (required)")
         if answer is None:
             raise typer.Abort()
         value = answer.strip()
@@ -1891,7 +1890,7 @@ def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
 
 def _prompt_optional_text(label: str, help_text: str) -> str | None:
     console.print(f"[dim]{help_text}[/dim]")
-    answer = questionary.text(f"{label} (optional)").ask()
+    answer = ask_text(f"{label} (optional)")
     if answer is None:
         raise typer.Abort()
     return answer.strip() or None

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -33,6 +33,7 @@ from rich.text import Text
 from ..utils import (
     PlainTyper,
     build_table,
+    confirm,
     confirm_or_skip,
     format_resources,
     get_console,
@@ -1427,7 +1428,7 @@ def download_file(
 
         # Check if local file already exists
         if os.path.exists(local_file):
-            if not typer.confirm(f"File {local_file} already exists. Overwrite?"):
+            if not confirm(f"File {local_file} already exists. Overwrite?"):
                 console.print("Download cancelled.")
                 return
 
@@ -1475,7 +1476,7 @@ def reset_cache(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Reset sandbox authentication cache"""
-    if yes or typer.confirm("Are you sure you want to clear the sandbox auth cache?"):
+    if yes or confirm("Are you sure you want to clear the sandbox auth cache?"):
         try:
             client = APIClient()
             sandbox_client = SandboxClient(client)

--- a/packages/prime/src/prime_cli/commands/secrets.py
+++ b/packages/prime/src/prime_cli/commands/secrets.py
@@ -16,6 +16,7 @@ from ..utils import (
 )
 from ..utils.prompt import (
     any_provided,
+    confirm,
     prompt_for_value,
     require_selection,
     validate_env_var_name,
@@ -287,8 +288,7 @@ def secret_delete(
             secret_name = secret_data.get("name", secret_id)
 
         if not yes:
-            confirm = typer.confirm(f"Delete secret '{secret_name}'?")
-            if not confirm:
+            if not confirm(f"Delete secret '{secret_name}'?"):
                 console.print("\n[dim]Cancelled.[/dim]")
                 raise typer.Exit()
 

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -6,7 +6,7 @@ import typer
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, ask_select, get_console
 from .teams import fetch_teams
 
 app = PlainTyper(
@@ -118,7 +118,7 @@ def switch(
     current_team_id = config.team_id
     choices = _account_choices(teams, current_team_id)
 
-    selected = questionary.select("Switch account", choices=choices).ask()
+    selected = ask_select("Switch account", choices)
     if selected is None:
         raise typer.Exit(1)
     if selected == "personal":

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
+import questionary
 import typer
-from click.exceptions import Abort
 
 from prime_cli.core import Config
 
@@ -16,6 +16,19 @@ app = PlainTyper(
 console = get_console()
 
 PERSONAL_TARGET = "personal"
+
+
+def _account_choices(teams: list[dict], current_team_id: Optional[str]) -> list[questionary.Choice]:
+    personal_label = "Personal (current)" if current_team_id is None else "Personal"
+    choices = [questionary.Choice(personal_label, value=PERSONAL_TARGET)]
+    for team in teams:
+        name = team.get("name", "Unknown")
+        slug = str(team.get("slug") or "").strip()
+        role = str(team.get("role", "member")).lower()
+        current = " (current)" if team.get("teamId") == current_team_id else ""
+        details = f"slug: {slug}, role: {role}" if slug else f"role: {role}"
+        choices.append(questionary.Choice(f"{name} ({details}){current}", value=team))
+    return choices
 
 
 def _select_team_by_target(teams: list[dict], target: str) -> Optional[dict]:
@@ -102,31 +115,13 @@ def switch(
         _switch_to_team(config, selected_team)
         return
 
-    console.print("\n[bold]Switch account:[/bold]\n")
     current_team_id = config.team_id
+    choices = _account_choices(teams, current_team_id)
 
-    personal_label = "Personal"
-    if current_team_id is None:
-        personal_label += " [green](current)[/green]"
-    console.print(f"  [cyan](1)[/cyan] {personal_label}")
-
-    for idx, team in enumerate(teams, start=2):
-        name = team.get("name", "Unknown")
-        slug = str(team.get("slug") or "").strip()
-        role = str(team.get("role", "member")).lower()
-        current_badge = " [green](current)[/green]" if team.get("teamId") == current_team_id else ""
-        details = f"slug: {slug}, role: {role}" if slug else f"role: {role}"
-        console.print(f"  [cyan]({idx})[/cyan] {name} [dim]({details})[/dim]{current_badge}")
-
-    while True:
-        try:
-            selection = typer.prompt("Select", type=int, default=1)
-            if selection == 1:
-                _switch_to_personal(config)
-                return
-            if 2 <= selection <= len(teams) + 1:
-                _switch_to_team(config, teams[selection - 2])
-                return
-            console.print(f"[red]Invalid selection. Enter 1-{len(teams) + 1}.[/red]")
-        except Abort:
-            raise typer.Exit(1)
+    selected = questionary.select("Switch account", choices=choices).ask()
+    if selected is None:
+        raise typer.Exit(1)
+    if selected == "personal":
+        _switch_to_personal(config)
+        return
+    _switch_to_team(config, selected)

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -26,6 +26,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from .agent_picker import AgentMenu, select_agents
 from .lab_agents import (
     agent_capability,
     agent_project_skills_dirs,
@@ -1666,42 +1667,30 @@ def _resolve_setup_agents(value: str | None, *, no_interactive: bool) -> tuple[s
     )
 
 
+def _agent_menu() -> AgentMenu:
+    menu: AgentMenu = []
+    for name in SUPPORTED_AGENTS:
+        capability = agent_capability(name)
+        menu.append((name, capability.label, not capability.missing_requirements()))
+    return menu
+
+
+def _default_primary_index(menu: AgentMenu) -> int:
+    for index, (_, _, installed) in enumerate(menu):
+        if installed:
+            return index
+    for index, (name, _, _) in enumerate(menu):
+        if name == "codex":
+            return index
+    return 0
+
+
 def _prompt_for_agents() -> tuple[str, ...]:
-    print(f"Supported coding agents: {', '.join(SUPPORTED_AGENTS)}")
-    while True:
-        try:
-            raw_primary = _prompt_input("Primary coding agent [codex]: ").strip()
-            primary = raw_primary or "codex"
-            selected = [_normalize_supported_agent(primary, allow_all=False)]
-            break
-        except EOFError as exc:
-            raise ValueError("Agent selection was cancelled.") from exc
-        except ValueError as exc:
-            print(exc)
-
-    try:
-        use_multiple_raw = _prompt_input("Using multiple coding agents? [y/N]: ").strip().lower()
-    except EOFError as exc:
-        raise ValueError("Agent selection was cancelled.") from exc
-
-    if use_multiple_raw in {"y", "yes"}:
-        while True:
-            try:
-                additional_raw = _prompt_input("Additional agents (comma-separated): ").strip()
-                additional_agents = _parse_agents(additional_raw) if additional_raw else []
-                break
-            except EOFError as exc:
-                raise ValueError("Agent selection was cancelled.") from exc
-            except ValueError as exc:
-                print(exc)
-        for agent in additional_agents:
-            if agent not in selected:
-                selected.append(agent)
-    return tuple(selected)
-
-
-def _prompt_input(prompt: str) -> str:
-    return input(prompt)
+    menu = _agent_menu()
+    selected = select_agents(menu, _default_primary_index(menu))
+    if not selected:
+        raise ValueError("Agent selection was cancelled.")
+    return selected
 
 
 def _resolve_explicit_agents(value: str) -> tuple[str, ...]:

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -22,6 +22,7 @@ from .params import optional_team_params
 from .plain import DefaultCommandGroup, PlainAwareTyperGroup, PlainTyper, get_console, is_plain_mode
 from .prompt import (
     any_provided,
+    confirm,
     confirm_or_skip,
     prompt_for_value,
     require_selection,
@@ -48,6 +49,7 @@ __all__ = [
     "json_help",
     "json_output_help",
     "any_provided",
+    "confirm",
     "confirm_or_skip",
     "prompt_for_value",
     "select_item_interactive",

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -21,7 +21,12 @@ from .json_help import json_help, json_output_help
 from .params import optional_team_params
 from .plain import DefaultCommandGroup, PlainAwareTyperGroup, PlainTyper, get_console, is_plain_mode
 from .prompt import (
+    PROMPT_STYLE,
     any_provided,
+    ask_checkbox,
+    ask_password,
+    ask_select,
+    ask_text,
     confirm,
     confirm_or_skip,
     prompt_for_value,
@@ -48,7 +53,12 @@ __all__ = [
     "strip_ansi",
     "json_help",
     "json_output_help",
+    "PROMPT_STYLE",
     "any_provided",
+    "ask_checkbox",
+    "ask_password",
+    "ask_select",
+    "ask_text",
     "confirm",
     "confirm_or_skip",
     "prompt_for_value",

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -1,8 +1,8 @@
 import re
 from typing import Any, Callable, Dict, List, Optional
 
+import questionary
 import typer
-from rich.markup import escape
 
 from .plain import get_console
 
@@ -23,11 +23,16 @@ def validate_env_var_name(name: str, item_type: str = "secret") -> bool:
     return False
 
 
+def confirm(message: str, default: bool = False) -> bool:
+    """Ask a yes/no question inline. Returns ``default`` behaviour on cancel (False)."""
+    return bool(questionary.confirm(message, default=default).ask())
+
+
 def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool:
     """Show confirmation prompt or skip if --yes flag is provided."""
     if yes_flag:
         return True
-    return bool(typer.confirm(message, default=default))
+    return confirm(message, default=default)
 
 
 def any_provided(*values: Any) -> bool:
@@ -70,7 +75,7 @@ def select_item_interactive(
     display_fn: Optional[Callable[[Dict[str, Any]], str]] = None,
     page_size: Optional[int] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Display items and let user select one interactively.
+    """Display items and let the user pick one with arrow keys.
 
     Args:
         items: List of items to select from
@@ -78,8 +83,7 @@ def select_item_interactive(
         item_type: Type of item being selected (e.g., "secret", "variable")
         display_fn: Function to format each item for display.
                    Defaults to showing 'name' and 'description' fields.
-        page_size: When set and there are more items than this, show them
-                   page_size at a time with [n]ext / [p]rev navigation.
+        page_size: Rows to show at once before scrolling.
 
     Returns:
         Selected item or None if cancelled
@@ -88,93 +92,8 @@ def select_item_interactive(
         return None
 
     formatter = display_fn or _default_display_fn
-
-    if page_size is not None and len(items) > page_size:
-        return _select_item_paged(items, action, item_type, formatter, page_size)
-
-    console.print(f"\n[bold]Select a {item_type} to {action}:[/bold]\n")
-    for i, item in enumerate(items, 1):
-        console.print(f"  {i}. {formatter(item)}")
-    console.print()
-
-    while True:
-        try:
-            selection_str = typer.prompt("Select (empty to cancel)", default="")
-            if not selection_str:
-                return None
-            selection = int(selection_str)
-            if 1 <= selection <= len(items):
-                return items[selection - 1]
-            console.print(f"[red]Please enter a number between 1 and {len(items)}[/red]")
-        except ValueError:
-            console.print("[red]Please enter a valid number[/red]")
-        except KeyboardInterrupt:
-            return None
-
-
-def _select_item_paged(
-    items: List[Dict[str, Any]],
-    action: str,
-    item_type: str,
-    formatter: Callable[[Dict[str, Any]], str],
-    page_size: int,
-) -> Optional[Dict[str, Any]]:
-    """Paged variant of the interactive selector with next/prev navigation.
-
-    Selection numbers are global (1..len(items)) — the number printed next to an
-    item is what you type, on any page.
-    """
-    total = len(items)
-    total_pages = (total + page_size - 1) // page_size
-    page = 0
-
-    while True:
-        start = page * page_size
-        end = min(start + page_size, total)
-
-        console.print(
-            f"\n[bold]Select a {item_type} to {action} (page {page + 1}/{total_pages}):[/bold]\n"
-        )
-        for i in range(start, end):
-            console.print(f"  {i + 1}. {formatter(items[i])}")
-
-        nav = []
-        if page + 1 < total_pages:
-            nav.append("[n] next page")
-        if page > 0:
-            nav.append("[p] prev page")
-        console.print(f"\n[dim]{escape('  '.join(nav))}[/dim]\n")
-
-        try:
-            choice = typer.prompt("Select (empty to cancel)", default="").strip()
-        except KeyboardInterrupt:
-            return None
-
-        if not choice:
-            return None
-
-        lowered = choice.lower()
-        if lowered == "n":
-            if page + 1 < total_pages:
-                page += 1
-            else:
-                console.print("[red]Already on the last page[/red]")
-            continue
-        if lowered == "p":
-            if page > 0:
-                page -= 1
-            else:
-                console.print("[red]Already on the first page[/red]")
-            continue
-
-        try:
-            selection = int(choice)
-        except ValueError:
-            console.print("[red]Please enter a number, or 'n'/'p' to navigate[/red]")
-            continue
-        if 1 <= selection <= total:
-            return items[selection - 1]
-        console.print(f"[red]Please enter a number between 1 and {total}[/red]")
+    choices = [questionary.Choice(title=formatter(item), value=item) for item in items]
+    return questionary.select(f"Select a {item_type} to {action}", choices=choices).ask()
 
 
 def prompt_for_value(
@@ -192,11 +111,10 @@ def prompt_for_value(
     Returns:
         The entered value, or None if cancelled
     """
-    try:
-        suffix = " (empty to cancel)" if required else ""
-        value = typer.prompt(f"{prompt_text}{suffix}", default="", hide_input=hide_input)
-        if required and not value:
-            return None
-        return value
-    except KeyboardInterrupt:
+    ask = questionary.password if hide_input else questionary.text
+    value = ask(prompt_text).ask()
+    if value is None:
         return None
+    if required and not value:
+        return None
+    return value

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -8,6 +8,35 @@ from .plain import get_console
 
 console = get_console()
 
+# Shared look for every interactive prompt: a green accent and no reverse-video
+# bar on the current row (prompt_toolkit's default "selected" style is reverse).
+PROMPT_STYLE = questionary.Style(
+    [
+        ("qmark", "fg:green bold"),
+        ("pointer", "fg:green bold"),
+        ("highlighted", "fg:green bold noreverse"),
+        ("selected", "fg:green noreverse"),
+        ("answer", "fg:green bold"),
+    ]
+)
+
+
+def ask_select(message: str, choices: List[Any], **kwargs: Any) -> Any:
+    return questionary.select(message, choices=choices, style=PROMPT_STYLE, **kwargs).ask()
+
+
+def ask_checkbox(message: str, choices: List[Any], **kwargs: Any) -> Any:
+    return questionary.checkbox(message, choices=choices, style=PROMPT_STYLE, **kwargs).ask()
+
+
+def ask_text(message: str, **kwargs: Any) -> Any:
+    return questionary.text(message, style=PROMPT_STYLE, **kwargs).ask()
+
+
+def ask_password(message: str, **kwargs: Any) -> Any:
+    return questionary.password(message, style=PROMPT_STYLE, **kwargs).ask()
+
+
 _ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 
@@ -25,7 +54,7 @@ def validate_env_var_name(name: str, item_type: str = "secret") -> bool:
 
 def confirm(message: str, default: bool = False) -> bool:
     """Ask a yes/no question inline. Returns ``default`` behaviour on cancel (False)."""
-    return bool(questionary.confirm(message, default=default).ask())
+    return bool(questionary.confirm(message, default=default, style=PROMPT_STYLE).ask())
 
 
 def confirm_or_skip(message: str, yes_flag: bool, default: bool = False) -> bool:
@@ -93,7 +122,7 @@ def select_item_interactive(
 
     formatter = display_fn or _default_display_fn
     choices = [questionary.Choice(title=formatter(item), value=item) for item in items]
-    return questionary.select(f"Select a {item_type} to {action}", choices=choices).ask()
+    return ask_select(f"Select a {item_type} to {action}", choices)
 
 
 def prompt_for_value(
@@ -111,8 +140,8 @@ def prompt_for_value(
     Returns:
         The entered value, or None if cancelled
     """
-    ask = questionary.password if hide_input else questionary.text
-    value = ask(prompt_text).ask()
+    ask = ask_password if hide_input else ask_text
+    value = ask(prompt_text)
     if value is None:
         return None
     if required and not value:

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -8,10 +8,16 @@ from .plain import get_console
 
 console = get_console()
 
-# Shared look for every interactive prompt: questionary's default colours, with a
-# green current/checked row and no reverse-video bar (prompt_toolkit defaults the
-# "selected" class to reverse, which draws the highlight box we don't want).
-PROMPT_STYLE = questionary.Style([("selected", "fg:green noreverse")])
+# Shared look for every interactive prompt: questionary's default colours, with the
+# current row (single-select) and checked markers (multi-select) in green and no
+# reverse-video bar (prompt_toolkit defaults the "selected" class to reverse, which
+# draws the highlight box we don't want).
+PROMPT_STYLE = questionary.Style(
+    [
+        ("highlighted", "fg:green noreverse"),
+        ("selected", "fg:green noreverse"),
+    ]
+)
 
 
 def ask_select(message: str, choices: List[Any], **kwargs: Any) -> Any:

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -16,6 +16,7 @@ PROMPT_STYLE = questionary.Style(
     [
         ("highlighted", "fg:green noreverse"),
         ("selected", "fg:green noreverse"),
+        ("answer", "fg:green bold"),
     ]
 )
 

--- a/packages/prime/src/prime_cli/utils/prompt.py
+++ b/packages/prime/src/prime_cli/utils/prompt.py
@@ -8,17 +8,10 @@ from .plain import get_console
 
 console = get_console()
 
-# Shared look for every interactive prompt: a green accent and no reverse-video
-# bar on the current row (prompt_toolkit's default "selected" style is reverse).
-PROMPT_STYLE = questionary.Style(
-    [
-        ("qmark", "fg:green bold"),
-        ("pointer", "fg:green bold"),
-        ("highlighted", "fg:green bold noreverse"),
-        ("selected", "fg:green noreverse"),
-        ("answer", "fg:green bold"),
-    ]
-)
+# Shared look for every interactive prompt: questionary's default colours, with a
+# green current/checked row and no reverse-video bar (prompt_toolkit defaults the
+# "selected" class to reverse, which draws the highlight box we don't want).
+PROMPT_STYLE = questionary.Style([("selected", "fg:green noreverse")])
 
 
 def ask_select(message: str, choices: List[Any], **kwargs: Any) -> Any:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 import httpx
+import questionary
 import toml
 import typer
 
@@ -554,16 +555,16 @@ def _choose_remote_owner(env_name: str, candidates: list[tuple[str, str]]) -> tu
         )
         return selected
 
-    console.print(f"[cyan]Multiple remote environments found for '{env_name}':[/cyan]")
-    for idx, (label, slug) in enumerate(candidates, start=1):
-        console.print(f"  [cyan]({idx})[/cyan] {slug} [dim]({label})[/dim]")
-
-    default_idx = 1
-    while True:
-        selection = typer.prompt("Select owner", type=int, default=default_idx)
-        if 1 <= selection <= len(candidates):
-            return candidates[selection - 1]
-        console.print(f"[red]Invalid selection.[/red] Enter 1-{len(candidates)}.")
+    selected = questionary.select(
+        f"Multiple remote environments found for '{env_name}' — choose owner",
+        choices=[
+            questionary.Choice(f"{slug} ({label})", value=(label, slug))
+            for label, slug in candidates
+        ],
+    ).ask()
+    if selected is None:
+        raise typer.Exit(1)
+    return selected
 
 
 def _resolve_environment_reference(env_reference: str, env_dir_path: str) -> ResolvedEnvironment:

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -24,6 +24,7 @@ from .client import APIClient, APIError
 from .utils.env_metadata import find_environment_metadata, get_environment_metadata
 from .utils.eval_push import push_eval_results_to_hub
 from .utils.plain import get_console
+from .utils.prompt import ask_select
 from .verifiers_plugin import PrimeVerifiersPlugin, load_verifiers_prime_plugin
 
 console = get_console()
@@ -555,13 +556,13 @@ def _choose_remote_owner(env_name: str, candidates: list[tuple[str, str]]) -> tu
         )
         return selected
 
-    selected = questionary.select(
+    selected = ask_select(
         f"Multiple remote environments found for '{env_name}' — choose owner",
-        choices=[
+        [
             questionary.Choice(f"{slug} ({label})", value=(label, slug))
             for label, slug in candidates
         ],
-    ).ask()
+    )
     if selected is None:
         raise typer.Exit(1)
     return selected

--- a/packages/prime/tests/conftest.py
+++ b/packages/prime/tests/conftest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from prompt_toolkit.application import create_app_session
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+
+class Keys:
+    """Queue keystrokes for questionary prompts driven inside a CliRunner invoke."""
+
+    DOWN = "\x1b[B"
+    UP = "\x1b[A"
+    ENTER = "\r"
+    SPACE = " "
+    ESC = "\x1b"
+    CTRL_C = "\x03"
+
+    def __init__(self, pipe: object) -> None:
+        self._pipe = pipe
+
+    def send(self, text: str) -> "Keys":
+        self._pipe.send_text(text)  # type: ignore[attr-defined]
+        return self
+
+    def text(self, value: str) -> "Keys":
+        return self.send(value + self.ENTER)
+
+    def confirm(self, yes: bool = True) -> "Keys":
+        return self.send(("y" if yes else "n") + self.ENTER)
+
+    def select(self, down: int = 0) -> "Keys":
+        return self.send(self.DOWN * down + self.ENTER)
+
+    def cancel(self) -> "Keys":
+        return self.send(self.CTRL_C)
+
+    def check(self, downs: list[int]) -> "Keys":
+        cursor = 0
+        for target in downs:
+            self.send(self.DOWN * (target - cursor) + self.SPACE)
+            cursor = target
+        return self.send(self.ENTER)
+
+
+@pytest.fixture
+def keys() -> Iterator[Keys]:
+    with create_pipe_input() as pipe:
+        with create_app_session(input=pipe, output=DummyOutput()):
+            yield Keys(pipe)

--- a/packages/prime/tests/test_agent_picker.py
+++ b/packages/prime/tests/test_agent_picker.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from prime_cli.agent_picker import select_agents
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+MENU = [
+    ("amp", "Amp Code", False),
+    ("claude", "Claude", True),
+    ("codex", "Codex", True),
+    ("cursor", "Cursor", False),
+    ("grok", "Grok Build", True),
+]
+
+DOWN = "\x1b[B"
+UP = "\x1b[A"
+SPACE = " "
+ENTER = "\r"
+CTRL_C = "\x03"
+
+
+def _pick(menu: list[tuple[str, str, bool]], default_index: int, keys: str) -> object:
+    with create_pipe_input() as pipe:
+        pipe.send_text(keys)
+        return select_agents(menu, default_index, input=pipe, output=DummyOutput())
+
+
+def test_confirm_returns_default_selection() -> None:
+    assert _pick(MENU, 2, ENTER) == ("codex",)
+
+
+def test_space_toggles_extra_agent() -> None:
+    assert _pick(MENU, 2, DOWN * 4 + SPACE + ENTER) == ("codex", "grok")
+
+
+def test_result_follows_menu_order_not_pick_order() -> None:
+    assert _pick(MENU, 4, DOWN + SPACE + ENTER) == ("claude", "grok")
+
+
+def test_can_deselect_default() -> None:
+    assert _pick(MENU, 2, DOWN * 2 + SPACE + UP + SPACE + ENTER) == ("claude",)
+
+
+def test_confirm_requires_at_least_one() -> None:
+    keys = DOWN * 2 + SPACE + ENTER + SPACE + ENTER
+    assert _pick(MENU, 2, keys) == ("codex",)
+
+
+def test_ctrl_c_cancels() -> None:
+    assert _pick(MENU, 2, CTRL_C) is None

--- a/packages/prime/tests/test_env_secret.py
+++ b/packages/prime/tests/test_env_secret.py
@@ -234,32 +234,29 @@ class TestEnvSecretCreate:
         assert output["name"] == "NEW_SECRET"
         assert "id" in output
 
-    def test_create_secret_interactive(self, mock_env_secret_api: None) -> None:
+    def test_create_secret_interactive(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test creating an env secret interactively."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "create", "testuser/test-env"],
-            input="MY_NEW_SECRET\nsecret-value\n",
-        )
+        keys.text("MY_NEW_SECRET").text("secret-value")
+        result = runner.invoke(app, ["env", "secret", "create", "testuser/test-env"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Created secret" in result.output
 
-    def test_create_secret_interactive_cancel_name(self, mock_env_secret_api: None) -> None:
+    def test_create_secret_interactive_cancel_name(
+        self, mock_env_secret_api: None, keys: Any
+    ) -> None:
         """Test that create can be cancelled during name prompt."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "create", "testuser/test-env"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["env", "secret", "create", "testuser/test-env"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_create_secret_interactive_cancel_value(self, mock_env_secret_api: None) -> None:
+    def test_create_secret_interactive_cancel_value(
+        self, mock_env_secret_api: None, keys: Any
+    ) -> None:
         """Test that create can be cancelled during value prompt."""
+        keys.send(keys.ENTER)
         result = runner.invoke(
-            app,
-            ["env", "secret", "create", "testuser/test-env", "-n", "NEW_SECRET"],
-            input="\n",
+            app, ["env", "secret", "create", "testuser/test-env", "-n", "NEW_SECRET"]
         )
         assert result.exit_code == 0
         assert "Cancelled" in result.output
@@ -370,34 +367,28 @@ class TestEnvSecretUpdate:
         output = json.loads(result.output)
         assert "id" in output
 
-    def test_update_secret_no_changes_cancel(self, mock_env_secret_api: None) -> None:
+    def test_update_secret_no_changes_cancel(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test that update with no changes and empty interactive input cancels."""
+        keys.send(keys.ENTER)
         result = runner.invoke(
-            app,
-            ["env", "secret", "update", "testuser/test-env", "--id", "esecret-id-001"],
-            input="\n",
+            app, ["env", "secret", "update", "testuser/test-env", "--id", "esecret-id-001"]
         )
         assert result.exit_code == 0
         assert "No changes made" in result.output
 
-    def test_update_secret_interactive_select(self, mock_env_secret_api: None) -> None:
+    def test_update_secret_interactive_select(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test interactive secret selection for update."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "update", "testuser/test-env"],
-            # Select item 1, then provide new value
-            input="1\nnew-secret-value\n",
-        )
+        keys.select(0).text("new-secret-value")
+        result = runner.invoke(app, ["env", "secret", "update", "testuser/test-env"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Updated secret" in result.output
 
-    def test_update_secret_interactive_cancel_selection(self, mock_env_secret_api: None) -> None:
+    def test_update_secret_interactive_cancel_selection(
+        self, mock_env_secret_api: None, keys: Any
+    ) -> None:
         """Test cancelling interactive selection for update."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "update", "testuser/test-env"],
-            input="\n",
-        )
+        keys.cancel()
+        result = runner.invoke(app, ["env", "secret", "update", "testuser/test-env"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
@@ -415,34 +406,28 @@ class TestEnvSecretDelete:
         assert "Deleted secret" in result.output
         assert "testuser/test-env" in result.output
 
-    def test_delete_secret_cancelled(self, mock_env_secret_api: None) -> None:
+    def test_delete_secret_cancelled(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test cancelling env secret deletion."""
+        keys.confirm(False)
         result = runner.invoke(
-            app,
-            ["env", "secret", "delete", "testuser/test-env", "--id", "esecret-id-001"],
-            input="n\n",
+            app, ["env", "secret", "delete", "testuser/test-env", "--id", "esecret-id-001"]
         )
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_delete_secret_interactive_select(self, mock_env_secret_api: None) -> None:
+    def test_delete_secret_interactive_select(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test interactive secret selection for delete."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "delete", "testuser/test-env"],
-            # Select item 1, then confirm
-            input="1\ny\n",
-        )
+        keys.select(0).confirm(True)
+        result = runner.invoke(app, ["env", "secret", "delete", "testuser/test-env"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Deleted secret" in result.output
 
-    def test_delete_secret_interactive_cancel_selection(self, mock_env_secret_api: None) -> None:
+    def test_delete_secret_interactive_cancel_selection(
+        self, mock_env_secret_api: None, keys: Any
+    ) -> None:
         """Test cancelling interactive selection for delete."""
-        result = runner.invoke(
-            app,
-            ["env", "secret", "delete", "testuser/test-env"],
-            input="\n",
-        )
+        keys.cancel()
+        result = runner.invoke(app, ["env", "secret", "delete", "testuser/test-env"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
@@ -514,22 +499,22 @@ class TestEnvSecretUnlink:
         assert "Unlinked global secret" in result.output
         assert "testuser/test-env" in result.output
 
-    def test_unlink_secret_cancelled(self, mock_env_secret_api: None) -> None:
+    def test_unlink_secret_cancelled(self, mock_env_secret_api: None, keys: Any) -> None:
         """Test cancelling unlink confirmation."""
+        keys.confirm(False)
         result = runner.invoke(
-            app,
-            ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"],
-            input="n\n",
+            app, ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"]
         )
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_unlink_secret_confirmed_interactively(self, mock_env_secret_api: None) -> None:
+    def test_unlink_secret_confirmed_interactively(
+        self, mock_env_secret_api: None, keys: Any
+    ) -> None:
         """Test confirming unlink interactively."""
+        keys.confirm(True)
         result = runner.invoke(
-            app,
-            ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"],
-            input="y\n",
+            app, ["env", "secret", "unlink", "global-secret-id-123", "testuser/test-env"]
         )
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Unlinked global secret" in result.output

--- a/packages/prime/tests/test_env_var.py
+++ b/packages/prime/tests/test_env_var.py
@@ -202,35 +202,28 @@ class TestEnvVarCreate:
         assert output["name"] == "NEW_VAR"
         assert "id" in output
 
-    def test_create_variable_interactive_cancel_name(self) -> None:
+    def test_create_variable_interactive_cancel_name(self, keys: Any) -> None:
         """Test that create can be cancelled during name prompt."""
-        result = runner.invoke(
-            app,
-            ["env", "var", "create", "testuser/test-env"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["env", "var", "create", "testuser/test-env"])
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_create_variable_interactive_cancel_value(self, mock_env_var_api: None) -> None:
+    def test_create_variable_interactive_cancel_value(
+        self, mock_env_var_api: None, keys: Any
+    ) -> None:
         """Test that create can be cancelled during value prompt."""
-        result = runner.invoke(
-            app,
-            ["env", "var", "create", "testuser/test-env", "-n", "NEW_VAR"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["env", "var", "create", "testuser/test-env", "-n", "NEW_VAR"])
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_create_variable_interactive(self, mock_env_var_api: None) -> None:
+    def test_create_variable_interactive(self, mock_env_var_api: None, keys: Any) -> None:
         """Test creating a variable interactively."""
-        result = runner.invoke(
-            app,
-            ["env", "var", "create", "testuser/test-env"],
-            input="NEW_VAR\nmy-value\n",
-        )
+        keys.text("NEW_VAR").text("my-value")
+        result = runner.invoke(app, ["env", "var", "create", "testuser/test-env"])
 
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Created variable 'NEW_VAR'" in result.output
@@ -415,23 +408,23 @@ class TestEnvVarDelete:
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Variable deleted" in result.output
 
-    def test_delete_variable_cancelled(self, mock_env_var_api: None) -> None:
+    def test_delete_variable_cancelled(self, mock_env_var_api: None, keys: Any) -> None:
         """Test cancelling variable deletion."""
+        keys.confirm(False)
         result = runner.invoke(
-            app,
-            ["env", "var", "delete", "var-id-1234567890", "testuser/test-env"],
-            input="n\n",
+            app, ["env", "var", "delete", "var-id-1234567890", "testuser/test-env"]
         )
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_delete_variable_confirmed_interactively(self, mock_env_var_api: None) -> None:
+    def test_delete_variable_confirmed_interactively(
+        self, mock_env_var_api: None, keys: Any
+    ) -> None:
         """Test confirming deletion interactively."""
+        keys.confirm(True)
         result = runner.invoke(
-            app,
-            ["env", "var", "delete", "var-id-1234567890", "testuser/test-env"],
-            input="y\n",
+            app, ["env", "var", "delete", "var-id-1234567890", "testuser/test-env"]
         )
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Variable deleted" in result.output

--- a/packages/prime/tests/test_feedback.py
+++ b/packages/prime/tests/test_feedback.py
@@ -32,8 +32,8 @@ def capture_feedback_post(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
 def test_feedback_submits_general_without_run_id(
     capture_feedback_post: Dict[str, Any], keys: Any
 ) -> None:
-    # general is the default choice; blank run id; then the message
-    keys.send(keys.ENTER).send(keys.ENTER).text("The CLI is great")
+    # move down to general (bug, feature, general); blank run id; then the message
+    keys.send(keys.DOWN + keys.DOWN + keys.ENTER).send(keys.ENTER).text("The CLI is great")
     result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
@@ -47,8 +47,8 @@ def test_feedback_submits_general_without_run_id(
 
 
 def test_feedback_submits_bug_with_run_id(capture_feedback_post: Dict[str, Any], keys: Any) -> None:
-    # move up from general to bug, then run id, then message
-    keys.send(keys.UP + keys.UP + keys.ENTER).text("run_abc123").text("Training crashed on step 42")
+    # bug is the first choice, then run id, then message
+    keys.send(keys.ENTER).text("run_abc123").text("Training crashed on step 42")
     result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
@@ -60,7 +60,9 @@ def test_feedback_submits_bug_with_run_id(capture_feedback_post: Dict[str, Any],
 
 def test_feedback_rejects_empty_message(capture_feedback_post: Dict[str, Any], keys: Any) -> None:
     # general, no run id, one empty message (re-prompted), then the real one
-    keys.send(keys.ENTER).send(keys.ENTER).send(keys.ENTER).text("Actually here is my feedback")
+    keys.send(keys.DOWN + keys.DOWN + keys.ENTER).send(keys.ENTER).send(keys.ENTER).text(
+        "Actually here is my feedback"
+    )
     result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output

--- a/packages/prime/tests/test_feedback.py
+++ b/packages/prime/tests/test_feedback.py
@@ -30,10 +30,11 @@ def capture_feedback_post(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
 
 
 def test_feedback_submits_general_without_run_id(
-    capture_feedback_post: Dict[str, Any],
+    capture_feedback_post: Dict[str, Any], keys: Any
 ) -> None:
-    # 3 = general, blank run id, message on final prompt
-    result = runner.invoke(app, ["feedback"], input="3\n\nThe CLI is great\n", env=TEST_ENV)
+    # general is the default choice; blank run id; then the message
+    keys.send(keys.ENTER).send(keys.ENTER).text("The CLI is great")
+    result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
     assert "Feedback submitted" in result.output
@@ -45,15 +46,10 @@ def test_feedback_submits_general_without_run_id(
     assert payload["cli_version"]
 
 
-def test_feedback_submits_bug_with_run_id(
-    capture_feedback_post: Dict[str, Any],
-) -> None:
-    result = runner.invoke(
-        app,
-        ["feedback"],
-        input="1\nrun_abc123\nTraining crashed on step 42\n",
-        env=TEST_ENV,
-    )
+def test_feedback_submits_bug_with_run_id(capture_feedback_post: Dict[str, Any], keys: Any) -> None:
+    # move up from general to bug, then run id, then message
+    keys.send(keys.UP + keys.UP + keys.ENTER).text("run_abc123").text("Training crashed on step 42")
+    result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
     payload = capture_feedback_post["json"]
@@ -62,18 +58,10 @@ def test_feedback_submits_bug_with_run_id(
     assert payload["message"] == "Training crashed on step 42"
 
 
-def test_feedback_rejects_empty_message(
-    capture_feedback_post: Dict[str, Any],
-) -> None:
-    # category general, no run id, empty message once, then real message
-    result = runner.invoke(
-        app,
-        ["feedback"],
-        input="3\n\n\nActually here is my feedback\n",
-        env=TEST_ENV,
-    )
+def test_feedback_rejects_empty_message(capture_feedback_post: Dict[str, Any], keys: Any) -> None:
+    # general, no run id, one empty message (re-prompted), then the real one
+    keys.send(keys.ENTER).send(keys.ENTER).send(keys.ENTER).text("Actually here is my feedback")
+    result = runner.invoke(app, ["feedback"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
-    # Two '> ' prompts prove the first empty attempt was re-prompted.
-    assert result.output.count("> ") >= 2
     assert capture_feedback_post["json"]["message"] == "Actually here is my feedback"

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -205,32 +205,26 @@ def test_lab_setup_prompts_for_agent_when_interactive(monkeypatch: Any) -> None:
         def isatty(self) -> bool:
             return True
 
-    answers = iter(("droid", "y", "amp-code,claude-code"))
     monkeypatch.setattr(lab_setup.sys, "stdin", FakeStdin())
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    monkeypatch.setattr(
+        lab_setup, "select_agents", lambda _menu, _default_index: ("droid", "amp", "claude")
+    )
 
     options = parse_lab_setup_args([])
 
     assert options.agents == ("droid", "amp", "claude")
 
 
-def test_lab_setup_interactive_agent_prompt_retries_invalid_input(
-    monkeypatch: Any,
-    capsys: Any,
-) -> None:
+def test_lab_setup_interactive_agent_selection_can_be_cancelled(monkeypatch: Any) -> None:
     class FakeStdin:
         def isatty(self) -> bool:
             return True
 
-    answers = iter(("codx", "droid", "y", "amp-code,codx", "amp-code,claude-code"))
     monkeypatch.setattr(lab_setup.sys, "stdin", FakeStdin())
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    monkeypatch.setattr(lab_setup, "select_agents", lambda _menu, _default_index: None)
 
-    options = parse_lab_setup_args([])
-
-    assert options.agents == ("droid", "amp", "claude")
-    output = capsys.readouterr().out
-    assert "Unsupported coding agent 'codx'" in output
+    with pytest.raises(ValueError, match="Agent selection was cancelled"):
+        parse_lab_setup_args([])
 
 
 def test_lab_setup_non_interactive_requires_explicit_agent(monkeypatch: Any) -> None:

--- a/packages/prime/tests/test_pods_create.py
+++ b/packages/prime/tests/test_pods_create.py
@@ -183,6 +183,7 @@ class TestPodsCreate:
         mock_pod_availability: None,
         tmp_path: Any,
         monkeypatch: pytest.MonkeyPatch,
+        keys: Any,
     ) -> None:
         config_dir = tmp_path / ".prime"
         config_dir.mkdir()
@@ -205,6 +206,7 @@ class TestPodsCreate:
             )
         )
 
+        monkeypatch.setattr("prime_cli.core.Config.user_id", "user-1")
         monkeypatch.setattr(
             "prime_cli.commands.pods.fetch_team_members",
             lambda _client, _team_id: [
@@ -231,6 +233,7 @@ class TestPodsCreate:
 
         monkeypatch.setattr("prime_cli.commands.pods.PodsClient.create", mock_create)
 
+        keys.check([1])  # index 0 is "Everyone"; check the single other member
         result = runner.invoke(
             app,
             [
@@ -253,7 +256,6 @@ class TestPodsCreate:
                 "--add-members",
                 "--yes",
             ],
-            input="1\n",
             env=TEST_ENV,
         )
 

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -681,7 +681,9 @@ def test_sandbox_delete_by_label_all_users_passes_admin_scope(
     assert "Processed 1 sandbox(es)" in output
 
 
-def test_sandbox_ssh_no_id_picks_running_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sandbox_ssh_no_id_picks_running_sandbox(
+    monkeypatch: pytest.MonkeyPatch, keys: Any
+) -> None:
     """`prime sandbox ssh` with no ID lists running, non-VM sandboxes to pick from.
 
     Selecting one feeds its ID into the rest of the flow; we stop the flow right
@@ -725,7 +727,8 @@ def test_sandbox_ssh_no_id_picks_running_sandbox(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.get", mock_get)
 
-    result = runner.invoke(app, ["sandbox", "ssh"], input="1\n")
+    keys.select(0)
+    result = runner.invoke(app, ["sandbox", "ssh"])
 
     output = strip_ansi(result.output)
     # Only RUNNING sandboxes are requested, and the VM one is filtered out of the picker.
@@ -775,7 +778,9 @@ def test_sandbox_ssh_no_id_no_running_sandboxes(monkeypatch: pytest.MonkeyPatch)
     assert result.exit_code == 0
 
 
-def test_sandbox_ssh_no_id_pages_through_results(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sandbox_ssh_no_id_pages_through_results(
+    monkeypatch: pytest.MonkeyPatch, keys: Any
+) -> None:
     """The picker pages past page 1, even when page 1 holds only VMs.
 
     Guards against reporting "no running sandboxes" when the only SSH-able
@@ -830,7 +835,8 @@ def test_sandbox_ssh_no_id_pages_through_results(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.get", mock_get)
 
-    result = runner.invoke(app, ["sandbox", "ssh"], input="1\n")
+    keys.select(0)
+    result = runner.invoke(app, ["sandbox", "ssh"])
 
     output = strip_ansi(result.output)
     assert captured["pages_requested"] == [1, 2]
@@ -839,8 +845,10 @@ def test_sandbox_ssh_no_id_pages_through_results(monkeypatch: pytest.MonkeyPatch
     assert result.exit_code == 1
 
 
-def test_sandbox_ssh_no_id_picker_paginates_display(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With >50 SSH-able sandboxes the picker shows 50 per page with next/prev nav."""
+def test_sandbox_ssh_no_id_picker_scrolls_long_list(
+    monkeypatch: pytest.MonkeyPatch, keys: Any
+) -> None:
+    """With many SSH-able sandboxes the picker scrolls and still selects any item."""
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     monkeypatch.setattr("prime_cli.commands.sandbox.shutil.which", lambda _: "/usr/bin/ssh")
@@ -868,12 +876,10 @@ def test_sandbox_ssh_no_id_picker_paginates_display(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.get", mock_get)
 
-    # Advance to page 2, then select item 51 (global numbering -> sbx-050).
-    result = runner.invoke(app, ["sandbox", "ssh"], input="n\n51\n")
+    # Scroll down to the 51st item (sbx-050) and select it.
+    keys.select(50)
+    result = runner.invoke(app, ["sandbox", "ssh"])
 
-    output = strip_ansi(result.output)
-    assert "page 1/2" in output
-    assert "page 2/2" in output
     assert captured["get_id"] == "sbx-050"
     assert result.exit_code == 1
 

--- a/packages/prime/tests/test_secrets.py
+++ b/packages/prime/tests/test_secrets.py
@@ -192,33 +192,26 @@ class TestSecretsCreate:
         assert output["name"] == "NEW_SECRET"
         assert "id" in output
 
-    def test_create_secret_interactive_cancel_name(self, mock_secrets_api: None) -> None:
+    def test_create_secret_interactive_cancel_name(self, mock_secrets_api: None, keys: Any) -> None:
         """Test that create can be cancelled during name prompt."""
-        result = runner.invoke(
-            app,
-            ["secret", "create"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["secret", "create"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
-    def test_create_secret_interactive(self, mock_secrets_api: None) -> None:
+    def test_create_secret_interactive(self, mock_secrets_api: None, keys: Any) -> None:
         """Test creating a secret interactively."""
-        result = runner.invoke(
-            app,
-            ["secret", "create"],
-            input="MY_NEW_SECRET\nsecret-value\n",
-        )
+        keys.text("MY_NEW_SECRET").text("secret-value")
+        result = runner.invoke(app, ["secret", "create"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Created personal secret" in result.output
 
-    def test_create_secret_interactive_cancel_value(self, mock_secrets_api: None) -> None:
+    def test_create_secret_interactive_cancel_value(
+        self, mock_secrets_api: None, keys: Any
+    ) -> None:
         """Test that create can be cancelled during value prompt."""
-        result = runner.invoke(
-            app,
-            ["secret", "create", "-n", "MY_SECRET"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["secret", "create", "-n", "MY_SECRET"])
         assert result.exit_code == 0
         assert "Cancelled" in result.output
 
@@ -309,23 +302,17 @@ class TestSecretsUpdate:
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Updated secret" in result.output
 
-    def test_update_secret_no_changes(self, mock_secrets_api: None) -> None:
+    def test_update_secret_no_changes(self, mock_secrets_api: None, keys: Any) -> None:
         """Test that update prompts when no changes are provided."""
-        result = runner.invoke(
-            app,
-            ["secret", "update", "secret-id-1234567890"],
-            input="\n",
-        )
+        keys.send(keys.ENTER)
+        result = runner.invoke(app, ["secret", "update", "secret-id-1234567890"])
         assert result.exit_code == 0
         assert "No changes made" in result.output
 
-    def test_update_secret_interactive(self, mock_secrets_api: None) -> None:
+    def test_update_secret_interactive(self, mock_secrets_api: None, keys: Any) -> None:
         """Test updating a secret interactively."""
-        result = runner.invoke(
-            app,
-            ["secret", "update", "secret-id-1234567890"],
-            input="new-secret-value\n",
-        )
+        keys.text("new-secret-value")
+        result = runner.invoke(app, ["secret", "update", "secret-id-1234567890"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Updated secret" in result.output
 
@@ -354,13 +341,10 @@ class TestSecretsDelete:
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Deleted secret" in result.output
 
-    def test_delete_secret_cancelled(self, mock_secrets_api: None) -> None:
+    def test_delete_secret_cancelled(self, mock_secrets_api: None, keys: Any) -> None:
         """Test cancelling secret deletion."""
-        result = runner.invoke(
-            app,
-            ["secret", "delete", "secret-id-1234567890"],
-            input="n\n",
-        )
+        keys.confirm(False)
+        result = runner.invoke(app, ["secret", "delete", "secret-id-1234567890"])
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
@@ -530,13 +514,10 @@ class TestSecretsTeamContext:
 class TestSecretsDeleteEdgeCases:
     """Additional edge case tests for delete."""
 
-    def test_delete_secret_confirmed_yes(self, mock_secrets_api: None) -> None:
+    def test_delete_secret_confirmed_yes(self, mock_secrets_api: None, keys: Any) -> None:
         """Test deleting a secret by confirming interactively."""
-        result = runner.invoke(
-            app,
-            ["secret", "delete", "secret-id-1234567890"],
-            input="y\n",
-        )
+        keys.confirm(True)
+        result = runner.invoke(app, ["secret", "delete", "secret-id-1234567890"])
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert "Deleted secret" in result.output
 

--- a/packages/prime/tests/test_switch.py
+++ b/packages/prime/tests/test_switch.py
@@ -148,52 +148,25 @@ class TestSwitchCommand:
         assert result.exit_code == 1, result.output
         assert "Team 'none' not found." in result.output
 
-    def test_switch_interactive_selection(self, temp_home: None, mock_teams_api: None) -> None:
-        result = runner.invoke(app, ["switch"], input="2\n", env=TEST_ENV)
+    def test_switch_interactive_selection(
+        self, temp_home: None, mock_teams_api: None, keys: Any
+    ) -> None:
+        keys.select(1)
+        result = runner.invoke(app, ["switch"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
-        assert "Switch account:" in result.output
-        assert "Prime Team (slug: prime, role: admin)" in result.output
         assert "Switched to team 'Prime Team'." in result.output
 
-    def test_switch_interactive_handles_missing_slug_without_double_current(
-        self, temp_home: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
-    ) -> None:
-        monkeypatch.setenv("PRIME_API_KEY", "test-key")
+    def test_account_choices_marks_current_team_without_slug(self) -> None:
+        from prime_cli.commands.switch import _account_choices
 
-        config_dir = tmp_path / ".prime"
-        config_dir.mkdir()
-        (config_dir / "environments").mkdir()
-        (config_dir / "config.json").write_text(
-            '{"api_key":"","team_id":"cmf0ohr9s0026ilerf3w68s6n","team_name":"New team","team_role":"ADMIN","user_id":null,"base_url":"https://api.primeintellect.ai","frontend_url":"https://app.primeintellect.ai","inference_url":"https://api.pinference.ai/api/v1","ssh_key_path":"~/.ssh/id_rsa","current_environment":"production"}'
-        )
+        teams = [{"teamId": "team-1", "name": "New team", "slug": None, "role": "ADMIN"}]
+        labels = [choice.title for choice in _account_choices(teams, "team-1")]
 
-        def mock_get(
-            self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
-        ) -> Dict[str, Any]:
-            if endpoint == "/user/teams":
-                return {
-                    "data": [
-                        {
-                            "teamId": "cmf0ohr9s0026ilerf3w68s6n",
-                            "name": "New team",
-                            "slug": None,
-                            "role": "ADMIN",
-                            "createdAt": "2026-01-15T10:00:00Z",
-                        }
-                    ]
-                }
-            return {"data": []}
-
-        monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
-        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
-
-        result = runner.invoke(app, ["switch"], input="1\n", env=TEST_ENV)
-
-        assert result.exit_code == 0, result.output
-        assert "Personal (current)" not in result.output
-        assert "New team (role: admin) (current)" in result.output
-        assert "slug:" not in result.output
+        assert "Personal" in labels
+        assert "Personal (current)" not in labels
+        assert "New team (role: admin) (current)" in labels
+        assert not any("slug:" in label for label in labels)
 
     def test_switch_fails_when_team_is_forced_by_environment(
         self, temp_home: None, mock_teams_api: None

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -65,7 +65,7 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert Path("rl.toml").exists()
 
 
-def test_train_request_submits_model_request(monkeypatch) -> None:
+def test_train_request_submits_model_request(monkeypatch, keys: Any) -> None:
     captured: dict[str, Any] = {}
 
     def mock_post(self: Any, endpoint: str, json: dict[str, Any] | None = None) -> dict:
@@ -75,10 +75,10 @@ def test_train_request_submits_model_request(monkeypatch) -> None:
 
     monkeypatch.setattr("prime_cli.client.APIClient.post", mock_post)
 
+    keys.text("openai/gpt-oss-120b, meta-llama/Llama-4").text("SFT distillation")
     result = runner.invoke(
         app,
         ["train", "request"],
-        input="openai/gpt-oss-120b, meta-llama/Llama-4\nSFT distillation\n",
         env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1355,6 +1355,7 @@ dependencies = [
     { name = "prime-tunnel" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "questionary" },
     { name = "rich" },
     { name = "textual" },
     { name = "textual-plot" },
@@ -1384,6 +1385,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
     { name = "textual", specifier = ">=6.1.0" },
@@ -1494,6 +1496,18 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.0.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
 
 [[package]]
 name = "propcache"
@@ -1975,6 +1989,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2062,7 +2088,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.8.dev57"
+version = "0.1.8.dev56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -2073,9 +2099,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/bd/7ab1762fd112e000903ede086a71828e34300f9b1f8090dddddc19f6e628/renderers-0.1.8.dev57.tar.gz", hash = "sha256:8d26839132308749df00a0e318b6978c476306d77ae6b219c14f2b7e24bfba6f", size = 342299, upload-time = "2026-07-10T20:12:47.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/56/faaf018d98e54d680c05ade7f44c2424e98d6bba66eb077aa64421f8dd64/renderers-0.1.8.dev56.tar.gz", hash = "sha256:a60db2b52d4e63b57bed5de9566509ca78ef969614c28060a19f25b608d7f62b", size = 337885, upload-time = "2026-07-08T02:55:58.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/39/af2d1379029271b999a12fa11dd7b3eab2454fed6439ed3c0e9915d66dea/renderers-0.1.8.dev57-py3-none-any.whl", hash = "sha256:a994af6bcf856b614f238016843b4ca709cac53e401dadba9b503d883ca67b90", size = 189335, upload-time = "2026-07-10T20:12:46.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/b0c19c0cbf9ca37393fa277572e42d1d7ec4be0b3e2dc1cc695e3bd23d4c/renderers-0.1.8.dev56-py3-none-any.whl", hash = "sha256:6c85817b09afea6e7300144612ad79a91a6d3cc0bc8c65ea5d10b6d3d3e949d8", size = 184721, upload-time = "2026-07-08T02:55:57.498Z" },
 ]
 
 [[package]]
@@ -2745,6 +2771,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a4/d5/b0ccd381d55c8f45d46f77df6ae59fbc23d19e901e2d523395598e5f4c93/virtualenv-20.35.3.tar.gz", hash = "sha256:4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44", size = 6002907, upload-time = "2025-10-10T21:23:33.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/73/d9a94da0e9d470a543c1b9d3ccbceb0f59455983088e727b8a1824ed90fb/virtualenv-20.35.3-py3-none-any.whl", hash = "sha256:63d106565078d8c8d0b206d48080f938a8b25361e19432d2c9db40d2899c810a", size = 5981061, upload-time = "2025-10-10T21:23:30.433Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The interactive prompts across the CLI are plain text today — type a number to pick from a numbered list, `y/N` to confirm, and so on. This swaps them for inline arrow-key prompts (via `questionary`), so choosing a coding agent, a team, a GPU config, or which teammates to share a pod with works the way people expect from a modern CLI: arrow keys to move, space to toggle in multi-selects, enter to confirm.

It started with `prime lab setup` — picking coding agents was the roughest spot, a flat comma-separated list where you had to type names — and once that was arrow-key driven the rest felt inconsistent, so I brought the whole CLI in line.

### What changed

- A small shared prompt layer in `utils/prompt.py` (`confirm`, `select_item_interactive` / `require_selection`, `prompt_for_value`) now backs onto questionary, so most commands pick it up for free.
- Lab agent picker: a checkbox list that shows each agent's install status; the first pick is treated as primary.
- The hand-rolled numbered menus become single-selects — team selection in `login` and `switch`, the `feedback` category, and the remote-owner picker in the verifiers bridge.
- Pod creation: GPU type / provider / configuration / image / node are selects, team members are a checkbox multi-select, and the disk/vCPU/memory prompts validate inline instead of erroring out and exiting.
- Confirmations and text/password prompts across `config`, `deployments`, `rl`, `logout`, `images`, `secrets`, `env`, and `sandbox`.
- Adds `questionary` to the dependencies.

### Testing

Interactive tests drive questionary through a prompt_toolkit pipe — there's a `keys` fixture in `tests/conftest.py` that queues keystrokes (`keys.select()`, `keys.confirm()`, `keys.text()`, `keys.check()`), so the existing `CliRunner` flows keep working without real TTY input.

The suite passes locally except for failures that predate this change and are unrelated to it — Unix-only `fcntl`, a few symlink/path assertions, and the textual TUI tests — all of which fail the same way on `main` on Windows.

## Before
<img width="1134" height="96" alt="image" src="https://github.com/user-attachments/assets/8283a91b-95da-4cff-b352-5219a756a5e9" />

## After
<img width="1011" height="296" alt="image" src="https://github.com/user-attachments/assets/7b09faf9-3f4d-499d-825d-62026f0f873a" />

## Before
<img width="568" height="210" alt="image" src="https://github.com/user-attachments/assets/90ed5fe8-26a1-47b6-a835-c06524d1cd05" />

## After
<img width="614" height="178" alt="image" src="https://github.com/user-attachments/assets/9e46a9f2-82a8-4309-af66-28e2617caa62" />

## Before
<img width="640" height="54" alt="image" src="https://github.com/user-attachments/assets/8e803ecd-5435-4b29-87a0-7b9b367faa2d" />


## After
<img width="666" height="59" alt="image" src="https://github.com/user-attachments/assets/145e31f6-1e39-4cce-a91b-1cddbcb5641c" />

## Before
<img width="599" height="85" alt="image" src="https://github.com/user-attachments/assets/1e29aabd-7c32-4c97-92eb-47049c31f985" />

## After
<img width="633" height="83" alt="image" src="https://github.com/user-attachments/assets/e67b633f-28ff-4f35-98d7-35f7d72ed6d7" />

## Before
<img width="572" height="333" alt="image" src="https://github.com/user-attachments/assets/f9fb40b0-3e20-4f23-87ca-a158e0c8daa0" />

## After
<img width="616" height="323" alt="image" src="https://github.com/user-attachments/assets/e62b7c52-c531-4f7d-8cb5-623fc64da571" />

