### PR TITLE
feat(config): project-local config discovery for CLI and SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,26 @@ command or SDK call run from that directory — or any directory below it — us
 it. Resolution order:
 
 1. `PRIME_CONFIG_DIR` — explicit config directory
-2. The nearest ancestor of the working directory containing `.prime/config.json`
-   (the search stops at your home directory and ignores files owned by other users)
+2. The nearest ancestor of the working directory containing a **trusted**
+   `.prime/config.json` (the search stops at your home directory and ignores
+   files owned by other users)
 3. `~/.prime/config.json`
+
+A project-local config is only used once you have trusted it. Files written by
+`prime login --local` / `prime config set-api-key --local` are trusted
+automatically; one you create by hand needs `prime config trust` (run in the
+project, or pass its path). Trust is tied to the file's content, so if it
+changes — say a `git pull` rewrote it — commands warn and ignore it until you
+trust it again. This is what stops a `.prime/config.json` committed to a
+repository you clone from pointing your `PRIME_API_KEY` at someone else's
+server. `prime config untrust` withdraws approval.
 
 A project-local config replaces the global one entirely; it is not merged with
 it. `PRIME_API_KEY` and the other `PRIME_*` environment variables still take
-precedence over either file. `prime config view` shows which file is active.
-Add `.prime/` to the project's `.gitignore` so the key is never committed.
+precedence over either file. `prime config view` shows which file is active and
+lists any untrusted files it skipped. Add `.prime/` to the project's
+`.gitignore` so the key is never committed — the `--local` commands warn if the
+enclosing repository does not ignore it.
 
 ### Environments Hub
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ A project-local config is only used once you have trusted it. Files written by
 automatically; one you create by hand needs `prime config trust` (run in the
 project, or pass its path). Trust is tied to the file's content, so if it
 changes — say a `git pull` rewrote it — commands warn and ignore it until you
-trust it again. This is what stops a `.prime/config.json` committed to a
+trust it again. The same applies to the named environments next to it
+(`.prime/environments/*.json`, used by `PRIME_CONTEXT` / `prime config use`):
+`prime config trust` approves them together with `config.json`. This is what stops a `.prime/config.json` committed to a
 repository you clone from pointing your `PRIME_API_KEY` at someone else's
 server. `prime config untrust` withdraws approval.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ prime config view
 
 **Security Note**: When using non-interactive mode, the API key may be visible in your shell history. For enhanced security, use interactive mode or environment variables.
 
+#### Project-Local Credentials
+
+By default the CLI and SDKs read `~/.prime/config.json`. On a shared machine, or
+when you want different credentials per project, keep them next to the code
+instead:
+
+```bash
+cd ~/code/prime
+prime login --local                 # or: prime config set-api-key --local
+```
+
+This writes `./.prime/config.json` (owner-only permissions) and every `prime`
+command or SDK call run from that directory — or any directory below it — uses
+it. Resolution order:
+
+1. `PRIME_CONFIG_DIR` — explicit config directory
+2. The nearest ancestor of the working directory containing `.prime/config.json`
+   (the search stops at your home directory and ignores files owned by other users)
+3. `~/.prime/config.json`
+
+A project-local config replaces the global one entirely; it is not merged with
+it. `PRIME_API_KEY` and the other `PRIME_*` environment variables still take
+precedence over either file. `prime config view` shows which file is active.
+Add `.prime/` to the project's `.gitignore` so the key is never committed.
+
 ### Environments Hub
 
 Access hundreds of verified environments on our community hub with deep integrations with sandboxes, training, and evaluation stack.

