### PR TITLE
improvement(images): pace bulk updates concurrently

### DIFF
--- a/packages/prime/src/prime_cli/commands/images_update_bulk.py
+++ b/packages/prime/src/prime_cli/commands/images_update_bulk.py
@@ -58,6 +58,10 @@ class BulkUpdateValidationError(Exception):
         self.problems = problems
 
 
+class _BatchNotDispatched(Exception):
+    """Raised when a queued batch is skipped after dispatch has stopped."""
+
+
 def _manifest_line(item: ImageUpdateItem) -> str:
     """Serialize one item back to its manifest JSONL form (API field names)."""
     return json.dumps(item.model_dump(by_alias=True, exclude_none=True), separators=(",", ":"))
@@ -252,6 +256,9 @@ def _send_update_batch(
     stop_dispatch: threading.Event,
 ):
     """Send one batch and stop future launches if transport/auth fails."""
+    if stop_dispatch.is_set():
+        raise _BatchNotDispatched
+
     try:
         return client.update_images(UpdateImagesRequest(dry_run=dry_run, updates=batch))
     except (UnauthorizedError, APIError):
@@ -278,14 +285,14 @@ def _dispatch_update_batches(
     """
     stop_dispatch = threading.Event()
     scheduled: dict[Future, tuple[int, List[ImageUpdateItem]]] = {}
-    never_dispatched: List[ImageUpdateItem] = []
+    never_dispatched_by_offset: dict[int, List[ImageUpdateItem]] = {}
 
     with ThreadPoolExecutor(max_workers=UPDATE_BULK_MAX_IN_FLIGHT) as executor:
         next_dispatch_at = time.monotonic()
         for offset in range(0, len(items), UPDATE_BULK_BATCH_SIZE):
             wait_seconds = max(0.0, next_dispatch_at - time.monotonic())
             if stop_dispatch.wait(wait_seconds):
-                never_dispatched.extend(items[offset:])
+                never_dispatched_by_offset[offset] = items[offset:]
                 break
 
             batch = items[offset : offset + UPDATE_BULK_BATCH_SIZE]
@@ -307,11 +314,18 @@ def _dispatch_update_batches(
         offset, batch = scheduled[future]
         try:
             response = future.result()
+        except _BatchNotDispatched:
+            never_dispatched_by_offset[offset] = batch
         except (UnauthorizedError, APIError) as exc:
             transport_failures[offset] = (batch, exc)
         else:
             completed[offset] = (batch, response.results)
 
+    never_dispatched = [
+        item
+        for offset in sorted(never_dispatched_by_offset)
+        for item in never_dispatched_by_offset[offset]
+    ]
     return completed, transport_failures, never_dispatched
 
 
@@ -387,10 +401,7 @@ def update_bulk(
         items,
         dry_run=dry_run,
     )
-
-    if any(isinstance(exc, UnauthorizedError) for _, exc in transport_failures.values()):
-        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
-        raise typer.Exit(1)
+    auth_failed = any(isinstance(exc, UnauthorizedError) for _, exc in transport_failures.values())
 
     outcomes: List[Tuple[ImageUpdateItem, ImageUpdateResult]] = []
     failed_items: List[ImageUpdateItem] = []
@@ -421,7 +432,9 @@ def update_bulk(
         f"[bold]Not sent:[/bold] {len(unsent_items)}"
     )
 
-    if transport_error is not None:
+    if auth_failed:
+        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
+    elif transport_error is not None:
         console.print(f"[red]Error: {transport_error}[/red]")
 
     retry_item_ids = {id(item) for item in failed_items + unsent_items}

--- a/packages/prime/src/prime_cli/commands/images_update_bulk.py
+++ b/packages/prime/src/prime_cli/commands/images_update_bulk.py
@@ -1,6 +1,9 @@
 """Bulk logical-image updates from a JSONL manifest (`prime images update-bulk`)."""
 
 import json
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
@@ -28,6 +31,12 @@ from .images_update_helpers import format_image_coordinate
 console = get_console()
 
 UPDATE_BULK_BATCH_SIZE = 100
+UPDATE_BULK_REQUEST_LIMIT = 40
+UPDATE_BULK_RATE_LIMIT_WINDOW_SECONDS = 60.0
+UPDATE_BULK_DISPATCH_INTERVAL_SECONDS = (
+    UPDATE_BULK_RATE_LIMIT_WINDOW_SECONDS / UPDATE_BULK_REQUEST_LIMIT
+)
+UPDATE_BULK_MAX_IN_FLIGHT = UPDATE_BULK_REQUEST_LIMIT
 _MANIFEST_KEYS = {"source", "set"}
 _NESTED_MANIFEST_MODELS = {
     "source": ImageUpdateSource,
@@ -235,6 +244,77 @@ def _print_outcomes(
             console.print(f"  [red]✗[/red] {_result_source_label(item)}: {message}{code}")
 
 
+def _send_update_batch(
+    client: ImageClient,
+    batch: List[ImageUpdateItem],
+    *,
+    dry_run: bool,
+    stop_dispatch: threading.Event,
+):
+    """Send one batch and stop future launches if transport/auth fails."""
+    try:
+        return client.update_images(UpdateImagesRequest(dry_run=dry_run, updates=batch))
+    except (UnauthorizedError, APIError):
+        stop_dispatch.set()
+        raise
+
+
+def _dispatch_update_batches(
+    client: ImageClient,
+    items: List[ImageUpdateItem],
+    *,
+    dry_run: bool,
+) -> tuple[
+    dict[int, tuple[List[ImageUpdateItem], List[ImageUpdateResult]]],
+    dict[int, tuple[List[ImageUpdateItem], APIError]],
+    List[ImageUpdateItem],
+]:
+    """Launch 100-item batches on cadence without waiting for each response.
+
+    The platform permits 50 PATCH /images requests per 60 seconds per token;
+    this command budgets 40, so launches are separated by 1.5 seconds. A
+    transport/auth failure stops future launches, while batches already in
+    flight are allowed to finish.
+    """
+    stop_dispatch = threading.Event()
+    scheduled: dict[Future, tuple[int, List[ImageUpdateItem]]] = {}
+    never_dispatched: List[ImageUpdateItem] = []
+
+    with ThreadPoolExecutor(max_workers=UPDATE_BULK_MAX_IN_FLIGHT) as executor:
+        next_dispatch_at = time.monotonic()
+        for offset in range(0, len(items), UPDATE_BULK_BATCH_SIZE):
+            wait_seconds = max(0.0, next_dispatch_at - time.monotonic())
+            if stop_dispatch.wait(wait_seconds):
+                never_dispatched.extend(items[offset:])
+                break
+
+            batch = items[offset : offset + UPDATE_BULK_BATCH_SIZE]
+            future = executor.submit(
+                _send_update_batch,
+                client,
+                batch,
+                dry_run=dry_run,
+                stop_dispatch=stop_dispatch,
+            )
+            scheduled[future] = (offset, batch)
+            # Base the next launch on the actual dispatch time so scheduler
+            # delays never cause a catch-up burst that exceeds the rate limit.
+            next_dispatch_at = time.monotonic() + UPDATE_BULK_DISPATCH_INTERVAL_SECONDS
+
+    completed: dict[int, tuple[List[ImageUpdateItem], List[ImageUpdateResult]]] = {}
+    transport_failures: dict[int, tuple[List[ImageUpdateItem], APIError]] = {}
+    for future in as_completed(scheduled):
+        offset, batch = scheduled[future]
+        try:
+            response = future.result()
+        except (UnauthorizedError, APIError) as exc:
+            transport_failures[offset] = (batch, exc)
+        else:
+            completed[offset] = (batch, response.results)
+
+    return completed, transport_failures, never_dispatched
+
+
 def update_bulk(
     manifest: Path = typer.Option(
         ...,
@@ -266,8 +346,10 @@ def update_bulk(
     Apply many logical-image updates from a JSONL manifest.
 
     Every line is validated before anything is sent. Updates are applied in
-    batches of 100; each update is independent, so one failure does not stop
-    the rest. Failed updates are written to a re-runnable failures manifest.
+    batches of 100, launched at 40 requests per minute without waiting for the
+    previous response; each update is independent, so one item failure does
+    not stop the rest. Failed updates are written to a re-runnable failures
+    manifest.
 
     \b
     Example manifest lines:
@@ -300,23 +382,31 @@ def update_bulk(
         return
 
     client = ImageClient(APIClient())
+    completed, transport_failures, never_dispatched = _dispatch_update_batches(
+        client,
+        items,
+        dry_run=dry_run,
+    )
+
+    if any(isinstance(exc, UnauthorizedError) for _, exc in transport_failures.values()):
+        console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
+        raise typer.Exit(1)
+
     outcomes: List[Tuple[ImageUpdateItem, ImageUpdateResult]] = []
     failed_items: List[ImageUpdateItem] = []
-    unsent_items: List[ImageUpdateItem] = []
-    transport_error: Optional[str] = None
+    unsent_by_offset = {offset: batch for offset, (batch, _) in transport_failures.items()}
+    if never_dispatched:
+        unsent_by_offset[len(items) - len(never_dispatched)] = never_dispatched
+    unsent_items = [
+        item for offset in sorted(unsent_by_offset) for item in unsent_by_offset[offset]
+    ]
+    transport_error = (
+        str(transport_failures[min(transport_failures)][1]) if transport_failures else None
+    )
 
-    for offset in range(0, len(items), UPDATE_BULK_BATCH_SIZE):
-        batch = items[offset : offset + UPDATE_BULK_BATCH_SIZE]
-        try:
-            response = client.update_images(UpdateImagesRequest(dry_run=dry_run, updates=batch))
-        except UnauthorizedError:
-            console.print("[red]Error: Not authenticated. Please run 'prime login' first.[/red]")
-            raise typer.Exit(1)
-        except APIError as exc:
-            transport_error = str(exc)
-            unsent_items.extend(items[offset:])
-            break
-        for item, result in zip(batch, response.results):
+    for offset in sorted(completed):
+        batch, results = completed[offset]
+        for item, result in zip(batch, results):
             outcomes.append((item, result))
             if not result.success:
                 failed_items.append(item)
@@ -334,7 +424,8 @@ def update_bulk(
     if transport_error is not None:
         console.print(f"[red]Error: {transport_error}[/red]")
 
-    retry_items = failed_items + unsent_items
+    retry_item_ids = {id(item) for item in failed_items + unsent_items}
+    retry_items = [item for item in items if id(item) in retry_item_ids]
     if retry_items and not dry_run:
         _write_failures_manifest(failures_out, retry_items)
         console.print(

--- a/packages/prime/tests/test_images_update_bulk.py
+++ b/packages/prime/tests/test_images_update_bulk.py
@@ -1,6 +1,8 @@
 """Tests for `prime images update-bulk`."""
 
 import json
+import threading
+import time
 
 import pytest
 from prime_cli.main import app
@@ -63,6 +65,55 @@ def test_update_bulk_applies_manifest(tmp_path, monkeypatch):
     assert captured[0]["json"]["mode"] == "explicit"
     assert len(captured[0]["json"]["updates"]) == 2
     assert "Updated:" in result.output and "Failed:" in result.output
+
+
+def test_update_bulk_dispatches_batches_on_cadence_without_waiting(tmp_path, monkeypatch):
+    request_started_at = []
+    second_request_started = threading.Event()
+    first_request_finished = threading.Event()
+    request_lock = threading.Lock()
+
+    class DummyAPIClient:
+        def request(self, method, path, json=None, params=None):
+            with request_lock:
+                request_number = len(request_started_at) + 1
+                request_started_at.append(time.monotonic())
+
+            if request_number == 1:
+                assert second_request_started.wait(timeout=1.0)
+                first_request_finished.set()
+            else:
+                second_request_started.set()
+
+            return {
+                "success": True,
+                "dryRun": False,
+                "results": [
+                    {"source": update["source"], "success": True} for update in json["updates"]
+                ],
+            }
+
+    monkeypatch.setattr("prime_cli.commands.images_update_bulk.APIClient", DummyAPIClient)
+    monkeypatch.setattr(
+        "prime_cli.commands.images_update_bulk.UPDATE_BULK_DISPATCH_INTERVAL_SECONDS",
+        0.02,
+    )
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    manifest = _write_manifest(
+        tmp_path,
+        [_rename_line(f"image-{index}", f"renamed-{index}") for index in range(200)],
+    )
+
+    result = runner.invoke(
+        app,
+        ["images", "update-bulk", "--manifest", str(manifest)],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(request_started_at) == 2
+    assert request_started_at[1] - request_started_at[0] >= 0.015
+    assert first_request_finished.is_set()
 
 
 def test_update_bulk_validates_all_lines_before_sending(tmp_path, monkeypatch):

--- a/packages/prime/tests/test_images_update_bulk.py
+++ b/packages/prime/tests/test_images_update_bulk.py
@@ -116,6 +116,53 @@ def test_update_bulk_dispatches_batches_on_cadence_without_waiting(tmp_path, mon
     assert first_request_finished.is_set()
 
 
+def test_dispatch_update_batches_skips_queued_batches_after_transport_failure(monkeypatch):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from prime_cli.commands import images_update_bulk
+    from prime_sandboxes import APIError, ImageUpdateItem
+
+    all_batches_submitted = threading.Event()
+    submit_count = 0
+
+    class TrackingExecutor(ThreadPoolExecutor):
+        def submit(self, fn, /, *args, **kwargs):
+            nonlocal submit_count
+            future = super().submit(fn, *args, **kwargs)
+            submit_count += 1
+            if submit_count == 3:
+                all_batches_submitted.set()
+            return future
+
+    class FailingImageClient:
+        def __init__(self):
+            self.sent_batches = []
+
+        def update_images(self, request):
+            self.sent_batches.append(request.updates)
+            assert all_batches_submitted.wait(timeout=1.0)
+            raise APIError("HTTP 500: boom")
+
+    items = [
+        ImageUpdateItem.model_validate(_rename_line(f"image-{index}", f"renamed-{index}"))
+        for index in range(3)
+    ]
+    client = FailingImageClient()
+    monkeypatch.setattr(images_update_bulk, "ThreadPoolExecutor", TrackingExecutor)
+    monkeypatch.setattr(images_update_bulk, "UPDATE_BULK_BATCH_SIZE", 1)
+    monkeypatch.setattr(images_update_bulk, "UPDATE_BULK_MAX_IN_FLIGHT", 1)
+    monkeypatch.setattr(images_update_bulk, "UPDATE_BULK_DISPATCH_INTERVAL_SECONDS", 0)
+
+    completed, transport_failures, never_dispatched = images_update_bulk._dispatch_update_batches(
+        client, items, dry_run=False
+    )
+
+    assert len(client.sent_batches) == 1
+    assert completed == {}
+    assert list(transport_failures) == [0]
+    assert never_dispatched == items[1:]
+
+
 def test_update_bulk_validates_all_lines_before_sending(tmp_path, monkeypatch):
     captured = []
     _patch_success_client(monkeypatch, captured)
@@ -320,3 +367,56 @@ def test_update_bulk_transport_failure_records_unsent(tmp_path, monkeypatch):
     assert "Not sent:" in result.output
     retry_lines = [json.loads(line) for line in failures_out.read_text().splitlines() if line]
     assert retry_lines == [_rename_line("a", "a2")]
+
+
+def test_update_bulk_auth_failure_preserves_completed_results_and_retry_manifest(
+    tmp_path, monkeypatch
+):
+    from prime_sandboxes import ImageUpdateResult, UnauthorizedError
+
+    updates = [
+        _rename_line("completed", "completed-2"),
+        _rename_line("unauthorized", "unauthorized-2"),
+        _rename_line("never-dispatched", "never-dispatched-2"),
+    ]
+    manifest = _write_manifest(tmp_path, updates)
+    failures_out = tmp_path / "failed.jsonl"
+
+    def fake_dispatch(client, items, *, dry_run):
+        return (
+            {
+                0: (
+                    [items[0]],
+                    [ImageUpdateResult(source=items[0].source, success=True)],
+                )
+            },
+            {1: ([items[1]], UnauthorizedError("token expired"))},
+            [items[2]],
+        )
+
+    monkeypatch.setattr("prime_cli.commands.images_update_bulk.APIClient", lambda: object())
+    monkeypatch.setattr(
+        "prime_cli.commands.images_update_bulk._dispatch_update_batches",
+        fake_dispatch,
+    )
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    result = runner.invoke(
+        app,
+        [
+            "images",
+            "update-bulk",
+            "--manifest",
+            str(manifest),
+            "--failures-out",
+            str(failures_out),
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Updated: 1" in result.output
+    assert "Not sent: 2" in result.output
+    assert "Not authenticated" in result.output
+    retry_lines = [json.loads(line) for line in failures_out.read_text().splitlines() if line]
+    assert retry_lines == updates[1:]


### PR DESCRIPTION
## Summary
- launch 100-image update batches on a fixed 40-request-per-minute cadence
- allow batches to overlap instead of waiting for each prior response
- stop future launches on transport/auth failures while preserving ordered results and retry manifests
- add regression coverage proving the next batch starts before the previous response completes

## Validation
- uv run ruff format --check packages/prime/src/prime_cli/commands/images_update_bulk.py packages/prime/tests/test_images_update_bulk.py
- uv run ruff check packages/prime/src/prime_cli/commands/images_update_bulk.py packages/prime/tests/test_images_update_bulk.py
- uv run pytest packages/prime/tests/test_images_update_bulk.py -q
- uv run ty check packages/prime/src/prime_cli/commands/images_update_bulk.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bulk image mutation traffic patterns (concurrency and rate limiting) and error/retry handling; behavior is well tested but affects real registry updates at scale.
> 
> **Overview**
> **`prime images update-bulk`** no longer waits for each PATCH `/images` batch before starting the next. It still chunks manifests into **100-item** batches but schedules them on a **40 requests/minute** cadence (1.5s between launches) via a thread pool, so multiple batches can be in flight while staying under the platform rate limit.
> 
> On **`UnauthorizedError`** or **`APIError`**, future launches are cancelled while in-flight work finishes; completed per-item results are still reported, and **not sent** / failed lines go to the failures manifest in original manifest order. Auth failures get a dedicated login message instead of a generic transport error.
> 
> Tests cover cadence (second batch starts before the first response returns), skipping queued batches after transport failure, and preserving partial success plus retry output when auth fails mid-run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94539f1d52629fa8228369d65066cf63ec2b334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->