### PR TITLE
release: prime-traces 0.0.3

### DIFF
--- a/packages/prime-traces/src/prime_traces/__init__.py
+++ b/packages/prime-traces/src/prime_traces/__init__.py
@@ -49,7 +49,7 @@ from .models import (
 )
 from .traces import SupportsToRecord, TraceRecord, TracesClient
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 __all__ = [
     # Clients & config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no runtime logic edits; risk is limited to release/tag/PyPI process if publish fails.
> 
> **Overview**
> Bumps **`prime-traces`** from **0.0.2** to **0.0.3** in `packages/prime-traces/src/prime_traces/__init__.py` so the traces release workflow can publish a PyPI build that includes the **#871** fix (`Config.traces_url` defaulting to the traces service instead of `api.primeintellect.ai`).
> 
> There are no functional code changes in this PR—only the version string—so downstream installs from PyPI can pick up the corrected default URL and avoid trace upload 404s that still affect **0.0.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c86ea812e56a7f8e41986de5cbbc3c71c8b18c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->