### PR TITLE
Add spinner and status poll to prime train stop

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -403,7 +403,11 @@ class RLClient:
         blow past it) - the client-wide default applies when omitted.
         """
         try:
-            response = self.client.request("GET", f"/rft/runs/{run_id}", timeout=timeout)
+            # Only forward `timeout` when a caller actually set it, so
+            # existing callers/mocks that don't expect the kwarg at all
+            # see the exact same call shape as before.
+            kwargs = {"timeout": timeout} if timeout is not None else {}
+            response = self.client.get(f"/rft/runs/{run_id}", **kwargs)
             return RLRun.model_validate(response.get("run"))
         except APIError:
             # Preserve typed subclasses (NotFoundError, UnauthorizedError, …)

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -395,10 +395,15 @@ class RLClient:
                 raise APIError(f"Failed to list checkpoints: {e.response.text}")
             raise APIError(f"Failed to list checkpoints: {str(e)}")
 
-    def get_run(self, run_id: str) -> RLRun:
-        """Get details of a specific Hosted Training run."""
+    def get_run(self, run_id: str, timeout: Optional[int] = None) -> RLRun:
+        """Get details of a specific Hosted Training run.
+
+        `timeout` bounds this specific request (e.g. so a caller polling
+        against a wall-clock deadline can't have a single stalled request
+        blow past it) - the client-wide default applies when omitted.
+        """
         try:
-            response = self.client.get(f"/rft/runs/{run_id}")
+            response = self.client.request("GET", f"/rft/runs/{run_id}", timeout=timeout)
             return RLRun.model_validate(response.get("run"))
         except APIError:
             # Preserve typed subclasses (NotFoundError, UnauthorizedError, …)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -110,6 +110,11 @@ HOSTED_TRAINING_LOG_STARTUP_POLL_SECONDS = 10
 HOSTED_TRAINING_LOG_STARTUP_POLLS = 18
 HOSTED_TRAINING_LOG_FOLLOW_POLL_SECONDS = 5
 
+HOSTED_TRAINING_STOP_POLL_SECONDS = 3
+HOSTED_TRAINING_STOP_MAX_POLLS = 60
+
+TERMINAL_RUN_STATUSES = {"STOPPED", "FAILED", "COMPLETED"}
+
 # Log level colors for rich console
 LEVEL_STYLES = {
     "DEBUG": "dim",
@@ -2310,10 +2315,30 @@ def stop_run(
         api_client = APIClient()
         rl_client = RLClient(api_client)
 
-        run = rl_client.stop_run(run_id)
+        with console.status("[bold blue]Stopping run...", spinner="dots"):
+            run = rl_client.stop_run(run_id)
 
+            attempts = 0
+            while (
+                run.status.upper() not in TERMINAL_RUN_STATUSES
+                and attempts < HOSTED_TRAINING_STOP_MAX_POLLS
+            ):
+                time.sleep(HOSTED_TRAINING_STOP_POLL_SECONDS)
+                run = rl_client.get_run(run_id)
+                attempts += 1
+
+        if run.status.upper() not in TERMINAL_RUN_STATUSES:
+            console.print(
+                f"[yellow]Run {run_id} did not reach a terminal state after "
+                f"{HOSTED_TRAINING_STOP_MAX_POLLS * HOSTED_TRAINING_STOP_POLL_SECONDS}s "
+                f"- it's still being torn down in the background.[/yellow]"
+            )
+            console.print(f"Check status with: prime train get {run_id}")
+            raise typer.Exit(0)
+
+        color = _get_status_color(run.status)
         console.print(f"[green]✓ Run {run_id} stopped successfully[/green]")
-        console.print(f"Status: {run.status}")
+        console.print(f"Status: [{color}]{run.status}[/{color}]")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -2318,26 +2318,40 @@ def stop_run(
         with console.status("[bold blue]Stopping run...", spinner="dots"):
             run = rl_client.stop_run(run_id)
 
-            attempts = 0
-            while (
-                run.status.upper() not in TERMINAL_RUN_STATUSES
-                and attempts < HOSTED_TRAINING_STOP_MAX_POLLS
-            ):
-                time.sleep(HOSTED_TRAINING_STOP_POLL_SECONDS)
-                run = rl_client.get_run(run_id)
-                attempts += 1
+            # Monotonic deadline (not an attempt counter) so a slow or
+            # stalled get_run call can't push the total wait past the
+            # advertised cap - the per-request timeout below is capped to
+            # whatever's left on the deadline too.
+            stop_budget_seconds = HOSTED_TRAINING_STOP_MAX_POLLS * HOSTED_TRAINING_STOP_POLL_SECONDS
+            deadline = time.monotonic() + stop_budget_seconds
+            while run.status.upper() not in TERMINAL_RUN_STATUSES:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(HOSTED_TRAINING_STOP_POLL_SECONDS, remaining))
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                run = rl_client.get_run(run_id, timeout=max(1, int(remaining)))
 
-        if run.status.upper() not in TERMINAL_RUN_STATUSES:
+        status_upper = run.status.upper()
+        if status_upper not in TERMINAL_RUN_STATUSES:
             console.print(
                 f"[yellow]Run {run_id} did not reach a terminal state after "
-                f"{HOSTED_TRAINING_STOP_MAX_POLLS * HOSTED_TRAINING_STOP_POLL_SECONDS}s "
-                f"- it's still being torn down in the background.[/yellow]"
+                f"{stop_budget_seconds:.0f}s - it's still being torn down in the "
+                f"background.[/yellow]"
             )
             console.print(f"Check status with: prime train get {run_id}")
             raise typer.Exit(0)
 
         color = _get_status_color(run.status)
-        console.print(f"[green]✓ Run {run_id} stopped successfully[/green]")
+        if status_upper == "STOPPED":
+            console.print(f"[green]✓ Run {run_id} stopped successfully[/green]")
+        else:
+            console.print(
+                f"[yellow]Run {run_id} reached a terminal state before the stop "
+                f"completed - it was not actively stopped.[/yellow]"
+            )
         console.print(f"Status: [{color}]{run.status}[/{color}]")
 
     except APIError as e:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -20,7 +20,7 @@ from rich.table import Table
 from prime_cli.core import Config
 
 from ..api.rl import EnvServerInfo, RLClient, RLRun
-from ..client import APIClient, APIError, APITimeoutError, ValidationError
+from ..client import APIClient, APIError, ValidationError
 from ..utils import (
     DefaultCommandGroup,
     PlainTyper,
@@ -2334,10 +2334,11 @@ def stop_run(
                     break
                 try:
                     run = rl_client.get_run(run_id, timeout=max(1, int(remaining)))
-                except APITimeoutError:
+                except APIError:
                     # The stop itself already succeeded (rl_client.stop_run
-                    # returned above) - a stalled status poll is the
-                    # deadline doing its job, not a failed stop. Fall
+                    # returned above) - a timeout, transient connection
+                    # failure, or 5xx on a *follow-up status poll* is
+                    # inconclusive about the stop, not a failed stop. Fall
                     # through to the same give-up messaging as running out
                     # of poll budget, instead of a hard error.
                     break

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -20,7 +20,7 @@ from rich.table import Table
 from prime_cli.core import Config
 
 from ..api.rl import EnvServerInfo, RLClient, RLRun
-from ..client import APIClient, APIError, ValidationError
+from ..client import APIClient, APIError, APITimeoutError, ValidationError
 from ..utils import (
     DefaultCommandGroup,
     PlainTyper,
@@ -2332,7 +2332,15 @@ def stop_run(
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
-                run = rl_client.get_run(run_id, timeout=max(1, int(remaining)))
+                try:
+                    run = rl_client.get_run(run_id, timeout=max(1, int(remaining)))
+                except APITimeoutError:
+                    # The stop itself already succeeded (rl_client.stop_run
+                    # returned above) - a stalled status poll is the
+                    # deadline doing its job, not a failed stop. Fall
+                    # through to the same give-up messaging as running out
+                    # of poll budget, instead of a hard error.
+                    break
 
         status_upper = run.status.upper()
         if status_upper not in TERMINAL_RUN_STATUSES:

--- a/packages/prime/src/prime_cli/core/client.py
+++ b/packages/prime/src/prime_cli/core/client.py
@@ -173,9 +173,14 @@ class APIClient:
             u = getattr(req, "url", "?")
             raise APIError(f"Request failed: {e.__class__.__name__} at {method} {u}: {e}") from e
 
-    def get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Make a GET request to the API"""
-        return self.request("GET", endpoint, params=params)
+        return self.request("GET", endpoint, params=params, timeout=timeout)
 
     def post(self, endpoint: str, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a POST request to the API"""

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -225,3 +225,28 @@ def test_train_stop_survives_a_stalled_poll_request(monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     assert "did not reach a terminal state" in result.output
     assert "Error:" not in result.output
+
+
+def test_train_stop_survives_any_poll_api_error(monkeypatch) -> None:
+    """Not just timeouts - any APIError on a follow-up status poll (a
+    transient connection failure, a 5xx, ...) is inconclusive about the
+    stop, not a failed stop, since stop_run already succeeded."""
+    from prime_cli.core import APIError
+
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        if method == "PUT":
+            return {"run": _fake_run_payload("RUNNING")}
+        raise APIError("HTTP 502: Bad Gateway")
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_POLL_SECONDS", 0.01)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "did not reach a terminal state" in result.output
+    assert "Error:" not in result.output

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -138,7 +138,11 @@ def test_train_stop_polls_until_terminal(monkeypatch) -> None:
         return {"run": _fake_run_payload(next(statuses))}
 
     monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
-    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    # Poll loop now runs against a real monotonic deadline (so a stalled
+    # request can't push the total wait past the advertised cap) - shrink
+    # the interval instead of faking time.sleep away, or the deadline
+    # check would busy-loop for real wall-clock seconds with no delay.
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_POLL_SECONDS", 0.01)
 
     result = runner.invoke(
         app,
@@ -160,7 +164,7 @@ def test_train_stop_gives_up_after_max_polls(monkeypatch) -> None:
         return {"run": _fake_run_payload("RUNNING")}
 
     monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
-    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_POLL_SECONDS", 0.01)
     monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_MAX_POLLS", 2)
 
     result = runner.invoke(
@@ -171,4 +175,28 @@ def test_train_stop_gives_up_after_max_polls(monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     assert "did not reach a terminal state" in result.output
-    assert "prime train get run-1" in result.output
+
+
+def test_train_stop_reports_non_stopped_terminal_status_accurately(monkeypatch) -> None:
+    """A run that transitions to FAILED/COMPLETED while stop is polling
+    was not actively stopped - the CLI must not claim success."""
+    statuses = iter(["RUNNING", "FAILED"])
+
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        return {"run": _fake_run_payload(next(statuses))}
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_POLL_SECONDS", 0.01)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    normalized_output = " ".join(result.output.split())
+
+    assert result.exit_code == 0, result.output
+    assert "stopped successfully" not in normalized_output
+    assert "was not actively stopped" in normalized_output
+    assert "FAILED" in normalized_output

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -94,3 +94,81 @@ def test_train_request_submits_model_request(monkeypatch) -> None:
         "Models:\nopenai/gpt-oss-120b, meta-llama/Llama-4\n\n"
         "Context:\nSFT distillation"
     )
+
+
+def _fake_run_payload(status: str, run_id: str = "run-1") -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "userId": "user-1",
+        "status": status,
+        "createdAt": "2026-08-25T00:00:00Z",
+        "updatedAt": "2026-08-25T00:00:00Z",
+    }
+
+
+def test_train_stop_returns_immediately_when_already_terminal(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        calls.append((method, endpoint))
+        return {"run": _fake_run_payload("STOPPED")}
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "stopped successfully" in result.output
+    assert calls == [("PUT", "/rft/runs/run-1/stop")], (
+        "a stop that already returns a terminal status should not poll at all"
+    )
+
+
+def test_train_stop_polls_until_terminal(monkeypatch) -> None:
+    statuses = iter(["RUNNING", "RUNNING", "STOPPED"])
+    calls: list[tuple[str, str]] = []
+
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        calls.append((method, endpoint))
+        return {"run": _fake_run_payload(next(statuses))}
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "stopped successfully" in result.output
+    assert calls == [
+        ("PUT", "/rft/runs/run-1/stop"),
+        ("GET", "/rft/runs/run-1"),
+        ("GET", "/rft/runs/run-1"),
+    ]
+
+
+def test_train_stop_gives_up_after_max_polls(monkeypatch) -> None:
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        return {"run": _fake_run_payload("RUNNING")}
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_MAX_POLLS", 2)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "did not reach a terminal state" in result.output
+    assert "prime train get run-1" in result.output

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -200,3 +200,28 @@ def test_train_stop_reports_non_stopped_terminal_status_accurately(monkeypatch) 
     assert "stopped successfully" not in normalized_output
     assert "was not actively stopped" in normalized_output
     assert "FAILED" in normalized_output
+
+
+def test_train_stop_survives_a_stalled_poll_request(monkeypatch) -> None:
+    """A poll request that itself times out (deadline enforced at the
+    transport level) must not be reported as a failed stop - stop_run
+    already succeeded before polling started."""
+    from prime_cli.core import APITimeoutError
+
+    def mock_request(self, method, endpoint, params=None, json=None, timeout=None):
+        if method == "PUT":
+            return {"run": _fake_run_payload("RUNNING")}
+        raise APITimeoutError("Request timed out")
+
+    monkeypatch.setattr("prime_cli.core.client.APIClient.request", mock_request)
+    monkeypatch.setattr("prime_cli.commands.rl.HOSTED_TRAINING_STOP_POLL_SECONDS", 0.01)
+
+    result = runner.invoke(
+        app,
+        ["train", "stop", "run-1", "--force"],
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "did not reach a terminal state" in result.output
+    assert "Error:" not in result.output


### PR DESCRIPTION
`prime train stop` made a single blocking API call with no progress indication - once the backend call ran long, it was indistinguishable from a hang (see platform PR for the backend-side fix to the actual slowness/hang).

- Wraps the stop call in a spinner (`console.status`, matching the pattern already used elsewhere in this CLI).
- Polls run status afterward until it reaches a terminal state (STOPPED/FAILED/COMPLETED), bounded to 3 minutes with a friendly give-up message pointing at `prime train get <run_id>` instead of hanging forever.

ENG-5590

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and HTTP timeout plumbing for train stop; no auth or billing changes; behavior is more bounded and user-facing messaging is clearer.
> 
> **Overview**
> **`prime train stop`** no longer looks like a hang on slow stops: it shows a spinner during the stop request and then polls run status until **STOPPED**, **FAILED**, or **COMPLETED**, capped at about **3 minutes** (3s interval × 60). The wait uses a **monotonic deadline** so one slow status fetch cannot exceed that budget; each poll can pass a **per-request timeout** tied to time left on the deadline.
> 
> The HTTP stack exposes **`timeout` on `APIClient.get`**, and **`RLClient.get_run`** forwards it only when set so existing callers and mocks keep the same call shape.
> 
> **User messaging** is more honest: success only when the run ends in **STOPPED**; **FAILED** / **COMPLETED** get a warning that the run was not actively stopped; if polling exhausts the budget or a follow-up status call errors after stop already succeeded, the CLI exits **0** with guidance to run **`prime train get`**, not a hard error.
> 
> Tests cover immediate terminal stop, polling, budget exhaustion, non-STOPPED terminals, and poll timeouts / **APIError** on status polls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8276a346909bf9b2f52a65e213eccf00d54e30b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->