### PR TITLE
Lower sandbox default memory to 1 GB

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -181,7 +181,7 @@ class CreateSandboxRequest(BaseModel):
     docker_image: str
     start_command: Optional[str] = "tail -f /dev/null"
     cpu_cores: float = 1.0
-    memory_gb: float = 2.0
+    memory_gb: float = 1.0
     disk_size_gb: float = 5.0
     gpu_count: int = 0
     gpu_type: Optional[str] = None

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -20,7 +20,7 @@ def test_create_sandbox_request_defaults():
     assert request.name == "test-sandbox"
     assert request.docker_image == "python:3.11-slim"
     assert request.cpu_cores == 1
-    assert request.memory_gb == 2
+    assert request.memory_gb == 1
     assert request.disk_size_gb == 5
     assert request.gpu_count == 0
     assert request.gpu_type is None

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -503,7 +503,7 @@ def create(
         "tail -f /dev/null", help="Command to run in the container"
     ),
     cpu_cores: float = typer.Option(1.0, help="Number of CPU cores"),
-    memory_gb: float = typer.Option(2.0, help="Memory in GB"),
+    memory_gb: float = typer.Option(1.0, help="Memory in GB"),
     disk_size_gb: float = typer.Option(10.0, help="Disk size in GB"),
     gpu_count: int = typer.Option(0, help="Number of GPUs"),
     gpu_type: Optional[str] = typer.Option(

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -570,6 +570,8 @@ def test_sandbox_create_vm_without_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Successfully created sandbox sbx-vm-123" in output
     assert captured["request"].vm is True
     assert captured["request"].gpu_count == 0
+    assert captured["request"].cpu_cores == 1.0
+    assert captured["request"].memory_gb == 1.0
 
 
 def test_sandbox_delete_by_label_scopes_to_caller(


### PR DESCRIPTION
Summary:
- change the prime sandbox create CLI default from 2 GB to 1 GB
- align the prime-sandboxes SDK request default at 1 GB
- add regression coverage for the VM CLI request and SDK model defaults

Related platform PR:
- https://github.com/PrimeIntellect-ai/platform/pull/3606

Validation:
- 51 focused CLI and SDK tests passed
- Ruff checks passed
- Commit hooks passed: Ruff, Ruff format, and ty