### PR TITLE
Validate VM sandbox secrets in the CLI and SDK

### DIFF
--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -95,6 +95,7 @@ The SDK looks for credentials in this order:
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
+    vm=True,
     environment_vars={
         "DEBUG": "true",
         "LOG_LEVEL": "info"
@@ -107,6 +108,12 @@ request = CreateSandboxRequest(
 
 sandbox = sandbox_client.create(request)
 ```
+
+For VM sandboxes, secret values are sent only to the authenticated platform API over HTTPS. The
+platform resolves the canonical tenant from the authenticated user and optional `team_id`, then
+binds a KMS ciphertext envelope to that tenant and the new sandbox ID. The CLI and SDK never
+construct KMS AAD or accept a KMS key or pre-encrypted envelope. Environment and secret keys must
+be distinct shell variable names, and values are subject to the VM runtime's size limits.
 
 **Note:** Secrets are never displayed in logs or outputs. When retrieving sandbox details, only the secret keys are shown with values masked as `***`.
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -278,6 +278,8 @@ class SandboxListResponse(BaseModel):
 class CreateSandboxRequest(BaseModel):
     """Create sandbox request model"""
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     name: str
     docker_image: str
     start_command: Optional[str] = "tail -f /dev/null"

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -1,5 +1,7 @@
 """Pydantic models for Prime Sandboxes SDK."""
 
+import json
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
@@ -20,6 +22,105 @@ class SandboxStatus(str, Enum):
 
 
 MAX_EGRESS_POLICY_ENTRIES = 256
+
+VM_ENV_MAX_KEY_BYTES = 128
+VM_ENV_MAX_VALUE_BYTES = 16 * 1024
+VM_ENV_MAX_TOTAL_BYTES = 32 * 1024
+VM_ENV_MAX_VARIABLES = 256
+VM_SECRETS_MAX_PLAINTEXT_BYTES = 32 * 1024
+
+_VM_ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_VM_ENV_RESERVED_KEYS = frozenset(
+    {
+        "SANDBOX_ID",
+        "SANDBOX_NAME",
+        "DISK_MOUNT_PATH",
+        "SANDBOX_IDLE_TIMEOUT_SECONDS",
+        "PRIME_GUESTBRIDGE_ADDRESS",
+    }
+)
+
+
+def _utf8_size(value: str, *, description: str) -> int:
+    try:
+        return len(value.encode("utf-8"))
+    except UnicodeEncodeError as exc:
+        raise ValueError(f"{description} must be valid UTF-8") from exc
+
+
+def _validate_vm_environment_map(name: str, values: Optional[Dict[str, str]]) -> int:
+    if not values:
+        return 0
+    if len(values) > VM_ENV_MAX_VARIABLES:
+        raise ValueError(
+            f"{name} contains {len(values)} variables; maximum is {VM_ENV_MAX_VARIABLES}"
+        )
+
+    total_bytes = 0
+    for key, value in values.items():
+        key_bytes = _utf8_size(key, description=f"{name} key")
+        if key_bytes > VM_ENV_MAX_KEY_BYTES:
+            raise ValueError(f"{name} key {key!r} exceeds the {VM_ENV_MAX_KEY_BYTES}-byte limit")
+        if not _VM_ENV_KEY_PATTERN.fullmatch(key):
+            raise ValueError(
+                f"{name} key {key!r} is invalid; keys must match {_VM_ENV_KEY_PATTERN.pattern}"
+            )
+        if key in _VM_ENV_RESERVED_KEYS:
+            raise ValueError(f"{name} key {key!r} is reserved by the VM sandbox runtime")
+
+        value_bytes = _utf8_size(value, description=f"{name} value for {key!r}")
+        if value_bytes > VM_ENV_MAX_VALUE_BYTES:
+            raise ValueError(
+                f"{name} value for {key!r} exceeds the {VM_ENV_MAX_VALUE_BYTES}-byte limit"
+            )
+        if "\x00" in value:
+            raise ValueError(f"{name} value for {key!r} must not contain NUL bytes")
+        total_bytes += key_bytes + value_bytes
+
+    if total_bytes > VM_ENV_MAX_TOTAL_BYTES:
+        raise ValueError(f"{name} uses {total_bytes} bytes; maximum is {VM_ENV_MAX_TOTAL_BYTES}")
+    return total_bytes
+
+
+def validate_vm_environment(
+    environment_vars: Optional[Dict[str, str]],
+    secrets: Optional[Dict[str, str]],
+) -> None:
+    """Mirror the VM runtime's environment and secret plaintext contract."""
+    public_bytes = _validate_vm_environment_map("environment_vars", environment_vars)
+    secret_bytes = _validate_vm_environment_map("secrets", secrets)
+
+    public_keys = set(environment_vars or {})
+    duplicate_keys = public_keys.intersection(secrets or {})
+    if duplicate_keys:
+        duplicate = min(duplicate_keys)
+        raise ValueError(
+            f"environment key {duplicate!r} is present in both environment_vars and secrets"
+        )
+
+    variable_count = len(environment_vars or {}) + len(secrets or {})
+    if variable_count > VM_ENV_MAX_VARIABLES:
+        raise ValueError(
+            f"VM environment contains {variable_count} variables; maximum is {VM_ENV_MAX_VARIABLES}"
+        )
+
+    total_bytes = public_bytes + secret_bytes
+    if total_bytes > VM_ENV_MAX_TOTAL_BYTES:
+        raise ValueError(
+            f"combined VM environment uses {total_bytes} bytes; maximum is {VM_ENV_MAX_TOTAL_BYTES}"
+        )
+
+    if secrets:
+        plaintext = json.dumps(
+            secrets,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if len(plaintext) > VM_SECRETS_MAX_PLAINTEXT_BYTES:
+            raise ValueError(
+                f"serialized VM secrets use {len(plaintext)} bytes; "
+                f"maximum is {VM_SECRETS_MAX_PLAINTEXT_BYTES}"
+            )
 
 
 def _validate_egress_entry(entry: str) -> None:
@@ -239,6 +340,12 @@ class CreateSandboxRequest(BaseModel):
                 "idle_timeout_minutes must be <= timeout_minutes "
                 f"(got idle={self.idle_timeout_minutes}, lifetime={self.timeout_minutes})"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_vm_environment_and_secrets(self) -> "CreateSandboxRequest":
+        if self.vm:
+            validate_vm_environment(self.environment_vars, self.secrets)
         return self
 
 

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -425,6 +425,23 @@ class TestAsyncAPIClientRetry:
 
 
 class TestCreateSandboxIdempotencyPayload:
+    def test_vm_create_sends_plaintext_secrets_only_to_platform_api(self):
+        client = SandboxClient(APIClient(api_key="test-key"))
+        recording = RecordingCreateAPIClient()
+        client.client = recording
+        request = CreateSandboxRequest(
+            name="sandbox",
+            docker_image="python:3.11-slim",
+            vm=True,
+            secrets={"TOKEN": "secret"},
+        )
+
+        client.create(request)
+
+        payload = recording.calls[0][2]["json"]
+        assert payload["secrets"] == {"TOKEN": "secret"}
+        assert "encrypted_secrets" not in payload
+
     def test_sync_create_does_not_reuse_generated_idempotency_key_on_request_reuse(self):
         client = SandboxClient(APIClient(api_key="test-key"))
         recording = RecordingCreateAPIClient()

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -139,6 +139,20 @@ def test_vm_sandbox_rejects_invalid_environment_contract(environment_vars, secre
         )
 
 
+def test_vm_sandbox_validation_error_hides_secret_input():
+    secret = "super-sensitive-secret-value"
+
+    with pytest.raises(ValidationError, match="reserved") as exc_info:
+        CreateSandboxRequest(
+            name="vm-sandbox",
+            docker_image="python:3.11-slim",
+            vm=True,
+            secrets={"SANDBOX_ID": secret},
+        )
+
+    assert secret not in str(exc_info.value)
+
+
 def test_vm_sandbox_rejects_too_many_combined_variables():
     with pytest.raises(ValidationError, match="257 variables"):
         CreateSandboxRequest(

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -105,6 +105,75 @@ def test_create_sandbox_request_gpu_type_none_matches_default():
     assert request_none.gpu_type is None
 
 
+def test_vm_sandbox_accepts_environment_variables_and_secrets():
+    request = CreateSandboxRequest(
+        name="vm-sandbox",
+        docker_image="python:3.11-slim",
+        vm=True,
+        environment_vars={"PUBLIC_VALUE": "hello"},
+        secrets={"API_TOKEN": "secret"},
+    )
+
+    assert request.environment_vars == {"PUBLIC_VALUE": "hello"}
+    assert request.secrets == {"API_TOKEN": "secret"}
+
+
+@pytest.mark.parametrize(
+    ("environment_vars", "secrets", "message"),
+    [
+        ({"1INVALID": "value"}, None, "must match"),
+        ({"SANDBOX_ID": "value"}, None, "reserved"),
+        (None, {"TOKEN": "before\x00after"}, "NUL"),
+        ({"TOKEN": "public"}, {"TOKEN": "secret"}, "both"),
+        (None, {"TOKEN": "x" * (16 * 1024 + 1)}, "16384-byte limit"),
+    ],
+)
+def test_vm_sandbox_rejects_invalid_environment_contract(environment_vars, secrets, message):
+    with pytest.raises(ValidationError, match=message):
+        CreateSandboxRequest(
+            name="vm-sandbox",
+            docker_image="python:3.11-slim",
+            vm=True,
+            environment_vars=environment_vars,
+            secrets=secrets,
+        )
+
+
+def test_vm_sandbox_rejects_too_many_combined_variables():
+    with pytest.raises(ValidationError, match="257 variables"):
+        CreateSandboxRequest(
+            name="vm-sandbox",
+            docker_image="python:3.11-slim",
+            vm=True,
+            environment_vars={f"PUBLIC_{index}": "x" for index in range(128)},
+            secrets={f"SECRET_{index}": "x" for index in range(129)},
+        )
+
+
+def test_vm_sandbox_rejects_oversized_serialized_secret_payload():
+    # The key/value total is below 32 KiB, but JSON framing pushes the KMS
+    # plaintext beyond its independent 32 KiB limit.
+    secrets = {f"K{index}": "x" * 155 for index in range(200)}
+
+    with pytest.raises(ValidationError, match="serialized VM secrets"):
+        CreateSandboxRequest(
+            name="vm-sandbox",
+            docker_image="python:3.11-slim",
+            vm=True,
+            secrets=secrets,
+        )
+
+
+def test_container_sandbox_keeps_existing_environment_contract():
+    request = CreateSandboxRequest(
+        name="container-sandbox",
+        docker_image="python:3.11-slim",
+        environment_vars={"container.style.key": "value"},
+    )
+
+    assert request.environment_vars == {"container.style.key": "value"}
+
+
 def test_sandbox_status_enum():
     """Test SandboxStatus enum values"""
     assert SandboxStatus.PENDING == "PENDING"

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -710,28 +710,35 @@ def create(
             console.print("[red]Error:[/red] --network-allow/--network-deny require --vm")
             raise typer.Exit(1)
 
-        request = CreateSandboxRequest(
-            name=name,
-            docker_image=docker_image,
-            start_command=start_command,
-            cpu_cores=cpu_cores,
-            memory_gb=memory_gb,
-            disk_size_gb=disk_size_gb,
-            gpu_count=gpu_count,
-            gpu_type=gpu_type,
-            vm=vm,
-            network_allowlist=network_allow,
-            network_denylist=network_deny,
-            timeout_minutes=timeout_minutes,
-            environment_vars=env_vars if env_vars else None,
-            secrets=secrets_vars if secrets_vars else None,
-            labels=labels if labels else [],
-            team_id=team_id,
-            region=region,
-            registry_credentials_id=registry_credentials_id,
-            **request_kwargs,
-            guaranteed=guaranteed,
-        )
+        try:
+            request = CreateSandboxRequest(
+                name=name,
+                docker_image=docker_image,
+                start_command=start_command,
+                cpu_cores=cpu_cores,
+                memory_gb=memory_gb,
+                disk_size_gb=disk_size_gb,
+                gpu_count=gpu_count,
+                gpu_type=gpu_type,
+                vm=vm,
+                network_allowlist=network_allow,
+                network_denylist=network_deny,
+                timeout_minutes=timeout_minutes,
+                environment_vars=env_vars if env_vars else None,
+                secrets=secrets_vars if secrets_vars else None,
+                labels=labels if labels else [],
+                team_id=team_id,
+                region=region,
+                registry_credentials_id=registry_credentials_id,
+                **request_kwargs,
+                guaranteed=guaranteed,
+            )
+        except ValidationError as e:
+            # Render messages only because the rejected model input may contain
+            # secret values.
+            messages = "; ".join(error["msg"] for error in e.errors(include_url=False))
+            console.print(f"[red]Invalid sandbox configuration:[/red] {escape(messages)}")
+            raise typer.Exit(1)
 
         # Show configuration summary
         console.print("\n[bold]Sandbox Configuration:[/bold]")
@@ -771,8 +778,19 @@ def create(
             console.print(f"Secrets: {obfuscated_secrets}")
 
         if confirm_or_skip("\nDo you want to create this sandbox?", yes, default=True):
-            with console.status("[bold blue]Creating sandbox...", spinner="dots"):
-                sandbox = sandbox_client.create(request)
+            try:
+                with console.status("[bold blue]Creating sandbox...", spinner="dots"):
+                    sandbox = sandbox_client.create(request)
+            except ValidationError:
+                # The SDK validates the response after the API request. At this
+                # point the sandbox may exist, so do not describe this as a
+                # rejected configuration or encourage an immediate retry.
+                console.print(
+                    "[red]Sandbox creation status is unknown:[/red] The API returned "
+                    "an unexpected response, and the sandbox may have been created. "
+                    "Check 'prime sandbox list' before retrying."
+                )
+                raise typer.Exit(1)
 
             console.print(f"\n[green]Successfully created sandbox {sandbox.id}[/green]")
             if getattr(sandbox, "pending_image_build_id", None):
@@ -791,12 +809,6 @@ def create(
 
     except typer.Exit:
         raise
-    except ValidationError as e:
-        # Pydantic's full exception includes the rejected input, which may
-        # contain secret values. Render messages only.
-        messages = "; ".join(error["msg"] for error in e.errors(include_url=False))
-        console.print(f"[red]Invalid sandbox configuration:[/red] {escape(messages)}")
-        raise typer.Exit(1)
     except UnauthorizedError as e:
         console.print(f"[red]Unauthorized:[/red] {str(e)}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -26,6 +26,7 @@ from prime_sandboxes import (
     SandboxNotRunningError,
     UnauthorizedError,
 )
+from pydantic import ValidationError
 from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
@@ -591,6 +592,12 @@ def create(
                     console.print("[red]Environment variables must be in KEY=VALUE format[/red]")
                     raise typer.Exit(1)
                 key, value = env_var.split("=", 1)
+                if vm and key in env_vars:
+                    console.print(
+                        f"[red]Environment variable {escape(key)!r} was provided "
+                        "more than once[/red]"
+                    )
+                    raise typer.Exit(1)
                 env_vars[key] = value
 
         secrets_vars = {}
@@ -600,7 +607,19 @@ def create(
                     console.print("[red]Secrets must be in KEY=VALUE format[/red]")
                     raise typer.Exit(1)
                 key, value = secret_var.split("=", 1)
+                if vm and key in secrets_vars:
+                    console.print(f"[red]Secret {escape(key)!r} was provided more than once[/red]")
+                    raise typer.Exit(1)
                 secrets_vars[key] = value
+
+        duplicate_keys = set(env_vars).intersection(secrets_vars) if vm else set()
+        if duplicate_keys:
+            duplicate = min(duplicate_keys)
+            console.print(
+                f"[red]Environment key {escape(duplicate)!r} cannot be both "
+                "an environment variable and a secret[/red]"
+            )
+            raise typer.Exit(1)
 
         if gpu_count > 0 and not gpu_type:
             console.print(
@@ -772,6 +791,12 @@ def create(
 
     except typer.Exit:
         raise
+    except ValidationError as e:
+        # Pydantic's full exception includes the rejected input, which may
+        # contain secret values. Render messages only.
+        messages = "; ".join(error["msg"] for error in e.errors(include_url=False))
+        console.print(f"[red]Invalid sandbox configuration:[/red] {escape(messages)}")
+        raise typer.Exit(1)
     except UnauthorizedError as e:
         console.print(f"[red]Unauthorized:[/red] {str(e)}")
         raise typer.Exit(1)

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -432,8 +432,40 @@ def test_sandbox_create_sanitizes_vm_secret_validation_errors(
 
     output = strip_ansi(result.output)
     assert result.exit_code == 1
+    assert "Invalid sandbox configuration" in output
     assert "reserved" in output
     assert "must-not-leak" not in output
+
+
+def test_sandbox_create_reports_unknown_status_for_invalid_api_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from prime_sandboxes import Sandbox
+
+    _configure_cli(monkeypatch)
+
+    def mock_create(self: Any, request: Any) -> Any:
+        return Sandbox.model_validate(
+            {
+                "id": "sbx-maybe-created",
+                "secrets": {"API_TOKEN": "response-secret-must-not-leak"},
+            }
+        )
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "python:3.11-slim", "--yes"],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "Sandbox creation status is unknown" in output
+    assert "sandbox may have been created" in output
+    assert "prime sandbox list" in output
+    assert "Invalid sandbox configuration" not in output
+    assert "response-secret-must-not-leak" not in output
 
 
 def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -347,6 +347,95 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
     assert captured["request"].vm is True
 
 
+def test_sandbox_create_vm_forwards_secrets_without_displaying_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cli(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-secret-123")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.11-slim",
+            "--vm",
+            "--env",
+            "PUBLIC_VALUE=hello",
+            "--secret",
+            "API_TOKEN=super-secret-value",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["request"].environment_vars == {"PUBLIC_VALUE": "hello"}
+    assert captured["request"].secrets == {"API_TOKEN": "super-secret-value"}
+    assert "super-secret-value" not in strip_ansi(result.output)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (["--env", "TOKEN=public", "--secret", "TOKEN=secret"], "cannot be both"),
+        (["--secret", "TOKEN=one", "--secret", "TOKEN=two"], "provided more than once"),
+    ],
+)
+def test_sandbox_create_rejects_duplicate_environment_keys_without_api_call(
+    monkeypatch: pytest.MonkeyPatch,
+    arguments: list[str],
+    message: str,
+) -> None:
+    _configure_cli(monkeypatch)
+    called = False
+
+    def mock_create(self: Any, request: Any) -> Any:
+        nonlocal called
+        called = True
+        return SimpleNamespace(id="unexpected")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "python:3.11-slim", "--vm", *arguments, "--yes"],
+    )
+
+    assert result.exit_code == 1
+    assert message in strip_ansi(result.output)
+    assert not called
+
+
+def test_sandbox_create_sanitizes_vm_secret_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cli(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.11-slim",
+            "--vm",
+            "--secret",
+            "SANDBOX_ID=must-not-leak",
+            "--yes",
+        ],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "reserved" in output
+    assert "must-not-leak" not in output
+
+
 def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")


### PR DESCRIPTION
## Summary

Companion client changes for PrimeIntellect-ai/platform#3611.

- validate VM sandbox environment variables and secrets against the platform contract before sending a create request
- reject invalid names, reserved platform variables, NUL values, byte/count limits, and public/secret key collisions
- reject duplicate VM `--env` and `--secret` options instead of silently overwriting values
- keep container sandbox behavior unchanged
- continue sending plaintext secrets only to the authenticated platform API; clients do not select deployment KMS keys or construct tenant-bound ciphertext
- render validation failures without echoing secret values
- document the VM-specific limits and encryption boundary

## Why encryption stays server-side

The CLI and SDK do not own the canonical tenant identity or the deployment KMS key. The authenticated sandbox-ingress service resolves that context, validates the combined environment, constructs tenant-and-sandbox-bound AAD, and sends only ciphertext into the VM control plane.

## Validation

- focused Prime sandbox and CLI suites: 67 passed
- Ruff passed
- ty passed

The broader package run reached its live sandbox timeout test after the focused suite; that test requires a responsive external sandbox service and was not used as a unit-test signal for this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox create path for VM workloads and secret handling (validation and error rendering), but hardens behavior and does not move encryption or KMS into clients.
> 
> **Overview**
> Adds **client-side validation** for VM sandbox `environment_vars` and `secrets` so create requests match the platform/VM runtime contract before they hit the API. Validation runs only when `vm=True`; container sandboxes keep their existing looser env key rules.
> 
> The SDK introduces `validate_vm_environment` on `CreateSandboxRequest` (shell-style key names, reserved runtime keys, UTF-8/size/count limits, no NULs, no overlap between public env and secrets, and a cap on serialized secrets JSON for KMS). `CreateSandboxRequest` uses `hide_input_in_errors` so validation failures do not echo secret values.
> 
> The **`prime sandbox create`** flow rejects duplicate VM `--env` / `--secret` flags and keys shared between env and secrets, surfaces Pydantic errors as message-only text, and treats post-API response validation failures as **unknown creation status** (warn to list before retry). Docs clarify that plaintext secrets go to the authenticated API only and KMS binding stays server-side; create still sends `secrets` in JSON, not `encrypted_secrets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3383572e9d0ce678e3d04fbf31740fcf44e7a00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->