### PR TITLE
fix(traces): default traces_url to the traces service, not the platform API

### DIFF
--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -93,7 +93,7 @@ asyncio.run(main())
 | Source                 | Meaning                                                                |
 | ---------------------- | ---------------------------------------------------------------------- |
 | `PRIME_API_KEY`        | Platform API token, needs `traces:read` / `traces:write` scopes        |
-| `PRIME_TRACES_URL`     | Base URL of the Prime Traces service (**required** during closed beta) |
+| `PRIME_TRACES_URL`     | Base URL of the Prime Traces service; defaults to `https://prime-traces.pintel.dev` |
 | `PRIME_TEAM_ID`        | Optional team context, sent as `X-Prime-Team-ID`                       |
 | `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)           |
 

--- a/packages/prime-traces/examples/basic_usage.py
+++ b/packages/prime-traces/examples/basic_usage.py
@@ -4,9 +4,10 @@ Basic usage example for the prime-traces SDK.
 
 This demonstrates the standalone SDK without any CLI dependencies.
 
-Credentials come from PRIME_API_KEY / ~/.prime/config.json. Point
-PRIME_TRACES_URL at the Prime Traces service — e.g. the service's local
-compose stack: PRIME_TRACES_URL=http://localhost:8083
+Credentials come from PRIME_API_KEY / ~/.prime/config.json. The client talks
+to the production Prime Traces service by default; set PRIME_TRACES_URL to
+point it elsewhere — e.g. the service's local compose stack:
+PRIME_TRACES_URL=http://localhost:8083
 """
 
 import tempfile

--- a/packages/prime-traces/src/prime_traces/core/config.py
+++ b/packages/prime-traces/src/prime_traces/core/config.py
@@ -17,6 +17,7 @@ class Config:
     """
 
     DEFAULT_BASE_URL: str = "https://api.primeintellect.ai"
+    DEFAULT_TRACES_URL: str = "https://prime-traces.pintel.dev"
 
     def __init__(self) -> None:
         self.config_dir = Path.home() / ".prime"
@@ -66,12 +67,11 @@ class Config:
     def traces_url(self) -> str:
         """Base URL of the Prime Traces service.
 
-        Prime Traces is a separately deployed service, so it gets its own
-        override: precedence is PRIME_TRACES_URL > config "traces_url" >
-        the platform base URL. The fallback assumes the service is
-        path-routed under the platform domain; whether production uses that
-        or a dedicated domain is still an open deployment decision, and this
-        property is the single place that absorbs it.
+        Prime Traces is deployed on its own domain, not path-routed under the
+        platform API: ``{base_url}/api/v1/traces`` does not exist, and a client
+        pointed there gets a 404 for every request. So the fallback is the
+        service's own production URL, never ``base_url``. Precedence is
+        PRIME_TRACES_URL > config "traces_url" > DEFAULT_TRACES_URL.
 
         For local development against the service's compose stack:
         PRIME_TRACES_URL=http://localhost:8083
@@ -82,4 +82,4 @@ class Config:
         file_val = self.config.get("traces_url")
         if file_val:
             return self._strip_api_v1(file_val)
-        return self.base_url
+        return self.DEFAULT_TRACES_URL

--- a/packages/prime-traces/tests/test_sdk_config.py
+++ b/packages/prime-traces/tests/test_sdk_config.py
@@ -51,3 +51,22 @@ def test_config_values_read_from_file():
     config = Config()
     assert config.api_key == "file-key"
     assert config.traces_url == "https://traces.example"
+
+
+def test_traces_url_defaults_to_the_traces_service(monkeypatch):
+    """No override anywhere: the traces service's own domain, never the platform
+    API — ``/api/v1/traces`` is not routed there, so that fallback 404s."""
+    assert Config().traces_url == Config.DEFAULT_TRACES_URL
+    assert Config().traces_url != Config().base_url
+    # A platform override says nothing about where traces lives.
+    monkeypatch.setenv("PRIME_API_BASE_URL", "https://api.dev.example/api/v1")
+    config = Config()
+    assert config.base_url == "https://api.dev.example"
+    assert config.traces_url == Config.DEFAULT_TRACES_URL
+
+
+def test_traces_url_env_overrides_file(monkeypatch):
+    _write_config(json.dumps({"traces_url": "https://traces.file.example"}))
+    assert Config().traces_url == "https://traces.file.example"
+    monkeypatch.setenv("PRIME_TRACES_URL", "http://localhost:8083/api/v1/")
+    assert Config().traces_url == "http://localhost:8083"


### PR DESCRIPTION
## Why

`prime_traces.core.config.Config.traces_url` fell back to `base_url` when neither `PRIME_TRACES_URL` nor a config-file `traces_url` was set. Prime Traces is deployed on its own domain (`prime-traces.pintel.dev`); `api.primeintellect.ai` only mounts `/agent-traces`, so every request from an unconfigured client went to `https://api.primeintellect.ai/api/v1/traces` and got `{"detail":"Not Found"}`.

This is what makes the prime-runs traces sink (#856) retire loudly for every account that hasn't set the URL — including accounts in the beta — and why the `service_not_enabled` quiet path there is unreachable by default: the request never reaches the service that would return it.

## What

- `Config.DEFAULT_TRACES_URL = "https://prime-traces.pintel.dev"`; `traces_url` resolves `PRIME_TRACES_URL` > config `traces_url` > that default. `base_url` is no longer consulted — a platform override says nothing about where traces lives.
- Tests: default is the service (and stays so under `PRIME_API_BASE_URL`); env still overrides the file.
- README / `examples/basic_usage.py`: the env var is an override, not a requirement.

No version bump (CI's guard reserves those for `release/*`); a `release: prime-traces 0.0.3` PR should follow so `prime-runs` can depend on `prime-traces>=0.0.3`.

Not touched: the `prime` CLI has the same fallback in `prime_cli/core/config.py` (`traces_url` → `base_url`), which affects `prime traces …` commands; that's a separate package release, so left for a follow-up.

## Test plan

- [x] `uv run pytest packages/prime-traces/tests` — 150 passed
- [x] `ruff check` / `ruff format --check` on the changed files
- [x] Probed both hosts: `POST https://api.primeintellect.ai/api/v1/traces` → 404 `Not Found`; `https://prime-traces.pintel.dev/api/v1/traces` → answers (405 unauthenticated GET/POST mismatch, i.e. the route exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpNehr64sniVfqKo62GKPw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default endpoint behavior for all unconfigured clients; fixes broken defaults but alters where traffic goes without explicit configuration.
> 
> **Overview**
> **Fixes out-of-the-box SDK clients** that never set `PRIME_TRACES_URL` or `traces_url` in config. Those clients previously fell back to the platform `base_url`, so requests went to `/api/v1/traces` on `api.primeintellect.ai` and returned 404 instead of reaching Prime Traces.
> 
> `Config` now defines **`DEFAULT_TRACES_URL`** (`https://prime-traces.pintel.dev`) and **`traces_url`** resolves env → config file → that default, **without** using `base_url`. Docs and **`basic_usage.py`** describe `PRIME_TRACES_URL` as an optional override. New tests lock in the default (including when `PRIME_API_BASE_URL` is set) and env-over-file precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1230c83c5f7f41f0b4cdcab36829280bd5d8c16d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->