### PR TITLE
release: cli 0.6.18 + sandbox 0.2.31

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -54,7 +54,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.30"
+__version__ = "0.2.31"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.28",
+    "prime-sandboxes>=0.2.31",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.17"
+__version__ = "0.6.18"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## prime-sandboxes 0.2.30 → 0.2.31

- #781 adds manual VM image builds to the sync and async image clients.
- #781 supports sandboxes waiting on automatic first-use VM image conversion, including dedicated image-build timeout handling.

## prime 0.6.17 → 0.6.18

- #781 adds `prime images build-vm` and surfaces pending VM image builds during sandbox creation.
- #787 fixes resetting the configured inference URL.

Also bumps `prime-sandboxes>=0.2.28` → `>=0.2.31` in `packages/prime/pyproject.toml` so the new CLI code always installs with the required SDK APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no application logic changes in the diff.
> 
> **Overview**
> Release bump for **`prime`** **0.6.17 → 0.6.18** and **`prime-sandboxes`** **0.2.30 → 0.2.31**. The diff only updates `__version__` in each package and raises the CLI’s **`prime-sandboxes`** floor from **`>=0.2.28`** to **`>=0.2.31`** so installs pick up the sandbox SDK APIs this release depends on.
> 
> Per the release notes, **0.2.31** covers manual VM image builds on sync/async image clients and sandbox flows that wait on first-use VM conversion (including image-build timeout handling). **0.6.18** ships **`prime images build-vm`**, pending VM build UX during sandbox creation, and a fix for resetting the configured inference URL—those behaviors land in earlier merged work; this PR publishes the versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d79f401872169ff5d3068f24fbd9a3a6bda7c68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->