### PR TITLE
fix: raise eval push payload limit to 100 MiB

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -220,7 +220,7 @@ class EvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        max_payload_bytes: int = 25 * 1024 * 1024,
+        max_payload_bytes: int = 100 * 1024 * 1024,
         max_workers: int = 4,
         progress_callback: Optional[Callable[[int], None]] = None,
     ) -> Dict[str, Any]:
@@ -576,7 +576,7 @@ class AsyncEvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        max_payload_bytes: int = 25 * 1024 * 1024,
+        max_payload_bytes: int = 100 * 1024 * 1024,
         max_concurrent: int = 4,
         progress_callback: Optional[Callable[[int], None]] = None,
     ) -> Dict[str, Any]:


### PR DESCRIPTION
Follows #637 (which raised the eval-push payload limit 2 → 25 MiB).

Computer-use environments embed a full 1920×1080 screenshot per step in the trace, so a **single rollout's sample exceeds 25 MiB** and gets dropped on `--push` — leaving those runs with no hosted rollout link. Observed while validating the `cua_world_v1` / `osworld_v2_v1` research environments:

- `sample 0 is too large to upload (53564890 > 26214400 bytes)` — cua_world, kimi-k3 (~51 MiB @ 15 turns)
- `sample 0 is too large to upload (78391638 > 26214400 bytes)` — osworld_v2, qwen (~75 MiB @ 50 steps)

At ~1.5–3.5 MiB per screenshot, one rollout can run well past 25 MiB, and longer/higher-res computer-use rollouts go higher still (a 50-turn cua rollout would be ~170 MiB). Raises `max_payload_bytes` **25 → 100 MiB** in both the sync and async `push_samples` (the same two spots #637 touched) for real headroom without compressing traces.

> Note: the client-side mirror `_MAX_SAMPLES_PAYLOAD_BYTES` in `verifiers/v1/utils/platform.py` (the `uv run eval --push` path, where the error above is actually raised) carries the same constant — companion PR: PrimeIntellect-ai/verifiers#2222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)