### PR TITLE
feat(images): expose platform VM artifact builds

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/images.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/images.py
@@ -63,9 +63,12 @@ class ImageClient:
         image_tag: str,
         *,
         team_id: Optional[str] = None,
+        owner_scope: Optional[Literal["platform"]] = None,
     ) -> dict:
         """Build a VM image from an existing container image."""
         payload = {"teamId": team_id} if team_id else {}
+        if owner_scope:
+            payload["ownerScope"] = owner_scope
         return self.client.request(
             "POST",
             f"/images/{image_name}/{image_tag}/vm-build",
@@ -137,9 +140,12 @@ class AsyncImageClient:
         image_tag: str,
         *,
         team_id: Optional[str] = None,
+        owner_scope: Optional[Literal["platform"]] = None,
     ) -> dict:
         """Build a VM image from an existing container image."""
         payload = {"teamId": team_id} if team_id else {}
+        if owner_scope:
+            payload["ownerScope"] = owner_scope
         return await self.client.request(
             "POST",
             f"/images/{image_name}/{image_tag}/vm-build",

--- a/packages/prime-sandboxes/tests/test_images_client.py
+++ b/packages/prime-sandboxes/tests/test_images_client.py
@@ -204,6 +204,24 @@ def test_image_client_transfer_image_accepts_bulk_transfer_response():
     assert response.failed[0].error == "source image not found"
 
 
+def test_image_client_build_vm_image_accepts_platform_owner_scope():
+    captured: dict[str, Any] = {}
+    client = ImageClient(DummyAPIClient({"buildId": "build-123"}, captured))
+
+    response = client.build_vm_image(
+        "org/ubuntu",
+        "22.04",
+        owner_scope="platform",
+    )
+
+    assert captured == {
+        "method": "POST",
+        "path": "/images/org/ubuntu/22.04/vm-build",
+        "json": {"ownerScope": "platform"},
+    }
+    assert response == {"buildId": "build-123"}
+
+
 class DummyAsyncAPIClient:
     def __init__(self, response: dict[str, Any], captured: dict[str, Any] | None = None) -> None:
         self.response = response
@@ -221,6 +239,28 @@ class DummyAsyncAPIClient:
             self.captured["path"] = path
             self.captured["json"] = json
         return self.response
+
+
+def test_async_image_client_build_vm_image_accepts_platform_owner_scope():
+    import asyncio
+
+    captured: dict[str, Any] = {}
+    client = AsyncImageClient(DummyAsyncAPIClient({"buildId": "build-123"}, captured))  # type: ignore[arg-type]
+
+    response = asyncio.run(
+        client.build_vm_image(
+            "org/ubuntu",
+            "22.04",
+            owner_scope="platform",
+        )
+    )
+
+    assert captured == {
+        "method": "POST",
+        "path": "/images/org/ubuntu/22.04/vm-build",
+        "json": {"ownerScope": "platform"},
+    }
+    assert response == {"buildId": "build-123"}
 
 
 def _update_images_response(reference: str) -> dict[str, Any]:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -773,23 +773,36 @@ def build_vm_image(
             "'prime/team-{teamId}/myapp:v1.0.0')"
         ),
     ),
+    platform_image: bool = typer.Option(
+        False,
+        "--platform-image",
+        help="Build the VM artifact for an org-less platform image (admins only)",
+    ),
 ):
     """
     Build a VM image from an existing container image.
 
-    Requires VM sandboxes to be enabled for your account and a linux/amd64
-    image. For team images, only the image creator or team admins can
-    trigger this. Track progress with 'prime images list'.
+    Requires a linux/amd64 image. Personal and team builds require VM
+    sandboxes to be enabled for the owning account. For team images, only
+    the image creator or team admins can trigger this. Platform images
+    require a platform admin with sandboxes:update permission.
 
     \b
     Examples:
         prime images build-vm myapp:v1.0.0
         prime images build-vm prime/alice/myapp:v1.0.0
         prime images build-vm prime/team-abc123/myapp:v1.0.0
+        prime images build-vm ubuntu:22.04 --platform-image
     """
     try:
-        image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
+        if platform_image:
+            image_name, image_tag = _parse_platform_image_reference(image_reference)
+            team_id = None
+        else:
+            image_name, image_tag, team_id = _parse_mutable_image_reference(image_reference)
         payload: dict[str, str] = {"teamId": team_id} if team_id else {}
