### PR TITLE
retry transient tunnel login failures on startup instead of exiting

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -56,6 +56,32 @@ def _parse_frpc_error(
     return TunnelConnectionError(tunnel_id=tunnel_id, message=message)
 
 
+# Server-side rejection reasons that retrying can never fix.
+_FATAL_LOGIN_ERRORS = (
+    "tunnel is inactive",
+    "tunnel not registered",
+    "invalid binding secret",
+    "invalid authentication token",
+    "token in login doesn't match",
+)
+
+
+def _scan_startup_line(line: str) -> Optional[str]:
+    """Classify an frpc startup log line.
+
+    Returns "connected" once the proxy is registered, "fatal" for login
+    failures that cannot succeed on retry, and None for anything else
+    (including transient login/connect failures frpc will retry).
+    """
+    lowered = line.lower()
+    if "start proxy success" in lowered:
+        return "connected"
+    if "login to the server failed" in lowered or "connect to server error" in lowered:
+        if any(reason in lowered for reason in _FATAL_LOGIN_ERRORS):
+            return "fatal"
+    return None
+
+
 class Tunnel:
     """Tunnel interface for exposing local services."""
 
@@ -378,6 +404,9 @@ user = "{self._tunnel_info.tunnel_id}"
 auth.method = "token"
 auth.token = "{self._tunnel_info.frp_token}"
 
+# Retry the initial login instead of exiting on the first transient failure
+loginFailExit = false
+
 # Per-tunnel binding secret
 metadatas.binding_secret = "{self._tunnel_info.binding_secret}"
 
@@ -459,13 +488,10 @@ subdomain = "{self._tunnel_info.tunnel_id}"
                                 line = line.strip()
                                 if line:
                                     self._output_lines.append(line)
-                                    # Check for success/failure indicators
-                                    if "start proxy success" in line.lower():
+                                    verdict = _scan_startup_line(line)
+                                    if verdict == "connected":
                                         return
-                                    if (
-                                        "login to the server failed" in line.lower()
-                                        or "connect to server error" in line.lower()
-                                    ):
+                                    if verdict == "fatal":
                                         raise _parse_frpc_error(self._output_lines, self.tunnel_id)
                         except (BlockingIOError, IOError):
                             pass  # No more data available on this pipe

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -418,7 +418,9 @@ def test_scan_startup_line_fatal_rejections():
         _frpc_line("W", "connect to server error: Tunnel not registered"),
         _frpc_line("W", "connect to server error: Invalid binding secret"),
         _frpc_line("W", "connect to server error: Invalid authentication token"),
-        _frpc_line("W", "login to the server failed: token in login doesn't match token from configuration"),
+        _frpc_line(
+            "W", "login to the server failed: token in login doesn't match token from configuration"
+        ),
     ]
     for line in fatal:
         assert _scan_startup_line(line) == "fatal"

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -380,3 +382,123 @@ async def test_client_bulk_delete_status_rejects_tunnel_ids():
 
     with pytest.raises(TunnelError, match="status cannot be combined with tunnel_ids"):
         await client.bulk_delete_tunnels(tunnel_ids=["t-1"], status="disconnected")