--- a/packages/prime-evals/README.md
+++ b/packages/prime-evals/README.md
@@ -106,7 +106,7 @@ The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
 2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: the nearest `.prime/config.json` at or above the working directory (created by `prime login --local`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
+3. **Config file**: the nearest trusted `.prime/config.json` at or above the working directory (created by `prime login --local`, or approved with `prime config trust`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
 
 ## Complete Example
 

--- a/packages/prime-evals/README.md
+++ b/packages/prime-evals/README.md
@@ -106,7 +106,7 @@ The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
 2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: `~/.prime/config.json` (created by `prime login` CLI command)
+3. **Config file**: the nearest `.prime/config.json` at or above the working directory (created by `prime login --local`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
 
 ## Complete Example
 

--- a/packages/prime-evals/src/prime_evals/core/config.py
+++ b/packages/prime-evals/src/prime_evals/core/config.py
@@ -1,18 +1,26 @@
 """Lightweight configuration for SDK packages."""
 
+import hashlib
 import json
 import os
+import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
 def global_config_dir() -> Path:
     """The per-user config directory, ~/.prime."""
     return Path.home() / CONFIG_DIR_NAME
+
+
+def trusted_configs_file() -> Path:
+    """The per-user registry of project-local configs approved via `prime config trust`."""
+    return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
 
 
 def _owned_by_current_user(path: Path) -> bool:
@@ -32,40 +40,112 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
-def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
-    """Find the nearest project-local config directory, or None.
+def _file_digest(path: Path) -> Optional[str]:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
 
-    Walks from `start` (default: the working directory) up through its parents
-    looking for `.prime/config.json`. The walk stops at the home directory:
-    `~/.prime` is the global config, and anything above home is not the user's
-    project. Only files owned by the current user count.
+
+def load_trusted_configs() -> dict[str, str]:
+    """Resolved config.json path -> content digest, for every approved local config."""
+    try:
+        data = json.loads(trusted_configs_file().read_text())
+    except (OSError, ValueError):
+        return {}
+    trusted = data.get("trusted") if isinstance(data, dict) else None
+    if not isinstance(trusted, dict):
+        return {}
+    return {str(path): str(digest) for path, digest in trusted.items()}
+
+
+def is_trusted_local_config(config_file: Path) -> bool:
+    """Whether the user approved this file *with its current content*.
+
+    Ownership alone is not enough: a `.prime/config.json` committed to a
+    repository the user clones is owned by the user, and could redirect an
+    environment-provided PRIME_API_KEY to an attacker's base_url. So a
+    discovered local config is only honored after `prime config trust`, and
+    the approval is tied to a content digest — if the file changes it has to
+    be trusted again. The SDK only reads the registry; the CLI maintains it.
+    """
+    digest = _file_digest(config_file)
+    if digest is None:
+        return False
+    return load_trusted_configs().get(str(config_file.resolve())) == digest
+
+
+def _candidate_local_config_files(start: Optional[Path] = None) -> Iterator[Path]:
+    """Owned `.prime/config.json` files from `start` upward, nearest first.
+
+    The walk stops at the home directory: `~/.prime` is the global config, and
+    anything above home is not the user's project.
     """
     try:
         current = (start or Path.cwd()).resolve()
         home = Path.home().resolve()
     except OSError:
-        return None
+        return
     for directory in (current, *current.parents):
         if directory == home:
             break
         config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
         if config_file.is_file() and _owned_by_current_user(config_file):
-            return directory / CONFIG_DIR_NAME
-    return None
+            yield config_file
 
 
-def resolve_config_dir() -> tuple[Path, str]:
-    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+def discover_local_config(start: Optional[Path] = None) -> tuple[Optional[Path], list[Path]]:
+    """The nearest *trusted* project-local config dir, plus untrusted files passed over.
 
-    Returns the directory and its source: "env", "local", or "global".
+    Untrusted candidates are skipped rather than stopping the search, so a
+    file planted in a nested directory cannot mask the user's own trusted one
+    further up.
+    """
+    untrusted: list[Path] = []
+    for config_file in _candidate_local_config_files(start):
+        if is_trusted_local_config(config_file):
+            return config_file.parent, untrusted
+        untrusted.append(config_file)
+    return None, untrusted
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest trusted project-local config directory, or None."""
+    return discover_local_config(start)[0]
+
+
+def resolve_config_dir() -> tuple[Path, str, list[Path]]:
+    """Choose the config directory: PRIME_CONFIG_DIR > trusted project-local > ~/.prime.
+
+    Returns the directory, its source ("env", "local", or "global"), and any
+    untrusted project-local config files that were ignored on the way.
     """
     explicit = os.getenv(CONFIG_DIR_ENV_VAR)
     if explicit and explicit.strip():
-        return Path(explicit.strip()).expanduser(), "env"
-    local = find_local_config_dir()
+        return Path(explicit.strip()).expanduser(), "env", []
+    local, untrusted = discover_local_config()
     if local is not None:
-        return local, "local"
-    return global_config_dir(), "global"
+        return local, "local", untrusted
+    return global_config_dir(), "global", untrusted
+
+
+UNTRUSTED_CONFIG_WARNING = "Ignoring untrusted project config"
+_warned_untrusted: set[Path] = set()
+
+
+def _warn_untrusted(untrusted: list[Path]) -> None:
+    """Warn once per file per process that a local config was ignored."""
+    for config_file in untrusted:
+        if config_file in _warned_untrusted:
+            continue
+        _warned_untrusted.add(config_file)
+        warnings.warn(
+            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; run "
+            f"'prime config trust {config_file.parent.parent}' to use it, or set "
+            f"{CONFIG_DIR_ENV_VAR}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 class Config:
@@ -80,17 +160,19 @@ class Config:
         """Load config from `config_dir`, or from the resolved location when omitted.
 
         Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
-        working directory holding `.prime/config.json` (see
-        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        working directory holding a *trusted* `.prime/config.json` (see
+        `discover_local_config`), then `~/.prime`. A project-local config is a
         complete replacement for the global one, never merged with it.
         """
+        self.untrusted_local_configs: list[Path] = []
         if config_dir is not None:
             self.config_dir = Path(config_dir).expanduser()
             self.config_source = "explicit"
         else:
-            self.config_dir, self.config_source = resolve_config_dir()
+            self.config_dir, self.config_source, self.untrusted_local_configs = resolve_config_dir()
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
+        _warn_untrusted(self.untrusted_local_configs)
 
     def _load_config(self) -> None:
         """Load configuration from file"""

--- a/packages/prime-evals/src/prime_evals/core/config.py
+++ b/packages/prime-evals/src/prime_evals/core/config.py
@@ -69,6 +69,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if not _owned_by_current_user(config_file):
+        # A trusted path swapped for someone else's file (same bytes or not)
+        # is not the file the user approved.
+        return False
     digest = _file_digest(config_file)
     if digest is None:
         return False

--- a/packages/prime-evals/src/prime_evals/core/config.py
+++ b/packages/prime-evals/src/prime_evals/core/config.py
@@ -5,18 +5,91 @@ import os
 from pathlib import Path
 from typing import Optional
 
+CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
+CONFIG_DIR_NAME = ".prime"
+CONFIG_FILE_NAME = "config.json"
+
+
+def global_config_dir() -> Path:
+    """The per-user config directory, ~/.prime."""
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def _owned_by_current_user(path: Path) -> bool:
+    """True when `path` (following symlinks) is owned by the running user.
+
+    Project-local configs are picked up by walking parent directories, so on a
+    shared machine anyone who can write to an ancestor could plant one that
+    points the SDK at their account. Refusing files we don't own closes that.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return True
+    try:
+        return path.stat().st_uid == getuid()
+    except OSError:
+        return False
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest project-local config directory, or None.
+
+    Walks from `start` (default: the working directory) up through its parents
+    looking for `.prime/config.json`. The walk stops at the home directory:
+    `~/.prime` is the global config, and anything above home is not the user's
+    project. Only files owned by the current user count.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+        home = Path.home().resolve()
+    except OSError:
+        return None
+    for directory in (current, *current.parents):
+        if directory == home:
+            break
+        config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+        if config_file.is_file() and _owned_by_current_user(config_file):
+            return directory / CONFIG_DIR_NAME
+    return None
+
+
+def resolve_config_dir() -> tuple[Path, str]:
+    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+
+    Returns the directory and its source: "env", "local", or "global".
+    """
+    explicit = os.getenv(CONFIG_DIR_ENV_VAR)
+    if explicit and explicit.strip():
+        return Path(explicit.strip()).expanduser(), "env"
+    local = find_local_config_dir()
+    if local is not None:
+        return local, "local"
+    return global_config_dir(), "global"
+
 
 class Config:
     """Minimal configuration class for SDK packages.
 
-    Reads from ~/.prime/config.json and environment variables.
+    Reads from a project-local or ~/.prime config.json and environment variables.
     """
 
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
 
-    def __init__(self) -> None:
-        self.config_dir = Path.home() / ".prime"
-        self.config_file = self.config_dir / "config.json"
+    def __init__(self, config_dir: Optional[Path | str] = None) -> None:
+        """Load config from `config_dir`, or from the resolved location when omitted.
+
+        Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
+        working directory holding `.prime/config.json` (see
+        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        complete replacement for the global one, never merged with it.
+        """
+        if config_dir is not None:
+            self.config_dir = Path(config_dir).expanduser()
+            self.config_source = "explicit"
+        else:
+            self.config_dir, self.config_source = resolve_config_dir()
+        self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
 
     def _load_config(self) -> None:

--- a/packages/prime-evals/src/prime_evals/core/config.py
+++ b/packages/prime-evals/src/prime_evals/core/config.py
@@ -69,6 +69,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if config_file.is_symlink() or config_file.parent.is_symlink():
+        # Project files reached through a symlink are never trusted (the CLI
+        # applies the same rule, and refuses to write through them).
+        return False
     if not _owned_by_current_user(config_file):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.

--- a/packages/prime-evals/tests/conftest.py
+++ b/packages/prime-evals/tests/conftest.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_prime_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Keep tests hermetic: never read the developer's real ~/.prime.
+
+    Config discovery also walks up from the working directory, so start each
+    test in a fresh tmp dir and ignore PRIME_CONFIG_DIR from the shell.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)
+    return tmp_path

--- a/packages/prime-evals/tests/conftest.py
+++ b/packages/prime-evals/tests/conftest.py
@@ -13,4 +13,5 @@ def isolated_prime_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Pa
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
     return tmp_path

--- a/packages/prime-evals/tests/test_config_discovery.py
+++ b/packages/prime-evals/tests/test_config_discovery.py
@@ -1,23 +1,43 @@
-"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest trusted .prime/ > ~/.prime.
 
 The conftest points Path.home at tmp_path and starts each test there.
 """
 
+import hashlib
 import json
 import os
 from pathlib import Path
 
+import pytest
+
 from prime_evals import Config
+from prime_evals.core import config as config_module
 
 
-def _write(directory: Path, **values: object) -> Path:
+@pytest.fixture(autouse=True)
+def reset_warning_dedup(monkeypatch):
+    monkeypatch.setattr(config_module, "_warned_untrusted", set())
+
+
+def _write(directory: Path, *, trusted: bool = True, **values: object) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "config.json"
     path.write_text(json.dumps(values))
+    if trusted and directory != Path.home() / ".prime":
+        _trust(path)
     return path
 
 
-def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+def _trust(path: Path) -> None:
+    """Approve a local config the way `prime config trust` does."""
+    registry = Path.home() / ".prime" / "trusted_configs.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    trusted = json.loads(registry.read_text())["trusted"] if registry.exists() else {}
+    trusted[str(path.resolve())] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    registry.write_text(json.dumps({"version": 1, "trusted": trusted}))
+
+
+def test_discovers_trusted_local_config_from_subdirectory(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
     project = tmp_path / "code" / "prime"
     _write(project / ".prime", api_key="local-key")
@@ -30,6 +50,33 @@ def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
     assert config.config_source == "local"
     assert config.config_dir == project / ".prime"
     assert config.api_key == "local-key"
+    assert config.untrusted_local_configs == []
+
+
+def test_untrusted_local_config_is_ignored_with_a_warning(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    planted = _write(project / ".prime", trusted=False, base_url="https://evil.example")
+    monkeypatch.chdir(project)
+
+    with pytest.warns(RuntimeWarning, match="prime config trust"):
+        config = Config()
+
+    assert config.config_source == "global"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.untrusted_local_configs == [planted]
+
+
+def test_trust_is_bound_to_file_content(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    monkeypatch.chdir(project)
+    assert Config().api_key == "local-key"
+
+    local.write_text(json.dumps({"api_key": "local-key", "base_url": "https://evil.example"}))
+
+    with pytest.warns(RuntimeWarning):
+        assert Config().config_source == "global"
 
 
 def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
@@ -37,7 +84,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
     project = tmp_path / "proj"
     _write(project / ".prime", base_url="https://local.example")
     monkeypatch.chdir(project)
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -47,7 +93,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
 
 def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
     assert config.config_source == "global"
@@ -61,10 +106,9 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="local-key")
     explicit = tmp_path / "elsewhere"
-    _write(explicit, api_key="explicit-key")
+    _write(explicit, trusted=False, api_key="explicit-key")
     monkeypatch.chdir(project)
     monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -80,4 +124,6 @@ def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     real_uid = os.getuid()
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
-    assert Config().config_source == "global"
+    config = Config()
+    assert config.config_source == "global"
+    assert config.untrusted_local_configs == []

--- a/packages/prime-evals/tests/test_config_discovery.py
+++ b/packages/prime-evals/tests/test_config_discovery.py
@@ -1,0 +1,83 @@
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+
+The conftest points Path.home at tmp_path and starts each test there.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from prime_evals import Config
+
+
+def _write(directory: Path, **values: object) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "code" / "prime"
+    _write(project / ".prime", api_key="local-key")
+    workdir = project / "envs" / "my-env"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+
+    config = Config()
+
+    assert config.config_source == "local"
+    assert config.config_dir == project / ".prime"
+    assert config.api_key == "local-key"
+
+
+def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    _write(project / ".prime", base_url="https://local.example")
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.base_url == "https://local.example"
+    assert config.api_key == ""
+
+
+def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+    assert config.config_source == "global"
+    assert config.api_key == "global-key"
+
+    monkeypatch.setenv("PRIME_API_KEY", "env-key")
+    assert Config().api_key == "env-key"
+
+
+def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="local-key")
+    explicit = tmp_path / "elsewhere"
+    _write(explicit, api_key="explicit-key")
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.config_source == "env"
+    assert config.config_dir == explicit
+    assert config.api_key == "explicit-key"
+
+
+def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="planted-key")
+    monkeypatch.chdir(project)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert Config().config_source == "global"

--- a/packages/prime-evals/tests/test_config_discovery.py
+++ b/packages/prime-evals/tests/test_config_discovery.py
@@ -117,6 +117,15 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     assert config.api_key == "explicit-key"
 
 
+def test_trust_requires_ownership_even_with_matching_digest(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert not config_module.is_trusted_local_config(local)
+
+
 def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="planted-key")

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -122,7 +122,7 @@ The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
 2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: `~/.prime/config.json` (created by `prime login` CLI command)
+3. **Config file**: the nearest `.prime/config.json` at or above the working directory (created by `prime login --local`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
 
 ## Advanced Features
 

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -122,7 +122,7 @@ The SDK looks for credentials in this order:
 
 1. **Direct parameter**: `APIClient(api_key="sk-...")`
 2. **Environment variable**: `export PRIME_API_KEY="sk-..."`
-3. **Config file**: the nearest `.prime/config.json` at or above the working directory (created by `prime login --local`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
+3. **Config file**: the nearest trusted `.prime/config.json` at or above the working directory (created by `prime login --local`, or approved with `prime config trust`), else `~/.prime/config.json` (created by `prime login`); `PRIME_CONFIG_DIR` overrides both
 
 ## Advanced Features
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -5,19 +5,92 @@ import os
 from pathlib import Path
 from typing import Optional
 
+CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
+CONFIG_DIR_NAME = ".prime"
+CONFIG_FILE_NAME = "config.json"
+
+
+def global_config_dir() -> Path:
+    """The per-user config directory, ~/.prime."""
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def _owned_by_current_user(path: Path) -> bool:
+    """True when `path` (following symlinks) is owned by the running user.
+
+    Project-local configs are picked up by walking parent directories, so on a
+    shared machine anyone who can write to an ancestor could plant one that
+    points the SDK at their account. Refusing files we don't own closes that.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return True
+    try:
+        return path.stat().st_uid == getuid()
+    except OSError:
+        return False
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest project-local config directory, or None.
+
+    Walks from `start` (default: the working directory) up through its parents
+    looking for `.prime/config.json`. The walk stops at the home directory:
+    `~/.prime` is the global config, and anything above home is not the user's
+    project. Only files owned by the current user count.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+        home = Path.home().resolve()
+    except OSError:
+        return None
+    for directory in (current, *current.parents):
+        if directory == home:
+            break
+        config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+        if config_file.is_file() and _owned_by_current_user(config_file):
+            return directory / CONFIG_DIR_NAME
+    return None
+
+
+def resolve_config_dir() -> tuple[Path, str]:
+    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+
+    Returns the directory and its source: "env", "local", or "global".
+    """
+    explicit = os.getenv(CONFIG_DIR_ENV_VAR)
+    if explicit and explicit.strip():
+        return Path(explicit.strip()).expanduser(), "env"
+    local = find_local_config_dir()
+    if local is not None:
+        return local, "local"
+    return global_config_dir(), "global"
+
 
 class Config:
     """Minimal configuration class for SDK packages.
 
-    Reads from ~/.prime/config.json and environment variables.
+    Reads from a project-local or ~/.prime config.json and environment variables.
     This is a simplified version that doesn't write configs.
     """
 
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
 
-    def __init__(self) -> None:
-        self.config_dir = Path.home() / ".prime"
-        self.config_file = self.config_dir / "config.json"
+    def __init__(self, config_dir: Optional[Path | str] = None) -> None:
+        """Load config from `config_dir`, or from the resolved location when omitted.
+
+        Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
+        working directory holding `.prime/config.json` (see
+        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        complete replacement for the global one, never merged with it.
+        """
+        if config_dir is not None:
+            self.config_dir = Path(config_dir).expanduser()
+            self.config_source = "explicit"
+        else:
+            self.config_dir, self.config_source = resolve_config_dir()
+        self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
 
     def _load_config(self) -> None:

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -69,6 +69,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if not _owned_by_current_user(config_file):
+        # A trusted path swapped for someone else's file (same bytes or not)
+        # is not the file the user approved.
+        return False
     digest = _file_digest(config_file)
     if digest is None:
         return False

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -1,18 +1,26 @@
 """Lightweight configuration for SDK packages."""
 
+import hashlib
 import json
 import os
+import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
 def global_config_dir() -> Path:
     """The per-user config directory, ~/.prime."""
     return Path.home() / CONFIG_DIR_NAME
+
+
+def trusted_configs_file() -> Path:
+    """The per-user registry of project-local configs approved via `prime config trust`."""
+    return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
 
 
 def _owned_by_current_user(path: Path) -> bool:
@@ -32,40 +40,112 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
-def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
-    """Find the nearest project-local config directory, or None.
+def _file_digest(path: Path) -> Optional[str]:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
 
-    Walks from `start` (default: the working directory) up through its parents
-    looking for `.prime/config.json`. The walk stops at the home directory:
-    `~/.prime` is the global config, and anything above home is not the user's
-    project. Only files owned by the current user count.
+
+def load_trusted_configs() -> dict[str, str]:
+    """Resolved config.json path -> content digest, for every approved local config."""
+    try:
+        data = json.loads(trusted_configs_file().read_text())
+    except (OSError, ValueError):
+        return {}
+    trusted = data.get("trusted") if isinstance(data, dict) else None
+    if not isinstance(trusted, dict):
+        return {}
+    return {str(path): str(digest) for path, digest in trusted.items()}
+
+
+def is_trusted_local_config(config_file: Path) -> bool:
+    """Whether the user approved this file *with its current content*.
+
+    Ownership alone is not enough: a `.prime/config.json` committed to a
+    repository the user clones is owned by the user, and could redirect an
+    environment-provided PRIME_API_KEY to an attacker's base_url. So a
+    discovered local config is only honored after `prime config trust`, and
+    the approval is tied to a content digest — if the file changes it has to
+    be trusted again. The SDK only reads the registry; the CLI maintains it.
+    """
+    digest = _file_digest(config_file)
+    if digest is None:
+        return False
+    return load_trusted_configs().get(str(config_file.resolve())) == digest
+
+
+def _candidate_local_config_files(start: Optional[Path] = None) -> Iterator[Path]:
+    """Owned `.prime/config.json` files from `start` upward, nearest first.
+
+    The walk stops at the home directory: `~/.prime` is the global config, and
+    anything above home is not the user's project.
     """
     try:
         current = (start or Path.cwd()).resolve()
         home = Path.home().resolve()
     except OSError:
-        return None
+        return
     for directory in (current, *current.parents):
         if directory == home:
             break
         config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
         if config_file.is_file() and _owned_by_current_user(config_file):
-            return directory / CONFIG_DIR_NAME
-    return None
+            yield config_file
 
 
-def resolve_config_dir() -> tuple[Path, str]:
-    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+def discover_local_config(start: Optional[Path] = None) -> tuple[Optional[Path], list[Path]]:
+    """The nearest *trusted* project-local config dir, plus untrusted files passed over.
 
-    Returns the directory and its source: "env", "local", or "global".
+    Untrusted candidates are skipped rather than stopping the search, so a
+    file planted in a nested directory cannot mask the user's own trusted one
+    further up.
+    """
+    untrusted: list[Path] = []
+    for config_file in _candidate_local_config_files(start):
+        if is_trusted_local_config(config_file):
+            return config_file.parent, untrusted
+        untrusted.append(config_file)
+    return None, untrusted
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest trusted project-local config directory, or None."""
+    return discover_local_config(start)[0]
+
+
+def resolve_config_dir() -> tuple[Path, str, list[Path]]:
+    """Choose the config directory: PRIME_CONFIG_DIR > trusted project-local > ~/.prime.
+
+    Returns the directory, its source ("env", "local", or "global"), and any
+    untrusted project-local config files that were ignored on the way.
     """
     explicit = os.getenv(CONFIG_DIR_ENV_VAR)
     if explicit and explicit.strip():
-        return Path(explicit.strip()).expanduser(), "env"
-    local = find_local_config_dir()
+        return Path(explicit.strip()).expanduser(), "env", []
+    local, untrusted = discover_local_config()
     if local is not None:
-        return local, "local"
-    return global_config_dir(), "global"
+        return local, "local", untrusted
+    return global_config_dir(), "global", untrusted
+
+
+UNTRUSTED_CONFIG_WARNING = "Ignoring untrusted project config"
+_warned_untrusted: set[Path] = set()
+
+
+def _warn_untrusted(untrusted: list[Path]) -> None:
+    """Warn once per file per process that a local config was ignored."""
+    for config_file in untrusted:
+        if config_file in _warned_untrusted:
+            continue
+        _warned_untrusted.add(config_file)
+        warnings.warn(
+            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; run "
+            f"'prime config trust {config_file.parent.parent}' to use it, or set "
+            f"{CONFIG_DIR_ENV_VAR}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 class Config:
@@ -81,17 +161,19 @@ class Config:
         """Load config from `config_dir`, or from the resolved location when omitted.
 
         Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
-        working directory holding `.prime/config.json` (see
-        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        working directory holding a *trusted* `.prime/config.json` (see
+        `discover_local_config`), then `~/.prime`. A project-local config is a
         complete replacement for the global one, never merged with it.
         """
+        self.untrusted_local_configs: list[Path] = []
         if config_dir is not None:
             self.config_dir = Path(config_dir).expanduser()
             self.config_source = "explicit"
         else:
-            self.config_dir, self.config_source = resolve_config_dir()
+            self.config_dir, self.config_source, self.untrusted_local_configs = resolve_config_dir()
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
+        _warn_untrusted(self.untrusted_local_configs)
 
     def _load_config(self) -> None:
         """Load configuration from file"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -69,6 +69,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if config_file.is_symlink() or config_file.parent.is_symlink():
+        # Project files reached through a symlink are never trusted (the CLI
+        # applies the same rule, and refuses to write through them).
+        return False
     if not _owned_by_current_user(config_file):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.

--- a/packages/prime-sandboxes/tests/conftest.py
+++ b/packages/prime-sandboxes/tests/conftest.py
@@ -22,6 +22,15 @@ def sandbox_client(tmp_path_factory):
         yield SandboxClient(client)
 
 
+@pytest.fixture(autouse=True)
+def isolated_config_discovery(monkeypatch, tmp_path):
+    """Config discovery walks up from the working directory looking for a
+    project-local .prime/config.json; keep it away from the developer's real
+    ~/.prime by starting each test in a fresh tmp dir."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)
+
+
 @pytest.fixture
 def unique_id():
     """Generate a unique ID for each test to avoid collisions in parallel runs"""

--- a/packages/prime-sandboxes/tests/test_config_discovery.py
+++ b/packages/prime-sandboxes/tests/test_config_discovery.py
@@ -1,5 +1,9 @@
-"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime."""
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest trusted .prime/ > ~/.prime.
 
+The conftest points Path.home at tmp_path and starts each test there.
+"""
+
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -7,6 +11,12 @@ from pathlib import Path
 import pytest
 
 from prime_sandboxes import Config
+from prime_sandboxes.core import config as config_module
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_dedup(monkeypatch):
+    monkeypatch.setattr(config_module, "_warned_untrusted", set())
 
 
 @pytest.fixture(autouse=True)
@@ -18,14 +28,25 @@ def fake_home(monkeypatch, tmp_path):
     monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
 
-def _write(directory: Path, **values: object) -> Path:
+def _write(directory: Path, *, trusted: bool = True, **values: object) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "config.json"
     path.write_text(json.dumps(values))
+    if trusted and directory != Path.home() / ".prime":
+        _trust(path)
     return path
 
 
-def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+def _trust(path: Path) -> None:
+    """Approve a local config the way `prime config trust` does."""
+    registry = Path.home() / ".prime" / "trusted_configs.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    trusted = json.loads(registry.read_text())["trusted"] if registry.exists() else {}
+    trusted[str(path.resolve())] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    registry.write_text(json.dumps({"version": 1, "trusted": trusted}))
+
+
+def test_discovers_trusted_local_config_from_subdirectory(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
     project = tmp_path / "code" / "prime"
     _write(project / ".prime", api_key="local-key")
@@ -38,6 +59,33 @@ def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
     assert config.config_source == "local"
     assert config.config_dir == project / ".prime"
     assert config.api_key == "local-key"
+    assert config.untrusted_local_configs == []
+
+
+def test_untrusted_local_config_is_ignored_with_a_warning(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    planted = _write(project / ".prime", trusted=False, base_url="https://evil.example")
+    monkeypatch.chdir(project)
+
+    with pytest.warns(RuntimeWarning, match="prime config trust"):
+        config = Config()
+
+    assert config.config_source == "global"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.untrusted_local_configs == [planted]
+
+
+def test_trust_is_bound_to_file_content(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    monkeypatch.chdir(project)
+    assert Config().api_key == "local-key"
+
+    local.write_text(json.dumps({"api_key": "local-key", "base_url": "https://evil.example"}))
+
+    with pytest.warns(RuntimeWarning):
+        assert Config().config_source == "global"
 
 
 def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
@@ -45,7 +93,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
     project = tmp_path / "proj"
     _write(project / ".prime", base_url="https://local.example")
     monkeypatch.chdir(project)
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -55,7 +102,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
 
 def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
     assert config.config_source == "global"
@@ -69,10 +115,9 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="local-key")
     explicit = tmp_path / "elsewhere"
-    _write(explicit, api_key="explicit-key")
+    _write(explicit, trusted=False, api_key="explicit-key")
     monkeypatch.chdir(project)
     monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -88,4 +133,6 @@ def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     real_uid = os.getuid()
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
-    assert Config().config_source == "global"
+    config = Config()
+    assert config.config_source == "global"
+    assert config.untrusted_local_configs == []

--- a/packages/prime-sandboxes/tests/test_config_discovery.py
+++ b/packages/prime-sandboxes/tests/test_config_discovery.py
@@ -12,8 +12,10 @@ from prime_sandboxes import Config
 @pytest.fixture(autouse=True)
 def fake_home(monkeypatch, tmp_path):
     """The conftest only isolates the working directory; these tests also
-    need ~ to be the tmp dir so "global" means a file they control."""
+    need ~ to be the tmp dir so "global" means a file they control, and no
+    PRIME_API_KEY in the environment (CI sets one) since env beats the file."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
 
 def _write(directory: Path, **values: object) -> Path:

--- a/packages/prime-sandboxes/tests/test_config_discovery.py
+++ b/packages/prime-sandboxes/tests/test_config_discovery.py
@@ -126,6 +126,15 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     assert config.api_key == "explicit-key"
 
 
+def test_trust_requires_ownership_even_with_matching_digest(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert not config_module.is_trusted_local_config(local)
+
+
 def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="planted-key")

--- a/packages/prime-sandboxes/tests/test_config_discovery.py
+++ b/packages/prime-sandboxes/tests/test_config_discovery.py
@@ -1,0 +1,89 @@
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from prime_sandboxes import Config
+
+
+@pytest.fixture(autouse=True)
+def fake_home(monkeypatch, tmp_path):
+    """The conftest only isolates the working directory; these tests also
+    need ~ to be the tmp dir so "global" means a file they control."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+def _write(directory: Path, **values: object) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "code" / "prime"
+    _write(project / ".prime", api_key="local-key")
+    workdir = project / "envs" / "my-env"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+
+    config = Config()
+
+    assert config.config_source == "local"
+    assert config.config_dir == project / ".prime"
+    assert config.api_key == "local-key"
+
+
+def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    _write(project / ".prime", base_url="https://local.example")
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.base_url == "https://local.example"
+    assert config.api_key == ""
+
+
+def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+    assert config.config_source == "global"
+    assert config.api_key == "global-key"
+
+    monkeypatch.setenv("PRIME_API_KEY", "env-key")
+    assert Config().api_key == "env-key"
+
+
+def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="local-key")
+    explicit = tmp_path / "elsewhere"
+    _write(explicit, api_key="explicit-key")
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.config_source == "env"
+    assert config.config_dir == explicit
+    assert config.api_key == "explicit-key"
+
+
+def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="planted-key")
+    monkeypatch.chdir(project)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert Config().config_source == "global"

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -96,8 +96,12 @@ asyncio.run(main())
 | `PRIME_TRACES_URL`     | Base URL of the Prime Traces service (**required** during closed beta) |
 | `PRIME_TEAM_ID`        | Optional team context, sent as `X-Prime-Team-ID`                       |
 | `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)           |
+| `PRIME_CONFIG_DIR`     | Optional explicit config directory                                     |
 
-Precedence is constructor argument → environment variable → config file.
+Precedence is constructor argument → environment variable → config file. The
+config file is the nearest `.prime/config.json` at or above the working
+directory (a project-local config from `prime login --local`), falling back to
+`~/.prime/config.json`.
 
 ## Not yet available
 

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -99,9 +99,9 @@ asyncio.run(main())
 | `PRIME_CONFIG_DIR`     | Optional explicit config directory                                     |
 
 Precedence is constructor argument → environment variable → config file. The
-config file is the nearest `.prime/config.json` at or above the working
-directory (a project-local config from `prime login --local`), falling back to
-`~/.prime/config.json`.
+config file is the nearest trusted `.prime/config.json` at or above the working
+directory (a project-local config from `prime login --local`, or one approved
+with `prime config trust`), falling back to `~/.prime/config.json`.
 
 ## Not yet available
 

--- a/packages/prime-traces/src/prime_traces/core/config.py
+++ b/packages/prime-traces/src/prime_traces/core/config.py
@@ -1,7 +1,7 @@
 """Lightweight configuration for the Prime Traces SDK.
 
-Mirrors the other prime SDK packages: reads ~/.prime/config.json plus
-environment variables, env taking precedence.
+Mirrors the other prime SDK packages: reads config.json (project-local or
+~/.prime) plus environment variables, env taking precedence.
 """
 
 import json
@@ -9,18 +9,91 @@ import os
 from pathlib import Path
 from typing import Optional
 
+CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
+CONFIG_DIR_NAME = ".prime"
+CONFIG_FILE_NAME = "config.json"
+
+
+def global_config_dir() -> Path:
+    """The per-user config directory, ~/.prime."""
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def _owned_by_current_user(path: Path) -> bool:
+    """True when `path` (following symlinks) is owned by the running user.
+
+    Project-local configs are picked up by walking parent directories, so on a
+    shared machine anyone who can write to an ancestor could plant one that
+    points the SDK at their account. Refusing files we don't own closes that.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return True
+    try:
+        return path.stat().st_uid == getuid()
+    except OSError:
+        return False
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest project-local config directory, or None.
+
+    Walks from `start` (default: the working directory) up through its parents
+    looking for `.prime/config.json`. The walk stops at the home directory:
+    `~/.prime` is the global config, and anything above home is not the user's
+    project. Only files owned by the current user count.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+        home = Path.home().resolve()
+    except OSError:
+        return None
+    for directory in (current, *current.parents):
+        if directory == home:
+            break
+        config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+        if config_file.is_file() and _owned_by_current_user(config_file):
+            return directory / CONFIG_DIR_NAME
+    return None
+
+
+def resolve_config_dir() -> tuple[Path, str]:
+    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+
+    Returns the directory and its source: "env", "local", or "global".
+    """
+    explicit = os.getenv(CONFIG_DIR_ENV_VAR)
+    if explicit and explicit.strip():
+        return Path(explicit.strip()).expanduser(), "env"
+    local = find_local_config_dir()
+    if local is not None:
+        return local, "local"
+    return global_config_dir(), "global"
+
 
 class Config:
     """Minimal configuration class for SDK packages.
 
-    Reads from ~/.prime/config.json and environment variables.
+    Reads from a project-local or ~/.prime config.json and environment variables.
     """
 
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
 
-    def __init__(self) -> None:
-        self.config_dir = Path.home() / ".prime"
-        self.config_file = self.config_dir / "config.json"
+    def __init__(self, config_dir: Optional[Path | str] = None) -> None:
+        """Load config from `config_dir`, or from the resolved location when omitted.
+
+        Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
+        working directory holding `.prime/config.json` (see
+        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        complete replacement for the global one, never merged with it.
+        """
+        if config_dir is not None:
+            self.config_dir = Path(config_dir).expanduser()
+            self.config_source = "explicit"
+        else:
+            self.config_dir, self.config_source = resolve_config_dir()
+        self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
 
     def _load_config(self) -> None:

--- a/packages/prime-traces/src/prime_traces/core/config.py
+++ b/packages/prime-traces/src/prime_traces/core/config.py
@@ -73,6 +73,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if not _owned_by_current_user(config_file):
+        # A trusted path swapped for someone else's file (same bytes or not)
+        # is not the file the user approved.
+        return False
     digest = _file_digest(config_file)
     if digest is None:
         return False

--- a/packages/prime-traces/src/prime_traces/core/config.py
+++ b/packages/prime-traces/src/prime_traces/core/config.py
@@ -73,6 +73,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if config_file.is_symlink() or config_file.parent.is_symlink():
+        # Project files reached through a symlink are never trusted (the CLI
+        # applies the same rule, and refuses to write through them).
+        return False
     if not _owned_by_current_user(config_file):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.

--- a/packages/prime-traces/src/prime_traces/core/config.py
+++ b/packages/prime-traces/src/prime_traces/core/config.py
@@ -4,19 +4,27 @@ Mirrors the other prime SDK packages: reads config.json (project-local or
 ~/.prime) plus environment variables, env taking precedence.
 """
 
+import hashlib
 import json
 import os
+import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
 def global_config_dir() -> Path:
     """The per-user config directory, ~/.prime."""
     return Path.home() / CONFIG_DIR_NAME
+
+
+def trusted_configs_file() -> Path:
+    """The per-user registry of project-local configs approved via `prime config trust`."""
+    return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
 
 
 def _owned_by_current_user(path: Path) -> bool:
@@ -36,40 +44,112 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
-def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
-    """Find the nearest project-local config directory, or None.
+def _file_digest(path: Path) -> Optional[str]:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
 
-    Walks from `start` (default: the working directory) up through its parents
-    looking for `.prime/config.json`. The walk stops at the home directory:
-    `~/.prime` is the global config, and anything above home is not the user's
-    project. Only files owned by the current user count.
+
+def load_trusted_configs() -> dict[str, str]:
+    """Resolved config.json path -> content digest, for every approved local config."""
+    try:
+        data = json.loads(trusted_configs_file().read_text())
+    except (OSError, ValueError):
+        return {}
+    trusted = data.get("trusted") if isinstance(data, dict) else None
+    if not isinstance(trusted, dict):
+        return {}
+    return {str(path): str(digest) for path, digest in trusted.items()}
+
+
+def is_trusted_local_config(config_file: Path) -> bool:
+    """Whether the user approved this file *with its current content*.
+
+    Ownership alone is not enough: a `.prime/config.json` committed to a
+    repository the user clones is owned by the user, and could redirect an
+    environment-provided PRIME_API_KEY to an attacker's base_url. So a
+    discovered local config is only honored after `prime config trust`, and
+    the approval is tied to a content digest — if the file changes it has to
+    be trusted again. The SDK only reads the registry; the CLI maintains it.
+    """
+    digest = _file_digest(config_file)
+    if digest is None:
+        return False
+    return load_trusted_configs().get(str(config_file.resolve())) == digest
+
+
+def _candidate_local_config_files(start: Optional[Path] = None) -> Iterator[Path]:
+    """Owned `.prime/config.json` files from `start` upward, nearest first.
+
+    The walk stops at the home directory: `~/.prime` is the global config, and
+    anything above home is not the user's project.
     """
     try:
         current = (start or Path.cwd()).resolve()
         home = Path.home().resolve()
     except OSError:
-        return None
+        return
     for directory in (current, *current.parents):
         if directory == home:
             break
         config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
         if config_file.is_file() and _owned_by_current_user(config_file):
-            return directory / CONFIG_DIR_NAME
-    return None
+            yield config_file
 
 
-def resolve_config_dir() -> tuple[Path, str]:
-    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+def discover_local_config(start: Optional[Path] = None) -> tuple[Optional[Path], list[Path]]:
+    """The nearest *trusted* project-local config dir, plus untrusted files passed over.
 
-    Returns the directory and its source: "env", "local", or "global".
+    Untrusted candidates are skipped rather than stopping the search, so a
+    file planted in a nested directory cannot mask the user's own trusted one
+    further up.
+    """
+    untrusted: list[Path] = []
+    for config_file in _candidate_local_config_files(start):
+        if is_trusted_local_config(config_file):
+            return config_file.parent, untrusted
+        untrusted.append(config_file)
+    return None, untrusted
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest trusted project-local config directory, or None."""
+    return discover_local_config(start)[0]
+
+
+def resolve_config_dir() -> tuple[Path, str, list[Path]]:
+    """Choose the config directory: PRIME_CONFIG_DIR > trusted project-local > ~/.prime.
+
+    Returns the directory, its source ("env", "local", or "global"), and any
+    untrusted project-local config files that were ignored on the way.
     """
     explicit = os.getenv(CONFIG_DIR_ENV_VAR)
     if explicit and explicit.strip():
-        return Path(explicit.strip()).expanduser(), "env"
-    local = find_local_config_dir()
+        return Path(explicit.strip()).expanduser(), "env", []
+    local, untrusted = discover_local_config()
     if local is not None:
-        return local, "local"
-    return global_config_dir(), "global"
+        return local, "local", untrusted
+    return global_config_dir(), "global", untrusted
+
+
+UNTRUSTED_CONFIG_WARNING = "Ignoring untrusted project config"
+_warned_untrusted: set[Path] = set()
+
+
+def _warn_untrusted(untrusted: list[Path]) -> None:
+    """Warn once per file per process that a local config was ignored."""
+    for config_file in untrusted:
+        if config_file in _warned_untrusted:
+            continue
+        _warned_untrusted.add(config_file)
+        warnings.warn(
+            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; run "
+            f"'prime config trust {config_file.parent.parent}' to use it, or set "
+            f"{CONFIG_DIR_ENV_VAR}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 class Config:
@@ -84,17 +164,19 @@ class Config:
         """Load config from `config_dir`, or from the resolved location when omitted.
 
         Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
-        working directory holding `.prime/config.json` (see
-        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        working directory holding a *trusted* `.prime/config.json` (see
+        `discover_local_config`), then `~/.prime`. A project-local config is a
         complete replacement for the global one, never merged with it.
         """
+        self.untrusted_local_configs: list[Path] = []
         if config_dir is not None:
             self.config_dir = Path(config_dir).expanduser()
             self.config_source = "explicit"
         else:
-            self.config_dir, self.config_source = resolve_config_dir()
+            self.config_dir, self.config_source, self.untrusted_local_configs = resolve_config_dir()
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
+        _warn_untrusted(self.untrusted_local_configs)
 
     def _load_config(self) -> None:
         """Load configuration from file"""

--- a/packages/prime-traces/tests/conftest.py
+++ b/packages/prime-traces/tests/conftest.py
@@ -17,6 +17,7 @@ _PRIME_ENV_VARS = (
     "PRIME_TRACES_URL",
     "PRIME_API_BASE_URL",
     "PRIME_BASE_URL",
+    "PRIME_CONFIG_DIR",
 )
 
 
@@ -30,6 +31,8 @@ def isolated_prime_config(monkeypatch, tmp_path):
     Mirrors the home-isolation fixture in prime-sandboxes' conftest.
     """
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Discovery also walks up from the working directory; start in the tmp dir.
+    monkeypatch.chdir(tmp_path)
     for name in _PRIME_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
     return tmp_path

--- a/packages/prime-traces/tests/test_config_discovery.py
+++ b/packages/prime-traces/tests/test_config_discovery.py
@@ -1,23 +1,43 @@
-"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest trusted .prime/ > ~/.prime.
 
 The conftest points Path.home at tmp_path and starts each test there.
 """
 
+import hashlib
 import json
 import os
 from pathlib import Path
 
+import pytest
+
 from prime_traces import Config
+from prime_traces.core import config as config_module
 
 
-def _write(directory: Path, **values: object) -> Path:
+@pytest.fixture(autouse=True)
+def reset_warning_dedup(monkeypatch):
+    monkeypatch.setattr(config_module, "_warned_untrusted", set())
+
+
+def _write(directory: Path, *, trusted: bool = True, **values: object) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "config.json"
     path.write_text(json.dumps(values))
+    if trusted and directory != Path.home() / ".prime":
+        _trust(path)
     return path
 
 
-def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+def _trust(path: Path) -> None:
+    """Approve a local config the way `prime config trust` does."""
+    registry = Path.home() / ".prime" / "trusted_configs.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    trusted = json.loads(registry.read_text())["trusted"] if registry.exists() else {}
+    trusted[str(path.resolve())] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    registry.write_text(json.dumps({"version": 1, "trusted": trusted}))
+
+
+def test_discovers_trusted_local_config_from_subdirectory(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
     project = tmp_path / "code" / "prime"
     _write(project / ".prime", api_key="local-key")
@@ -30,6 +50,33 @@ def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
     assert config.config_source == "local"
     assert config.config_dir == project / ".prime"
     assert config.api_key == "local-key"
+    assert config.untrusted_local_configs == []
+
+
+def test_untrusted_local_config_is_ignored_with_a_warning(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    planted = _write(project / ".prime", trusted=False, base_url="https://evil.example")
+    monkeypatch.chdir(project)
+
+    with pytest.warns(RuntimeWarning, match="prime config trust"):
+        config = Config()
+
+    assert config.config_source == "global"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.untrusted_local_configs == [planted]
+
+
+def test_trust_is_bound_to_file_content(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    monkeypatch.chdir(project)
+    assert Config().api_key == "local-key"
+
+    local.write_text(json.dumps({"api_key": "local-key", "base_url": "https://evil.example"}))
+
+    with pytest.warns(RuntimeWarning):
+        assert Config().config_source == "global"
 
 
 def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
@@ -37,7 +84,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
     project = tmp_path / "proj"
     _write(project / ".prime", base_url="https://local.example")
     monkeypatch.chdir(project)
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -47,7 +93,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
 
 def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
     assert config.config_source == "global"
@@ -61,10 +106,9 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="local-key")
     explicit = tmp_path / "elsewhere"
-    _write(explicit, api_key="explicit-key")
+    _write(explicit, trusted=False, api_key="explicit-key")
     monkeypatch.chdir(project)
     monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -80,4 +124,6 @@ def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     real_uid = os.getuid()
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
-    assert Config().config_source == "global"
+    config = Config()
+    assert config.config_source == "global"
+    assert config.untrusted_local_configs == []

--- a/packages/prime-traces/tests/test_config_discovery.py
+++ b/packages/prime-traces/tests/test_config_discovery.py
@@ -1,0 +1,83 @@
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+
+The conftest points Path.home at tmp_path and starts each test there.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from prime_traces import Config
+
+
+def _write(directory: Path, **values: object) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "code" / "prime"
+    _write(project / ".prime", api_key="local-key")
+    workdir = project / "envs" / "my-env"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+
+    config = Config()
+
+    assert config.config_source == "local"
+    assert config.config_dir == project / ".prime"
+    assert config.api_key == "local-key"
+
+
+def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    _write(project / ".prime", base_url="https://local.example")
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.base_url == "https://local.example"
+    assert config.api_key == ""
+
+
+def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+    assert config.config_source == "global"
+    assert config.api_key == "global-key"
+
+    monkeypatch.setenv("PRIME_API_KEY", "env-key")
+    assert Config().api_key == "env-key"
+
+
+def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="local-key")
+    explicit = tmp_path / "elsewhere"
+    _write(explicit, api_key="explicit-key")
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.config_source == "env"
+    assert config.config_dir == explicit
+    assert config.api_key == "explicit-key"
+
+
+def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="planted-key")
+    monkeypatch.chdir(project)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert Config().config_source == "global"

--- a/packages/prime-traces/tests/test_config_discovery.py
+++ b/packages/prime-traces/tests/test_config_discovery.py
@@ -117,6 +117,15 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     assert config.api_key == "explicit-key"
 
 
+def test_trust_requires_ownership_even_with_matching_digest(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert not config_module.is_trusted_local_config(local)
+
+
 def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="planted-key")

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -3,19 +3,92 @@ import os
 from pathlib import Path
 from typing import Optional
 
+CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
+CONFIG_DIR_NAME = ".prime"
+CONFIG_FILE_NAME = "config.json"
+
+
+def global_config_dir() -> Path:
+    """The per-user config directory, ~/.prime."""
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def _owned_by_current_user(path: Path) -> bool:
+    """True when `path` (following symlinks) is owned by the running user.
+
+    Project-local configs are picked up by walking parent directories, so on a
+    shared machine anyone who can write to an ancestor could plant one that
+    points the SDK at their account. Refusing files we don't own closes that.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return True
+    try:
+        return path.stat().st_uid == getuid()
+    except OSError:
+        return False
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest project-local config directory, or None.
+
+    Walks from `start` (default: the working directory) up through its parents
+    looking for `.prime/config.json`. The walk stops at the home directory:
+    `~/.prime` is the global config, and anything above home is not the user's
+    project. Only files owned by the current user count.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+        home = Path.home().resolve()
+    except OSError:
+        return None
+    for directory in (current, *current.parents):
+        if directory == home:
+            break
+        config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+        if config_file.is_file() and _owned_by_current_user(config_file):
+            return directory / CONFIG_DIR_NAME
+    return None
+
+
+def resolve_config_dir() -> tuple[Path, str]:
+    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+
+    Returns the directory and its source: "env", "local", or "global".
+    """
+    explicit = os.getenv(CONFIG_DIR_ENV_VAR)
+    if explicit and explicit.strip():
+        return Path(explicit.strip()).expanduser(), "env"
+    local = find_local_config_dir()
+    if local is not None:
+        return local, "local"
+    return global_config_dir(), "global"
+
 
 class Config:
     """Minimal configuration class for Prime Tunnel SDK.
 
-    Reads from ~/.prime/config.json and environment variables.
+    Reads from a project-local or ~/.prime config.json and environment variables.
     This is a simplified version that doesn't write configs.
     """
 
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
 
-    def __init__(self) -> None:
-        self.config_dir = Path.home() / ".prime"
-        self.config_file = self.config_dir / "config.json"
+    def __init__(self, config_dir: Optional[Path | str] = None) -> None:
+        """Load config from `config_dir`, or from the resolved location when omitted.
+
+        Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
+        working directory holding `.prime/config.json` (see
+        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        complete replacement for the global one, never merged with it.
+        """
+        if config_dir is not None:
+            self.config_dir = Path(config_dir).expanduser()
+            self.config_source = "explicit"
+        else:
+            self.config_dir, self.config_source = resolve_config_dir()
+        self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
 
     def _load_config(self) -> None:
@@ -64,7 +137,7 @@ class Config:
 
     @property
     def bin_dir(self) -> Path:
-        """Directory for binary files (frpc)."""
-        path = self.config_dir / "bin"
+        """Directory for binary files (frpc); always global, not per project."""
+        path = global_config_dir() / "bin"
         path.mkdir(parents=True, exist_ok=True)
         return path

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -1,16 +1,24 @@
+import hashlib
 import json
 import os
+import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
 def global_config_dir() -> Path:
     """The per-user config directory, ~/.prime."""
     return Path.home() / CONFIG_DIR_NAME
+
+
+def trusted_configs_file() -> Path:
+    """The per-user registry of project-local configs approved via `prime config trust`."""
+    return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
 
 
 def _owned_by_current_user(path: Path) -> bool:
@@ -30,40 +38,112 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
-def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
-    """Find the nearest project-local config directory, or None.
+def _file_digest(path: Path) -> Optional[str]:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
 
-    Walks from `start` (default: the working directory) up through its parents
-    looking for `.prime/config.json`. The walk stops at the home directory:
-    `~/.prime` is the global config, and anything above home is not the user's
-    project. Only files owned by the current user count.
+
+def load_trusted_configs() -> dict[str, str]:
+    """Resolved config.json path -> content digest, for every approved local config."""
+    try:
+        data = json.loads(trusted_configs_file().read_text())
+    except (OSError, ValueError):
+        return {}
+    trusted = data.get("trusted") if isinstance(data, dict) else None
+    if not isinstance(trusted, dict):
+        return {}
+    return {str(path): str(digest) for path, digest in trusted.items()}
+
+
+def is_trusted_local_config(config_file: Path) -> bool:
+    """Whether the user approved this file *with its current content*.
+
+    Ownership alone is not enough: a `.prime/config.json` committed to a
+    repository the user clones is owned by the user, and could redirect an
+    environment-provided PRIME_API_KEY to an attacker's base_url. So a
+    discovered local config is only honored after `prime config trust`, and
+    the approval is tied to a content digest — if the file changes it has to
+    be trusted again. The SDK only reads the registry; the CLI maintains it.
+    """
+    digest = _file_digest(config_file)
+    if digest is None:
+        return False
+    return load_trusted_configs().get(str(config_file.resolve())) == digest
+
+
+def _candidate_local_config_files(start: Optional[Path] = None) -> Iterator[Path]:
+    """Owned `.prime/config.json` files from `start` upward, nearest first.
+
+    The walk stops at the home directory: `~/.prime` is the global config, and
+    anything above home is not the user's project.
     """
     try:
         current = (start or Path.cwd()).resolve()
         home = Path.home().resolve()
     except OSError:
-        return None
+        return
     for directory in (current, *current.parents):
         if directory == home:
             break
         config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
         if config_file.is_file() and _owned_by_current_user(config_file):
-            return directory / CONFIG_DIR_NAME
-    return None
+            yield config_file
 
 
-def resolve_config_dir() -> tuple[Path, str]:
-    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+def discover_local_config(start: Optional[Path] = None) -> tuple[Optional[Path], list[Path]]:
+    """The nearest *trusted* project-local config dir, plus untrusted files passed over.
 
-    Returns the directory and its source: "env", "local", or "global".
+    Untrusted candidates are skipped rather than stopping the search, so a
+    file planted in a nested directory cannot mask the user's own trusted one
+    further up.
+    """
+    untrusted: list[Path] = []
+    for config_file in _candidate_local_config_files(start):
+        if is_trusted_local_config(config_file):
+            return config_file.parent, untrusted
+        untrusted.append(config_file)
+    return None, untrusted
+
+
+def find_local_config_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Find the nearest trusted project-local config directory, or None."""
+    return discover_local_config(start)[0]
+
+
+def resolve_config_dir() -> tuple[Path, str, list[Path]]:
+    """Choose the config directory: PRIME_CONFIG_DIR > trusted project-local > ~/.prime.
+
+    Returns the directory, its source ("env", "local", or "global"), and any
+    untrusted project-local config files that were ignored on the way.
     """
     explicit = os.getenv(CONFIG_DIR_ENV_VAR)
     if explicit and explicit.strip():
-        return Path(explicit.strip()).expanduser(), "env"
-    local = find_local_config_dir()
+        return Path(explicit.strip()).expanduser(), "env", []
+    local, untrusted = discover_local_config()
     if local is not None:
-        return local, "local"
-    return global_config_dir(), "global"
+        return local, "local", untrusted
+    return global_config_dir(), "global", untrusted
+
+
+UNTRUSTED_CONFIG_WARNING = "Ignoring untrusted project config"
+_warned_untrusted: set[Path] = set()
+
+
+def _warn_untrusted(untrusted: list[Path]) -> None:
+    """Warn once per file per process that a local config was ignored."""
+    for config_file in untrusted:
+        if config_file in _warned_untrusted:
+            continue
+        _warned_untrusted.add(config_file)
+        warnings.warn(
+            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; run "
+            f"'prime config trust {config_file.parent.parent}' to use it, or set "
+            f"{CONFIG_DIR_ENV_VAR}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
 
 class Config:
@@ -79,17 +159,19 @@ class Config:
         """Load config from `config_dir`, or from the resolved location when omitted.
 
         Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
-        working directory holding `.prime/config.json` (see
-        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        working directory holding a *trusted* `.prime/config.json` (see
+        `discover_local_config`), then `~/.prime`. A project-local config is a
         complete replacement for the global one, never merged with it.
         """
+        self.untrusted_local_configs: list[Path] = []
         if config_dir is not None:
             self.config_dir = Path(config_dir).expanduser()
             self.config_source = "explicit"
         else:
-            self.config_dir, self.config_source = resolve_config_dir()
+            self.config_dir, self.config_source, self.untrusted_local_configs = resolve_config_dir()
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self._load_config()
+        _warn_untrusted(self.untrusted_local_configs)
 
     def _load_config(self) -> None:
         """Load configuration from file."""

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -67,6 +67,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if not _owned_by_current_user(config_file):
+        # A trusted path swapped for someone else's file (same bytes or not)
+        # is not the file the user approved.
+        return False
     digest = _file_digest(config_file)
     if digest is None:
         return False

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -67,6 +67,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     the approval is tied to a content digest — if the file changes it has to
     be trusted again. The SDK only reads the registry; the CLI maintains it.
     """
+    if config_file.is_symlink() or config_file.parent.is_symlink():
+        # Project files reached through a symlink are never trusted (the CLI
+        # applies the same rule, and refuses to write through them).
+        return False
     if not _owned_by_current_user(config_file):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.

--- a/packages/prime-tunnel/tests/conftest.py
+++ b/packages/prime-tunnel/tests/conftest.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_prime_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Keep tests hermetic: never read the developer's real ~/.prime.
+
+    Config discovery also walks up from the working directory, so start each
+    test in a fresh tmp dir and ignore PRIME_CONFIG_DIR from the shell.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)
+    return tmp_path

--- a/packages/prime-tunnel/tests/conftest.py
+++ b/packages/prime-tunnel/tests/conftest.py
@@ -13,4 +13,5 @@ def isolated_prime_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Pa
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
     return tmp_path

--- a/packages/prime-tunnel/tests/test_config_discovery.py
+++ b/packages/prime-tunnel/tests/test_config_discovery.py
@@ -1,23 +1,43 @@
-"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest trusted .prime/ > ~/.prime.
 
 The conftest points Path.home at tmp_path and starts each test there.
 """
 
+import hashlib
 import json
 import os
 from pathlib import Path
 
+import pytest
+
 from prime_tunnel import Config
+from prime_tunnel.core import config as config_module
 
 
-def _write(directory: Path, **values: object) -> Path:
+@pytest.fixture(autouse=True)
+def reset_warning_dedup(monkeypatch):
+    monkeypatch.setattr(config_module, "_warned_untrusted", set())
+
+
+def _write(directory: Path, *, trusted: bool = True, **values: object) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "config.json"
     path.write_text(json.dumps(values))
+    if trusted and directory != Path.home() / ".prime":
+        _trust(path)
     return path
 
 
-def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+def _trust(path: Path) -> None:
+    """Approve a local config the way `prime config trust` does."""
+    registry = Path.home() / ".prime" / "trusted_configs.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    trusted = json.loads(registry.read_text())["trusted"] if registry.exists() else {}
+    trusted[str(path.resolve())] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    registry.write_text(json.dumps({"version": 1, "trusted": trusted}))
+
+
+def test_discovers_trusted_local_config_from_subdirectory(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
     project = tmp_path / "code" / "prime"
     _write(project / ".prime", api_key="local-key")
@@ -30,6 +50,33 @@ def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
     assert config.config_source == "local"
     assert config.config_dir == project / ".prime"
     assert config.api_key == "local-key"
+    assert config.untrusted_local_configs == []
+
+
+def test_untrusted_local_config_is_ignored_with_a_warning(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    planted = _write(project / ".prime", trusted=False, base_url="https://evil.example")
+    monkeypatch.chdir(project)
+
+    with pytest.warns(RuntimeWarning, match="prime config trust"):
+        config = Config()
+
+    assert config.config_source == "global"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.untrusted_local_configs == [planted]
+
+
+def test_trust_is_bound_to_file_content(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    monkeypatch.chdir(project)
+    assert Config().api_key == "local-key"
+
+    local.write_text(json.dumps({"api_key": "local-key", "base_url": "https://evil.example"}))
+
+    with pytest.warns(RuntimeWarning):
+        assert Config().config_source == "global"
 
 
 def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
@@ -37,7 +84,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
     project = tmp_path / "proj"
     _write(project / ".prime", base_url="https://local.example")
     monkeypatch.chdir(project)
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -47,7 +93,6 @@ def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch)
 
 def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
     _write(tmp_path / ".prime", api_key="global-key")
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
     assert config.config_source == "global"
@@ -61,10 +106,9 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="local-key")
     explicit = tmp_path / "elsewhere"
-    _write(explicit, api_key="explicit-key")
+    _write(explicit, trusted=False, api_key="explicit-key")
     monkeypatch.chdir(project)
     monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
 
     config = Config()
 
@@ -80,4 +124,6 @@ def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     real_uid = os.getuid()
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
-    assert Config().config_source == "global"
+    config = Config()
+    assert config.config_source == "global"
+    assert config.untrusted_local_configs == []

--- a/packages/prime-tunnel/tests/test_config_discovery.py
+++ b/packages/prime-tunnel/tests/test_config_discovery.py
@@ -1,0 +1,83 @@
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime.
+
+The conftest points Path.home at tmp_path and starts each test there.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from prime_tunnel import Config
+
+
+def _write(directory: Path, **values: object) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+def test_discovers_local_config_from_subdirectory(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "code" / "prime"
+    _write(project / ".prime", api_key="local-key")
+    workdir = project / "envs" / "my-env"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+
+    config = Config()
+
+    assert config.config_source == "local"
+    assert config.config_dir == project / ".prime"
+    assert config.api_key == "local-key"
+
+
+def test_local_config_replaces_global_rather_than_merging(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    project = tmp_path / "proj"
+    _write(project / ".prime", base_url="https://local.example")
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.base_url == "https://local.example"
+    assert config.api_key == ""
+
+
+def test_falls_back_to_global_and_env_var_still_wins(tmp_path, monkeypatch):
+    _write(tmp_path / ".prime", api_key="global-key")
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+    assert config.config_source == "global"
+    assert config.api_key == "global-key"
+
+    monkeypatch.setenv("PRIME_API_KEY", "env-key")
+    assert Config().api_key == "env-key"
+
+
+def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="local-key")
+    explicit = tmp_path / "elsewhere"
+    _write(explicit, api_key="explicit-key")
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+
+    config = Config()
+
+    assert config.config_source == "env"
+    assert config.config_dir == explicit
+    assert config.api_key == "explicit-key"
+
+
+def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    _write(project / ".prime", api_key="planted-key")
+    monkeypatch.chdir(project)
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert Config().config_source == "global"

--- a/packages/prime-tunnel/tests/test_config_discovery.py
+++ b/packages/prime-tunnel/tests/test_config_discovery.py
@@ -117,6 +117,15 @@ def test_prime_config_dir_env_var_beats_discovery(tmp_path, monkeypatch):
     assert config.api_key == "explicit-key"
 
 
+def test_trust_requires_ownership_even_with_matching_digest(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    local = _write(project / ".prime", api_key="local-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert not config_module.is_trusted_local_config(local)
+
+
 def test_ignores_local_config_owned_by_another_user(tmp_path, monkeypatch):
     project = tmp_path / "proj"
     _write(project / ".prime", api_key="planted-key")

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -82,9 +82,10 @@ prime login --local
 Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect.ai).
 
 `prime login --local` writes `./.prime/config.json`; commands run from that
-directory or below use it instead of `~/.prime/config.json`. Set
-`PRIME_CONFIG_DIR` to point at a config directory explicitly. `prime config view`
-shows which file is active.
+directory or below use it instead of `~/.prime/config.json`. A local config you
+wrote by hand must be approved once with `prime config trust` (approval is tied
+to the file's content). Set `PRIME_CONFIG_DIR` to point at a config directory
+explicitly. `prime config view` shows which file is active.
 
 ### Basic Usage
 

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -74,9 +74,17 @@ prime config set-api-key
 
 # Or use environment variable
 export PRIME_API_KEY="your-api-key-here"
+
+# Or keep credentials with a project instead of in ~/.prime (shared machines)
+prime login --local
 ```
 
 Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect.ai).
+
+`prime login --local` writes `./.prime/config.json`; commands run from that
+directory or below use it instead of `~/.prime/config.json`. Set
+`PRIME_CONFIG_DIR` to point at a config directory explicitly. `prime config view`
+shows which file is active.
 
 ### Basic Usage
 

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -16,6 +16,44 @@ from .teams import fetch_teams
 app = PlainTyper(help="Configure the CLI", no_args_is_help=True)
 console = get_console()
 
+LOCAL_OPTION_HELP = (
+    "Use a project-local config at ./.prime/config.json instead of ~/.prime/config.json. "
+    "Commands run from this directory (or any directory below it) will use it."
+)
+
+CONFIG_SOURCE_LABELS = {
+    "env": "from PRIME_CONFIG_DIR",
+    "local": "project-local",
+    "global": "global",
+    "explicit": "project-local",
+}
+
+
+def describe_config_file(config: Config) -> str:
+    """The active config file path plus how it was chosen, for display."""
+    label = CONFIG_SOURCE_LABELS.get(config.config_source, config.config_source)
+    return f"{config.config_file} ({label})"
+
+
+def print_local_config_notice(config: Config) -> None:
+    """Tell the user where a project-local config landed and how to keep it out of git."""
+    console.print(f"[blue]Using project-local config: {config.config_file}[/blue]")
+    project_root = config.config_dir.parent
+    if not (project_root / ".git").exists():
+        return
+    gitignore = project_root / ".gitignore"
+    try:
+        patterns = gitignore.read_text().splitlines() if gitignore.is_file() else []
+    except OSError:
+        patterns = []
+    if any(line.strip().strip("/") in (".prime", ".prime/") for line in patterns):
+        return
+    console.print(
+        "[yellow]Warning: .prime/ is not in .gitignore — add it so your API key "
+        "is never committed.[/yellow]"
+    )
+
+
 # Team ID validation pattern: CUID (v1)
 TEAM_ID_PATTERN = re.compile(r"^c[a-z0-9]{24}$")
 
@@ -46,6 +84,8 @@ def view() -> None:
 
     def _env_set(*names: str) -> bool:
         return any((val := os.getenv(n)) and val.strip() for n in names)
+
+    table.add_row("Config File", describe_config_file(config))
 
     # Show current environment
     table.add_row("Current Environment", settings["current_environment"])
@@ -122,6 +162,7 @@ def set_api_key(
         None,
         help="Your Prime Intellect API key. If not provided, you'll be prompted securely.",
     ),
+    local: bool = typer.Option(False, "--local", help=LOCAL_OPTION_HELP),
 ) -> None:
     """Set your API key (prompts securely if not provided)"""
     if api_key is None:
@@ -133,8 +174,10 @@ def set_api_key(
             default="",
         )
 
-    config = Config()
+    config = Config.local() if local else Config()
     config.set_api_key(api_key)
+    if local:
+        print_local_config_notice(config)
 
     if api_key:
         masked_key = f"{api_key[:6]}***{api_key[-4:]}" if len(api_key) > 10 else "***"

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -14,7 +14,7 @@ from prime_cli.core import Config
 from prime_cli.core.config import (
     CONFIG_DIR_NAME,
     CONFIG_FILE_NAME,
-    global_config_dir,
+    is_global_config_dir,
     is_trusted_local_config,
     trust_local_config,
     untrust_local_config,
@@ -135,8 +135,11 @@ def new_local_config() -> Config:
     config_file = config_dir / CONFIG_FILE_NAME
     # From the home directory, --local simply means the global config, which is
     # trusted as such and never in the registry.
-    is_global = config_dir.resolve() == global_config_dir().resolve()
-    if config_file.exists() and not is_global and not is_trusted_local_config(config_file):
+    if (
+        config_file.exists()
+        and not is_global_config_dir(config_dir)
+        and not is_trusted_local_config(config_file)
+    ):
         console.print(
             f"[red]{config_file} already exists but is not trusted. Review it and run "
             "'prime config trust', or delete it, before using --local.[/red]"

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -15,6 +15,7 @@ from prime_cli.core.config import (
     CONFIG_DIR_NAME,
     CONFIG_FILE_NAME,
     is_global_config_dir,
+    is_owned_by_current_user,
     is_trusted_local_config,
     trust_local_config,
     untrust_local_config,
@@ -133,6 +134,12 @@ def new_local_config() -> Config:
     """
     config_dir = Path.cwd() / CONFIG_DIR_NAME
     config_file = config_dir / CONFIG_FILE_NAME
+    if config_file.exists() and not is_owned_by_current_user(config_file):
+        console.print(
+            f"[red]{config_file} is not owned by you; refusing to write credentials into it. "
+            "Remove it (or fix its ownership) before using --local.[/red]"
+        )
+        raise typer.Exit(1)
     # From the home directory, --local simply means the global config, which is
     # trusted as such and never in the registry.
     if (

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -14,6 +14,7 @@ from prime_cli.core import Config
 from prime_cli.core.config import (
     CONFIG_DIR_NAME,
     CONFIG_FILE_NAME,
+    involves_symlink,
     is_global_config_dir,
     is_owned_by_current_user,
     is_trusted_local_config,
@@ -134,11 +135,12 @@ def new_local_config() -> Config:
     """
     config_dir = Path.cwd() / CONFIG_DIR_NAME
     config_file = config_dir / CONFIG_FILE_NAME
-    if config_file.is_symlink() and not is_global_config_dir(config_dir):
-        # A cloned repo can ship a (dangling) symlink to redirect the write.
+    if not is_global_config_dir(config_dir) and involves_symlink(config_file):
+        # A cloned repo can ship the file or the .prime directory as a
+        # (possibly dangling) symlink to redirect the write.
         console.print(
-            f"[red]{config_file} is a symlink; refusing to write credentials through it. "
-            "Remove it before using --local.[/red]"
+            f"[red]{config_file} or its .prime directory is a symlink; refusing to write "
+            "credentials through it. Remove the symlink before using --local.[/red]"
         )
         raise typer.Exit(1)
     if config_file.exists() and not is_owned_by_current_user(config_file):

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -14,6 +14,7 @@ from prime_cli.core import Config
 from prime_cli.core.config import (
     CONFIG_DIR_NAME,
     CONFIG_FILE_NAME,
+    is_trusted_local_config,
     trust_local_config,
     untrust_local_config,
 )
@@ -121,9 +122,21 @@ def new_local_config() -> Config:
     does not leave an empty file behind that would shadow the global config.
     A brand-new local config inherits the service URLs of whatever config is
     currently active, so it keeps targeting the same deployment.
+
+    An existing file that is not trusted is refused rather than adopted:
+    writing the key into it would also record trust for whatever base_url it
+    carries, which is exactly what a config planted in a cloned repository
+    wants. The user has to review it (`prime config trust`) or remove it first.
     """
+    config_file = Path.cwd() / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+    if config_file.exists() and not is_trusted_local_config(config_file):
+        console.print(
+            f"[red]{config_file} already exists but is not trusted. Review it and run "
+            "'prime config trust', or delete it, before using --local.[/red]"
+        )
+        raise typer.Exit(1)
     config = Config.local(create=False)
-    if not config.config_file.exists():
+    if not config_file.exists():
         config.adopt_urls(Config())
     return config
 

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -1,5 +1,8 @@
 import os
 import re
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -8,6 +11,12 @@ from rich.table import Table
 from rich.text import Text
 
 from prime_cli.core import Config
+from prime_cli.core.config import (
+    CONFIG_DIR_NAME,
+    CONFIG_FILE_NAME,
+    trust_local_config,
+    untrust_local_config,
+)
 
 from ..client import APIClient, APIError
 from ..utils import PlainTyper, get_console
@@ -19,6 +28,10 @@ console = get_console()
 LOCAL_OPTION_HELP = (
     "Use a project-local config at ./.prime/config.json instead of ~/.prime/config.json. "
     "Commands run from this directory (or any directory below it) will use it."
+)
+
+TRUST_PATH_HELP = (
+    "Project directory (or its .prime/ or config.json). Defaults to the current directory."
 )
 
 CONFIG_SOURCE_LABELS = {
@@ -35,23 +48,94 @@ def describe_config_file(config: Config) -> str:
     return f"{config.config_file} ({label})"
 
 
-def print_local_config_notice(config: Config) -> None:
-    """Tell the user where a project-local config landed and how to keep it out of git."""
-    console.print(f"[blue]Using project-local config: {config.config_file}[/blue]")
-    project_root = config.config_dir.parent
-    if not (project_root / ".git").exists():
-        return
-    gitignore = project_root / ".gitignore"
+def _git_repo_root(path: Path) -> Optional[Path]:
+    """The nearest enclosing git repository root (`.git` dir or worktree file), or None."""
+    for directory in (path, *path.parents):
+        if (directory / ".git").exists():
+            return directory
+    return None
+
+
+def _is_git_ignored(repo_root: Path, path: Path) -> Optional[bool]:
+    """Ask git whether `path` is ignored; None when git can't tell us."""
+    git = shutil.which("git")
+    if git is None:
+        return None
     try:
-        patterns = gitignore.read_text().splitlines() if gitignore.is_file() else []
-    except OSError:
-        patterns = []
-    if any(line.strip().strip("/") in (".prime", ".prime/") for line in patterns):
+        result = subprocess.run(
+            [git, "-C", str(repo_root), "check-ignore", "-q", "--", str(path)],
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _gitignore_mentions_prime(repo_root: Path, config_dir: Path) -> bool:
+    """Fallback without git: scan .gitignore files between the repo root and the config."""
+    for directory in (config_dir.parent, *config_dir.parent.parents):
+        gitignore = directory / ".gitignore"
+        try:
+            patterns = gitignore.read_text().splitlines() if gitignore.is_file() else []
+        except OSError:
+            patterns = []
+        if any(line.strip().strip("/") in (".prime", ".prime/") for line in patterns):
+            return True
+        if directory == repo_root:
+            break
+    return False
+
+
+def print_local_config_notice(config: Config) -> None:
+    """Tell the user where a project-local config landed and how to keep it out of git.
+
+    The config may sit in a subdirectory of a repository, so look for the
+    enclosing repo rather than only the config's parent, and let git decide
+    whether the file is actually ignored.
+    """
+    console.print(f"[blue]Using project-local config: {config.config_file}[/blue]")
+    config_dir = config.config_dir.resolve()
+    repo_root = _git_repo_root(config_dir.parent)
+    if repo_root is None:
+        return
+    ignored = _is_git_ignored(repo_root, config_dir / CONFIG_FILE_NAME)
+    if ignored is None:
+        ignored = _gitignore_mentions_prime(repo_root, config_dir)
+    if ignored:
         return
     console.print(
-        "[yellow]Warning: .prime/ is not in .gitignore — add it so your API key "
-        "is never committed.[/yellow]"
+        "[yellow]Warning: .prime/ is not ignored by the git repository at "
+        f"{repo_root} — add it to .gitignore so your API key is never committed.[/yellow]"
     )
+
+
+def new_local_config() -> Config:
+    """A project-local Config for the working directory that is not written yet.
+
+    Nothing touches disk until the first `set_*` call, so an aborted login
+    does not leave an empty file behind that would shadow the global config.
+    A brand-new local config inherits the service URLs of whatever config is
+    currently active, so it keeps targeting the same deployment.
+    """
+    config = Config.local(create=False)
+    if not config.config_file.exists():
+        config.adopt_urls(Config())
+    return config
+
+
+def _resolve_local_config_file(path: Optional[Path]) -> Path:
+    """Accept a project dir, its .prime dir, or the config.json itself."""
+    target = (path or Path.cwd()).expanduser()
+    if target.is_file():
+        return target
+    if target.name == CONFIG_DIR_NAME:
+        return target / CONFIG_FILE_NAME
+    return target / CONFIG_DIR_NAME / CONFIG_FILE_NAME
 
 
 # Team ID validation pattern: CUID (v1)
@@ -86,6 +170,8 @@ def view() -> None:
         return any((val := os.getenv(n)) and val.strip() for n in names)
 
     table.add_row("Config File", describe_config_file(config))
+    for ignored in config.untrusted_local_configs:
+        table.add_row("Ignored Config", f"{ignored} (untrusted; see 'prime config trust')")
 
     # Show current environment
     table.add_row("Current Environment", settings["current_environment"])
@@ -174,7 +260,7 @@ def set_api_key(
             default="",
         )
 
-    config = Config.local() if local else Config()
+    config = new_local_config() if local else Config()
     config.set_api_key(api_key)
     if local:
         print_local_config_notice(config)
@@ -472,6 +558,40 @@ def reset(
         config.set_ssh_key_path(Config.DEFAULT_SSH_KEY_PATH)
         config.set_current_environment("production")
         console.print("[green]Configuration reset to defaults![/green]")
+
+
+@app.command()
+def trust(
+    path: Optional[Path] = typer.Argument(None, help=TRUST_PATH_HELP),
+) -> None:
+    """Allow a project-local .prime/config.json to be used by commands run below it.
+
+    Discovered project configs are ignored until trusted, because one committed
+    to a repository you clone could redirect your API key elsewhere. Trust is
+    tied to the file's content: if it changes, run this again.
+    """
+    config_file = _resolve_local_config_file(path)
+    if not config_file.is_file():
+        console.print(f"[red]No config file at {config_file}[/red]")
+        raise typer.Exit(1)
+    try:
+        resolved = trust_local_config(config_file)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    console.print(f"[green]Trusted project config {resolved}[/green]")
+
+
+@app.command()
+def untrust(
+    path: Optional[Path] = typer.Argument(None, help=TRUST_PATH_HELP),
+) -> None:
+    """Stop using a project-local .prime/config.json."""
+    config_file = _resolve_local_config_file(path)
+    if untrust_local_config(config_file):
+        console.print(f"[green]Untrusted project config {config_file.resolve()}[/green]")
+    else:
+        console.print(f"[yellow]{config_file.resolve()} was not trusted[/yellow]")
 
 
 # Environment commands

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -14,6 +14,7 @@ from prime_cli.core import Config
 from prime_cli.core.config import (
     CONFIG_DIR_NAME,
     CONFIG_FILE_NAME,
+    global_config_dir,
     is_trusted_local_config,
     trust_local_config,
     untrust_local_config,
@@ -99,6 +100,8 @@ def print_local_config_notice(config: Config) -> None:
     enclosing repo rather than only the config's parent, and let git decide
     whether the file is actually ignored.
     """
+    if config.is_global:
+        return
     console.print(f"[blue]Using project-local config: {config.config_file}[/blue]")
     config_dir = config.config_dir.resolve()
     repo_root = _git_repo_root(config_dir.parent)
@@ -128,8 +131,12 @@ def new_local_config() -> Config:
     carries, which is exactly what a config planted in a cloned repository
     wants. The user has to review it (`prime config trust`) or remove it first.
     """
-    config_file = Path.cwd() / CONFIG_DIR_NAME / CONFIG_FILE_NAME
-    if config_file.exists() and not is_trusted_local_config(config_file):
+    config_dir = Path.cwd() / CONFIG_DIR_NAME
+    config_file = config_dir / CONFIG_FILE_NAME
+    # From the home directory, --local simply means the global config, which is
+    # trusted as such and never in the registry.
+    is_global = config_dir.resolve() == global_config_dir().resolve()
+    if config_file.exists() and not is_global and not is_trusted_local_config(config_file):
         console.print(
             f"[red]{config_file} already exists but is not trusted. Review it and run "
             "'prime config trust', or delete it, before using --local.[/red]"

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -134,6 +134,13 @@ def new_local_config() -> Config:
     """
     config_dir = Path.cwd() / CONFIG_DIR_NAME
     config_file = config_dir / CONFIG_FILE_NAME
+    if config_file.is_symlink() and not is_global_config_dir(config_dir):
+        # A cloned repo can ship a (dangling) symlink to redirect the write.
+        console.print(
+            f"[red]{config_file} is a symlink; refusing to write credentials through it. "
+            "Remove it before using --local.[/red]"
+        )
+        raise typer.Exit(1)
     if config_file.exists() and not is_owned_by_current_user(config_file):
         console.print(
             f"[red]{config_file} is not owned by you; refusing to write credentials into it. "
@@ -507,7 +514,7 @@ def _save_environment(
         console.print(f"[green]Saved current configuration as environment '{name}'![/green]")
         console.print("[yellow]Note: This includes your API key and team ID[/yellow]")
         console.print(f"[blue]Use 'prime config use {name}' to load it later[/blue]")
-    except ValueError as e:
+    except (ValueError, PermissionError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
 

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -14,6 +14,7 @@ from prime_cli.core import Config
 
 from ..client import APIClient, APIError
 from ..utils import PlainTyper, get_console
+from .config import LOCAL_OPTION_HELP, print_local_config_notice
 from .teams import fetch_teams
 
 app = PlainTyper(help="Login to Prime Intellect")
@@ -125,9 +126,12 @@ def decrypt_challenge_response(
 @app.callback(invoke_without_command=True)
 def login(
     headless: bool = typer.Option(False, "--headless", help="Don't attempt to open browser"),
+    local: bool = typer.Option(False, "--local", help=LOCAL_OPTION_HELP),
 ) -> None:
     """Login to Prime Intellect"""
-    config = Config()
+    config = Config.local() if local else Config()
+    if local:
+        print_local_config_notice(config)
     settings = config.view()
 
     if not settings["base_url"]:

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -14,7 +14,7 @@ from prime_cli.core import Config
 
 from ..client import APIClient, APIError
 from ..utils import PlainTyper, get_console
-from .config import LOCAL_OPTION_HELP, print_local_config_notice
+from .config import LOCAL_OPTION_HELP, new_local_config, print_local_config_notice
 from .teams import fetch_teams
 
 app = PlainTyper(help="Login to Prime Intellect")
@@ -129,7 +129,8 @@ def login(
     local: bool = typer.Option(False, "--local", help=LOCAL_OPTION_HELP),
 ) -> None:
     """Login to Prime Intellect"""
-    config = Config.local() if local else Config()
+    # A new local config is not written until login succeeds (see new_local_config).
+    config = new_local_config() if local else Config()
     if local:
         print_local_config_notice(config)
     settings = config.view()

--- a/packages/prime/src/prime_cli/commands/logout.py
+++ b/packages/prime/src/prime_cli/commands/logout.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import typer
@@ -17,35 +16,11 @@ _ENV_OVERRIDES = ("PRIME_API_KEY", "PRIME_TEAM_ID", "PRIME_USER_ID")
 def _clear_env_file(config: Config) -> None:
     """Rewrite the current environment's saved file from raw cleared config values.
 
-    Config.update_current_environment_file() reads env-precedence properties, so
-    PRIME_* shell vars would otherwise leak back onto disk right after logout.
+    `from_env=False` keeps PRIME_* shell vars from leaking back onto disk right
+    after logout; going through Config keeps the write owner-only and refreshes
+    the file's trust entry for project-local configs.
     """
-    if config.current_environment == "production":
-        return
-    try:
-        sanitized = config._sanitize_environment_name(config.current_environment)
-    except ValueError:
-        return
-    env_file = config.environments_dir / f"{sanitized}.json"
-    if not env_file.exists():
-        return
-    raw = config.config
-    env_file.write_text(
-        json.dumps(
-            {
-                "api_key": raw.get("api_key", ""),
-                "team_id": raw.get("team_id"),
-                "team_name": raw.get("team_name"),
-                "team_role": raw.get("team_role"),
-                "user_id": raw.get("user_id"),
-                "base_url": raw.get("base_url", Config.DEFAULT_BASE_URL),
-                "frontend_url": raw.get("frontend_url", Config.DEFAULT_FRONTEND_URL),
-                "inference_url": raw.get("inference_url", Config.DEFAULT_INFERENCE_URL),
-                "traces_url": raw.get("traces_url"),
-            },
-            indent=2,
-        )
-    )
+    config.update_current_environment_file(from_env=False)
 
 
 @app.callback(invoke_without_command=True)

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -410,12 +410,15 @@ class Config:
     def _environment_file_is_trusted(self, env_file: Path) -> bool:
         """Whether an environment file may be loaded from this config.
 
-        Only a *discovered* local config needs the check: its config.json was
-        vetted by digest, but a repository update can rewrite an environment
-        file while leaving config.json untouched. Explicit config dirs and
-        the global one are trusted as such.
+        Project configs need the check whether discovered or reached via
+        `Config.local()`: config.json is vetted by digest (or refused up
+        front), but a repository update can rewrite an environment file while
+        leaving config.json untouched. Mirrors `_record_trust`. The global
+        config and an explicit PRIME_CONFIG_DIR are trusted as such.
         """
-        return self.config_source != "local" or is_trusted_local_file(env_file)
+        if self.is_global or self.config_source not in ("local", "explicit"):
+            return True
+        return is_trusted_local_file(env_file)
 
     @property
     def api_key(self) -> str:
@@ -575,6 +578,12 @@ class Config:
             sanitized = self._sanitize_environment_name(selected_environment)
             env_file = self.environments_dir / f"{sanitized}.json"
             if env_file.exists():
+                # Read-modify-write would launder a rewritten file into trust.
+                if not self._environment_file_is_trusted(env_file):
+                    raise ValueError(
+                        f"Environment file {env_file} is not trusted; review it and run "
+                        f"'prime config trust {self.config_dir.parent}' first"
+                    )
                 env_config = json.loads(env_file.read_text())
                 if not isinstance(env_config, dict):
                     raise ValueError(f"Invalid configuration in {env_file}")

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -302,6 +302,20 @@ def _refuse_unsafe_write(path: Path, *, allow_symlink: bool) -> None:
         raise PermissionError(f"Refusing to write {path}: it is not owned by the current user")
 
 
+_warned_skipped_writes: set[Path] = set()
+
+
+def _warn_skipped_environment_write(env_file: Path) -> None:
+    """Tell the user (once per file per process) an environment file was left alone."""
+    if env_file in _warned_skipped_writes:
+        return
+    _warned_skipped_writes.add(env_file)
+    sys.stderr.write(
+        f"Not updating untrusted environment file {env_file}; review it and run "
+        f"'prime config trust {env_file.parent.parent.parent}' first.\n"
+    )
+
+
 def _write_private_json(path: Path, data: dict, *, allow_symlink: bool = False) -> None:
     """Write JSON readable only by the owner; these files hold API keys."""
     _refuse_unsafe_write(path, allow_symlink=allow_symlink)
@@ -718,6 +732,13 @@ class Config:
         sanitized_name = self._sanitize_environment_name(name)
         self._ensure_dirs()
         env_file = self.environments_dir / f"{sanitized_name}.json"
+        if env_file.exists() and not self._environment_file_is_trusted(env_file):
+            # Overwriting would put the API key into a file the repository
+            # controls (it may be tracked) and then record it as trusted.
+            raise ValueError(
+                f"Environment file {env_file} exists but is not trusted; review it and run "
+                f"'prime config trust {self.config_dir.parent}' first, or delete it"
+            )
         env_config = {
             "api_key": self.api_key,
             "team_id": self.team_id,
@@ -856,6 +877,12 @@ class Config:
                 sanitized_name = self._sanitize_environment_name(self.current_environment)
                 env_file = self.environments_dir / f"{sanitized_name}.json"
                 if env_file.exists():
+                    if not self._environment_file_is_trusted(env_file):
+                        # Implicit side effect of login/set-*: don't fail the
+                        # command, but never copy the key into a file the
+                        # repository rewrote (it may be tracked).
+                        _warn_skipped_environment_write(env_file)
+                        return
                     if from_env:
                         env_config = {
                             "api_key": self.api_key,

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Iterator, Optional
@@ -324,16 +325,31 @@ def _warn_skipped_environment_write(env_file: Path) -> None:
 
 
 def _write_private_json(path: Path, data: dict, *, allow_symlink: bool = False) -> None:
-    """Write JSON readable only by the owner; these files hold API keys."""
+    """Write JSON readable only by the owner, atomically; these files hold API keys.
+
+    The content goes to a fresh 0600 temporary file in the same directory
+    which is then renamed over the target, so:
+    - a legacy permissive file (say 0644) never holds the new secret, not
+      even between write and chmod — it is replaced, not rewritten;
+    - readers (the SDKs load the trust registry on every `Config()`) see
+      either the old or the new content, never an empty or partial file.
+    A user-owned symlink in the global config dir is honored by replacing
+    its target; project-local symlinks were refused before we get here.
+    """
     _refuse_unsafe_write(path, allow_symlink=allow_symlink)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(json.dumps(data, indent=2))
+    target = path.resolve() if path.is_symlink() else path
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
     try:
-        # Pre-existing files keep their old mode through O_CREAT; tighten them too.
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(data, indent=2))
+        os.chmod(tmp_name, 0o600)  # mkstemp already uses 0600; be explicit
+        os.replace(tmp_name, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 class ConfigModel(BaseModel):

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -6,6 +6,80 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
+CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
+CONFIG_DIR_NAME = ".prime"
+CONFIG_FILE_NAME = "config.json"
+
+
+def global_config_dir() -> Path:
+    """The per-user config directory, ~/.prime."""
+    return Path.home() / CONFIG_DIR_NAME
+
+
+def _owned_by_current_user(path: Path) -> bool:
+    """True when `path` (following symlinks) is owned by the running user.
+
+    Project-local configs are picked up by walking parent directories, so on a
+    shared machine anyone who can write to an ancestor could plant one that
+    points the CLI at their account. Refusing files we don't own closes that.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return True
+    try:
+        return path.stat().st_uid == getuid()
+    except OSError:
+        return False
+
+
+def find_local_config_dir(start: Path | None = None) -> Path | None:
+    """Find the nearest project-local config directory, or None.
+
+    Walks from `start` (default: the working directory) up through its parents
+    looking for `.prime/config.json`. The walk stops at the home directory:
+    `~/.prime` is the global config, and anything above home is not the user's
+    project. Only files owned by the current user count.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+        home = Path.home().resolve()
+    except OSError:
+        return None
+    for directory in (current, *current.parents):
+        if directory == home:
+            break
+        config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
+        if config_file.is_file() and _owned_by_current_user(config_file):
+            return directory / CONFIG_DIR_NAME
+    return None
+
+
+def resolve_config_dir() -> tuple[Path, str]:
+    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+
+    Returns the directory and its source: "env", "local", or "global".
+    """
+    explicit = os.getenv(CONFIG_DIR_ENV_VAR)
+    if explicit and explicit.strip():
+        return Path(explicit.strip()).expanduser(), "env"
+    local = find_local_config_dir()
+    if local is not None:
+        return local, "local"
+    return global_config_dir(), "global"
+
+
+def _write_private_json(path: Path, data: dict) -> None:
+    """Write JSON readable only by the owner; these files hold API keys."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(json.dumps(data, indent=2))
+    try:
+        # Pre-existing files keep their old mode through O_CREAT; tighten them too.
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
 
 class ConfigModel(BaseModel):
     api_key: str = ""
@@ -30,9 +104,20 @@ class Config:
     DEFAULT_INFERENCE_URL: str = "https://api.pinference.ai/api/v1"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
-    def __init__(self) -> None:
-        self.config_dir = Path.home() / ".prime"
-        self.config_file = self.config_dir / "config.json"
+    def __init__(self, config_dir: Path | str | None = None) -> None:
+        """Load config from `config_dir`, or from the resolved location when omitted.
+
+        Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
+        working directory holding `.prime/config.json` (see
+        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        complete replacement for the global one, never merged with it.
+        """
+        if config_dir is not None:
+            self.config_dir = Path(config_dir).expanduser()
+            self.config_source = "explicit"
+        else:
+            self.config_dir, self.config_source = resolve_config_dir()
+        self.config_file = self.config_dir / CONFIG_FILE_NAME
         self.environments_dir = self.config_dir / "environments"
         self._ensure_config_dir()
         self._load_config()
@@ -42,6 +127,21 @@ class Config:
         if context:
             self.load_environment(context, persist=False)
 
+    @classmethod
+    def local(cls, directory: Path | str | None = None) -> "Config":
+        """A Config stored in `<directory>/.prime` (default: the working directory).
+
+        Creates the directory and a default config file if they don't exist, so
+        subsequent `Config()` calls from anywhere under `directory` discover it.
+        """
+        root = Path(directory) if directory is not None else Path.cwd()
+        return cls(config_dir=root / CONFIG_DIR_NAME)
+
+    @property
+    def is_global(self) -> bool:
+        """Whether this config is the per-user ~/.prime one."""
+        return self.config_dir == global_config_dir()
+
     @staticmethod
     def _strip_api_v1(url: str) -> str:
         # make base_url consistent even if user passed a /api/v1 variant
@@ -49,7 +149,7 @@ class Config:
 
     def _ensure_config_dir(self) -> None:
         """Create config directory if it doesn't exist"""
-        self.config_dir.mkdir(exist_ok=True)
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         self.environments_dir.mkdir(exist_ok=True)
         if not self.config_file.exists():
             self._save_config(
@@ -75,7 +175,7 @@ class Config:
 
     def _save_config(self, config: dict) -> None:
         """Save configuration to file"""
-        self.config_file.write_text(json.dumps(config, indent=2))
+        _write_private_json(self.config_file, config)
         self.config = config
 
     @property
@@ -224,13 +324,12 @@ class Config:
             )
 
         update_root = (
-            not context_override
-            or root_environment.casefold() == selected_environment.casefold()
+            not context_override or root_environment.casefold() == selected_environment.casefold()
         )
 
         if update_root:
             root_config["traces_url"] = traces_url
-            self.config_file.write_text(json.dumps(root_config, indent=2))
+            _write_private_json(self.config_file, root_config)
 
         if selected_environment != "production":
             sanitized = self._sanitize_environment_name(selected_environment)
@@ -240,7 +339,7 @@ class Config:
                 if not isinstance(env_config, dict):
                     raise ValueError(f"Invalid configuration in {env_file}")
                 env_config["traces_url"] = traces_url
-                env_file.write_text(json.dumps(env_config, indent=2))
+                _write_private_json(env_file, env_config)
 
         self.config["traces_url"] = traces_url
 
@@ -327,7 +426,7 @@ class Config:
             "inference_url": self.inference_url,
             "traces_url": self._configured_traces_url(),
         }
-        env_file.write_text(json.dumps(env_config, indent=2))
+        _write_private_json(env_file, env_config)
 
     def delete_environment(self, name: str) -> None:
         """Delete a saved environment configuration."""
@@ -449,7 +548,7 @@ class Config:
                         "inference_url": self.inference_url,
                         "traces_url": self._stored_traces_url(),
                     }
-                    env_file.write_text(json.dumps(env_config, indent=2))
+                    _write_private_json(env_file, env_config)
             except ValueError:
                 # Skip updating if environment name is invalid
                 pass

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -84,7 +84,7 @@ def _save_trusted_configs(trusted: dict[str, str]) -> None:
     _write_private_json(trusted_configs_file(), {"version": 1, "trusted": trusted})
 
 
-def is_trusted_local_config(config_file: Path) -> bool:
+def is_trusted_local_file(path: Path) -> bool:
     """Whether the user approved this file *with its current content*.
 
     Ownership alone is not enough: a `.prime/config.json` committed to a
@@ -95,36 +95,68 @@ def is_trusted_local_config(config_file: Path) -> bool:
     `git pull`) it has to be trusted again. Files the CLI writes itself
     (`prime login --local`, `prime config set-api-key --local`) are trusted
     as part of the write.
+
+    The same rule covers the named environment files next to a local config
+    (`.prime/environments/<name>.json`): `PRIME_CONTEXT` / `prime config use`
+    load URLs from them, so they are part of the same trust boundary.
     """
-    if not _owned_by_current_user(config_file):
+    if not _owned_by_current_user(path):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.
         return False
-    digest = _file_digest(config_file)
+    digest = _file_digest(path)
     if digest is None:
         return False
-    return load_trusted_configs().get(str(config_file.resolve())) == digest
+    return load_trusted_configs().get(str(path.resolve())) == digest
+
+
+is_trusted_local_config = is_trusted_local_file
+
+
+def _local_environment_files(config_file: Path) -> list[Path]:
+    """The named environment files that belong to a local config."""
+    environments_dir = config_file.parent / "environments"
+    if not environments_dir.is_dir():
+        return []
+    return sorted(p for p in environments_dir.glob("*.json") if p.is_file())
+
+
+def trust_local_file(path: Path) -> Path:
+    """Approve a single file with its current content; returns its resolved path."""
+    path = path.resolve()
+    digest = _file_digest(path)
+    if digest is None:
+        raise ValueError(f"Cannot read {path}")
+    if not _owned_by_current_user(path):
+        raise ValueError(f"Refusing to trust {path}: not owned by the current user")
+    trusted = load_trusted_configs()
+    trusted[str(path)] = digest
+    _save_trusted_configs(trusted)
+    return path
 
 
 def trust_local_config(config_file: Path) -> Path:
-    """Approve `config_file` for discovery; returns its resolved path."""
-    config_file = config_file.resolve()
-    digest = _file_digest(config_file)
-    if digest is None:
-        raise ValueError(f"Cannot read {config_file}")
-    if not _owned_by_current_user(config_file):
-        raise ValueError(f"Refusing to trust {config_file}: not owned by the current user")
-    trusted = load_trusted_configs()
-    trusted[str(config_file)] = digest
-    _save_trusted_configs(trusted)
-    return config_file
+    """Approve `config_file` and its environment files; returns the resolved config path."""
+    resolved = trust_local_file(config_file)
+    for env_file in _local_environment_files(resolved):
+        if _owned_by_current_user(env_file):
+            trust_local_file(env_file)
+    return resolved
 
 
 def untrust_local_config(config_file: Path) -> bool:
-    """Withdraw approval; returns whether the file was trusted before."""
+    """Withdraw approval for the config and its environment files.
+
+    Returns whether the config file was trusted before.
+    """
+    resolved = config_file.resolve()
     trusted = load_trusted_configs()
-    removed = trusted.pop(str(config_file.resolve()), None) is not None
-    if removed:
+    removed = trusted.pop(str(resolved), None) is not None
+    env_prefix = str(resolved.parent / "environments") + os.sep
+    stale = [key for key in trusted if key.startswith(env_prefix)]
+    for key in stale:
+        del trusted[key]
+    if removed or stale:
         _save_trusted_configs(trusted)
     return removed
 
@@ -157,7 +189,7 @@ def discover_local_config(start: Path | None = None) -> tuple[Path | None, list[
     """
     untrusted: list[Path] = []
     for config_file in _candidate_local_config_files(start):
-        if is_trusted_local_config(config_file):
+        if is_trusted_local_file(config_file):
             return config_file.parent, untrusted
         untrusted.append(config_file)
     return None, untrusted
@@ -192,15 +224,15 @@ _warned_untrusted: set[Path] = set()
 warnings.filterwarnings("ignore", message=UNTRUSTED_CONFIG_WARNING)
 
 
-def _warn_untrusted(untrusted: list[Path]) -> None:
-    """Tell the user (once per file per process) that a local config was ignored."""
-    for config_file in untrusted:
-        if config_file in _warned_untrusted:
+def _warn_untrusted(untrusted: list[Path], kind: str = "project config") -> None:
+    """Tell the user (once per file per process) that a local file was ignored."""
+    for path in untrusted:
+        if path in _warned_untrusted:
             continue
-        _warned_untrusted.add(config_file)
+        _warned_untrusted.add(path)
+        project = path.parent.parent if kind == "project config" else path.parent.parent.parent
         sys.stderr.write(
-            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; "
-            f"run 'prime config trust {config_file.parent.parent}' to use it.\n"
+            f"Ignoring untrusted {kind} {path}; run 'prime config trust {project}' to use it.\n"
         )
 
 
@@ -364,15 +396,26 @@ class Config:
         self.config = config
         self._record_trust()
 
-    def _record_trust(self) -> None:
-        """Re-approve a project-local config after the CLI itself changed it.
+    def _record_trust(self, path: Path | None = None) -> None:
+        """Re-approve a project-local file after the CLI itself changed it.
 
         Trust is bound to the file's content digest, so every write by the CLI
         has to refresh it. Only discovered/explicit project configs need this;
         the global config and an explicit PRIME_CONFIG_DIR are trusted as such.
+        Applies to config.json and to the environment files next to it.
         """
         if self.config_source in ("local", "explicit") and not self.is_global:
-            trust_local_config(self.config_file)
+            trust_local_file(path or self.config_file)
+
+    def _environment_file_is_trusted(self, env_file: Path) -> bool:
+        """Whether an environment file may be loaded from this config.
+
+        Only a *discovered* local config needs the check: its config.json was
+        vetted by digest, but a repository update can rewrite an environment
+        file while leaving config.json untouched. Explicit config dirs and
+        the global one are trusted as such.
+        """
+        return self.config_source != "local" or is_trusted_local_file(env_file)
 
     @property
     def api_key(self) -> str:
@@ -537,6 +580,7 @@ class Config:
                     raise ValueError(f"Invalid configuration in {env_file}")
                 env_config["traces_url"] = traces_url
                 _write_private_json(env_file, env_config)
+                self._record_trust(env_file)
 
         self.config["traces_url"] = traces_url
 
@@ -625,6 +669,7 @@ class Config:
             "traces_url": self._configured_traces_url(),
         }
         _write_private_json(env_file, env_config)
+        self._record_trust(env_file)
 
     def delete_environment(self, name: str) -> None:
         """Delete a saved environment configuration."""
@@ -678,6 +723,15 @@ class Config:
             sanitized_name = self._sanitize_environment_name(name)
             env_file = self.environments_dir / f"{sanitized_name}.json"
             if env_file.exists():
+                if not self._environment_file_is_trusted(env_file):
+                    if persist:
+                        raise ValueError(
+                            f"Environment file {env_file} is not trusted; review it and run "
+                            f"'prime config trust {self.config_dir.parent}' to use it"
+                        )
+                    # PRIME_CONTEXT: don't take the whole command down, just skip it.
+                    _warn_untrusted([env_file], kind="environment file")
+                    return False
                 try:
                     env_config = json.loads(env_file.read_text())
                 except json.JSONDecodeError as e:
@@ -747,6 +801,7 @@ class Config:
                         "traces_url": self._stored_traces_url(),
                     }
                     _write_private_json(env_file, env_config)
+                    self._record_trust(env_file)
             except ValueError:
                 # Skip updating if environment name is invalid
                 pass

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -55,6 +55,11 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
+def is_owned_by_current_user(path: Path) -> bool:
+    """Public form of the ownership check used by discovery and the --local guard."""
+    return _owned_by_current_user(path)
+
+
 def _file_digest(path: Path) -> str | None:
     try:
         return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
@@ -91,6 +96,10 @@ def is_trusted_local_config(config_file: Path) -> bool:
     (`prime login --local`, `prime config set-api-key --local`) are trusted
     as part of the write.
     """
+    if not _owned_by_current_user(config_file):
+        # A trusted path swapped for someone else's file (same bytes or not)
+        # is not the file the user approved.
+        return False
     digest = _file_digest(config_file)
     if digest is None:
         return False
@@ -195,8 +204,33 @@ def _warn_untrusted(untrusted: list[Path]) -> None:
         )
 
 
+def _refuse_unless_owned(path: Path) -> None:
+    """Refuse to write into a file (or through a symlink) the current user doesn't own.
+
+    On a shared machine someone with write access to the directory could swap
+    the file for their own, or for a symlink pointing anywhere; O_TRUNC would
+    then hand them the secret or clobber the target. A brand-new path is fine.
+    Windows has no uid model; the check is skipped there.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return
+    try:
+        stats = [path.lstat()]
+    except FileNotFoundError:
+        return
+    if path.is_symlink():
+        try:
+            stats.append(path.stat())
+        except FileNotFoundError:
+            pass  # dangling symlink owned by the user: creating the target is intended
+    if any(st.st_uid != getuid() for st in stats):
+        raise PermissionError(f"Refusing to write {path}: it is not owned by the current user")
+
+
 def _write_private_json(path: Path, data: dict) -> None:
     """Write JSON readable only by the owner; these files hold API keys."""
+    _refuse_unless_owned(path)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         f.write(json.dumps(data, indent=2))

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -569,27 +569,33 @@ class Config:
             not context_override or root_environment.casefold() == selected_environment.casefold()
         )
 
+        # Validate everything before the first write so a refusal leaves no
+        # half-applied state (root updated, environment file not).
+        env_file: Path | None = None
+        if selected_environment != "production":
+            sanitized = self._sanitize_environment_name(selected_environment)
+            env_file = self.environments_dir / f"{sanitized}.json"
+            if not env_file.exists():
+                env_file = None
+            elif not self._environment_file_is_trusted(env_file):
+                # Read-modify-write would launder a rewritten file into trust.
+                raise ValueError(
+                    f"Environment file {env_file} is not trusted; review it and run "
+                    f"'prime config trust {self.config_dir.parent}' first"
+                )
+
         if update_root:
             root_config["traces_url"] = traces_url
             _write_private_json(self.config_file, root_config)
             self._record_trust()
 
-        if selected_environment != "production":
-            sanitized = self._sanitize_environment_name(selected_environment)
-            env_file = self.environments_dir / f"{sanitized}.json"
-            if env_file.exists():
-                # Read-modify-write would launder a rewritten file into trust.
-                if not self._environment_file_is_trusted(env_file):
-                    raise ValueError(
-                        f"Environment file {env_file} is not trusted; review it and run "
-                        f"'prime config trust {self.config_dir.parent}' first"
-                    )
-                env_config = json.loads(env_file.read_text())
-                if not isinstance(env_config, dict):
-                    raise ValueError(f"Invalid configuration in {env_file}")
-                env_config["traces_url"] = traces_url
-                _write_private_json(env_file, env_config)
-                self._record_trust(env_file)
+        if env_file is not None:
+            env_config = json.loads(env_file.read_text())
+            if not isinstance(env_config, dict):
+                raise ValueError(f"Invalid configuration in {env_file}")
+            env_config["traces_url"] = traces_url
+            _write_private_json(env_file, env_config)
+            self._record_trust(env_file)
 
         self.config["traces_url"] = traces_url
 

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -178,6 +178,13 @@ def trust_local_config(config_file: Path) -> Path:
     return resolved
 
 
+def forget_trusted_file(path: Path) -> None:
+    """Drop a single file's registry entry (e.g. after deleting it)."""
+    trusted = load_trusted_configs()
+    if trusted.pop(str(path.resolve()), None) is not None:
+        _save_trusted_configs(trusted)
+
+
 def untrust_local_config(config_file: Path) -> bool:
     """Withdraw approval for the config and its environment files.
 
@@ -766,10 +773,19 @@ class Config:
             )
 
         env_file = self.environments_dir / f"{sanitized_name}.json"
+        if not self.is_global and involves_symlink(env_file):
+            # unlink() through a symlinked environments/ dir would delete
+            # whatever external file the link points at.
+            raise ValueError(
+                f"Refusing to delete {env_file}: it, its directory, or its .prime directory "
+                "is a symlink"
+            )
         if not env_file.exists():
             raise ValueError(f"Unknown environment: {name}")
 
         env_file.unlink()
+        if not self.is_global:
+            forget_trusted_file(env_file)
 
     def load_environment(self, name: str, persist: bool = True) -> bool:
         """Load a named environment configuration.

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -5,8 +5,14 @@ import re
 import sys
 import tempfile
 import warnings
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Callable, Iterator, Optional
+
+try:
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None  # type: ignore[assignment]
 
 from pydantic import BaseModel, ConfigDict
 
@@ -108,6 +114,41 @@ def _save_trusted_configs(trusted: dict[str, str]) -> None:
     )
 
 
+@contextmanager
+def _registry_lock() -> Iterator[None]:
+    """Serialize registry transactions across processes (flock; no-op on Windows).
+
+    Writes are atomic on their own, but two CLI processes updating different
+    projects would each load the same registry and the later replace would
+    drop the other's entry. The lock is a sibling file so the registry itself
+    can still be atomically replaced while held.
+    """
+    global_config_dir().mkdir(parents=True, exist_ok=True)
+    lock_path = global_config_dir() / f"{TRUSTED_CONFIGS_FILE_NAME}.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _update_trusted_configs(mutate: Callable[[dict[str, str]], bool]) -> None:
+    """Run a load-modify-save transaction on the registry under the lock.
+
+    `mutate` edits the dict in place and returns whether anything changed.
+    """
+    with _registry_lock():
+        trusted = load_trusted_configs()
+        if mutate(trusted):
+            _save_trusted_configs(trusted)
+
+
 def is_trusted_local_file(path: Path) -> bool:
     """Whether the user approved this file *with its current content*.
 
@@ -164,9 +205,12 @@ def trust_local_file(path: Path) -> Path:
         raise ValueError(f"Cannot read {path}")
     if not _owned_by_current_user(path):
         raise ValueError(f"Refusing to trust {path}: not owned by the current user")
-    trusted = load_trusted_configs()
-    trusted[str(path)] = digest
-    _save_trusted_configs(trusted)
+
+    def _set(trusted: dict[str, str]) -> bool:
+        trusted[str(path)] = digest
+        return True
+
+    _update_trusted_configs(_set)
     return path
 
 
@@ -181,9 +225,8 @@ def trust_local_config(config_file: Path) -> Path:
 
 def forget_trusted_file(path: Path) -> None:
     """Drop a single file's registry entry (e.g. after deleting it)."""
-    trusted = load_trusted_configs()
-    if trusted.pop(str(path.resolve()), None) is not None:
-        _save_trusted_configs(trusted)
+    key = str(path.resolve())
+    _update_trusted_configs(lambda trusted: trusted.pop(key, None) is not None)
 
 
 def untrust_local_config(config_file: Path) -> bool:
@@ -192,14 +235,18 @@ def untrust_local_config(config_file: Path) -> bool:
     Returns whether the config file was trusted before.
     """
     resolved = config_file.resolve()
-    trusted = load_trusted_configs()
-    removed = trusted.pop(str(resolved), None) is not None
-    env_prefix = str(resolved.parent / "environments") + os.sep
-    stale = [key for key in trusted if key.startswith(env_prefix)]
-    for key in stale:
-        del trusted[key]
-    if removed or stale:
-        _save_trusted_configs(trusted)
+    env_prefix = str(resolved.parent / ENVIRONMENTS_DIR_NAME) + os.sep
+    removed = False
+
+    def _drop(trusted: dict[str, str]) -> bool:
+        nonlocal removed
+        removed = trusted.pop(str(resolved), None) is not None
+        stale = [key for key in trusted if key.startswith(env_prefix)]
+        for key in stale:
+            del trusted[key]
+        return removed or bool(stale)
+
+    _update_trusted_configs(_drop)
     return removed
 
 

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -20,6 +20,19 @@ def global_config_dir() -> Path:
     return Path.home() / CONFIG_DIR_NAME
 
 
+def is_global_config_dir(path: Path) -> bool:
+    """Whether `path` is ~/.prime, comparing physical paths.
+
+    `Path.cwd()` is always the physical path while `Path.home()` may go through
+    a symlink (a symlinked home, macOS /var -> /private/var), so an unresolved
+    comparison would call the global config "project-local".
+    """
+    try:
+        return path.resolve() == global_config_dir().resolve()
+    except OSError:
+        return False
+
+
 def trusted_configs_file() -> Path:
     """The per-user registry of project-local configs the user has approved."""
     return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
@@ -273,8 +286,8 @@ class Config:
 
     @property
     def is_global(self) -> bool:
-        """Whether this config is the per-user ~/.prime one."""
-        return self.config_dir == global_config_dir()
+        """Whether this config is the per-user ~/.prime one (symlink-insensitive)."""
+        return is_global_config_dir(self.config_dir)
 
     @staticmethod
     def _strip_api_v1(url: str) -> str:

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ConfigDict
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+ENVIRONMENTS_DIR_NAME = "environments"
 TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
@@ -53,6 +54,26 @@ def _owned_by_current_user(path: Path) -> bool:
         return path.stat().st_uid == getuid()
     except OSError:
         return False
+
+
+def _project_config_dir_of(path: Path) -> Path:
+    """The `.prime` directory a config.json or environments/<name>.json belongs to."""
+    if path.parent.name == ENVIRONMENTS_DIR_NAME:
+        return path.parent.parent
+    return path.parent
+
+
+def involves_symlink(path: Path) -> bool:
+    """Whether `path`, its parent directory, or its `.prime` directory is a symlink.
+
+    Project-local files are never trusted or written through symlinks: a
+    cloned repository can ship `.prime`, `.prime/environments`, or the file
+    itself as a link that redirects a credential write outside the ignored
+    tree (or onto an existing file). Checking only the leaf is not enough.
+    """
+    config_dir = _project_config_dir_of(path)
+    candidates = {path, path.parent, config_dir}
+    return any(candidate.is_symlink() for candidate in candidates)
 
 
 def is_owned_by_current_user(path: Path) -> bool:
@@ -102,6 +123,10 @@ def is_trusted_local_file(path: Path) -> bool:
     (`.prime/environments/<name>.json`): `PRIME_CONTEXT` / `prime config use`
     load URLs from them, so they are part of the same trust boundary.
     """
+    if involves_symlink(path):
+        # Never trusted, so never discovered or loaded — and therefore never
+        # written to, which is the property that matters (see involves_symlink).
+        return False
     if not _owned_by_current_user(path):
         # A trusted path swapped for someone else's file (same bytes or not)
         # is not the file the user approved.
@@ -117,15 +142,21 @@ is_trusted_local_config = is_trusted_local_file
 
 def _local_environment_files(config_file: Path) -> list[Path]:
     """The named environment files that belong to a local config."""
-    environments_dir = config_file.parent / "environments"
-    if not environments_dir.is_dir():
+    environments_dir = config_file.parent / ENVIRONMENTS_DIR_NAME
+    if not environments_dir.is_dir() or environments_dir.is_symlink():
         return []
     # Symlinked environment files are never written to and never trusted.
-    return sorted(p for p in environments_dir.glob("*.json") if p.is_file() and not p.is_symlink())
+    return sorted(
+        p for p in environments_dir.glob("*.json") if p.is_file() and not involves_symlink(p)
+    )
 
 
 def trust_local_file(path: Path) -> Path:
     """Approve a single file with its current content; returns its resolved path."""
+    if involves_symlink(path):
+        raise ValueError(
+            f"Refusing to trust {path}: it, its directory, or its .prime directory is a symlink"
+        )
     path = path.resolve()
     digest = _file_digest(path)
     if digest is None:
@@ -253,13 +284,15 @@ def _refuse_unsafe_write(path: Path, *, allow_symlink: bool) -> None:
     target exists. A brand-new path is fine. Windows has no uid model; the
     ownership part is skipped there.
     """
+    if not allow_symlink and involves_symlink(path):
+        raise PermissionError(
+            f"Refusing to write {path}: it, its directory, or its .prime directory is a symlink"
+        )
     try:
         stats = [path.lstat()]
     except FileNotFoundError:
         return
     if path.is_symlink():
-        if not allow_symlink:
-            raise PermissionError(f"Refusing to write through symlink {path}")
         try:
             stats.append(path.stat())
         except FileNotFoundError:

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -1,19 +1,28 @@
+import hashlib
 import json
 import os
 import re
+import sys
+import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from pydantic import BaseModel, ConfigDict
 
 CONFIG_DIR_ENV_VAR = "PRIME_CONFIG_DIR"
 CONFIG_DIR_NAME = ".prime"
 CONFIG_FILE_NAME = "config.json"
+TRUSTED_CONFIGS_FILE_NAME = "trusted_configs.json"
 
 
 def global_config_dir() -> Path:
     """The per-user config directory, ~/.prime."""
     return Path.home() / CONFIG_DIR_NAME
+
+
+def trusted_configs_file() -> Path:
+    """The per-user registry of project-local configs the user has approved."""
+    return global_config_dir() / TRUSTED_CONFIGS_FILE_NAME
 
 
 def _owned_by_current_user(path: Path) -> bool:
@@ -33,40 +42,144 @@ def _owned_by_current_user(path: Path) -> bool:
         return False
 
 
-def find_local_config_dir(start: Path | None = None) -> Path | None:
-    """Find the nearest project-local config directory, or None.
+def _file_digest(path: Path) -> str | None:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
 
-    Walks from `start` (default: the working directory) up through its parents
-    looking for `.prime/config.json`. The walk stops at the home directory:
-    `~/.prime` is the global config, and anything above home is not the user's
-    project. Only files owned by the current user count.
+
+def load_trusted_configs() -> dict[str, str]:
+    """Resolved config.json path -> content digest, for every approved local config."""
+    try:
+        data = json.loads(trusted_configs_file().read_text())
+    except (OSError, ValueError):
+        return {}
+    trusted = data.get("trusted") if isinstance(data, dict) else None
+    if not isinstance(trusted, dict):
+        return {}
+    return {str(path): str(digest) for path, digest in trusted.items()}
+
+
+def _save_trusted_configs(trusted: dict[str, str]) -> None:
+    global_config_dir().mkdir(parents=True, exist_ok=True)
+    _write_private_json(trusted_configs_file(), {"version": 1, "trusted": trusted})
+
+
+def is_trusted_local_config(config_file: Path) -> bool:
+    """Whether the user approved this file *with its current content*.
+
+    Ownership alone is not enough: a `.prime/config.json` committed to a
+    repository the user clones is owned by the user, and could redirect an
+    environment-provided PRIME_API_KEY to an attacker's base_url. So a
+    discovered local config is only honored after `prime config trust`, and
+    the approval is tied to a content digest — if the file changes (e.g. via
+    `git pull`) it has to be trusted again. Files the CLI writes itself
+    (`prime login --local`, `prime config set-api-key --local`) are trusted
+    as part of the write.
+    """
+    digest = _file_digest(config_file)
+    if digest is None:
+        return False
+    return load_trusted_configs().get(str(config_file.resolve())) == digest
+
+
+def trust_local_config(config_file: Path) -> Path:
+    """Approve `config_file` for discovery; returns its resolved path."""
+    config_file = config_file.resolve()
+    digest = _file_digest(config_file)
+    if digest is None:
+        raise ValueError(f"Cannot read {config_file}")
+    if not _owned_by_current_user(config_file):
+        raise ValueError(f"Refusing to trust {config_file}: not owned by the current user")
+    trusted = load_trusted_configs()
+    trusted[str(config_file)] = digest
+    _save_trusted_configs(trusted)
+    return config_file
+
+
+def untrust_local_config(config_file: Path) -> bool:
+    """Withdraw approval; returns whether the file was trusted before."""
+    trusted = load_trusted_configs()
+    removed = trusted.pop(str(config_file.resolve()), None) is not None
+    if removed:
+        _save_trusted_configs(trusted)
+    return removed
+
+
+def _candidate_local_config_files(start: Path | None = None) -> Iterator[Path]:
+    """Owned `.prime/config.json` files from `start` upward, nearest first.
+
+    The walk stops at the home directory: `~/.prime` is the global config, and
+    anything above home is not the user's project.
     """
     try:
         current = (start or Path.cwd()).resolve()
         home = Path.home().resolve()
     except OSError:
-        return None
+        return
     for directory in (current, *current.parents):
         if directory == home:
             break
         config_file = directory / CONFIG_DIR_NAME / CONFIG_FILE_NAME
         if config_file.is_file() and _owned_by_current_user(config_file):
-            return directory / CONFIG_DIR_NAME
-    return None
+            yield config_file
 
 
-def resolve_config_dir() -> tuple[Path, str]:
-    """Choose the config directory: PRIME_CONFIG_DIR > project-local > ~/.prime.
+def discover_local_config(start: Path | None = None) -> tuple[Path | None, list[Path]]:
+    """The nearest *trusted* project-local config dir, plus untrusted files passed over.
 
-    Returns the directory and its source: "env", "local", or "global".
+    Untrusted candidates are skipped rather than stopping the search, so a
+    file planted in a nested directory cannot mask the user's own trusted one
+    further up.
+    """
+    untrusted: list[Path] = []
+    for config_file in _candidate_local_config_files(start):
+        if is_trusted_local_config(config_file):
+            return config_file.parent, untrusted
+        untrusted.append(config_file)
+    return None, untrusted
+
+
+def find_local_config_dir(start: Path | None = None) -> Path | None:
+    """Find the nearest trusted project-local config directory, or None."""
+    return discover_local_config(start)[0]
+
+
+def resolve_config_dir() -> tuple[Path, str, list[Path]]:
+    """Choose the config directory: PRIME_CONFIG_DIR > trusted project-local > ~/.prime.
+
+    Returns the directory, its source ("env", "local", or "global"), and any
+    untrusted project-local config files that were ignored on the way.
     """
     explicit = os.getenv(CONFIG_DIR_ENV_VAR)
     if explicit and explicit.strip():
-        return Path(explicit.strip()).expanduser(), "env"
-    local = find_local_config_dir()
+        return Path(explicit.strip()).expanduser(), "env", []
+    local, untrusted = discover_local_config()
     if local is not None:
-        return local, "local"
-    return global_config_dir(), "global"
+        return local, "local", untrusted
+    return global_config_dir(), "global", untrusted
+
+
+UNTRUSTED_CONFIG_WARNING = "Ignoring untrusted project config"
+_warned_untrusted: set[Path] = set()
+
+# The SDKs bundled into the CLI resolve the same config and each raise a
+# RuntimeWarning for an ignored local file; the CLI prints one line instead.
+# This module loads before any command module constructs an SDK client.
+warnings.filterwarnings("ignore", message=UNTRUSTED_CONFIG_WARNING)
+
+
+def _warn_untrusted(untrusted: list[Path]) -> None:
+    """Tell the user (once per file per process) that a local config was ignored."""
+    for config_file in untrusted:
+        if config_file in _warned_untrusted:
+            continue
+        _warned_untrusted.add(config_file)
+        sys.stderr.write(
+            f"{UNTRUSTED_CONFIG_WARNING} {config_file}; "
+            f"run 'prime config trust {config_file.parent.parent}' to use it.\n"
+        )
 
 
 def _write_private_json(path: Path, data: dict) -> None:
@@ -104,23 +217,30 @@ class Config:
     DEFAULT_INFERENCE_URL: str = "https://api.pinference.ai/api/v1"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
-    def __init__(self, config_dir: Path | str | None = None) -> None:
+    def __init__(self, config_dir: Path | str | None = None, *, create: bool = True) -> None:
         """Load config from `config_dir`, or from the resolved location when omitted.
 
         Resolution order: `PRIME_CONFIG_DIR`, then the nearest ancestor of the
-        working directory holding `.prime/config.json` (see
-        `find_local_config_dir`), then `~/.prime`. A project-local config is a
+        working directory holding a *trusted* `.prime/config.json` (see
+        `discover_local_config`), then `~/.prime`. A project-local config is a
         complete replacement for the global one, never merged with it.
+
+        With `create=False` nothing is written until the first `set_*` call, so
+        a flow that may still fail (e.g. login) does not leave a default file
+        behind that would shadow the global config.
         """
+        self.untrusted_local_configs: list[Path] = []
         if config_dir is not None:
             self.config_dir = Path(config_dir).expanduser()
             self.config_source = "explicit"
         else:
-            self.config_dir, self.config_source = resolve_config_dir()
+            self.config_dir, self.config_source, self.untrusted_local_configs = resolve_config_dir()
         self.config_file = self.config_dir / CONFIG_FILE_NAME
         self.environments_dir = self.config_dir / "environments"
-        self._ensure_config_dir()
+        if create:
+            self._ensure_config_dir()
         self._load_config()
+        _warn_untrusted(self.untrusted_local_configs)
 
         # Check for PRIME_CONTEXT env var to temporarily override config
         context = os.getenv("PRIME_CONTEXT")
@@ -128,14 +248,28 @@ class Config:
             self.load_environment(context, persist=False)
 
     @classmethod
-    def local(cls, directory: Path | str | None = None) -> "Config":
+    def local(cls, directory: Path | str | None = None, *, create: bool = True) -> "Config":
         """A Config stored in `<directory>/.prime` (default: the working directory).
 
-        Creates the directory and a default config file if they don't exist, so
-        subsequent `Config()` calls from anywhere under `directory` discover it.
+        Writing to it (or constructing with `create=True`) creates the file and
+        trusts it, so subsequent `Config()` calls from anywhere under
+        `directory` discover it.
         """
         root = Path(directory) if directory is not None else Path.cwd()
-        return cls(config_dir=root / CONFIG_DIR_NAME)
+        return cls(config_dir=root / CONFIG_DIR_NAME, create=create)
+
+    def adopt_urls(self, other: "Config") -> None:
+        """Copy the stored service URLs (not credentials) from another config.
+
+        Used when creating a project-local config so it keeps pointing at the
+        same deployment the user already had configured (e.g. a dev base_url)
+        instead of silently resetting to production. In-memory only; persisted
+        by the next `set_*` call.
+        """
+        for key in ("base_url", "frontend_url", "inference_url", "traces_url"):
+            value = other.config.get(key)
+            if value:
+                self.config[key] = value
 
     @property
     def is_global(self) -> bool:
@@ -147,10 +281,13 @@ class Config:
         # make base_url consistent even if user passed a /api/v1 variant
         return url.rstrip("/").removesuffix("/api/v1")
 
-    def _ensure_config_dir(self) -> None:
-        """Create config directory if it doesn't exist"""
+    def _ensure_dirs(self) -> None:
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.environments_dir.mkdir(exist_ok=True)
+
+    def _ensure_config_dir(self) -> None:
+        """Create config directory and a default config file if they don't exist"""
+        self._ensure_dirs()
         if not self.config_file.exists():
             self._save_config(
                 ConfigModel(
@@ -175,8 +312,20 @@ class Config:
 
     def _save_config(self, config: dict) -> None:
         """Save configuration to file"""
+        self._ensure_dirs()
         _write_private_json(self.config_file, config)
         self.config = config
+        self._record_trust()
+
+    def _record_trust(self) -> None:
+        """Re-approve a project-local config after the CLI itself changed it.
+
+        Trust is bound to the file's content digest, so every write by the CLI
+        has to refresh it. Only discovered/explicit project configs need this;
+        the global config and an explicit PRIME_CONFIG_DIR are trusted as such.
+        """
+        if self.config_source in ("local", "explicit") and not self.is_global:
+            trust_local_config(self.config_file)
 
     @property
     def api_key(self) -> str:
@@ -330,6 +479,7 @@ class Config:
         if update_root:
             root_config["traces_url"] = traces_url
             _write_private_json(self.config_file, root_config)
+            self._record_trust()
 
         if selected_environment != "production":
             sanitized = self._sanitize_environment_name(selected_environment)
@@ -414,6 +564,7 @@ class Config:
             raise ValueError("Cannot save custom environment with reserved name 'production'")
 
         sanitized_name = self._sanitize_environment_name(name)
+        self._ensure_dirs()
         env_file = self.environments_dir / f"{sanitized_name}.json"
         env_config = {
             "api_key": self.api_key,

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -81,7 +81,9 @@ def load_trusted_configs() -> dict[str, str]:
 
 def _save_trusted_configs(trusted: dict[str, str]) -> None:
     global_config_dir().mkdir(parents=True, exist_ok=True)
-    _write_private_json(trusted_configs_file(), {"version": 1, "trusted": trusted})
+    _write_private_json(
+        trusted_configs_file(), {"version": 1, "trusted": trusted}, allow_symlink=True
+    )
 
 
 def is_trusted_local_file(path: Path) -> bool:
@@ -118,7 +120,8 @@ def _local_environment_files(config_file: Path) -> list[Path]:
     environments_dir = config_file.parent / "environments"
     if not environments_dir.is_dir():
         return []
-    return sorted(p for p in environments_dir.glob("*.json") if p.is_file())
+    # Symlinked environment files are never written to and never trusted.
+    return sorted(p for p in environments_dir.glob("*.json") if p.is_file() and not p.is_symlink())
 
 
 def trust_local_file(path: Path) -> Path:
@@ -236,33 +239,39 @@ def _warn_untrusted(untrusted: list[Path], kind: str = "project config") -> None
         )
 
 
-def _refuse_unless_owned(path: Path) -> None:
-    """Refuse to write into a file (or through a symlink) the current user doesn't own.
+def _refuse_unsafe_write(path: Path, *, allow_symlink: bool) -> None:
+    """Refuse to write into a file the current user doesn't own, or through a symlink.
 
     On a shared machine someone with write access to the directory could swap
-    the file for their own, or for a symlink pointing anywhere; O_TRUNC would
-    then hand them the secret or clobber the target. A brand-new path is fine.
-    Windows has no uid model; the check is skipped there.
+    the file for their own; O_TRUNC would then hand them the secret. A symlink
+    is worse: a cloned repository can ship `.prime/config.json -> ../leak.json`
+    (dangling, so the path looks absent) and the write would create a
+    credential file outside the ignored `.prime/` directory — or clobber
+    whatever an existing link points at. Project-local config dirs therefore
+    never write through symlinks; the global `~/.prime` may, for users who
+    keep dotfiles symlinked, as long as link and target are theirs and the
+    target exists. A brand-new path is fine. Windows has no uid model; the
+    ownership part is skipped there.
     """
-    getuid = getattr(os, "getuid", None)
-    if getuid is None:
-        return
     try:
         stats = [path.lstat()]
     except FileNotFoundError:
         return
     if path.is_symlink():
+        if not allow_symlink:
+            raise PermissionError(f"Refusing to write through symlink {path}")
         try:
             stats.append(path.stat())
         except FileNotFoundError:
-            pass  # dangling symlink owned by the user: creating the target is intended
-    if any(st.st_uid != getuid() for st in stats):
+            raise PermissionError(f"Refusing to write through dangling symlink {path}") from None
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and any(st.st_uid != getuid() for st in stats):
         raise PermissionError(f"Refusing to write {path}: it is not owned by the current user")
 
 
-def _write_private_json(path: Path, data: dict) -> None:
+def _write_private_json(path: Path, data: dict, *, allow_symlink: bool = False) -> None:
     """Write JSON readable only by the owner; these files hold API keys."""
-    _refuse_unless_owned(path)
+    _refuse_unsafe_write(path, allow_symlink=allow_symlink)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as f:
         f.write(json.dumps(data, indent=2))
@@ -389,10 +398,14 @@ class Config:
         else:
             self.config = {}
 
+    def _write_json(self, path: Path, data: dict) -> None:
+        """Owner-only JSON write; symlinks are only followed for the global config."""
+        _write_private_json(path, data, allow_symlink=self.is_global)
+
     def _save_config(self, config: dict) -> None:
         """Save configuration to file"""
         self._ensure_dirs()
-        _write_private_json(self.config_file, config)
+        self._write_json(self.config_file, config)
         self.config = config
         self._record_trust()
 
@@ -586,7 +599,7 @@ class Config:
 
         if update_root:
             root_config["traces_url"] = traces_url
-            _write_private_json(self.config_file, root_config)
+            self._write_json(self.config_file, root_config)
             self._record_trust()
 
         if env_file is not None:
@@ -594,7 +607,7 @@ class Config:
             if not isinstance(env_config, dict):
                 raise ValueError(f"Invalid configuration in {env_file}")
             env_config["traces_url"] = traces_url
-            _write_private_json(env_file, env_config)
+            self._write_json(env_file, env_config)
             self._record_trust(env_file)
 
         self.config["traces_url"] = traces_url
@@ -683,7 +696,7 @@ class Config:
             "inference_url": self.inference_url,
             "traces_url": self._configured_traces_url(),
         }
-        _write_private_json(env_file, env_config)
+        self._write_json(env_file, env_config)
         self._record_trust(env_file)
 
     def delete_environment(self, name: str) -> None:
@@ -796,26 +809,46 @@ class Config:
             raise
         return False
 
-    def update_current_environment_file(self) -> None:
-        """Update the current environment's saved file with current config"""
+    def update_current_environment_file(self, *, from_env: bool = True) -> None:
+        """Update the current environment's saved file with current config.
+
+        With `from_env=False` the raw stored values are written instead of the
+        env-precedence properties, so PRIME_* shell variables can't leak back
+        onto disk (logout relies on this). Either way the write goes through
+        the private writer and refreshes the file's trust entry.
+        """
         if self.current_environment != "production":
             # Only update custom environments, not the built-in production
             try:
                 sanitized_name = self._sanitize_environment_name(self.current_environment)
                 env_file = self.environments_dir / f"{sanitized_name}.json"
                 if env_file.exists():
-                    env_config = {
-                        "api_key": self.api_key,
-                        "team_id": self.team_id,
-                        "team_name": None if self.team_id_from_env else self.team_name,
-                        "team_role": None if self.team_id_from_env else self.team_role,
-                        "user_id": self.user_id,
-                        "base_url": self.base_url,
-                        "frontend_url": self.frontend_url,
-                        "inference_url": self.inference_url,
-                        "traces_url": self._stored_traces_url(),
-                    }
-                    _write_private_json(env_file, env_config)
+                    if from_env:
+                        env_config = {
+                            "api_key": self.api_key,
+                            "team_id": self.team_id,
+                            "team_name": None if self.team_id_from_env else self.team_name,
+                            "team_role": None if self.team_id_from_env else self.team_role,
+                            "user_id": self.user_id,
+                            "base_url": self.base_url,
+                            "frontend_url": self.frontend_url,
+                            "inference_url": self.inference_url,
+                            "traces_url": self._stored_traces_url(),
+                        }
+                    else:
+                        raw = self.config
+                        env_config = {
+                            "api_key": raw.get("api_key", ""),
+                            "team_id": raw.get("team_id"),
+                            "team_name": raw.get("team_name"),
+                            "team_role": raw.get("team_role"),
+                            "user_id": raw.get("user_id"),
+                            "base_url": raw.get("base_url", self.DEFAULT_BASE_URL),
+                            "frontend_url": raw.get("frontend_url", self.DEFAULT_FRONTEND_URL),
+                            "inference_url": raw.get("inference_url", self.DEFAULT_INFERENCE_URL),
+                            "traces_url": raw.get("traces_url"),
+                        }
+                    self._write_json(env_file, env_config)
                     self._record_trust(env_file)
             except ValueError:
                 # Skip updating if environment name is invalid

--- a/packages/prime/tests/conftest.py
+++ b/packages/prime/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_discovery(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Keep config discovery away from the developer's machine.
+
+    `Config()` walks up from the working directory looking for a project-local
+    `.prime/config.json`; run from the repo checkout that walk would reach the
+    developer's real ~/.prime — and tests that patch HOME would then read and
+    *write* it. Start every test in a fresh tmp dir and ignore any
+    PRIME_CONFIG_DIR from the developer's shell. Tests that need a different
+    working directory still call `monkeypatch.chdir` themselves.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PRIME_CONFIG_DIR", raising=False)

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -12,6 +12,7 @@ from prime_cli.core import config as config_module
 from prime_cli.core.config import (
     Config,
     find_local_config_dir,
+    is_trusted_local_config,
     load_trusted_configs,
     trust_local_config,
 )
@@ -278,6 +279,65 @@ def test_adopt_urls_copies_service_urls_but_not_credentials(home: Path, project:
     assert config.api_key == ""
 
 
+def test_trust_requires_ownership_even_with_matching_digest(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A trusted path replaced by someone else's file with the same bytes is not trusted."""
+    write_config(project / ".prime", api_key="local-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert not is_trusted_local_config(project / ".prime" / "config.json")
+
+
+def test_writes_refuse_files_owned_by_another_user(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local = write_config(project / ".prime", api_key="local-key")
+    before = local.read_text()
+    config = Config(config_dir=project / ".prime")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    with pytest.raises(PermissionError, match="not owned"):
+        config.set_api_key("stolen")
+
+    assert local.read_text() == before
+
+
+def test_writes_refuse_symlinks_owned_by_another_user(
+    home: Path, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A planted symlink must not turn O_TRUNC into a write to wherever it points."""
+    (project / ".prime").mkdir(parents=True)
+    target = tmp_path / "victim.json"
+    target.write_text(json.dumps({"api_key": "precious"}))
+    (project / ".prime" / "config.json").symlink_to(target)
+    config = Config(config_dir=project / ".prime")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    with pytest.raises(PermissionError, match="not owned"):
+        config.set_api_key("x")
+
+    assert json.loads(target.read_text()) == {"api_key": "precious"}
+
+
+def test_writes_follow_symlinks_the_user_owns(home: Path, project: Path, tmp_path: Path) -> None:
+    """Dotfile-style symlinked configs keep working."""
+    (project / ".prime").mkdir(parents=True)
+    target = tmp_path / "dotfiles" / "prime.json"
+    target.parent.mkdir()
+    target.write_text(json.dumps({"api_key": "old"}))
+    link = project / ".prime" / "config.json"
+    link.symlink_to(target)
+
+    Config(config_dir=project / ".prime").set_api_key("new")
+
+    assert link.is_symlink()
+    assert json.loads(target.read_text())["api_key"] == "new"
+
+
 def test_global_config_file_is_created_private(home: Path) -> None:
     config = Config()
 
@@ -418,6 +478,22 @@ class TestCli:
         assert planted.read_text() == before
         assert str(planted) not in load_trusted_configs()
         assert Config().config_source == "global"
+
+    def test_local_refuses_existing_file_owned_by_another_user(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even a previously trusted path, if swapped for someone else's file."""
+        planted = write_config(project / ".prime", api_key="theirs")
+        before = planted.read_text()
+        monkeypatch.chdir(project)
+        real_uid = os.getuid()
+        monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "not owned by you" in result.output
+        assert planted.read_text() == before
 
     def test_local_updates_existing_trusted_file(
         self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -491,6 +491,55 @@ class TestLocalEnvironments:
         assert "symlink" in result.output
         assert not (project / "leak.json").exists()
 
+    def test_save_refuses_symlinked_environments_directory(
+        self, home: Path, project: Path, tmp_path: Path
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (project / ".prime" / "environments").symlink_to(outside, target_is_directory=True)
+
+        result = runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+        assert not (outside / "dev.json").exists()
+
+    def test_symlinked_file_is_never_trusted_even_if_target_is(
+        self, home: Path, project: Path, tmp_path: Path
+    ) -> None:
+        """Registry entries key on the resolved path; a link to a trusted target
+        must not ride on that entry."""
+        real = write_config(tmp_path / "real" / ".prime", api_key="real-key")
+        (project / ".prime").mkdir(parents=True)
+        link = project / ".prime" / "config.json"
+        link.symlink_to(real)
+
+        assert not is_trusted_local_config(link)
+        assert Config().config_source == "global"
+        result = runner.invoke(app, ["config", "trust", str(project)], env=TEST_ENV)
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+
+    def test_set_traces_url_refuses_symlinked_environment_before_any_write(
+        self, home: Path, project: Path, tmp_path: Path
+    ) -> None:
+        root = write_config(project / ".prime", api_key="local-key", current_environment="dev")
+        real_env = tmp_path / "real-dev.json"
+        real_env.write_text(json.dumps({"base_url": "https://api.dev.example"}))
+        env_dir = project / ".prime" / "environments"
+        env_dir.mkdir()
+        (env_dir / "dev.json").symlink_to(real_env)
+        before_root, before_env = root.read_text(), real_env.read_text()
+
+        result = runner.invoke(
+            app, ["config", "set-traces-url", "https://traces.example"], env=TEST_ENV
+        )
+
+        assert result.exit_code != 0, result.output
+        assert root.read_text() == before_root
+        assert real_env.read_text() == before_env
+
     def test_trust_skips_symlinked_environment_files(self, home: Path, project: Path) -> None:
         write_config(project / ".prime", trusted=False, api_key="local-key")
         real = self.write_env(project, "real", base_url="https://api.dev.example")
@@ -700,6 +749,26 @@ class TestCli:
         assert "symlink" in result.output
         assert not (project / "leak.json").exists()
         assert load_trusted_configs() == {}
+
+    def test_local_refuses_symlinked_prime_directory(
+        self,
+        home: Path,
+        project: Path,
+        tmp_path: Path,
+        no_network: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`.prime -> ../outside` shipped in a repo must not redirect the write either."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (project / ".prime").symlink_to(outside, target_is_directory=True)
+        monkeypatch.chdir(project)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+        assert not (outside / "config.json").exists()
 
     def test_local_updates_existing_trusted_file(
         self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -414,6 +414,42 @@ class TestLocalEnvironments:
         assert result.exit_code == 1, result.output
         assert "Error: Environment file" in result.output
 
+    def test_login_local_ignores_planted_environment_file(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Config.local() is 'explicit', which must gate environment files like 'local'."""
+        self.write_env(project, "dev", base_url="https://evil.example")
+        monkeypatch.chdir(project)
+        monkeypatch.setenv("PRIME_CONTEXT", "dev")
+        posted: list[str] = []
+
+        def record(url: str, *args: object, **kwargs: object) -> None:
+            posted.append(url)
+            raise httpx.ConnectError("offline")
+
+        monkeypatch.setattr("prime_cli.commands.login.httpx.post", record)
+
+        result = runner.invoke(app, ["login", "--local", "--headless"], env=TEST_ENV)
+
+        assert result.exit_code == 1
+        assert posted and all("evil.example" not in url for url in posted), posted
+        assert posted[0].startswith(Config.DEFAULT_BASE_URL)
+
+    def test_set_traces_url_refuses_to_launder_untrusted_environment_file(
+        self, home: Path, project: Path
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key", current_environment="dev")
+        env_file = self.write_env(project, "dev", base_url="https://evil.example")
+        before = env_file.read_text()
+
+        result = runner.invoke(
+            app, ["config", "set-traces-url", "https://traces.example"], env=TEST_ENV
+        )
+
+        assert result.exit_code != 0, result.output
+        assert env_file.read_text() == before
+        assert str(env_file) not in load_trusted_configs()
+
     def test_global_config_environments_need_no_trust(
         self, home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -438,16 +438,17 @@ class TestLocalEnvironments:
     def test_set_traces_url_refuses_to_launder_untrusted_environment_file(
         self, home: Path, project: Path
     ) -> None:
-        write_config(project / ".prime", api_key="local-key", current_environment="dev")
+        root = write_config(project / ".prime", api_key="local-key", current_environment="dev")
         env_file = self.write_env(project, "dev", base_url="https://evil.example")
-        before = env_file.read_text()
+        before_env, before_root = env_file.read_text(), root.read_text()
 
         result = runner.invoke(
             app, ["config", "set-traces-url", "https://traces.example"], env=TEST_ENV
         )
 
         assert result.exit_code != 0, result.output
-        assert env_file.read_text() == before
+        assert env_file.read_text() == before_env
+        assert root.read_text() == before_root  # refused before any write, not half-applied
         assert str(env_file) not in load_trusted_configs()
 
     def test_global_config_environments_need_no_trust(

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -447,6 +447,26 @@ class TestCli:
         assert load_trusted_configs() == {}
         assert "project-local" not in result.output
 
+    def test_local_from_symlinked_home_is_still_the_global_config(
+        self, tmp_path: Path, home: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Path.cwd() is the physical path while Path.home() may go through a
+        symlink; the global check must not depend on which spelling it sees."""
+        link = tmp_path / "home-link"
+        link.symlink_to(home, target_is_directory=True)
+        monkeypatch.setenv("HOME", str(link))
+        monkeypatch.setattr(Path, "home", lambda: link)
+        global_file = write_config(link / ".prime", api_key="old")
+        monkeypatch.chdir(home)  # physical path
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "new"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(global_file.read_text())["api_key"] == "new"
+        assert load_trusted_configs() == {}
+        assert "project-local" not in result.output
+        assert Config.local(create=False).is_global
+
     def test_failed_login_local_leaves_no_file_behind(
         self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -1,0 +1,239 @@
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime."""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from prime_cli.core.config import Config, find_local_config_dir
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {"COLUMNS": "200", "LINES": "50", "PRIME_DISABLE_VERSION_CHECK": "1"}
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A fake home *inside* tmp_path so there is room above it for tests."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+    monkeypatch.delenv("PRIME_BASE_URL", raising=False)
+    monkeypatch.delenv("PRIME_API_BASE_URL", raising=False)
+    return home
+
+
+@pytest.fixture
+def project(home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project dir under home; the working directory is a subdirectory of it."""
+    project = home / "code" / "prime"
+    workdir = project / "envs" / "my-env"
+    workdir.mkdir(parents=True)
+    monkeypatch.chdir(workdir)
+    return project
+
+
+def write_config(directory: Path, **values: object) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.json"
+    path.write_text(json.dumps(values))
+    return path
+
+
+def test_falls_back_to_global_without_local_config(home: Path, project: Path) -> None:
+    write_config(home / ".prime", api_key="global-key")
+
+    config = Config()
+
+    assert config.config_source == "global"
+    assert config.config_dir == home / ".prime"
+    assert config.is_global
+    assert config.api_key == "global-key"
+
+
+def test_discovers_local_config_in_ancestor_of_cwd(home: Path, project: Path) -> None:
+    write_config(home / ".prime", api_key="global-key")
+    write_config(project / ".prime", api_key="local-key")
+
+    config = Config()
+
+    assert config.config_source == "local"
+    assert config.config_dir == project / ".prime"
+    assert not config.is_global
+    assert config.api_key == "local-key"
+
+
+def test_nearest_local_config_wins(home: Path, project: Path) -> None:
+    write_config(project / ".prime", api_key="outer-key")
+    write_config(project / "envs" / ".prime", api_key="inner-key")
+
+    assert Config().api_key == "inner-key"
+
+
+def test_local_config_replaces_global_rather_than_merging(home: Path, project: Path) -> None:
+    """A planted local file must never combine its base_url with the global API key."""
+    write_config(home / ".prime", api_key="global-key")
+    write_config(project / ".prime", base_url="https://local.example")
+
+    config = Config()
+
+    assert config.base_url == "https://local.example"
+    assert config.api_key == ""
+
+
+def test_env_vars_still_override_local_config(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_config(project / ".prime", api_key="local-key")
+    monkeypatch.setenv("PRIME_API_KEY", "env-key")
+
+    assert Config().api_key == "env-key"
+
+
+def test_prime_config_dir_env_var_beats_local_discovery(
+    home: Path, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_config(project / ".prime", api_key="local-key")
+    explicit = tmp_path / "elsewhere"
+    write_config(explicit, api_key="explicit-key")
+    monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
+
+    config = Config()
+
+    assert config.config_source == "env"
+    assert config.config_dir == explicit
+    assert config.api_key == "explicit-key"
+
+
+def test_discovery_stops_at_home(home: Path, project: Path, tmp_path: Path) -> None:
+    """A .prime/ above the home directory is not the user's project."""
+    write_config(tmp_path / ".prime", api_key="above-home-key")
+
+    config = Config()
+
+    assert config.config_source == "global"
+    assert config.config_dir == home / ".prime"
+    assert config.api_key == ""
+
+
+def test_home_itself_is_global_not_local(home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_config(home / ".prime", api_key="global-key")
+    monkeypatch.chdir(home)
+
+    config = Config()
+
+    assert config.config_source == "global"
+    assert config.api_key == "global-key"
+
+
+def test_ignores_local_config_owned_by_another_user(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_config(project / ".prime", api_key="planted-key")
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    assert find_local_config_dir() is None
+    assert Config().config_source == "global"
+
+
+def test_writes_go_to_the_discovered_local_file(home: Path, project: Path) -> None:
+    global_file = write_config(home / ".prime", api_key="global-key")
+    local_file = write_config(project / ".prime", api_key="local-key")
+
+    Config().set_api_key("rotated-key")
+
+    assert json.loads(local_file.read_text())["api_key"] == "rotated-key"
+    assert json.loads(global_file.read_text())["api_key"] == "global-key"
+    assert stat.S_IMODE(local_file.stat().st_mode) == 0o600
+
+
+def test_config_local_creates_file_that_later_calls_discover(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_config(home / ".prime", api_key="global-key")
+    monkeypatch.chdir(project)
+
+    created = Config.local()
+    created.set_api_key("local-key")
+
+    local_file = project / ".prime" / "config.json"
+    assert created.config_file == local_file
+    assert stat.S_IMODE(local_file.stat().st_mode) == 0o600
+
+    monkeypatch.chdir(project / "envs" / "my-env")
+    assert Config().api_key == "local-key"
+    assert json.loads((home / ".prime" / "config.json").read_text())["api_key"] == "global-key"
+
+
+def test_global_config_file_is_created_private(home: Path) -> None:
+    config = Config()
+
+    assert config.config_file == home / ".prime" / "config.json"
+    assert stat.S_IMODE(config.config_file.stat().st_mode) == 0o600
+
+
+class TestCli:
+    def test_view_shows_active_config_file(self, home: Path, project: Path) -> None:
+        write_config(project / ".prime", api_key="local-key")
+
+        result = runner.invoke(app, ["config", "view"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert "Config File" in result.output
+        assert "project-local" in result.output
+
+    def test_view_labels_global_config(self, home: Path, project: Path) -> None:
+        result = runner.invoke(app, ["config", "view"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert "(global)" in result.output
+
+    def test_set_api_key_local_creates_project_config(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        global_file = write_config(home / ".prime", api_key="global-key")
+        monkeypatch.chdir(project)
+        (project / ".git").mkdir()
+        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+        def no_network(*args: object, **kwargs: object) -> None:
+            raise AssertionError("must not call the API in this test")
+
+        monkeypatch.setattr("prime_cli.commands.config.APIClient", no_network)
+
+        result = runner.invoke(
+            app, ["config", "set-api-key", "--local", "local-key-1234567"], env=TEST_ENV
+        )
+
+        assert result.exit_code == 0, result.output
+        local_file = project / ".prime" / "config.json"
+        assert json.loads(local_file.read_text())["api_key"] == "local-key-1234567"
+        assert json.loads(global_file.read_text())["api_key"] == "global-key"
+        assert "project-local config" in result.output
+        assert ".gitignore" in result.output  # .git exists but .prime/ is not ignored
+
+    def test_set_api_key_local_is_quiet_when_gitignored(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(project)
+        (project / ".git").mkdir()
+        (project / ".gitignore").write_text("outputs/\n/.prime/\n")
+        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+        def no_network(*args: object, **kwargs: object) -> None:
+            raise AssertionError("must not call the API in this test")
+
+        monkeypatch.setattr("prime_cli.commands.config.APIClient", no_network)
+
+        result = runner.invoke(
+            app, ["config", "set-api-key", "--local", "local-key-1234567"], env=TEST_ENV
+        )
+
+        assert result.exit_code == 0, result.output
+        assert ".gitignore" not in result.output

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -32,6 +32,7 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: home)
     monkeypatch.setattr(config_module, "_warned_untrusted", set())
+    monkeypatch.setattr(config_module, "_warned_skipped_writes", set())
     for var in ("PRIME_API_KEY", "PRIME_BASE_URL", "PRIME_API_BASE_URL", "PRIME_CONTEXT"):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
@@ -566,6 +567,49 @@ class TestLocalEnvironments:
 
         result = runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV)
         assert result.exit_code == 0, result.output
+
+    def test_login_side_effect_does_not_write_into_untrusted_environment_file(
+        self, home: Path, project: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A checkout rewrote the (tracked) env file; the post-login update must leave it alone."""
+        write_config(project / ".prime", api_key="old", current_environment="dev")
+        env_file = self.write_env(project, "dev", base_url="https://evil.example")
+        before = env_file.read_text()
+
+        config = Config()
+        config.set_api_key("fresh-key")
+        config.update_current_environment_file()
+
+        assert env_file.read_text() == before
+        assert str(env_file) not in load_trusted_configs()
+        assert "Not updating untrusted environment file" in capsys.readouterr().err
+
+    def test_logout_does_not_write_into_untrusted_environment_file(
+        self, home: Path, project: Path
+    ) -> None:
+        write_config(project / ".prime", api_key="old", current_environment="dev")
+        env_file = self.write_env(project, "dev", api_key="theirs")
+        before = env_file.read_text()
+
+        result = runner.invoke(app, ["logout", "--yes"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert env_file.read_text() == before
+        assert json.loads((project / ".prime" / "config.json").read_text())["api_key"] == ""
+
+    def test_save_refuses_to_overwrite_untrusted_environment_file(
+        self, home: Path, project: Path
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        env_file = self.write_env(project, "dev", base_url="https://evil.example")
+        before = env_file.read_text()
+
+        result = runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "Error: Environment file" in result.output
+        assert env_file.read_text() == before
+        assert str(env_file) not in load_trusted_configs()
 
     def test_global_config_environments_need_no_trust(
         self, home: Path, monkeypatch: pytest.MonkeyPatch

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -1,12 +1,20 @@
-"""Project-local config discovery: PRIME_CONFIG_DIR > nearest .prime/ > ~/.prime."""
+"""Project-local config discovery: PRIME_CONFIG_DIR > nearest trusted .prime/ > ~/.prime."""
 
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path
 
+import httpx
 import pytest
-from prime_cli.core.config import Config, find_local_config_dir
+from prime_cli.core import config as config_module
+from prime_cli.core.config import (
+    Config,
+    find_local_config_dir,
+    load_trusted_configs,
+    trust_local_config,
+)
 from prime_cli.main import app
 from typer.testing import CliRunner
 
@@ -22,9 +30,10 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: home)
-    monkeypatch.delenv("PRIME_API_KEY", raising=False)
-    monkeypatch.delenv("PRIME_BASE_URL", raising=False)
-    monkeypatch.delenv("PRIME_API_BASE_URL", raising=False)
+    monkeypatch.setattr(config_module, "_warned_untrusted", set())
+    for var in ("PRIME_API_KEY", "PRIME_BASE_URL", "PRIME_API_BASE_URL", "PRIME_CONTEXT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
     return home
 
 
@@ -38,11 +47,26 @@ def project(home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return project
 
 
-def write_config(directory: Path, **values: object) -> Path:
+@pytest.fixture
+def no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("must not call the API in this test")
+
+    monkeypatch.setattr("prime_cli.commands.config.APIClient", fail)
+
+
+def write_config(directory: Path, *, trusted: bool = True, **values: object) -> Path:
+    """Write `<directory>/config.json`; local ones are trusted unless told otherwise."""
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / "config.json"
     path.write_text(json.dumps(values))
+    if trusted and directory != Path.home() / ".prime":
+        trust_local_config(path)
     return path
+
+
+def git_init(directory: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(directory)], check=True)
 
 
 def test_falls_back_to_global_without_local_config(home: Path, project: Path) -> None:
@@ -56,7 +80,7 @@ def test_falls_back_to_global_without_local_config(home: Path, project: Path) ->
     assert config.api_key == "global-key"
 
 
-def test_discovers_local_config_in_ancestor_of_cwd(home: Path, project: Path) -> None:
+def test_discovers_trusted_local_config_in_ancestor_of_cwd(home: Path, project: Path) -> None:
     write_config(home / ".prime", api_key="global-key")
     write_config(project / ".prime", api_key="local-key")
 
@@ -66,17 +90,62 @@ def test_discovers_local_config_in_ancestor_of_cwd(home: Path, project: Path) ->
     assert config.config_dir == project / ".prime"
     assert not config.is_global
     assert config.api_key == "local-key"
+    assert config.untrusted_local_configs == []
 
 
-def test_nearest_local_config_wins(home: Path, project: Path) -> None:
+def test_nearest_trusted_local_config_wins(home: Path, project: Path) -> None:
     write_config(project / ".prime", api_key="outer-key")
     write_config(project / "envs" / ".prime", api_key="inner-key")
 
     assert Config().api_key == "inner-key"
 
 
+def test_untrusted_local_config_is_ignored_with_a_warning(
+    home: Path, project: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A .prime/config.json that came with a cloned repo is owned by the user but
+    must not be honored until they explicitly trust it."""
+    write_config(home / ".prime", api_key="global-key")
+    planted = write_config(project / ".prime", trusted=False, base_url="https://evil.example")
+
+    config = Config()
+
+    assert config.config_source == "global"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.untrusted_local_configs == [planted]
+    err = capsys.readouterr().err
+    assert "Ignoring untrusted project config" in err
+    assert f"prime config trust {project}" in err
+
+    # Warned once per process, not once per Config() call.
+    Config()
+    assert "Ignoring untrusted" not in capsys.readouterr().err
+
+
+def test_untrusted_nested_config_does_not_mask_trusted_outer_one(home: Path, project: Path) -> None:
+    write_config(project / ".prime", api_key="outer-key")
+    write_config(project / "envs" / ".prime", trusted=False, api_key="planted-key")
+
+    config = Config()
+
+    assert config.api_key == "outer-key"
+    assert config.untrusted_local_configs == [project / "envs" / ".prime" / "config.json"]
+
+
+def test_trust_is_bound_to_file_content(home: Path, project: Path) -> None:
+    """If the file changes under the user (e.g. git pull), it needs trusting again."""
+    local = write_config(project / ".prime", api_key="local-key")
+    assert Config().api_key == "local-key"
+
+    local.write_text(json.dumps({"api_key": "local-key", "base_url": "https://evil.example"}))
+
+    assert Config().config_source == "global"
+    trust_local_config(local)
+    assert Config().base_url == "https://evil.example"
+
+
 def test_local_config_replaces_global_rather_than_merging(home: Path, project: Path) -> None:
-    """A planted local file must never combine its base_url with the global API key."""
+    """A local file must never combine its base_url with the global API key."""
     write_config(home / ".prime", api_key="global-key")
     write_config(project / ".prime", base_url="https://local.example")
 
@@ -100,7 +169,7 @@ def test_prime_config_dir_env_var_beats_local_discovery(
 ) -> None:
     write_config(project / ".prime", api_key="local-key")
     explicit = tmp_path / "elsewhere"
-    write_config(explicit, api_key="explicit-key")
+    write_config(explicit, trusted=False, api_key="explicit-key")
     monkeypatch.setenv("PRIME_CONFIG_DIR", str(explicit))
 
     config = Config()
@@ -108,10 +177,11 @@ def test_prime_config_dir_env_var_beats_local_discovery(
     assert config.config_source == "env"
     assert config.config_dir == explicit
     assert config.api_key == "explicit-key"
+    assert config.untrusted_local_configs == []
 
 
 def test_discovery_stops_at_home(home: Path, project: Path, tmp_path: Path) -> None:
-    """A .prime/ above the home directory is not the user's project."""
+    """A .prime/ above the home directory is not the user's project, even if trusted."""
     write_config(tmp_path / ".prime", api_key="above-home-key")
 
     config = Config()
@@ -139,10 +209,14 @@ def test_ignores_local_config_owned_by_another_user(
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
     assert find_local_config_dir() is None
-    assert Config().config_source == "global"
+    config = Config()
+    assert config.config_source == "global"
+    assert config.untrusted_local_configs == []  # not even a candidate
 
 
-def test_writes_go_to_the_discovered_local_file(home: Path, project: Path) -> None:
+def test_writes_go_to_the_discovered_local_file_and_keep_it_trusted(
+    home: Path, project: Path
+) -> None:
     global_file = write_config(home / ".prime", api_key="global-key")
     local_file = write_config(project / ".prime", api_key="local-key")
 
@@ -151,9 +225,11 @@ def test_writes_go_to_the_discovered_local_file(home: Path, project: Path) -> No
     assert json.loads(local_file.read_text())["api_key"] == "rotated-key"
     assert json.loads(global_file.read_text())["api_key"] == "global-key"
     assert stat.S_IMODE(local_file.stat().st_mode) == 0o600
+    # The CLI's own write refreshed the trust digest.
+    assert Config().api_key == "rotated-key"
 
 
-def test_config_local_creates_file_that_later_calls_discover(
+def test_config_local_creates_trusted_file_that_later_calls_discover(
     home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     write_config(home / ".prime", api_key="global-key")
@@ -165,10 +241,41 @@ def test_config_local_creates_file_that_later_calls_discover(
     local_file = project / ".prime" / "config.json"
     assert created.config_file == local_file
     assert stat.S_IMODE(local_file.stat().st_mode) == 0o600
+    assert str(local_file) in load_trusted_configs()
 
     monkeypatch.chdir(project / "envs" / "my-env")
     assert Config().api_key == "local-key"
     assert json.loads((home / ".prime" / "config.json").read_text())["api_key"] == "global-key"
+
+
+def test_config_local_without_create_writes_nothing_until_first_set(
+    home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(project)
+
+    config = Config.local(create=False)
+    assert not (project / ".prime").exists()
+    assert config.api_key == ""
+
+    config.set_api_key("local-key")
+    assert json.loads((project / ".prime" / "config.json").read_text())["api_key"] == "local-key"
+    assert Config().config_source == "local"
+
+
+def test_adopt_urls_copies_service_urls_but_not_credentials(home: Path, project: Path) -> None:
+    write_config(
+        home / ".prime",
+        api_key="global-key",
+        base_url="https://api.dev.example",
+        frontend_url="https://app.dev.example",
+    )
+
+    config = Config.local(project, create=False)
+    config.adopt_urls(Config())
+
+    assert config.base_url == "https://api.dev.example"
+    assert config.frontend_url == "https://app.dev.example"
+    assert config.api_key == ""
 
 
 def test_global_config_file_is_created_private(home: Path) -> None:
@@ -188,24 +295,50 @@ class TestCli:
         assert "Config File" in result.output
         assert "project-local" in result.output
 
-    def test_view_labels_global_config(self, home: Path, project: Path) -> None:
+    def test_view_labels_global_config_and_lists_ignored_files(
+        self, home: Path, project: Path
+    ) -> None:
+        write_config(project / ".prime", trusted=False, api_key="planted-key")
+
         result = runner.invoke(app, ["config", "view"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert "(global)" in result.output
+        assert "Ignored Config" in result.output
 
-    def test_set_api_key_local_creates_project_config(
+    def test_trust_and_untrust_commands(
         self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_config(home / ".prime", api_key="global-key")
+        local = write_config(project / ".prime", trusted=False, api_key="local-key")
+        assert Config().api_key == "global-key"
+
+        result = runner.invoke(app, ["config", "trust", str(project)], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        assert str(local) in load_trusted_configs()
+        assert Config().api_key == "local-key"
+
+        # Accepts the .prime dir or the file itself, and defaults to cwd.
+        monkeypatch.chdir(project)
+        result = runner.invoke(app, ["config", "untrust"], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        assert Config().api_key == "global-key"
+        result = runner.invoke(app, ["config", "trust", str(project / ".prime")], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        assert Config().api_key == "local-key"
+
+    def test_trust_rejects_missing_file(self, home: Path, project: Path) -> None:
+        result = runner.invoke(app, ["config", "trust", str(project)], env=TEST_ENV)
+
+        assert result.exit_code == 1
+        assert "No config file" in result.output
+
+    def test_set_api_key_local_creates_trusted_project_config(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         global_file = write_config(home / ".prime", api_key="global-key")
         monkeypatch.chdir(project)
-        (project / ".git").mkdir()
-        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
-
-        def no_network(*args: object, **kwargs: object) -> None:
-            raise AssertionError("must not call the API in this test")
-
-        monkeypatch.setattr("prime_cli.commands.config.APIClient", no_network)
+        git_init(project)
 
         result = runner.invoke(
             app, ["config", "set-api-key", "--local", "local-key-1234567"], env=TEST_ENV
@@ -215,25 +348,68 @@ class TestCli:
         local_file = project / ".prime" / "config.json"
         assert json.loads(local_file.read_text())["api_key"] == "local-key-1234567"
         assert json.loads(global_file.read_text())["api_key"] == "global-key"
+        assert str(local_file) in load_trusted_configs()
         assert "project-local config" in result.output
-        assert ".gitignore" in result.output  # .git exists but .prime/ is not ignored
+        assert ".gitignore" in result.output  # a repo, and .prime/ is not ignored
 
-    def test_set_api_key_local_is_quiet_when_gitignored(
-        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    def test_set_api_key_local_inherits_urls_from_active_config(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A new local config keeps targeting the deployment already configured."""
+        write_config(home / ".prime", api_key="global-key", base_url="https://api.dev.example")
         monkeypatch.chdir(project)
-        (project / ".git").mkdir()
-        (project / ".gitignore").write_text("outputs/\n/.prime/\n")
-        monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
 
-        def no_network(*args: object, **kwargs: object) -> None:
-            raise AssertionError("must not call the API in this test")
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
 
-        monkeypatch.setattr("prime_cli.commands.config.APIClient", no_network)
+        assert result.exit_code == 0, result.output
+        saved = json.loads((project / ".prime" / "config.json").read_text())
+        assert saved["base_url"] == "https://api.dev.example"
+        assert saved["api_key"] == "k"
 
-        result = runner.invoke(
-            app, ["config", "set-api-key", "--local", "local-key-1234567"], env=TEST_ENV
-        )
+    def test_gitignore_warning_from_subdirectory_of_repo(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The repo root may be several levels up from where --local is run."""
+        git_init(project)
+        workdir = project / "services" / "app"
+        workdir.mkdir(parents=True)
+        monkeypatch.chdir(workdir)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert ".gitignore" in result.output
+        assert str(project) in result.output
+
+    def test_gitignore_warning_silent_when_root_gitignore_covers_subdirectory(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        git_init(project)
+        (project / ".gitignore").write_text("outputs/\n.prime/\n")
+        workdir = project / "services" / "app"
+        workdir.mkdir(parents=True)
+        monkeypatch.chdir(workdir)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
 
         assert result.exit_code == 0, result.output
         assert ".gitignore" not in result.output
+
+    def test_failed_login_local_leaves_no_file_behind(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An aborted login must not create an empty local config that would
+        shadow the working global one."""
+        write_config(home / ".prime", api_key="global-key")
+        monkeypatch.chdir(project)
+
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise httpx.ConnectError("offline")
+
+        monkeypatch.setattr("prime_cli.commands.login.httpx.post", refuse)
+
+        result = runner.invoke(app, ["login", "--local", "--headless"], env=TEST_ENV)
+
+        assert result.exit_code == 1
+        assert not (project / ".prime").exists()
+        assert Config().api_key == "global-key"

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -611,6 +611,37 @@ class TestLocalEnvironments:
         assert env_file.read_text() == before
         assert str(env_file) not in load_trusted_configs()
 
+    def test_delete_refuses_symlinked_environments_directory(
+        self, home: Path, project: Path, tmp_path: Path
+    ) -> None:
+        """unlink() through `environments -> outside` would delete the external file."""
+        write_config(project / ".prime", api_key="local-key")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "dev.json"
+        victim.write_text(json.dumps({"api_key": "someone-elses"}))
+        (project / ".prime" / "environments").symlink_to(outside, target_is_directory=True)
+
+        result = runner.invoke(app, ["config", "delete", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+        assert victim.exists()
+
+    def test_delete_removes_environment_and_its_trust_entry(
+        self, home: Path, project: Path
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        assert runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV).exit_code == 0
+        env_file = project / ".prime" / "environments" / "dev.json"
+        assert str(env_file) in load_trusted_configs()
+
+        result = runner.invoke(app, ["config", "delete", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert not env_file.exists()
+        assert str(env_file) not in load_trusted_configs()
+
     def test_global_config_environments_need_no_trust(
         self, home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -680,6 +680,34 @@ def test_trust_registry_is_replaced_atomically(home: Path, project: Path) -> Non
     assert Config().api_key == "b"
 
 
+def test_concurrent_trust_updates_do_not_lose_entries(home: Path, tmp_path: Path) -> None:
+    """Load-modify-save on the registry is serialized, so parallel writers all land."""
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    files = []
+    for i in range(12):
+        d = tmp_path / f"proj{i}" / ".prime"
+        d.mkdir(parents=True)
+        f = d / "config.json"
+        f.write_text(json.dumps({"api_key": f"k{i}"}))
+        files.append(f)
+    barrier = threading.Barrier(len(files))
+
+    def trust(path: Path) -> None:
+        barrier.wait()
+        trust_local_config(path)
+
+    with ThreadPoolExecutor(max_workers=len(files)) as pool:
+        list(pool.map(trust, files))
+
+    trusted = load_trusted_configs()
+    assert all(str(f.resolve()) in trusted for f in files)
+    lock = home / ".prime" / "trusted_configs.json.lock"
+    assert lock.exists()
+    assert stat.S_IMODE(lock.stat().st_mode) == 0o600
+
+
 def test_global_config_file_is_created_private(home: Path) -> None:
     config = Config()
 

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -653,6 +653,33 @@ class TestLocalEnvironments:
         assert Config().base_url == "https://api.dev.example"
 
 
+def test_permissive_legacy_config_is_replaced_not_rewritten(home: Path) -> None:
+    """A 0644 file from an older CLI must never hold the new key, even briefly."""
+    legacy = write_config(home / ".prime", api_key="old")
+    legacy.chmod(0o644)
+    old_inode = legacy.stat().st_ino
+
+    Config().set_api_key("new")
+
+    assert stat.S_IMODE(legacy.stat().st_mode) == 0o600
+    assert legacy.stat().st_ino != old_inode  # atomic replace, not in-place truncate
+    assert json.loads(legacy.read_text())["api_key"] == "new"
+    assert not list((home / ".prime").glob("*.tmp"))
+
+
+def test_trust_registry_is_replaced_atomically(home: Path, project: Path) -> None:
+    registry = home / ".prime" / "trusted_configs.json"
+    write_config(project / ".prime", api_key="a")
+    first_inode = registry.stat().st_ino
+
+    Config().set_api_key("b")  # refreshes the trust entry
+
+    assert registry.stat().st_ino != first_inode
+    assert stat.S_IMODE(registry.stat().st_mode) == 0o600
+    assert not list((home / ".prime").glob("*.tmp"))
+    assert Config().api_key == "b"
+
+
 def test_global_config_file_is_created_private(home: Path) -> None:
     config = Config()
 

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -338,6 +338,93 @@ def test_writes_follow_symlinks_the_user_owns(home: Path, project: Path, tmp_pat
     assert json.loads(target.read_text())["api_key"] == "new"
 
 
+class TestLocalEnvironments:
+    """Named environment files next to a local config are inside its trust boundary."""
+
+    @staticmethod
+    def write_env(project: Path, name: str, **values: object) -> Path:
+        env_dir = project / ".prime" / "environments"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        env_file = env_dir / f"{name}.json"
+        env_file.write_text(json.dumps(values))
+        return env_file
+
+    def test_prime_context_ignores_untrusted_environment_file(
+        self,
+        home: Path,
+        project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A repo update can rewrite environments/<name>.json while config.json stays trusted."""
+        write_config(project / ".prime", api_key="local-key", base_url="https://api.dev.example")
+        self.write_env(project, "dev", base_url="https://evil.example")
+        monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+        config = Config()
+
+        assert config.config_source == "local"
+        assert config.base_url == "https://api.dev.example"
+        assert config.current_environment == "production"
+        assert "Ignoring untrusted environment file" in capsys.readouterr().err
+
+    def test_use_refuses_untrusted_environment_file(self, home: Path, project: Path) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        self.write_env(project, "dev", base_url="https://evil.example")
+
+        result = runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "Error: Environment file" in result.output  # long path gets ellipsized
+        assert Config().base_url == Config.DEFAULT_BASE_URL
+
+    def test_trust_command_covers_environment_files(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_config(project / ".prime", trusted=False, api_key="local-key")
+        env_file = self.write_env(project, "dev", base_url="https://api.dev.example")
+
+        result = runner.invoke(app, ["config", "trust", str(project)], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        assert str(env_file) in load_trusted_configs()
+
+        monkeypatch.setenv("PRIME_CONTEXT", "dev")
+        assert Config().base_url == "https://api.dev.example"
+
+        # Untrust drops the environment entries too.
+        result = runner.invoke(app, ["config", "untrust", str(project)], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        assert load_trusted_configs() == {}
+
+    def test_environment_saved_by_the_cli_is_trusted(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        monkeypatch.setenv("PRIME_BASE_URL", "https://api.dev.example")
+        assert runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV).exit_code == 0
+        monkeypatch.delenv("PRIME_BASE_URL")
+
+        assert runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV).exit_code == 0
+        assert Config().base_url == "https://api.dev.example"
+
+        # ...until someone rewrites it behind the CLI's back.
+        env_file = project / ".prime" / "environments" / "dev.json"
+        env_file.write_text(json.dumps({"base_url": "https://evil.example"}))
+        result = runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV)
+        assert result.exit_code == 1, result.output
+        assert "Error: Environment file" in result.output
+
+    def test_global_config_environments_need_no_trust(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_dir = home / ".prime" / "environments"
+        env_dir.mkdir(parents=True)
+        (env_dir / "dev.json").write_text(json.dumps({"base_url": "https://api.dev.example"}))
+        monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+        assert Config().base_url == "https://api.dev.example"
+
+
 def test_global_config_file_is_created_private(home: Path) -> None:
     config = Config()
 

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -317,25 +317,50 @@ def test_writes_refuse_symlinks_owned_by_another_user(
     real_uid = os.getuid()
     monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
 
-    with pytest.raises(PermissionError, match="not owned"):
+    with pytest.raises(PermissionError, match="symlink"):
         config.set_api_key("x")
 
     assert json.loads(target.read_text()) == {"api_key": "precious"}
 
 
-def test_writes_follow_symlinks_the_user_owns(home: Path, project: Path, tmp_path: Path) -> None:
-    """Dotfile-style symlinked configs keep working."""
-    (project / ".prime").mkdir(parents=True)
+def test_global_config_writes_follow_symlinks_the_user_owns(home: Path, tmp_path: Path) -> None:
+    """Dotfile-style symlinked ~/.prime/config.json keeps working."""
+    (home / ".prime").mkdir()
     target = tmp_path / "dotfiles" / "prime.json"
     target.parent.mkdir()
     target.write_text(json.dumps({"api_key": "old"}))
-    link = project / ".prime" / "config.json"
+    link = home / ".prime" / "config.json"
     link.symlink_to(target)
 
-    Config(config_dir=project / ".prime").set_api_key("new")
+    Config().set_api_key("new")
 
     assert link.is_symlink()
     assert json.loads(target.read_text())["api_key"] == "new"
+
+
+def test_project_config_writes_never_follow_symlinks(
+    home: Path, project: Path, tmp_path: Path
+) -> None:
+    """Even a user-owned symlink: a cloned repo's links are user-owned too."""
+    (project / ".prime").mkdir(parents=True)
+    target = tmp_path / "elsewhere.json"
+    target.write_text(json.dumps({"api_key": "precious"}))
+    (project / ".prime" / "config.json").symlink_to(target)
+
+    with pytest.raises(PermissionError, match="symlink"):
+        Config(config_dir=project / ".prime").set_api_key("x")
+
+    assert json.loads(target.read_text()) == {"api_key": "precious"}
+
+
+def test_global_config_writes_refuse_dangling_symlinks(home: Path, tmp_path: Path) -> None:
+    (home / ".prime").mkdir()
+    (home / ".prime" / "config.json").symlink_to(tmp_path / "nowhere.json")
+
+    with pytest.raises(PermissionError, match="dangling"):
+        Config(config_dir=home / ".prime", create=False).set_api_key("x")
+
+    assert not (tmp_path / "nowhere.json").exists()
 
 
 class TestLocalEnvironments:
@@ -450,6 +475,48 @@ class TestLocalEnvironments:
         assert env_file.read_text() == before_env
         assert root.read_text() == before_root  # refused before any write, not half-applied
         assert str(env_file) not in load_trusted_configs()
+
+    def test_save_refuses_symlinked_environment_file(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`environments/dev.json -> ../../leak.json` shipped in a repo must not redirect `save`."""
+        write_config(project / ".prime", api_key="local-key")
+        env_dir = project / ".prime" / "environments"
+        env_dir.mkdir()
+        (env_dir / "dev.json").symlink_to(Path("..") / ".." / "leak.json")
+
+        result = runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+        assert not (project / "leak.json").exists()
+
+    def test_trust_skips_symlinked_environment_files(self, home: Path, project: Path) -> None:
+        write_config(project / ".prime", trusted=False, api_key="local-key")
+        real = self.write_env(project, "real", base_url="https://api.dev.example")
+        (project / ".prime" / "environments" / "linked.json").symlink_to(real)
+
+        result = runner.invoke(app, ["config", "trust", str(project)], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        trusted = load_trusted_configs()
+        assert str(real) in trusted
+        assert str(project / ".prime" / "environments" / "linked.json") not in trusted
+
+    def test_logout_keeps_environment_file_trusted(
+        self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_config(project / ".prime", api_key="local-key")
+        assert runner.invoke(app, ["config", "save", "dev"], env=TEST_ENV).exit_code == 0
+        assert runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV).exit_code == 0
+
+        result = runner.invoke(app, ["logout", "--yes"], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
+        env_file = project / ".prime" / "environments" / "dev.json"
+        assert json.loads(env_file.read_text())["api_key"] == ""
+
+        result = runner.invoke(app, ["config", "use", "dev"], env=TEST_ENV)
+        assert result.exit_code == 0, result.output
 
     def test_global_config_environments_need_no_trust(
         self, home: Path, monkeypatch: pytest.MonkeyPatch
@@ -618,6 +685,21 @@ class TestCli:
         assert result.exit_code == 1, result.output
         assert "not owned by you" in result.output
         assert planted.read_text() == before
+
+    def test_local_refuses_dangling_symlink_config(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cloned `.prime/config.json -> ../leak.json` must not redirect the credential write."""
+        (project / ".prime").mkdir(parents=True)
+        (project / ".prime" / "config.json").symlink_to(Path("..") / "leak.json")
+        monkeypatch.chdir(project)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "k"], env=TEST_ENV)
+
+        assert result.exit_code == 1, result.output
+        assert "symlink" in result.output
+        assert not (project / "leak.json").exists()
+        assert load_trusted_configs() == {}
 
     def test_local_updates_existing_trusted_file(
         self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -395,6 +395,44 @@ class TestCli:
         assert result.exit_code == 0, result.output
         assert ".gitignore" not in result.output
 
+    def test_local_refuses_existing_untrusted_file(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--local must not adopt (and then trust) a planted config that is already there."""
+        planted = write_config(
+            project / ".prime", trusted=False, base_url="https://evil.example", api_key="theirs"
+        )
+        before = planted.read_text()
+        monkeypatch.chdir(project)
+
+        def refuse(*args: object, **kwargs: object) -> None:
+            raise AssertionError("login must not contact the planted base_url")
+
+        monkeypatch.setattr("prime_cli.commands.login.httpx.post", refuse)
+
+        for args in (["config", "set-api-key", "--local", "k"], ["login", "--local", "--headless"]):
+            result = runner.invoke(app, args, env=TEST_ENV)
+            assert result.exit_code == 1, result.output
+            assert "not trusted" in result.output
+
+        assert planted.read_text() == before
+        assert str(planted) not in load_trusted_configs()
+        assert Config().config_source == "global"
+
+    def test_local_updates_existing_trusted_file(
+        self, home: Path, project: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        local = write_config(project / ".prime", api_key="old", base_url="https://api.dev.example")
+        monkeypatch.chdir(project)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "new"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        saved = json.loads(local.read_text())
+        assert saved["api_key"] == "new"
+        assert saved["base_url"] == "https://api.dev.example"
+        assert Config().api_key == "new"
+
     def test_failed_login_local_leaves_no_file_behind(
         self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/prime/tests/test_config_discovery.py
+++ b/packages/prime/tests/test_config_discovery.py
@@ -433,6 +433,20 @@ class TestCli:
         assert saved["base_url"] == "https://api.dev.example"
         assert Config().api_key == "new"
 
+    def test_local_from_home_directory_is_the_global_config(
+        self, home: Path, no_network: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """~/.prime is never in the trust registry; --local there must not refuse it."""
+        global_file = write_config(home / ".prime", api_key="old")
+        monkeypatch.chdir(home)
+
+        result = runner.invoke(app, ["config", "set-api-key", "--local", "new"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(global_file.read_text())["api_key"] == "new"
+        assert load_trusted_configs() == {}
+        assert "project-local" not in result.output
+
     def test_failed_login_local_leaves_no_file_behind(
         self, home: Path, project: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Lets the CLI and SDKs use **project-local credentials** instead of only `~/.prime/config.json` — e.g. on a shared box where all your code lives under `prime/`, put credentials at `prime/.prime/config.json` and everything run from there (or any subdirectory) uses them.

Config directory resolution, for the CLI and the `prime-sandboxes`, `prime-evals`, `prime-tunnel`, and `prime-traces` SDKs:

1. `PRIME_CONFIG_DIR` (explicit)
2. Nearest ancestor of the working directory containing a **trusted** `.prime/config.json`
3. `~/.prime` (unchanged default)

Per-field env vars (`PRIME_API_KEY`, `PRIME_TEAM_ID`, …) still take precedence over either file. All `Config()` call sites are no-arg, so every command and SDK client picks this up automatically.

```bash
cd ~/code/prime
prime login --local          # or: prime config set-api-key --local
prime config view            # "Config File" row shows the active file and why; lists ignored files

# a config.json you wrote by hand needs a one-time approval:
prime config trust           # or: prime config trust ~/code/prime
```

## Details

- **Explicit trust, à la `direnv allow`.** A discovered `.prime/config.json` is ignored (one warning line) until `prime config trust` records it in `~/.prime/trusted_configs.json` as resolved path → sha256 of content. A file that changes under the user (e.g. `git pull`) must be re-trusted. This is what stops a config committed to a cloned repository from pointing an environment-provided `PRIME_API_KEY` at someone else's `base_url`. Files the CLI writes itself (`--local` flows, `set-*`) refresh the entry; `PRIME_CONFIG_DIR` and explicit `Config(config_dir=…)` are trusted as such. Untrusted candidates are skipped rather than ending the search, so a nested planted file can't mask the user's trusted one further up. `prime config untrust` withdraws approval.
- **No merging.** A project-local config is a whole replacement for the global one. Merging would let a local file with only a `base_url` send the user's global API key elsewhere.
- **Shared-box hardening.** The upward walk stops at `$HOME`, and files not owned by the current uid are never candidates. Skipped on Windows, which has no uid model.
- **Nothing written until success.** `login --local` / `set-api-key --local` use `Config(create=False)`: the local file only appears on the first `set_*` call, so an aborted login can't leave an empty file that shadows the global config. A new local config inherits the service URLs of the currently active config instead of resetting to production.
- **Gitignore warning** walks up to the enclosing repo root and asks `git check-ignore` about the real path (with a `.gitignore` scan fallback), so `--local` from a subdirectory of a repo is covered.
- Config and environment files are now written **owner-only (0600)** — they hold API keys, and the CLI previously used the umask default.
- `prime-tunnel`'s frpc `bin_dir` deliberately stays under `~/.prime`.
- The SDK `Config` copies are kept dependency-free, so the discovery/trust helpers are duplicated into each (same pattern as the rest of those files). SDKs only *read* the trust registry; the CLI maintains it.

## Tests

- `test_config_discovery.py` in all five packages: global fallback, cwd/ancestor discovery, nearest-wins, untrusted ignored with warning, nested-untrusted doesn't mask trusted, trust bound to content, no-merge, env-var precedence, `PRIME_CONFIG_DIR` override, stop-at-home, ownership check, writes go to the discovered file and refresh trust, `create=False` defers writes, `adopt_urls`, `trust`/`untrust` CLI, `--local` flows incl. URL inheritance, aborted `login --local` leaves nothing, gitignore warning from a nested directory of a real `git init` repo.
- `conftest.py` in each package starts every test in a tmp working directory (and drops `PRIME_CONFIG_DIR` / `PRIME_API_KEY`). Without this, discovery run from a checkout under `$HOME` would reach the developer's real `~/.prime`, and tests that patch `HOME` would then read *and write* it.
- `prime` 1051 passed · `prime-sandboxes` 108 · `prime-evals` 20 · `prime-tunnel` 34 · `prime-traces` 155; `ruff` and `ty` clean.
- Smoke-tested the real CLI in a temp `$HOME`: hand-written local config ignored → `prime config trust` → used → file edited → ignored again; aborted `login --local` leaves no `.prime/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VNXu8DW3Ln4kmr6CGmWvw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how API keys and base URLs are resolved across the CLI and all SDKs; mistakes could misroute credentials or break existing setups that rely only on `~/.prime`.
> 
> **Overview**
> Adds **project-local credentials** so the CLI and Python SDKs can use `./.prime/config.json` (from `prime login --local` / `prime config set-api-key --local`) instead of only `~/.prime`. Resolution is **`PRIME_CONFIG_DIR` → nearest trusted ancestor `.prime/config.json` → `~/.prime`**; a local file **fully replaces** the global one (no merge). `PRIME_*` env vars still win over files.
> 
> **Trust (direnv-style):** discovered project configs are **ignored** until `prime config trust` records path → SHA-256 in `~/.prime/trusted_configs.json`; content changes require re-trust. CLI adds **`config trust` / `untrust`**, richer **`config view`**, gitignore warnings for `--local`, and deferred writes (`create=False`) so failed login does not leave an empty local config. **Hardening:** uid ownership on candidates, no project-local writes through symlinks, same trust rules for `.prime/environments/*.json`, owner-only atomic **0600** JSON writes, and flock on the trust registry.
> 
> The same discovery helpers are applied in **`prime_cli` and each SDK** (`prime-evals`, `prime-sandboxes`, `prime-traces`, `prime-tunnel`); **`prime-tunnel`** keeps frpc **`bin_dir`** under `~/.prime`. Docs and broad **`test_config_discovery`** + hermetic **`conftest`** fixtures cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826318d26667d24d7c707569654e025bd05513f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->