### PR TITLE
release: cli 0.6.21 + sandbox 0.2.34

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -68,7 +68,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.33"
+__version__ = "0.2.34"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.33",
+    "prime-sandboxes>=0.2.34",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.20"
+__version__ = "0.6.21"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Release bump for everything merged since v0.6.20.

- bump `prime` CLI/SDK to `0.6.21`
- bump `prime-sandboxes` SDK to `0.2.34`
- require `prime-sandboxes>=0.2.34` from `prime`

Included changes:
- #807 — `prime train models` shows FFT models by default
- #803 — paced concurrent bulk image updates
- #804 — sandbox default memory lowered to 1 GB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no runtime logic modified in this PR.
> 
> **Overview**
> **Release version bumps** for the `prime` CLI/SDK and `prime-sandboxes` package, with no functional code changes in this diff.
> 
> Bumps `__version__` in `prime_cli` to **0.6.21** and in `prime_sandboxes` to **0.2.34**, and updates the `prime` package dependency from `prime-sandboxes>=0.2.33` to **`>=0.2.34`** so installs align with the new sandbox SDK release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cd2505a0f3decfb94bf8e154470ea51271d75c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->