### PR TITLE
ENG-4283: --gpu-type flag for hosted full-FT dispatch

### DIFF
--- a/packages/prime/src/prime_cli/api/training.py
+++ b/packages/prime/src/prime_cli/api/training.py
@@ -6,7 +6,7 @@ own helm release on a registered PrimeCluster. Auth is the standard API
 token; admin role is gated server-side.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -18,14 +18,6 @@ class HostedTrainingRunResponse(BaseModel):
 
     run_id: str = Field(..., alias="runId")
     token_value: str = Field(..., alias="tokenValue")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class AvailableGpuTypesResponse(BaseModel):
-    """Response from GET /v1/training/available-gpu-types."""
-
-    gpu_types: List[str] = Field(default_factory=list, alias="gpuTypes")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -58,18 +50,6 @@ class HostedTrainingClient:
         """
         response = self.client.request("DELETE", f"/training/runs/{run_id}")
         return response if isinstance(response, dict) else {"runId": run_id}
-
-    def list_available_gpu_types(self, team_id: Optional[str] = None) -> AvailableGpuTypesResponse:
-        """GET /v1/training/available-gpu-types. Distinct GPU types the
-        caller could dispatch a dedicated FFT run on. Same principal
-        collapse as the dispatch picker: `team_id` wins when set,
-        otherwise the caller's personal allocations.
-        """
-        params: Dict[str, Any] = {}
-        if team_id:
-            params["team_id"] = team_id
-        response = self.client.get("/training/available-gpu-types", params=params)
-        return AvailableGpuTypesResponse.model_validate(response)
 
 
 def build_payload_from_toml(

--- a/packages/prime/src/prime_cli/api/training.py
+++ b/packages/prime/src/prime_cli/api/training.py
@@ -60,6 +60,7 @@ def build_payload_from_toml(
     image_tag: Optional[str] = None,
     wandb_api_key: Optional[str] = None,
     hf_token: Optional[str] = None,
+    gpu_type: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the /v1/training/runs payload from a prime-rl-style TOML dict.
 
@@ -67,14 +68,17 @@ def build_payload_from_toml(
     per-component (trainer / orchestrator / inference) and bake each
     into the corresponding pod's startup command. Anything outside the
     handful of platform-authoritative overlays (chart-side scrape ports,
-    monitor URL, secret name) flows through unchanged — same e2e
+    monitor URL, secret name) flows through unchanged - same e2e
     behaviour as `uv run rl @ rl.toml`.
 
     What stays out of `config`:
       - secrets (wandb / hf): materialised into a per-run k8s Secret,
       - run name: lives on the platform's RFTRun row, not the TOML,
       - team_id: links the RFTRun to a team for billing/access scoping,
-      - image_tag: chart-level (which prime-rl image to pull).
+      - image_tag: chart-level (which prime-rl image to pull),
+      - gpu_type: narrows the backend picker to clusters with matching
+        PrimeCluster.gpuType (e.g. "H200_141GB"); omit for the default
+        auto-pick with no type preference.
 
     Cluster targeting is backend-side (auto-pick first uncordoned).
     """
