### PR TITLE
fix(images): allow namespaced platform destinations in transfer-bulk

### DIFF
--- a/packages/prime/src/prime_cli/commands/images_transfer_bulk.py
+++ b/packages/prime/src/prime_cli/commands/images_transfer_bulk.py
@@ -91,8 +91,18 @@ class TransferSpec:
         return line
 
 
-def derive_transfer_destination(source_ref: str) -> tuple[str, str]:
-    """Derive the (name, tag) a transfer gets when no destination is given."""
+def derive_transfer_destination(
+    source_ref: str, *, keep_namespace: bool = False
+) -> tuple[str, str]:
+    """Derive the (name, tag) a transfer gets when no destination is given.
+
+    With ``keep_namespace`` (platform-image transfers) the name is the full
+    source path minus the registry host: org-less platform images carry the
+    Docker Hub namespace inside their name (docker.io/ns/app:v1 -> ns/app:v1),
+    which is how the backend stores them and how sandbox-create resolution and
+    auto-import match raw references. Otherwise only the last path segment is
+    kept, matching how the server derives personal/team destinations.
+    """
     ref = (source_ref or "").strip()
     if not ref:
         raise ValueError("empty image reference")
@@ -126,7 +136,7 @@ def derive_transfer_destination(source_ref: str) -> tuple[str, str]:
     if not repository:
         raise ValueError("missing repository")
 
-    name = repository.split("/")[-1].lower()
+    name = repository.lower() if keep_namespace else repository.split("/")[-1].lower()
     if tag is None:
         assert digest is not None
         tag = "sha256-" + digest.split(":", 1)[1][:16]
