### PR TITLE
release: cli 0.6.20 + sandbox 0.2.33

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -68,7 +68,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.32"
+__version__ = "0.2.33"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.32",
+    "prime-sandboxes>=0.2.33",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.19"
+__version__ = "0.6.20"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

- bump `prime` CLI/full SDK to `0.6.20`
- bump `prime-sandboxes` SDK to `0.2.33`
- require `prime-sandboxes>=0.2.33` from `prime`

## Validation

- version/dependency import validation
- `git diff --check`
- pre-commit: Ruff lint, Ruff format, `ty`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency floor updates only; no runtime or API logic changes in the diff.
> 
> **Overview**
> **Release-only version bump** for the `prime` CLI/SDK and the `prime-sandboxes` package, with no functional code changes in this diff.
> 
> `prime-sandboxes` is bumped to **0.2.33** in `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`. The `prime` package is bumped to **0.6.20** in `packages/prime/src/prime_cli/__init__.py`, and `packages/prime/pyproject.toml` now pins **`prime-sandboxes>=0.2.33`** (was `>=0.2.32`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ff60e8575fee1675eac3e6bdc91c1e9a2817e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->