+
+
+# -- startup login retry tests --
+
+
+def _frpc_line(level: str, msg: str) -> str:
+    return f"2026-07-28 00:00:00.000 [{level}] [client/service.go:319] {msg}"
+
+
+def test_scan_startup_line_connected():
+    from prime_tunnel.tunnel import _scan_startup_line
+
+    line = _frpc_line("I", "[t-test123] start proxy success")
+    assert _scan_startup_line(line) == "connected"
+
+
+def test_scan_startup_line_transient_failures_are_not_fatal():
+    from prime_tunnel.tunnel import _scan_startup_line
+
+    transient = [
+        _frpc_line("W", "connect to server error: dial tcp 1.2.3.4:7000: i/o timeout"),
+        _frpc_line("W", "connect to server error: Tunnel validation failed"),
+        _frpc_line("W", "login to the server failed: EOF"),
+    ]
+    for line in transient:
+        assert _scan_startup_line(line) is None
+
+
+def test_scan_startup_line_fatal_rejections():
+    from prime_tunnel.tunnel import _scan_startup_line
+
+    fatal = [
+        _frpc_line("W", "connect to server error: Tunnel is inactive"),
+        _frpc_line("W", "connect to server error: Tunnel not registered"),
+        _frpc_line("W", "connect to server error: Invalid binding secret"),
+        _frpc_line("W", "connect to server error: Invalid authentication token"),
+        _frpc_line("W", "login to the server failed: token in login doesn't match token from configuration"),
+    ]
+    for line in fatal:
+        assert _scan_startup_line(line) == "fatal"
+
+
+def test_scan_startup_line_ignores_unrelated_lines():
+    from prime_tunnel.tunnel import _scan_startup_line
+
+    assert _scan_startup_line(_frpc_line("I", "try to connect to server...")) is None
+    # Rejection reason without a login/connect failure marker is not fatal
+    assert _scan_startup_line(_frpc_line("I", "tunnel is inactive")) is None
+
+
+def test_frpc_config_disables_login_fail_exit(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    tunnel = _make_started_tunnel()
+    config_file = tunnel._write_frpc_config()
+    content = config_file.read_text()
+    assert "loginFailExit = false" in content
+    assert 'auth.token = "tok"' in content
+
+
+def _make_fake_frpc(lines: list[str]):
+    """Fake Popen whose stdout is a real pipe (fcntl-compatible) fed with lines."""
+    read_fd, write_fd = os.pipe()
+    stdout = os.fdopen(read_fd, "r")
+    for line in lines:
+        os.write(write_fd, (line + "\n").encode())
+
+    process = MagicMock()
+    process.poll.return_value = None
+    process.stdout = stdout
+    process.stderr = None
+    return process, write_fd
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_rides_out_transient_failure():
+    tunnel = Tunnel(local_port=8080, connection_timeout=5.0)
+    process, write_fd = _make_fake_frpc(
+        [
+            _frpc_line("W", "connect to server error: dial tcp 1.2.3.4:7000: i/o timeout"),
+            _frpc_line("I", "[t-test123] start proxy success"),
+        ]
+    )
+    tunnel._process = process
+    try:
+        await tunnel._wait_for_connection()  # should not raise
+    finally:
+        os.close(write_fd)
+        process.stdout.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_fails_fast_on_rejection():
+    from prime_tunnel.exceptions import TunnelConnectionError
+
+    tunnel = Tunnel(local_port=8080, connection_timeout=5.0)
+    process, write_fd = _make_fake_frpc(
+        [_frpc_line("W", "connect to server error: Tunnel is inactive")]
+    )
+    tunnel._process = process
+    try:
+        with pytest.raises(TunnelConnectionError, match="Tunnel is inactive"):
+            await tunnel._wait_for_connection()
+    finally:
+        os.close(write_fd)
+        process.stdout.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_connection_times_out_on_persistent_transient_failure():
+    tunnel = Tunnel(local_port=8080, connection_timeout=0.5)
+    process, write_fd = _make_fake_frpc(
+        [_frpc_line("W", "connect to server error: dial tcp 1.2.3.4:7000: i/o timeout")]
+    )
+    tunnel._process = process
+    try:
+        with pytest.raises(TunnelTimeoutError):
+            await tunnel._wait_for_connection()
+    finally:
+        os.close(write_fd)
+        process.stdout.close()


### PR DESCRIPTION
the frpc config leaves loginFailExit at its default (true) and the SDK's startup watcher treats the first login to the server failed / connect to server error line in frpc output as fatal. So a single transient failure during tunnel startup kills frpc and the SDK then deletes the tunnel registration. Anything already holding that tunnel URL 404s permanently. This is one of the amplifiers behind the "404 Tunnel not found" errors


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tunnel connect/cleanup behavior on startup; misclassified log lines could delay failure or abort too early, but scope is limited to prime-tunnel with solid test coverage.
> 
> **Overview**
> **Tunnel startup no longer tears down registration on the first transient frpc login/connect error**, addressing a path where a brief network blip caused frpc to exit, the SDK to run cleanup (including deleting the tunnel), and clients to see permanent **404 Tunnel not found**.
> 
> Generated frpc config now sets **`loginFailExit = false`** so frpc keeps retrying instead of exiting on the first login failure. Startup log handling uses **`_scan_startup_line`** to treat **"start proxy success"** as connected, only **fail fast** when login/connect errors match known **fatal** server reasons (inactive tunnel, bad token/binding secret, etc.), and **ignore** other login/connect lines until success or **`connection_timeout`**.
> 
> Tests cover line classification, config output, riding out transient errors, fast-fail on rejections, and timeout on endless transient failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71804a71d4bd29a6d45921aa4168b0d55759448f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->