### PR TITLE
release: cli 0.6.29 + sandbox 0.2.40

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -79,7 +79,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.39"
+__version__ = "0.2.40"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.39",
+    "prime-sandboxes>=0.2.40",
     "prime-evals>=0.2.3",
     "prime-traces>=0.0.1",
     "prime-tunnel>=0.1.9",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.28"
+__version__ = "0.6.29"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Release `prime-sandboxes` 0.2.40 with the live-process/exec RPC hardening from #837, and Prime CLI 0.6.29 with the `prime train stop` spinner and status poll from #865.

This PR also raises the CLI dependency floor to `prime-sandboxes>=0.2.40`, so a CLI install pulls the hardened SDK instead of resolving back to 0.2.39.

I validated #837 against a live dev VM sandbox. A mid-stream transient fault now re-attaches by pid and the process survives with its exit code intact, and the background-job `mkdir` guard stops an ambiguous launch timeout from running the command twice. Two limits a reviewer should know: recovery from a fault that arrives *before* the PID event depends on sandboxd echoing the session tag, which the deployed sandboxd does not do, so that path is inert; and live-process control RPCs (stdin/signal) still fail on a transient fault, because they only retry `UNAUTHENTICATED`. Both are addressed by the in-flight idempotency-key work, not by this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)