### PR TITLE
ci(release): gate the prime release on an installable prime-sandboxes floor

### DIFF
--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -15,7 +15,35 @@ on:
         type: string
 
 jobs:
+  await-sandboxes-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The CLI image installs the wheel with its dependencies resolved from PyPI, and
+      # release-sandboxes.yml runs independently of this workflow. Tagging or publishing
+      # before prime-sandboxes is installable would strand the release: the CLI tag
+      # already exists, so a rerun skips it, and every image build fails.
+      - name: Wait for the required prime-sandboxes version on PyPI
+        run: |
+          FLOOR=$(sed -nE 's/.*"prime-sandboxes>=([^"]+)".*/\1/p' packages/prime/pyproject.toml | head -n1)
+          if [ -z "$FLOOR" ]; then
+            echo "::error::Unable to parse the prime-sandboxes floor from packages/prime/pyproject.toml"
+            exit 1
+          fi
+          echo "Waiting for prime-sandboxes==$FLOOR to become installable"
+          for _ in $(seq 1 40); do
+            if python3 -m pip download --quiet --no-deps --no-cache-dir --dest /tmp/floor-check "prime-sandboxes==$FLOOR"; then
+              echo "prime-sandboxes $FLOOR is installable"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::prime-sandboxes $FLOOR is still not on PyPI after 10 minutes; check the Release prime-sandboxes workflow"
+          exit 1
+
   tag-and-release:
+    needs: await-sandboxes-release
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:


### PR DESCRIPTION
`release-prime.yml` and `release-sandboxes.yml` run independently, so a push that changes both packages releases the CLI without waiting for the SDK. `packages/prime/Dockerfile` installs the CLI wheel with its dependencies resolved from PyPI, so if `prime-sandboxes` is not published yet, all three image builds fail after the CLI tag, GitHub release, and PyPI upload already happened. A rerun then skips the release because the tag exists, so recovery is manual. #869 raises the floor to `prime-sandboxes>=0.2.40` and would be the first release to hit this.

This adds an `await-sandboxes-release` job that `tag-and-release` now needs. It reads the `prime-sandboxes>=` floor from `packages/prime/pyproject.toml` and polls `pip download` until that exact version resolves, for up to 10 minutes.

The gate waits on PyPI rather than on the sibling workflow's Actions status, because PyPI availability is the condition the Docker build actually needs. It also covers index propagation after that workflow finishes, and it needs no handling for the race on when the sibling run appears. A CLI-only release passes in seconds because the floor is already published. If the sandbox release fails, this job times out and the CLI is never tagged or published with an unsatisfiable floor, at the cost of a 10-minute wait before the failure surfaces.

Merge this before #869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)