### PR TITLE
pin ruff to match uv.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Run Ruff
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4.1.0
       with:
-        version: "0.14.0"
+        version-file: "uv.lock"
 
   lock-check:
     # Advisory check: warns (does not fail) if uv.lock has drifted from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Run Ruff
-      uses: chartboost/ruff-action@v1
+      uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.14.0"
 
   lock-check:
     # Advisory check: warns (does not fail) if uv.lock has drifted from


### PR DESCRIPTION
ci lint is broken for every PR in that repo since ruff 0.16.0 dropped
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application, auth, or runtime behavior is affected.
> 
> **Overview**
> CI **lint-format** now runs Ruff via **`astral-sh/ruff-action@v4.1.0`** instead of **`chartboost/ruff-action@v1`**, with **`version-file: uv.lock`** so the workflow uses the same Ruff version as local dev and pre-commit.
> 
> This keeps CI lint results aligned with what contributors see after `uv sync`, avoiding drift when the floating `@v1` action pulled a newer Ruff than the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cdf2a846ef42c318bca6e3fd6a3a38e6ef4000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->