+        if platform_image:
+            payload["ownerScope"] = "platform"
 
         client = APIClient()
         response = client.request(
@@ -798,14 +811,20 @@ def build_vm_image(
             json=payload,
         )
 
-        context = f" (team: {team_id})" if team_id else ""
+        if platform_image:
+            context = " (platform)"
+        else:
+            context = f" (team: {team_id})" if team_id else ""
         console.print(
             f"[green]✓[/green] VM image build queued for {image_name}:{image_tag}{context}"
         )
         build_id = response.get("buildId") if isinstance(response, dict) else None
         if build_id:
             console.print(f"[bold]Build ID:[/bold] {build_id}")
-        console.print("Track progress with: prime images list")
+        list_command = (
+            "prime images list --platform-image" if platform_image else "prime images list"
+        )
+        console.print(f"Track progress with: {list_command}")
     except UnauthorizedError:
         console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
         raise typer.Exit(1)
@@ -1037,6 +1056,19 @@ def list_images(
 def _looks_like_registry_host(value: str) -> bool:
     # Docker treats localhost as a registry host even without a dot or port.
     return "." in value or ":" in value or value == "localhost"
+
+
+def _parse_platform_image_reference(image_reference: str) -> tuple[str, str]:
+    """Parse an org-less platform image reference, preserving name namespaces."""
+    if ":" not in image_reference:
+        console.print("[red]Error: Image reference must include a tag (e.g., ubuntu:22.04)[/red]")
+        raise typer.Exit(1)
+
+    image_name, image_tag = image_reference.rsplit(":", 1)
+    if not image_name or not image_tag:
+        console.print("[red]Error: Platform image reference must use image:tag[/red]")
+        raise typer.Exit(1)
+    return image_name, image_tag
 
 
 def _parse_mutable_image_reference(image_reference: str) -> tuple[str, str, Optional[str]]:

--- a/packages/prime/tests/test_images_build_vm.py
+++ b/packages/prime/tests/test_images_build_vm.py
@@ -1,0 +1,73 @@
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+    "PRIME_TEAM_ID": "",
+}
+
+
+def _patch_api(monkeypatch, captured):
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            captured["method"] = method
+            captured["path"] = path
+            captured["json"] = json
+            return {"buildId": "build-123"}
+
+    monkeypatch.setattr("prime_cli.commands.images.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+
+def test_build_vm_platform_image_sends_owner_scope(monkeypatch):
+    captured = {}
+    _patch_api(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["images", "build-vm", "ubuntu:22.04", "--platform-image"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "method": "POST",
+        "path": "/images/ubuntu/22.04/vm-build",
+        "json": {"ownerScope": "platform"},
+    }
+    assert "(platform)" in result.output
+    assert "prime images list --platform-image" in result.output
+
+
+def test_build_vm_platform_image_preserves_namespaced_name(monkeypatch):
+    captured = {}
+    _patch_api(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["images", "build-vm", "org/ubuntu:22.04", "--platform-image"],
+        env={**TEST_ENV, "PRIME_TEAM_ID": "team-context"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/images/org/ubuntu/22.04/vm-build"
+    assert captured["json"] == {"ownerScope": "platform"}
+
+
+def test_build_vm_team_image_behavior_is_unchanged(monkeypatch):
+    captured = {}
+    _patch_api(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        ["images", "build-vm", "myapp:v1"],
+        env={**TEST_ENV, "PRIME_TEAM_ID": "team-context"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/images/myapp/v1/vm-build"
+    assert captured["json"] == {"teamId": "team-context"}


### PR DESCRIPTION
## Summary
- add --platform-image to prime images build-vm
- preserve namespaced platform image names and ignore configured team context
- add owner_scope=platform support to sync and async ImageClient VM build methods

## Dependency
- requires PrimeIntellect-ai/platform#3573

## Testing
- uv run --project packages/prime pytest packages/prime/tests/test_images_build_vm.py packages/prime/tests/test_images_push.py -q
- uv run --project packages/prime-sandboxes pytest packages/prime-sandboxes/tests/test_images_client.py -q
- focused Ruff check and format verification
- repository commit hooks (Ruff, format, type check)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API/CLI surface with tests; personal/team `build-vm` paths unchanged unless `--platform-image` is used. Actual authorization is enforced server-side.
> 
> **Overview**
> Adds **`--platform-image`** to **`prime images build-vm`** so platform admins can queue VM artifacts for org-less platform container images, aligned with existing platform push/list behavior.
> 
> When the flag is set, references are parsed via **`_parse_platform_image_reference`** (supports namespaced names like `org/ubuntu:22.04`), configured team context is ignored, and the VM-build request sends **`ownerScope: platform`** instead of **`teamId`**. Help text and success output call out platform scope and suggest **`prime images list --platform-image`** for tracking.
> 
> **`ImageClient.build_vm_image`** and **`AsyncImageClient.build_vm_image`** gain an optional **`owner_scope="platform"`** that maps to the same JSON field. CLI and SDK coverage is added in **`test_images_build_vm.py`** and **`test_images_client.py`**.
> 
> Depends on backend support (e.g. platform#3573).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9fdff1c9acd7c755b772064a957795a995797ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->