@@ -143,8 +153,14 @@ _DUPLICATE_DEST_HINT = (
 # ---------------------------------------------------------------------------
 
 
-def load_transfer_manifest(manifest_path: Path, default_platform: str) -> list[TransferSpec]:
-    """Parse and fully validate a JSONL transfer manifest."""
+def load_transfer_manifest(
+    manifest_path: Path, default_platform: str, *, platform_image: bool = False
+) -> list[TransferSpec]:
+    """Parse and fully validate a JSONL transfer manifest.
+
+    With ``platform_image``, destinations keep the source's registry namespace
+    and "image" overrides may be namespaced ('ns/name:tag').
+    """
     problems: list[str] = []
     specs: list[TransferSpec] = []
 
@@ -184,7 +200,9 @@ def load_transfer_manifest(manifest_path: Path, default_platform: str) -> list[T
             continue
 
         try:
-            derived_name, derived_tag = derive_transfer_destination(source)
+            derived_name, derived_tag = derive_transfer_destination(
+                source, keep_namespace=platform_image
+            )
         except ValueError as e:
             problems.append(f"{where}: invalid source '{source}' ({e})")
             continue
@@ -198,10 +216,17 @@ def load_transfer_manifest(manifest_path: Path, default_platform: str) -> list[T
                 dest_name, dest_tag = image.rsplit(":", 1)
             else:
                 dest_name, dest_tag = image, "latest"
-            if not dest_name or "/" in dest_name:
-                problems.append(
-                    f"{where}: invalid destination '{image}'; use simple names like 'myapp:v1'"
+            # '/' separates owner from name in personal/team image paths, so
+            # only platform images (org-less, stored under their Docker Hub
+            # namespace) may use a single-level namespace in the destination.
+            segments = dest_name.split("/")
+            if len(segments) > (2 if platform_image else 1) or not all(segments):
+                hint = (
+                    "use 'name:tag' or a namespaced 'ns/name:tag'"
+                    if platform_image
+                    else "use simple names like 'myapp:v1'"
                 )
+                problems.append(f"{where}: invalid destination '{image}'; {hint}")
                 continue
             if not _TAG_RE.match(dest_tag):
                 problems.append(f"{where}: invalid destination tag '{dest_tag}'")
@@ -236,7 +261,7 @@ def load_transfer_manifest(manifest_path: Path, default_platform: str) -> list[T
 
 
 def load_harbor_transfer_specs(
-    root: Path, *, platform: str
+    root: Path, *, platform: str, platform_image: bool = False
 ) -> tuple[list[TransferSpec], list[tuple[str, str]]]:
     """Resolve transfer specs from a Harbor tasks directory.
 
@@ -282,7 +307,9 @@ def load_harbor_transfer_specs(
         first_task_by_source[docker_image] = task_dir.name
 
         try:
-            dest_name, dest_tag = derive_transfer_destination(docker_image)
+            dest_name, dest_tag = derive_transfer_destination(
+                docker_image, keep_namespace=platform_image
+            )
         except ValueError as e:
             problems.append(f"{task_dir.name}: invalid docker_image '{docker_image}' ({e})")
             continue
@@ -321,6 +348,7 @@ def load_hf_specs(
     split: str,
     column: Optional[str],
     platform: str,
+    platform_image: bool = False,
 ) -> tuple[list[TransferSpec], list[str]]:
     """Resolve transfer specs from a Hugging Face dataset column.
 
@@ -366,7 +394,7 @@ def load_hf_specs(
     specs: list[TransferSpec] = []
     for ref, row_idx in sources:
         try:
-            dest_name, dest_tag = derive_transfer_destination(ref)
+            dest_name, dest_tag = derive_transfer_destination(ref, keep_namespace=platform_image)
         except ValueError as e:
             problems.append(f"{dataset_id} row {row_idx}: invalid image reference '{ref}' ({e})")
             continue
@@ -520,7 +548,10 @@ def transfer_bulk(
     platform_image: bool = typer.Option(
         False,
         "--platform-image",
-        help="Transfer org-less platform images (admins only; implies --public)",
+        help=(
+            "Transfer org-less platform images (admins only; implies --public; "
+            "destinations keep the source's registry namespace)"
+        ),
     ),
     concurrency: int = typer.Option(
         DEFAULT_MAX_IN_FLIGHT, "--concurrency", help="Maximum transfers in flight at once"
@@ -566,6 +597,10 @@ def transfer_bulk(
     \b
     Admins can pass --platform-image to transfer org-less public platform
     images, exactly like 'prime images push --source-image --platform-image'.
+    Platform destinations keep the source's registry namespace — the backend
+    stores platform images under their Docker Hub path, so
+    docker.io/ns/app:v1 lands as ns/app:v1 — and manifest "image" overrides
+    may be namespaced ('ns/name:tag').
 
     \b
     Examples:
@@ -607,7 +642,9 @@ def transfer_bulk(
                 if not manifest_path.is_file():
                     raise BulkPushValidationError([f"manifest not found: {manifest_path}"])
                 source_desc = f"manifest {manifest_path}"
-                specs = load_transfer_manifest(manifest_path, default_platform=platform)
+                specs = load_transfer_manifest(
+                    manifest_path, default_platform=platform, platform_image=platform_image
+                )
             elif harbor is not None:
                 harbor_root = harbor.resolve()
                 if not harbor_root.is_dir():
@@ -615,7 +652,9 @@ def transfer_bulk(
                         [f"Harbor task directory not found: {harbor_root}"]
                     )
                 source_desc = f"Harbor tasks in {harbor_root}"
-                specs, skipped = load_harbor_transfer_specs(harbor_root, platform=platform)
+                specs, skipped = load_harbor_transfer_specs(
+                    harbor_root, platform=platform, platform_image=platform_image
+                )
             else:
                 assert hf_dataset is not None
                 source_desc = f"Hugging Face dataset {normalize_hf_dataset_id(hf_dataset)}"
@@ -626,6 +665,7 @@ def transfer_bulk(
                     split=hf_split,
                     column=column,
                     platform=platform,
+                    platform_image=platform_image,
                 )
         except BulkPushValidationError as e:
             console.print(

--- a/packages/prime/tests/test_images_transfer_bulk.py
+++ b/packages/prime/tests/test_images_transfer_bulk.py
@@ -186,6 +186,21 @@ def test_derive_destination_matches_server_rules():
         derive_transfer_destination("a/app:v1,b/app:v2")
 
 
+def test_derive_destination_keeps_namespace_for_platform_images():
+    # Platform images are stored under their Docker Hub path: only the
+    # registry host is stripped, the namespace stays in the name.
+    assert derive_transfer_destination("docker.io/ns/app:v1", keep_namespace=True) == (
+        "ns/app",
+        "v1",
+    )
+    assert derive_transfer_destination("ns/app", keep_namespace=True) == ("ns/app", "latest")
+    assert derive_transfer_destination("ubuntu", keep_namespace=True) == ("ubuntu", "latest")
+    assert derive_transfer_destination("ghcr.io/Org/My-App:v1", keep_namespace=True) == (
+        "org/my-app",
+        "v1",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Manifest mode
 # ---------------------------------------------------------------------------
@@ -700,6 +715,118 @@ def test_platform_image_rejects_private(tmp_path, fake_api):
     assert result.exit_code == 1
     assert "Platform images must be public" in result.output
     assert fake_api.post_build_count() == 0
+
+
+def test_platform_image_derives_namespaced_destinations(tmp_path, fake_api):
+    manifest = tmp_path / "transfers.jsonl"
+    # Same trailing name from two namespaces: distinct destinations in
+    # platform mode, so no duplicate-destination problem.
+    _write_manifest(
+        manifest,
+        [{"source": "docker.io/a/app:v2"}, {"source": "b/app:v2"}],
+    )
+    result = runner.invoke(
+        app,
+        ["images", "transfer-bulk", "--manifest", str(manifest), "--platform-image", "--dry-run"],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+    assert "a/app:v2" in result.output
+    assert "b/app:v2" in result.output
+
+    result = runner.invoke(
+        app,
+        ["images", "transfer-bulk", "--manifest", str(manifest), "--platform-image"],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+    assert fake_api.post_build_count() == 2
+    # Derived destinations are display-only; the server derives its own.
+    assert all("image_name" not in p for p in fake_api.payloads)
+
+
+def test_platform_image_accepts_namespaced_destination_override(tmp_path, fake_api):
+    manifest = tmp_path / "transfers.jsonl"
+    _write_manifest(
+        manifest,
+        [{"source": "ghcr.io/org/app:v1", "image": "ns/app:v1"}],
+    )
+    result = runner.invoke(
+        app,
+        ["images", "transfer-bulk", "--manifest", str(manifest), "--platform-image"],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+    assert fake_api.payloads[0]["image_name"] == "ns/app"
+    assert fake_api.payloads[0]["image_tag"] == "v1"
+    assert fake_api.payloads[0]["owner_scope"] == "platform"
+
+
+def test_platform_image_rejects_multi_level_destination_override(tmp_path, fake_api):
+    manifest = tmp_path / "transfers.jsonl"
+    _write_manifest(
+        manifest,
+        [{"source": "ghcr.io/org/app:v1", "image": "a/b/app:v1"}],
+    )
+    result = runner.invoke(
+        app,
+        ["images", "transfer-bulk", "--manifest", str(manifest), "--platform-image"],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 1
+    assert "invalid destination 'a/b/app:v1'" in result.output
+    assert "use 'name:tag' or a namespaced 'ns/name:tag'" in result.output
+    assert fake_api.post_build_count() == 0
+
+
+def test_namespaced_destination_override_still_rejected_without_platform_image(tmp_path, fake_api):
+    manifest = tmp_path / "transfers.jsonl"
+    _write_manifest(
+        manifest,
+        [{"source": "ghcr.io/org/app:v1", "image": "ns/app:v1"}],
+    )
+    result = runner.invoke(
+        app, ["images", "transfer-bulk", "--manifest", str(manifest)], env=TEST_ENV
+    )
+    assert result.exit_code == 1
+    assert "invalid destination 'ns/app:v1'" in result.output
+    assert "use simple names like 'myapp:v1'" in result.output
+    assert fake_api.post_build_count() == 0
+
+
+def test_platform_image_keeps_namespace_in_harbor_and_hf_modes(tmp_path, fake_api, monkeypatch):
+    root = tmp_path / "tasks"
+    _make_harbor_task(root, "task-a", docker_image="ghcr.io/org/img-a:v1")
+    result = runner.invoke(
+        app,
+        ["images", "transfer-bulk", "--harbor", str(root), "--platform-image", "--dry-run"],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+    assert "org/img-a:v1" in result.output
+
+    _fake_hf(
+        monkeypatch,
+        info=HF_INFO_ONE_CONFIG,
+        pages={0: ["docker.io/ns/img-b:v1"]},
+        total=1,
+    )
+    result = runner.invoke(
+        app,
+        [
+            "images",
+            "transfer-bulk",
+            "--hf",
+            "org/ds",
+            "--column",
+            "docker_image",
+            "--platform-image",
+            "--dry-run",
+        ],
+        env=TEST_ENV,
+    )
+    assert result.exit_code == 0, result.output
+    assert "ns/img-b:v1" in result.output
 
 
 def test_platform_image_ignores_team_context(tmp_path, fake_api):


### PR DESCRIPTION
## Problem

`prime images transfer-bulk --platform-image` (admin-only) could not land an image under its canonical Docker Hub path:

1. **Destination validation** rejected any `/` in a user-supplied `"image"` override (`invalid destination ...; use simple names like 'myapp:v1'`).
2. **`derive_transfer_destination`** stripped the namespace from the source, so `docker.io/ns/app:v1` derived to `app:v1`.

This is a backend-vs-CLI asymmetry: org-less platform images **must** carry the Hub namespace inside `imageName` — that is how the backend stores them, and how sandbox-create resolution and auto-import match raw references (e.g. `imageName` `swerebenchv2/foo`). The single-image path already allows this (`prime images push --source-image --platform-image` skips the `/` check), but the bulk command applied the personal/team rules unconditionally. For personal/team images the strict rule is correct, since `/` is the owner separator in the full image path there.

## Fix

When `--platform-image` is set:

- Derived destinations keep the full source path minus the registry host (`docker.io/ns/app:v1` → `ns/app:v1`), in all three modes (`--manifest`, `--harbor`, `--hf`).
- Manifest `"image"` overrides may use a single-level namespace (`ns/name:tag`); multi-level paths are still rejected.

Personal/team (non-platform) validation is byte-for-byte unchanged. Command help text and the validation error message updated accordingly.

## Testing

- New unit tests for `keep_namespace` derivation.
- New CLI tests: namespaced overrides accepted under `--platform-image`, multi-level rejected, non-platform `/` rejection unchanged, namespace preservation in Harbor/HF modes, and namespace-distinct sources no longer colliding as duplicate destinations.
- `uv run pytest packages/prime/tests`: 942 passed, 5 skipped. `ruff check`/`ruff format --check`/`ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)