@@ -89,4 +93,6 @@ def build_payload_from_toml(
         payload["wandbApiKey"] = wandb_api_key
     if hf_token:
         payload["hfToken"] = hf_token
+    if gpu_type:
+        payload["gpuType"] = gpu_type
     return payload

--- a/packages/prime/src/prime_cli/api/training.py
+++ b/packages/prime/src/prime_cli/api/training.py
@@ -6,7 +6,7 @@ own helm release on a registered PrimeCluster. Auth is the standard API
 token; admin role is gated server-side.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -18,6 +18,14 @@ class HostedTrainingRunResponse(BaseModel):
 
     run_id: str = Field(..., alias="runId")
     token_value: str = Field(..., alias="tokenValue")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AvailableGpuTypesResponse(BaseModel):
+    """Response from GET /v1/training/available-gpu-types."""
+
+    gpu_types: List[str] = Field(default_factory=list, alias="gpuTypes")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -50,6 +58,18 @@ class HostedTrainingClient:
         """
         response = self.client.request("DELETE", f"/training/runs/{run_id}")
         return response if isinstance(response, dict) else {"runId": run_id}
+
+    def list_available_gpu_types(self, team_id: Optional[str] = None) -> AvailableGpuTypesResponse:
+        """GET /v1/training/available-gpu-types. Distinct GPU types the
+        caller could dispatch a dedicated FFT run on. Same principal
+        collapse as the dispatch picker: `team_id` wins when set,
+        otherwise the caller's personal allocations.
+        """
+        params: Dict[str, Any] = {}
+        if team_id:
+            params["team_id"] = team_id
+        response = self.client.get("/training/available-gpu-types", params=params)
+        return AvailableGpuTypesResponse.model_validate(response)
 
 
 def build_payload_from_toml(

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1320,6 +1320,18 @@ def create_run(
         )
         return
 
+    # --gpu-type is full-FT only. The LoRA path below never reads it, so
+    # silently letting the flag through would launch a run with the GPU
+    # constraint dropped - misleading for a knob that affects expensive
+    # hardware placement. Reject explicitly.
+    if gpu_type or raw_cfg.get("gpu_type") is not None:
+        console.print(
+            "[red]Error:[/red] --gpu-type (and top-level `gpu_type` in the "
+            "TOML) is only supported for full-FT runs. Drop the flag or use "
+            "a full-FT config."
+        )
+        raise typer.Exit(1)
+
     console.print(f"[dim]Loading config from {config_path}[/dim]\n")
     cfg = load_config(config_path)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -919,6 +919,7 @@ def _dispatch_full_finetune_run(
     output: str,
     yes: bool,
     image_tag: Optional[str] = None,
+    gpu_type: Optional[str] = None,
 ) -> None:
     """Hand off to /api/v1/training/runs (full-FT prime-rl on a registered
     PrimeCluster). Reuses the shared env-file plumbing for WANDB / HF
@@ -1012,6 +1013,20 @@ def _dispatch_full_finetune_run(
         raise typer.Exit(1)
     resolved_image_tag = image_tag or config_image_tag
 
+    # `gpu_type` is request-level (narrows the backend cluster picker to
+    # PrimeClusters with matching gpuType), not prime-rl config. Two ways
+    # to set it: `--gpu-type` (CLI flag) or top-level `gpu_type = "..."`
+    # in the TOML. CLI flag wins. Falling through to None keeps today's
+    # "no preference, backend auto-picks" behaviour.
+    config_gpu_type = raw_cfg.get("gpu_type")
+    if config_gpu_type is not None and not isinstance(config_gpu_type, str):
+        console.print(
+            f"[red]Error:[/red] gpu_type in {config_path} must be a string, "
+            f"got {type(config_gpu_type).__name__}."
+        )
+        raise typer.Exit(1)
+    resolved_gpu_type = gpu_type or config_gpu_type
+
     # Same deprecation pass as the LoRA path. In the prime-rl-native shape
     # the deprecated keys live one level down, under `[orchestrator]` — and
     # this config ships verbatim to the dedicated training endpoint, where
@@ -1029,7 +1044,9 @@ def _dispatch_full_finetune_run(
     # phantom paths. `image_tag` is similarly chart-level — the backend
     # parses it off the request body, not the embedded prime-rl config.
     config_payload = {
-        k: v for k, v in raw_cfg.items() if k not in ("env_file", "env_files", "image_tag")
+        k: v
+        for k, v in raw_cfg.items()
+        if k not in ("env_file", "env_files", "image_tag", "gpu_type")
     }
 
     payload = build_payload_from_toml(
@@ -1039,6 +1056,7 @@ def _dispatch_full_finetune_run(
         image_tag=resolved_image_tag,
         wandb_api_key=secrets.get("WANDB_API_KEY"),
         hf_token=secrets.get("HF_TOKEN"),
+        gpu_type=resolved_gpu_type,
     )
 
     # `--output json` is a formatting switch: still dispatch the run,
@@ -1262,6 +1280,17 @@ def create_run(
             "if unset, then to the backend default."
         ),
     ),
+    gpu_type: Optional[str] = typer.Option(
+        None,
+        "--gpu-type",
+        help=(
+            "GPU type to dispatch on (full-FT only, e.g. 'H200_141GB', "
+            "'B200_180GB'). Narrows the backend cluster picker to "
+            "PrimeClusters with matching gpuType. Falls back to a top-level "
+            '`gpu_type = "..."` in the TOML if unset, then to the backend '
+            "default (no preference, auto-pick)."
+        ),
+    ),
 ) -> None:
     """Launch a Hosted Training run from a config file.
 
@@ -1287,6 +1316,7 @@ def create_run(
             output=output,
             yes=yes,
             image_tag=image_tag,
+            gpu_type=gpu_type,
         )
         return
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1755,17 +1755,13 @@ def list_gpus(
 
     if not response.gpu_types:
         console.print(
-            "[yellow]No GPU types available.[/yellow] "
-            "Your account has no ClusterAllocation on any live PrimeCluster - "
-            "ask an admin to assign one before dispatching a full-FT run."
+            "[yellow]No GPU types available.[/yellow] Contact support if you need access."
         )
         return
 
-    table = Table(title="Available GPU types (full-FT dispatch)")
-    table.add_column("gpu_type", style="cyan")
+    console.print("[bold]Available GPU types[/bold] [dim](full-FT dispatch)[/dim]")
     for gpu_type in response.gpu_types:
-        table.add_row(gpu_type)
-    console.print(table)
+        console.print(f"  [cyan]{gpu_type}[/cyan]")
 
 
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1726,6 +1726,48 @@ def list_models(
         raise typer.Exit(1)
 
 
+@app.command("available-gpu-types", rich_help_panel="Commands")
+def available_gpu_types(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List GPU types you can dispatch a full-FT run on.
+
+    Uses the same principal collapse as dispatch: your active team from
+    `prime config` when set, otherwise personal allocations. Pass any of
+    these to `prime train run --gpu-type <value>` to steer dispatch.
+    """
+    from ..api.training import HostedTrainingClient
+
+    validate_output_format(output, console)
+
+    try:
+        api_client = APIClient()
+        client = HostedTrainingClient(api_client)
+        config = Config()
+        response = client.list_available_gpu_types(team_id=config.team_id)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if output == "json":
+        output_data_as_json({"gpuTypes": response.gpu_types}, console)
+        return
+
+    if not response.gpu_types:
+        console.print(
+            "[yellow]No GPU types available.[/yellow] "
+            "Your account has no ClusterAllocation on any live PrimeCluster - "
+            "ask an admin to assign one before dispatching a full-FT run."
+        )
+        return
+
+    table = Table(title="Available GPU types (full-FT dispatch)")
+    table.add_column("gpu_type", style="cyan")
+    for gpu_type in response.gpu_types:
+        table.add_row(gpu_type)
+    console.print(table)
+
+
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
     console.print(f"\n[bold]{label}[/bold] [dim](required)[/dim]")
     console.print(f"[dim]{help_text}[/dim]")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1726,48 +1726,6 @@ def list_models(
         raise typer.Exit(1)
 
 
-@app.command("available-gpu-types", rich_help_panel="Commands")
-def available_gpu_types(
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """List GPU types you can dispatch a full-FT run on.
-
-    Uses the same principal collapse as dispatch: your active team from
-    `prime config` when set, otherwise personal allocations. Pass any of
-    these to `prime train run --gpu-type <value>` to steer dispatch.
-    """
-    from ..api.training import HostedTrainingClient
-
-    validate_output_format(output, console)
-
-    try:
-        api_client = APIClient()
-        client = HostedTrainingClient(api_client)
-        config = Config()
-        response = client.list_available_gpu_types(team_id=config.team_id)
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-
-    if output == "json":
-        output_data_as_json({"gpuTypes": response.gpu_types}, console)
-        return
-
-    if not response.gpu_types:
-        console.print(
-            "[yellow]No GPU types available.[/yellow] "
-            "Your account has no ClusterAllocation on any live PrimeCluster - "
-            "ask an admin to assign one before dispatching a full-FT run."
-        )
-        return
-
-    table = Table(title="Available GPU types (full-FT dispatch)")
-    table.add_column("gpu_type", style="cyan")
-    for gpu_type in response.gpu_types:
-        table.add_row(gpu_type)
-    console.print(table)
-
-
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
     console.print(f"\n[bold]{label}[/bold] [dim](required)[/dim]")
     console.print(f"[dim]{help_text}[/dim]")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1726,6 +1726,48 @@ def list_models(
         raise typer.Exit(1)
 
 
+@app.command("gpus", rich_help_panel="Commands")
+def list_gpus(
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List GPU types you can dispatch a full-FT run on.
+
+    Uses the active team from `prime config` when set, otherwise your
+    personal allocations. Pass any value to `prime train run
+    --gpu-type <value>` to steer dispatch.
+    """
+    from ..api.training import HostedTrainingClient
+
+    validate_output_format(output, console)
+
+    try:
+        api_client = APIClient()
+        client = HostedTrainingClient(api_client)
+        config = Config()
+        response = client.list_available_gpu_types(team_id=config.team_id)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if output == "json":
+        output_data_as_json({"gpuTypes": response.gpu_types}, console)
+        return
+
+    if not response.gpu_types:
+        console.print(
+            "[yellow]No GPU types available.[/yellow] "
+            "Your account has no ClusterAllocation on any live PrimeCluster - "
+            "ask an admin to assign one before dispatching a full-FT run."
+        )
+        return
+
+    table = Table(title="Available GPU types (full-FT dispatch)")
+    table.add_column("gpu_type", style="cyan")
+    for gpu_type in response.gpu_types:
+        table.add_row(gpu_type)
+    console.print(table)
+
+
 def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
     console.print(f"\n[bold]{label}[/bold] [dim](required)[/dim]")
     console.print(f"[dim]{help_text}[/dim]")

--- a/uv.lock
+++ b/uv.lock
@@ -12,10 +12,12 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-prime-tunnel = false
-prime-sandboxes = false
 verifiers = false
 tasksets = false
+prime-pydantic-config = "2099-12-31T23:00:00Z"
+prime-tunnel = false
+prime-sandboxes = false
+renderers = "2099-12-31T23:00:00Z"
 harnesses = false
 prime-evals = false
 prime = false

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,10 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-verifiers = false
-tasksets = false
-prime-pydantic-config = "2099-12-31T23:00:00Z"
 prime-tunnel = false
 prime-sandboxes = false
-renderers = "2099-12-31T23:00:00Z"
+verifiers = false
+tasksets = false
 harnesses = false
 prime-evals = false
 prime = false


### PR DESCRIPTION
Adds a `--gpu-type` flag to `prime train run` so hosted full-FT dispatch can steer to a specific GPU type. Pairs with platform PR [PrimeIntellect-ai/platform#3554](https://github.com/PrimeIntellect-ai/platform/pull/3554). Closes [ENG-4283](https://linear.app/primeintellect/issue/ENG-4283) on the CLI side.

- `--gpu-type H200_141GB` on `prime train run` (or top-level `gpu_type = "H200_141GB"` in the TOML) narrows the backend picker to matching `PrimeCluster.gpuType`.
- CLI flag wins over TOML; omitting both keeps today's auto-pick.
- `gpu_type` is stripped from the shipped TOML (request-level, not prime-rl config) alongside `image_tag`.
- Small `uv.lock` reorder from the `ty` pre-commit hook resync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where full-FT runs land on cluster hardware; defaults preserve auto-pick, but wrong GPU type values could fail dispatch or pick no cluster until the backend responds.
> 
> **Overview**
> Adds **GPU-type steering** for hosted full-parameter training: `prime train run` accepts `--gpu-type` (or top-level `gpu_type` in the TOML; the flag wins) and sends it as request-level `gpuType` on `POST /v1/training/runs`, without embedding it in the shipped prime-rl config (stripped like `image_tag`).
> 
> Introduces **`prime train gpus`** to call `GET /v1/training/available-gpu-types` (scoped by active team from `prime config` when set) and list dispatchable GPU type strings in table or JSON.
> 
> On the **LoRA path**, `--gpu-type` or TOML `gpu_type` now **errors explicitly** so placement constraints are not silently ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e6f91efda255c16aa836d4004685c2fc0f4c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->