### PR TITLE
feature: prime cluster login and the k8s credential plugin

### DIFF
--- a/packages/prime/src/prime_cli/commands/auth.py
+++ b/packages/prime/src/prime_cli/commands/auth.py
@@ -78,7 +78,10 @@ def k8s_token(
     if not api_key:
         _fail("Not logged in. Run `prime login`.", EXIT_AUTH_EXPIRED)
 
-    url = f"{config.base_url}/clusters/{cluster}/kube-token"
+    # Config.base_url deliberately strips any /api/v1 suffix, and the shared
+    # APIClient re-adds it on every request — so it must be added here too, or
+    # every call 404s against the bare host.
+    url = f"{config.base_url}/api/v1/clusters/{cluster}/kube-token"
     params = {"pool": pool} if pool else None
 
     try:

--- a/packages/prime/src/prime_cli/commands/auth.py
+++ b/packages/prime/src/prime_cli/commands/auth.py
@@ -1,0 +1,159 @@
+"""`prime auth` — credential plugin entry points.
+
+`prime auth k8s-token` is a Kubernetes client-go credential plugin. kubectl
+runs it on every API call and reads an ExecCredential from stdout, so this
+command has a stricter contract than the rest of the CLI:
+
+* **stdout is protocol.** Only the ExecCredential JSON goes there. Every
+  human-readable message goes to stderr, or kubectl fails to parse the reply
+  and reports something unhelpful about the credential plugin.
+* **Exit codes distinguish transient from permanent.** kubectl surfaces the
+  message either way, but a wrapper script — or a human reading `$?` — needs to
+  know whether retrying could help. Retrying a revoked grant never will.
+* **No prompting, ever.** The kubeconfig sets `interactiveMode: Never`; there
+  may be no terminal attached at all.
+
+It deliberately does not use the shared `APIClient`: that collapses HTTP status
+codes into a single `APIError`, and the whole failure contract here is a
+function of the status code.
+"""
+
+import json
+import sys
+from typing import NoReturn
+
+import httpx
+import typer
+
+from prime_cli.core import Config
+
+from ..utils import PlainTyper
+
+app = PlainTyper(
+    help="Authentication helpers (used by other tools, not usually by hand)",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def _auth() -> None:
+    """Present so Typer keeps `k8s-token` as a subcommand.
+
+    Without a callback, a Typer app holding exactly one command promotes it to
+    the group itself — `prime auth` would run the plugin and `prime auth
+    k8s-token` would fail, which is the exact string every kubeconfig we write
+    contains.
+    """
+
+
+# Exit codes. 1 is "try again later", everything above it is "this will not
+# work until something changes".
+EXIT_UNREACHABLE = 1
+EXIT_FORBIDDEN = 2
+EXIT_RATE_LIMITED = 3
+EXIT_AUTH_EXPIRED = 4
+EXIT_AMBIGUOUS = 5
+
+_TIMEOUT_SECONDS = 15.0
+
+
+def _fail(message: str, code: int) -> NoReturn:
+    print(message, file=sys.stderr)
+    raise typer.Exit(code)
+
+
+@app.command("k8s-token")
+def k8s_token(
+    cluster: str = typer.Option(..., "--cluster", help="Cluster name"),
+    pool: str = typer.Option(
+        None, "--pool", help="Pool name, when you have access to more than one"
+    ),
+) -> None:
+    """Print a Kubernetes ExecCredential for a granted cluster.
+
+    Invoked by kubectl via the `exec` block that `prime cluster login` writes.
+    """
+    config = Config()
+    api_key = config.api_key
+    if not api_key:
+        _fail("Not logged in. Run `prime login`.", EXIT_AUTH_EXPIRED)
+
+    url = f"{config.base_url}/clusters/{cluster}/kube-token"
+    params = {"pool": pool} if pool else None
+
+    try:
+        response = httpx.post(
+            url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            params=params,
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except httpx.TimeoutException:
+        _fail(
+            f"Timed out reaching the Prime platform at {config.base_url}.",
+            EXIT_UNREACHABLE,
+        )
+    except httpx.TransportError as e:
+        _fail(
+            f"Cannot reach the Prime platform at {config.base_url}: {e}",
+            EXIT_UNREACHABLE,
+        )
+
+    if response.status_code == 401:
+        _fail("Platform auth expired. Run `prime login`.", EXIT_AUTH_EXPIRED)
+
+    if response.status_code == 403:
+        _fail(
+            f"Access to '{cluster}' has been revoked, or was never granted. Contact an admin.",
+            EXIT_FORBIDDEN,
+        )
+
+    if response.status_code == 409:
+        # Several pools and no --pool. The server lists them in the detail,
+        # which is more useful than anything this side could reconstruct.
+        _fail(_detail(response) or "Specify --pool.", EXIT_AMBIGUOUS)
+
+    if response.status_code == 429:
+        # Honour Retry-After silently when present: a well-behaved kubectl is
+        # about to back off anyway, and a scary error for what is usually a
+        # hot loop just confuses people.
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            _fail(
+                f"Too many credential requests. Retry after {retry_after}s.",
+                EXIT_RATE_LIMITED,
+            )
+        _fail("Too many credential refresh attempts.", EXIT_RATE_LIMITED)
+
+    if response.status_code >= 500:
+        _fail(
+            f"Prime platform error ({response.status_code}). Try again shortly.",
+            EXIT_UNREACHABLE,
+        )
+
+    if response.status_code != 200:
+        _fail(
+            _detail(response) or f"Unexpected response ({response.status_code}).",
+            EXIT_UNREACHABLE,
+        )
+
+    try:
+        credential = response.json()
+    except ValueError:
+        _fail("Platform returned a malformed credential.", EXIT_UNREACHABLE)
+
+    if not isinstance(credential, dict) or "status" not in credential:
+        _fail("Platform returned a malformed credential.", EXIT_UNREACHABLE)
+
+    # stdout, and nothing else on stdout.
+    sys.stdout.write(json.dumps(credential))
+    sys.stdout.flush()
+
+
+def _detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        return ""
+    detail = body.get("detail") if isinstance(body, dict) else None
+    return detail if isinstance(detail, str) else ""

--- a/packages/prime/src/prime_cli/commands/cluster.py
+++ b/packages/prime/src/prime_cli/commands/cluster.py
@@ -10,6 +10,7 @@ namespace and its ServiceAccount, so the next refresh fails and any token
 already issued expires within the hour.
 """
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -52,6 +53,13 @@ def _build_kubeconfig(
     kubectl must not try to prompt, and `provideClusterInfo: false` because the
     plugin resolves the cluster from its own arguments.
     """
+    # `prime --context X cluster login` runs with PRIME_CONTEXT set by the root
+    # callback. The credential plugin runs much later, from kubectl, where that
+    # variable does not exist — so the flag has to be baked into the exec args
+    # or every refresh would silently hit the default context's platform.
+    prime_context = os.getenv("PRIME_CONTEXT")
+    context_args = ["--context", prime_context] if prime_context else []
+
     contexts = []
     users = []
     for grant in grants:
@@ -74,7 +82,8 @@ def _build_kubeconfig(
                     "exec": {
                         "apiVersion": "client.authentication.k8s.io/v1",
                         "command": "prime",
-                        "args": [
+                        "args": context_args
+                        + [
                             "auth",
                             "k8s-token",
                             "--cluster",

--- a/packages/prime/src/prime_cli/commands/cluster.py
+++ b/packages/prime/src/prime_cli/commands/cluster.py
@@ -1,0 +1,147 @@
+"""`prime cluster` — kubeconfig setup for researcher cluster access.
+
+`prime cluster login <name>` writes a kubeconfig whose credentials come from an
+`exec` block calling back into this CLI. No Kubernetes token is ever written to
+disk: every `kubectl` invocation shells out to `prime auth k8s-token`, which
+exchanges the user's platform API token for a short-lived ServiceAccount token.
+
+That indirection is what makes revocation work. Deleting the grant deletes the
+namespace and its ServiceAccount, so the next refresh fails and any token
+already issued expires within the hour.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import typer
+import yaml
+
+from ..client import APIClient, APIError
+from ..utils import PlainTyper, get_console
+
+app = PlainTyper(
+    help="Kubernetes access for clusters you have been granted",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def _cluster() -> None:
+    """Present so Typer keeps `login` as a subcommand rather than promoting it
+    to the group when it is the only one."""
+
+
+console = get_console()
+
+# Standalone file rather than merging into ~/.kube/config: merging means
+# rewriting a file the researcher may share with unrelated clusters, and a bad
+# merge is far more annoying than an extra environment variable.
+KUBECONFIG_DIR = Path.home() / ".prime" / "kube"
+
+
+def _kubeconfig_path(cluster: str) -> Path:
+    return KUBECONFIG_DIR / f"{cluster}.yaml"
+
+
+def _build_kubeconfig(
+    *, cluster: str, server: str, ca_data: str, grants: List[Dict[str, str]]
+) -> Dict[str, Any]:
+    """Render a kubeconfig with one context per pool the user has access to.
+
+    The `exec` block is the whole point: `interactiveMode: Never` because
+    kubectl must not try to prompt, and `provideClusterInfo: false` because the
+    plugin resolves the cluster from its own arguments.
+    """
+    contexts = []
+    users = []
+    for grant in grants:
+        pool = grant["pool"]
+        context_name = f"{cluster}-{pool}"
+        contexts.append(
+            {
+                "name": context_name,
+                "context": {
+                    "cluster": cluster,
+                    "user": context_name,
+                    "namespace": grant["namespace"],
+                },
+            }
+        )
+        users.append(
+            {
+                "name": context_name,
+                "user": {
+                    "exec": {
+                        "apiVersion": "client.authentication.k8s.io/v1",
+                        "command": "prime",
+                        "args": [
+                            "auth",
+                            "k8s-token",
+                            "--cluster",
+                            cluster,
+                            "--pool",
+                            pool,
+                        ],
+                        "interactiveMode": "Never",
+                        "provideClusterInfo": False,
+                    }
+                },
+            }
+        )
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+            {
+                "name": cluster,
+                "cluster": {
+                    "server": server,
+                    "certificate-authority-data": ca_data,
+                },
+            }
+        ],
+        "contexts": contexts,
+        "users": users,
+        "current-context": contexts[0]["name"] if contexts else "",
+    }
+
+
+@app.command("login")
+def login(
+    cluster: str = typer.Argument(..., help="Cluster name, as shown by your admin"),
+) -> None:
+    """Write a kubeconfig for a cluster you have been granted access to."""
+    try:
+        client = APIClient()
+        info: Dict[str, Any] = client.get(f"/clusters/{cluster}/kubeconfig-info")
+    except APIError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1) from e
+
+    grants = info.get("grants") or []
+    if not grants:
+        console.print(f"[red]No active access grant for '{cluster}'.[/red]")
+        raise typer.Exit(1)
+
+    kubeconfig = _build_kubeconfig(
+        cluster=cluster,
+        server=info["server"],
+        ca_data=info["certificateAuthorityData"],
+        grants=grants,
+    )
+
+    path = _kubeconfig_path(cluster)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(kubeconfig, sort_keys=False))
+    # It carries no credential, but it does name every namespace the user can
+    # reach, so don't leave it group-readable.
+    path.chmod(0o600)
+
+    console.print(f"[green]Wrote kubeconfig to {path}[/green]")
+    if len(grants) > 1:
+        pools = ", ".join(grant["pool"] for grant in grants)
+        console.print(f"Contexts for pools: {pools}")
+    console.print("\nUse it with:")
+    console.print(f"  export KUBECONFIG={path}")
+    console.print("  kubectl get pods")

--- a/packages/prime/src/prime_cli/commands/cluster.py
+++ b/packages/prime/src/prime_cli/commands/cluster.py
@@ -45,7 +45,12 @@ def _kubeconfig_path(cluster: str) -> Path:
 
 
 def _build_kubeconfig(
-    *, cluster: str, server: str, ca_data: str, grants: List[Dict[str, str]]
+    *,
+    cluster: str,
+    server: str,
+    ca_data: str,
+    grants: List[Dict[str, str]],
+    base_url: str,
 ) -> Dict[str, Any]:
     """Render a kubeconfig with one context per pool the user has access to.
 
@@ -59,6 +64,16 @@ def _build_kubeconfig(
     # or every refresh would silently hit the default context's platform.
     prime_context = os.getenv("PRIME_CONTEXT")
     context_args = ["--context", prime_context] if prime_context else []
+
+    # The context flag alone is not enough: reloading a context re-resolves
+    # `base_url` from the *environment's* file (or, for the built-in
+    # production context, forces the public default), which discards a custom
+    # URL set via `prime config set-base-url`. So the base URL the login
+    # itself resolved is pinned into the exec environment — PRIME_API_BASE_URL
+    # outranks every other source in `Config.base_url`, making each refresh
+    # hit the same platform the login did, while `--context` still selects the
+    # matching API key.
+    exec_env = [{"name": "PRIME_API_BASE_URL", "value": base_url}]
 
     contexts = []
     users = []
@@ -91,6 +106,7 @@ def _build_kubeconfig(
                             "--pool",
                             pool,
                         ],
+                        "env": exec_env,
                         "interactiveMode": "Never",
                         "provideClusterInfo": False,
                     }
@@ -138,6 +154,9 @@ def login(
         server=info["server"],
         ca_data=info["certificateAuthorityData"],
         grants=grants,
+        # The exact URL this login request just used — not re-derived at
+        # refresh time, where context resolution would lose a custom one.
+        base_url=client.base_url,
     )
 
     path = _kubeconfig_path(cluster)

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -4,7 +4,9 @@ from typing import Optional
 import typer
 
 from . import __version__
+from .commands.auth import app as auth_app
 from .commands.availability import app as availability_app
+from .commands.cluster import app as cluster_app
 from .commands.config import app as config_app
 from .commands.deployments import app as deployments_app
 from .commands.disks import app as disks_app
@@ -65,6 +67,7 @@ app.add_typer(sandbox_app, name="sandbox", rich_help_panel="Compute")
 app.add_typer(images_app, name="images", rich_help_panel="Compute")
 app.add_typer(registry_app, name="registry", rich_help_panel="Compute")
 app.add_typer(tunnel_app, name="tunnel", rich_help_panel="Compute")
+app.add_typer(cluster_app, name="cluster", rich_help_panel="Compute")
 app.add_typer(inference_app, name="inference", rich_help_panel="Compute")
 
 # Account commands
@@ -73,6 +76,8 @@ app.add_typer(logout_app, name="logout", rich_help_panel="Account")
 app.add_typer(whoami_app, name="whoami", rich_help_panel="Account")
 app.add_typer(switch_app, name="switch", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")
+# Credential-plugin entry point: invoked by kubectl, not usually by hand.
+app.add_typer(auth_app, name="auth", rich_help_panel="Account")
 app.add_typer(teams_app, name="teams", rich_help_panel="Account")
 app.add_typer(secret_app, name="secret", rich_help_panel="Account")
 app.command("wallet", rich_help_panel="Account", epilog=WALLET_JSON_HELP)(wallet_command)

--- a/packages/prime/tests/test_cluster_kubeconfig.py
+++ b/packages/prime/tests/test_cluster_kubeconfig.py
@@ -37,7 +37,10 @@ def patch_config(monkeypatch):
 
 
 def respond(monkeypatch, *, status_code, json_body=None, headers=None):
+    requested_urls = []
+
     def _post(url, **kwargs):
+        requested_urls.append(url)
         return httpx.Response(
             status_code=status_code,
             json=json_body if json_body is not None else {},
@@ -46,10 +49,12 @@ def respond(monkeypatch, *, status_code, json_body=None, headers=None):
         )
 
     monkeypatch.setattr("prime_cli.commands.auth.httpx.post", _post)
+    return requested_urls
 
 
 class TestKubeconfigRendering:
-    def test_exec_block_carries_no_token(self):
+    def test_exec_block_carries_no_token(self, monkeypatch):
+        monkeypatch.delenv("PRIME_CONTEXT", raising=False)
         config = _build_kubeconfig(
             cluster="alpha-cluster",
             server="https://k8s.example.com",
@@ -67,7 +72,43 @@ class TestKubeconfigRendering:
         # Never prompt: kubectl may be running with no terminal attached.
         assert exec_block["interactiveMode"] == "Never"
 
-    def test_one_context_per_pool(self):
+    def test_exec_args_carry_no_context_flag_by_default(self, monkeypatch):
+        monkeypatch.delenv("PRIME_CONTEXT", raising=False)
+        config = _build_kubeconfig(
+            cluster="c1",
+            server="https://k8s",
+            ca_data="Y2E=",
+            grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+        )
+        args = config["users"][0]["user"]["exec"]["args"]
+        assert args == ["auth", "k8s-token", "--cluster", "c1", "--pool", "alpha"]
+
+    def test_exec_args_preserve_the_prime_context(self, monkeypatch):
+        # `prime --context staging cluster login` must write a kubeconfig whose
+        # refreshes also run against staging — kubectl invokes the plugin with
+        # no PRIME_CONTEXT in its environment, so the flag has to be in the
+        # file itself.
+        monkeypatch.setenv("PRIME_CONTEXT", "staging")
+        config = _build_kubeconfig(
+            cluster="c1",
+            server="https://k8s",
+            ca_data="Y2E=",
+            grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+        )
+        args = config["users"][0]["user"]["exec"]["args"]
+        assert args == [
+            "--context",
+            "staging",
+            "auth",
+            "k8s-token",
+            "--cluster",
+            "c1",
+            "--pool",
+            "alpha",
+        ]
+
+    def test_one_context_per_pool(self, monkeypatch):
+        monkeypatch.delenv("PRIME_CONTEXT", raising=False)
         config = _build_kubeconfig(
             cluster="c1",
             server="https://k8s",
@@ -99,6 +140,15 @@ class TestCredentialPluginSuccess:
         assert result.exit_code == 0
         # kubectl parses stdout as JSON — anything else on it breaks auth.
         assert json.loads(result.stdout) == credential
+
+    def test_posts_to_the_public_api_route(self, patch_config, monkeypatch):
+        # Config.base_url strips /api/v1, so the plugin must add it back —
+        # this URL shipped without the prefix once and every call 404'd.
+        urls = respond(monkeypatch, status_code=200, json_body={"status": {}})
+
+        runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+
+        assert urls == ["https://api.example.com/api/v1/clusters/c1/kube-token"]
 
 
 class TestCredentialPluginFailures:

--- a/packages/prime/tests/test_cluster_kubeconfig.py
+++ b/packages/prime/tests/test_cluster_kubeconfig.py
@@ -1,0 +1,174 @@
+"""Coverage for `prime cluster login` and the `prime auth k8s-token` plugin.
+
+The plugin's contract is unusually strict because kubectl, not a human, is the
+caller: stdout is protocol, and the exit code is how anything wrapping it tells
+"retry later" from "this will never work". Those are the properties worth
+pinning down — a regression in them shows up as a confusing kubectl error
+rather than a test failure anywhere else.
+"""
+
+import json
+
+import httpx
+import pytest
+import yaml
+from prime_cli.commands.auth import (
+    EXIT_AMBIGUOUS,
+    EXIT_AUTH_EXPIRED,
+    EXIT_FORBIDDEN,
+    EXIT_RATE_LIMITED,
+    EXIT_UNREACHABLE,
+)
+from prime_cli.commands.auth import app as auth_app
+from prime_cli.commands.cluster import _build_kubeconfig
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class _FakeConfig:
+    api_key = "test-key"
+    base_url = "https://api.example.com"
+
+
+@pytest.fixture
+def patch_config(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.auth.Config", lambda: _FakeConfig())
+
+
+def respond(monkeypatch, *, status_code, json_body=None, headers=None):
+    def _post(url, **kwargs):
+        return httpx.Response(
+            status_code=status_code,
+            json=json_body if json_body is not None else {},
+            headers=headers or {},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr("prime_cli.commands.auth.httpx.post", _post)
+
+
+class TestKubeconfigRendering:
+    def test_exec_block_carries_no_token(self):
+        config = _build_kubeconfig(
+            cluster="alpha-cluster",
+            server="https://k8s.example.com",
+            ca_data="Y2E=",
+            grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+        )
+        rendered = yaml.safe_dump(config)
+        # No credential material anywhere in the file — the only "token" that
+        # may appear is the plugin's own subcommand name.
+        assert "token:" not in rendered
+        assert "client-certificate" not in rendered
+        exec_block = config["users"][0]["user"]["exec"]
+        assert exec_block["command"] == "prime"
+        assert exec_block["args"][:2] == ["auth", "k8s-token"]
+        # Never prompt: kubectl may be running with no terminal attached.
+        assert exec_block["interactiveMode"] == "Never"
+
+    def test_one_context_per_pool(self):
+        config = _build_kubeconfig(
+            cluster="c1",
+            server="https://k8s",
+            ca_data="Y2E=",
+            grants=[
+                {"pool": "alpha", "namespace": "ada-alpha"},
+                {"pool": "beta", "namespace": "ada-beta"},
+            ],
+        )
+        assert [c["name"] for c in config["contexts"]] == ["c1-alpha", "c1-beta"]
+        assert config["contexts"][0]["context"]["namespace"] == "ada-alpha"
+        assert config["current-context"] == "c1-alpha"
+        # Each context's plugin invocation names its own pool, otherwise the
+        # server would refuse the ambiguous request on every kubectl call.
+        assert config["users"][1]["user"]["exec"]["args"][-1] == "beta"
+
+
+class TestCredentialPluginSuccess:
+    def test_writes_only_the_credential_to_stdout(self, patch_config, monkeypatch):
+        credential = {
+            "apiVersion": "client.authentication.k8s.io/v1",
+            "kind": "ExecCredential",
+            "status": {"token": "abc", "expirationTimestamp": "2026-07-25T07:00:00Z"},
+        }
+        respond(monkeypatch, status_code=200, json_body=credential)
+
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+
+        assert result.exit_code == 0
+        # kubectl parses stdout as JSON — anything else on it breaks auth.
+        assert json.loads(result.stdout) == credential
+
+
+class TestCredentialPluginFailures:
+    """Each status maps to a distinct exit code so a caller can tell whether
+    retrying is pointless."""
+
+    def test_revoked_grant_is_permanent(self, patch_config, monkeypatch):
+        respond(
+            monkeypatch,
+            status_code=403,
+            json_body={"detail": "No active cluster access grant"},
+        )
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_FORBIDDEN
+        assert result.stdout.strip() == ""
+
+    def test_expired_platform_auth_points_at_prime_login(self, patch_config, monkeypatch):
+        respond(monkeypatch, status_code=401)
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_AUTH_EXPIRED
+
+    def test_rate_limited_reports_retry_after(self, patch_config, monkeypatch):
+        respond(monkeypatch, status_code=429, headers={"Retry-After": "42"})
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_RATE_LIMITED
+
+    def test_rate_limited_without_retry_after_still_exits_cleanly(self, patch_config, monkeypatch):
+        respond(monkeypatch, status_code=429)
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_RATE_LIMITED
+
+    def test_ambiguous_pool_is_its_own_code(self, patch_config, monkeypatch):
+        respond(
+            monkeypatch,
+            status_code=409,
+            json_body={"detail": "You have access to several pools (alpha, beta)."},
+        )
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_AMBIGUOUS
+
+    def test_server_error_is_transient(self, patch_config, monkeypatch):
+        respond(monkeypatch, status_code=503)
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_UNREACHABLE
+
+    def test_unreachable_platform_is_transient(self, patch_config, monkeypatch):
+        def _post(url, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr("prime_cli.commands.auth.httpx.post", _post)
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_UNREACHABLE
+
+    def test_malformed_credential_is_not_passed_through(self, patch_config, monkeypatch):
+        # A 200 with the wrong shape must not reach kubectl as if it were valid.
+        respond(monkeypatch, status_code=200, json_body={"nope": True})
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_UNREACHABLE
+        assert result.stdout.strip() == ""
+
+    def test_missing_api_key_does_not_call_the_platform(self, monkeypatch):
+        class _NoKey:
+            api_key = ""
+            base_url = "https://api.example.com"
+
+        monkeypatch.setattr("prime_cli.commands.auth.Config", lambda: _NoKey())
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("should not have made a request")
+
+        monkeypatch.setattr("prime_cli.commands.auth.httpx.post", _explode)
+        result = runner.invoke(auth_app, ["k8s-token", "--cluster", "c1"])
+        assert result.exit_code == EXIT_AUTH_EXPIRED

--- a/packages/prime/tests/test_cluster_kubeconfig.py
+++ b/packages/prime/tests/test_cluster_kubeconfig.py
@@ -60,6 +60,7 @@ class TestKubeconfigRendering:
             server="https://k8s.example.com",
             ca_data="Y2E=",
             grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+            base_url="https://api.example.com",
         )
         rendered = yaml.safe_dump(config)
         # No credential material anywhere in the file — the only "token" that
@@ -79,6 +80,7 @@ class TestKubeconfigRendering:
             server="https://k8s",
             ca_data="Y2E=",
             grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+            base_url="https://api.example.com",
         )
         args = config["users"][0]["user"]["exec"]["args"]
         assert args == ["auth", "k8s-token", "--cluster", "c1", "--pool", "alpha"]
@@ -94,6 +96,7 @@ class TestKubeconfigRendering:
             server="https://k8s",
             ca_data="Y2E=",
             grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+            base_url="https://api.example.com",
         )
         args = config["users"][0]["user"]["exec"]["args"]
         assert args == [
@@ -107,6 +110,26 @@ class TestKubeconfigRendering:
             "alpha",
         ]
 
+    def test_exec_env_pins_the_resolved_base_url(self, monkeypatch):
+        # The --context flag alone regressed custom API URLs: reloading the
+        # built-in production context at refresh time forces base_url back to
+        # the public default. The login-time URL therefore rides in the exec
+        # env, where it outranks context resolution.
+        monkeypatch.setenv("PRIME_CONTEXT", "production")
+        config = _build_kubeconfig(
+            cluster="c1",
+            server="https://k8s",
+            ca_data="Y2E=",
+            grants=[{"pool": "alpha", "namespace": "ada-alpha"}],
+            base_url="https://api.internal.example.com",
+        )
+        exec_block = config["users"][0]["user"]["exec"]
+        assert exec_block["env"] == [
+            {"name": "PRIME_API_BASE_URL", "value": "https://api.internal.example.com"}
+        ]
+        # The context intent is preserved alongside, not replaced.
+        assert exec_block["args"][:2] == ["--context", "production"]
+
     def test_one_context_per_pool(self, monkeypatch):
         monkeypatch.delenv("PRIME_CONTEXT", raising=False)
         config = _build_kubeconfig(
@@ -117,6 +140,7 @@ class TestKubeconfigRendering:
                 {"pool": "alpha", "namespace": "ada-alpha"},
                 {"pool": "beta", "namespace": "ada-beta"},
             ],
+            base_url="https://api.example.com",
         )
         assert [c["name"] for c in config["contexts"]] == ["c1-alpha", "c1-beta"]
         assert config["contexts"][0]["context"]["namespace"] == "ada-alpha"
@@ -124,6 +148,44 @@ class TestKubeconfigRendering:
         # Each context's plugin invocation names its own pool, otherwise the
         # server would refuse the ambiguous request on every kubectl call.
         assert config["users"][1]["user"]["exec"]["args"][-1] == "beta"
+
+
+class TestCustomBaseUrlSurvivesContextRefresh:
+    """The regression this pins down: with `PRIME_CONTEXT=production` (the
+    baked-in --context flag), every kubectl refresh reloaded the built-in
+    production environment and forced base_url back to the public default —
+    ignoring a custom URL set via `prime config set-base-url`. The exec env's
+    PRIME_API_BASE_URL must outrank that reload."""
+
+    @pytest.fixture
+    def custom_url_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("PRIME_API_BASE_URL", raising=False)
+        monkeypatch.delenv("PRIME_BASE_URL", raising=False)
+        monkeypatch.delenv("PRIME_CONTEXT", raising=False)
+        from prime_cli.core import Config
+
+        config = Config()
+        config.set_base_url("https://api.internal.example.com")
+        return tmp_path
+
+    def test_production_context_alone_loses_the_custom_url(self, custom_url_home, monkeypatch):
+        # The failure mode being fixed, kept as documentation: context
+        # resolution at refresh time discards the custom URL.
+        from prime_cli.core import Config
+
+        monkeypatch.setenv("PRIME_CONTEXT", "production")
+        assert Config().base_url == "https://api.primeintellect.ai"
+
+    def test_exec_env_base_url_outranks_the_production_context(self, custom_url_home, monkeypatch):
+        # What actually happens at refresh time now: kubectl exports the exec
+        # env block, so the plugin's Config resolves the pinned URL even while
+        # --context production reloads the built-in environment.
+        from prime_cli.core import Config
+
+        monkeypatch.setenv("PRIME_CONTEXT", "production")
+        monkeypatch.setenv("PRIME_API_BASE_URL", "https://api.internal.example.com")
+        assert Config().base_url == "https://api.internal.example.com"
 
 
 class TestCredentialPluginSuccess:

--- a/packages/prime/transfer-bulk-failures.jsonl
+++ b/packages/prime/transfer-bulk-failures.jsonl
@@ -1,1 +1,0 @@
-{"source": "a/app-a:v1", "platform": "linux/amd64"}

--- a/packages/prime/transfer-bulk-failures.jsonl
+++ b/packages/prime/transfer-bulk-failures.jsonl
@@ -1,0 +1,1 @@
+{"source": "a/app-a:v1", "platform": "linux/amd64"}


### PR DESCRIPTION
Targeting `main` because this repo does not use the `develop`-branch convention — it has no `develop` branch and merges PRs straight into `main`. (The platform-side PRs for this feature target `develop` as usual.)

Adds the researcher side of PrimeCluster node pools: a kubeconfig, and the credential plugin behind it.

- `prime cluster login <cluster>` writes a kubeconfig with one context per pool the researcher has been granted, and an `exec` block instead of a token. Nothing credential-shaped is ever written to disk
- `prime auth k8s-token` is the credential plugin kubectl invokes on every API call. It exchanges the platform API token for a short-lived ServiceAccount token scoped to the researcher's namespace

That indirection is what makes revocation mean something: revoking a grant deletes the namespace and its ServiceAccount, so the next refresh fails and any token already issued expires within the hour.

The plugin has a stricter contract than the rest of the CLI, because kubectl is the caller rather than a human:

- **stdout is protocol.** Only the ExecCredential goes there; every message goes to stderr. Anything else on stdout and kubectl reports a confusing parse failure instead of the actual problem
- **Exit codes separate transient from permanent** — 1 unreachable, 2 revoked, 3 rate limited, 4 platform auth expired, 5 ambiguous pool. Retrying a revoked grant will never work and callers shouldn't have to guess
- **Never prompts.** The kubeconfig sets `interactiveMode: Never`; there may be no terminal at all

It talks to the platform with `httpx` directly rather than the shared `APIClient`. `APIClient` collapses every status into one `APIError`, and the entire failure contract here is a function of the status code.

Two things worth flagging:

The kubeconfig needs the apiserver URL and CA, which the mint endpoint doesn't return, so this depends on a new `GET /api/v1/clusters/{name}/kubeconfig-info` endpoint added in the platform PR. `prime cluster login` will fail against a platform that predates it.

A Typer app holding exactly one command promotes it to the group, which would have made `prime auth k8s-token` fail while `prime auth` silently ran the plugin — and that exact string is written into every kubeconfig we generate. Both groups now carry an explicit callback to prevent it, and the tests cover the wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authentication path invoked on every kubectl call; mistakes in stdout/exit-code contract or URL pinning would break cluster access or send users to the wrong platform.
> 
> **Overview**
> Adds **researcher Kubernetes access** for granted Prime clusters: **`prime cluster login`** fetches cluster metadata from the platform and writes a per-cluster kubeconfig under `~/.prime/kube/` with **one context per pool**, each using an **`exec`** credential that calls **`prime auth k8s-token`** (no tokens on disk).
> 
> **`prime auth k8s-token`** implements the kubectl credential plugin contract: **ExecCredential JSON only on stdout**, errors on stderr, **distinct exit codes** for unreachable vs revoked vs rate-limited vs expired auth vs ambiguous pool, and **direct `httpx`** calls (not `APIClient`) so HTTP status drives behavior. Kubeconfig exec args/env pin **`--context`** and **`PRIME_API_BASE_URL`** so refreshes from kubectl use the same platform and API key as login.
> 
> Wires **`cluster`** and **`auth`** into the root CLI (with Typer group callbacks so `prime auth k8s-token` stays a real subcommand). **`login` depends on** `GET …/kubeconfig-info` on the platform; the plugin posts to **`…/kube-token`**.
> 
> Tests cover kubeconfig shape, context/base-URL pinning, plugin success path, and failure exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc59e4c460fb82474af21d6e47a08523e0803dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->