### PR TITLE
improvement: remove Dominik from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @JannikSt @d42me @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper
+* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper


### PR DESCRIPTION
- Removes @d42me from the default codeowners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to GitHub review routing; no application or runtime behavior is affected.
> 
> **Overview**
> Removes **@d42me** from the default `CODEOWNERS` entry (`*`), so that user is no longer automatically requested as a reviewer on all repository changes.
> 
> The remaining default owners are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d5521fe3f7e04afd830b562618fe9f210db291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->