### PR TITLE
rm team id restriction from platform img list

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -860,9 +860,8 @@ def list_images(
     if num > 250:
         console.print("[red]Error:[/red] --num cannot exceed 250")
         raise typer.Exit(1)
-    if platform_image and config.team_id:
-        console.print("[red]Error: Platform images cannot be listed in a team context[/red]")
-        raise typer.Exit(1)
+    if platform_image and config.team_id and output != "json":
+        console.print("[dim]Team context ignored: platform images are org-less[/dim]")
 
     if all_images and output != "json":
         console.print(
@@ -925,8 +924,8 @@ def list_images(
             return
 
         # Table output
-        # Platform listings are never team-scoped (rejected above).
-        is_team_listing: bool = bool(config.team_id)
+        # Platform listings are org-less: any configured team is ignored.
+        is_team_listing: bool = bool(config.team_id) and not platform_image
         title: str
         if platform_image:
             title = "Platform Docker Images"

--- a/packages/prime/tests/test_images_list.py
+++ b/packages/prime/tests/test_images_list.py
@@ -797,16 +797,33 @@ def test_list_platform_image_forwards_owner_scope(monkeypatch):
     assert "Platform Docker Images" in result.output
 
 
-def test_list_platform_image_rejected_in_team_context(monkeypatch):
+def test_list_platform_image_ignores_team_context(monkeypatch):
     result, captured = _run_list_capturing_params(
         monkeypatch,
         ["--platform-image"],
+        payload=[_platform_row(image="ubuntu:22.04", pushed_at="2026-04-16T22:24:07")],
         team_id=TEAM_ID,
     )
-    assert result.exit_code == 1
-    assert "team context" in result.output
-    # Rejected client-side before any API request is made.
-    assert "params" not in captured
+    assert result.exit_code == 0, result.output
+    assert captured["params"].get("ownerScope") == "platform"
+    assert "teamId" not in captured["params"]
+    assert "Team context ignored" in result.output
+    assert "Platform Docker Images" in result.output
+    # Platform listings never render the team-scoped Owner column.
+    assert "Owner" not in result.output
+
+
+def test_list_platform_image_team_context_json_output_stays_clean(monkeypatch):
+    result, captured = _run_list_capturing_params(
+        monkeypatch,
+        ["--platform-image", "--output", "json"],
+        payload=[_platform_row(image="ubuntu:22.04", pushed_at="2026-04-16T22:24:07")],
+        team_id=TEAM_ID,
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["params"].get("ownerScope") == "platform"
+    assert "teamId" not in captured["params"]
+    assert "Team context ignored" not in result.output
 
 
 def test_list_platform_image_empty_shows_platform_push_hint(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CLI-only behavior change for admin platform listing; aligns with existing push/transfer semantics and is covered by updated tests.
> 
> **Overview**
> **`prime images list --platform-image`** no longer fails when a team is configured. It now matches push/transfer behavior: team context is ignored, the API is called with `ownerScope=platform` (no `teamId`), and table output shows a dim *Team context ignored* notice.
> 
> Table rendering treats platform listings as org-less—**`is_team_listing`** is false for `--platform-image`, so the title stays *Platform Docker Images* and the Owner column is omitted. JSON output stays machine-clean (no ignore message).
> 
> Tests were updated from expecting exit code 1 to success, plus coverage for JSON output without the notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7651ddfbd12ea866db108262378d2f41e464c563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->