### PR TITLE
Fix flaky Lab ladder loading test

### DIFF
--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -6702,8 +6702,10 @@ async def test_prime_lab_app_ladder_loads_platform_sections(tmp_path: Path) -> N
     )
 
     async with app.run_test() as pilot:
-        await pilot.pause()
-        await pilot.pause()
+        for _ in range(50):
+            if loaded_limits == [5, 10, 20]:
+                break
+            await pilot.pause()
 
     assert loaded_limits == [5, 10, 20]
 


### PR DESCRIPTION
Fixes the Python 3.11 CI race in test_prime_lab_app_ladder_loads_platform_sections by waiting boundedly for the full expected loader sequence instead of assuming two scheduler pauses are sufficient. Validation: full Lab test module passes under Python 3.11 (213 tests), the repaired test passes across 10 parallel Python 3.11 workers, and Ruff, formatting, ty, and git diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing fix with no production code changes.
> 
> **Overview**
> **Fixes flaky `test_prime_lab_app_ladder_loads_platform_sections`** by replacing two fixed `pilot.pause()` calls with a bounded wait (up to 50 pauses) until `loaded_limits` equals `[5, 10, 20]`.
> 
> The assertion is unchanged; only the synchronization before it is more reliable under Python 3.11’s async scheduler timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d929fc9209b58095db94645e2ca27688383a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->