### PR TITLE
prime-runs: RftBackend for training runs

### DIFF
--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -136,21 +136,33 @@ did by hand. Where it differs from an eval run:
 - **Metrics.** `log_metrics(values, step=...)` streams one row per call on its
   own uploader, so a slow sample upload never holds a step's metrics back.
   `_timestamp` is stamped on every row; non-finite values are dropped. The
-  endpoint allows 60 rows a minute per token.
+  endpoint allows 60 rows a minute per token. A row whose response was lost
+  is re-sent: the platform keeps one row per step, so nothing doubles.
 - **Samples.** Every record reaches Prime Traces. The training viewer's sample
-  table is one Parquet object per training step, uploaded every 10th step
-  (prime-rl's cadence) for episodes whose `run.work` says *training* work at
-  that step — verifiers' `TrainRunInfo`, which prime-rl stamps on every
-  dispatched episode. Log a step's episodes in one `log_episodes` call: the
-  platform keeps one object per step. Encoding needs pyarrow:
-  `pip install 'prime-runs[train]'`. Without it the table is skipped with a
-  warning and traces still flow.
+  table is a Parquet object per upload, keyed by the training step an episode
+  was *dispatched* at — `run.work.step` on verifiers' `TrainRunInfo`, which
+  prime-rl stamps on every dispatched episode — and uploaded every 10th step
+  (prime-rl's cadence) for training-work episodes. Objects are additive: a
+  step logged in several `log_episodes` calls (an off-policy episode landing
+  in a later batch) gets one object per call, each numbering its `sample_id`s
+  in its own range, and the viewer shows their union. So "step N" in the
+  sample viewer means dispatched at N, while the metrics logged at N describe
+  the batch trained at N. Encoding needs pyarrow: `pip install
+  'prime-runs[train]'`. Without it the table is skipped with a warning and
+  traces still flow.
 - **Attach.** `init(kind="train", id=os.environ["RUN_ID"])` joins a run a
-  managed launch created: nothing is registered, the platform keeps the run's
-  failure marking, and a clean `finish()` still completes it.
+  launcher created: nothing is registered, the platform keeps the run's
+  failure marking, and a clean `finish()` still completes it. The id must be
+  an external run's (one created through `POST /rft/external-runs`): the
+  platform's monitoring endpoints answer 400 for a hosted run.
 - **Status.** The RFT vocabulary is `completed | failed`. `cancelled` and
   `crashed` are reported as `failed` with the reason in `error_message`; a
   clean `finish()` is an idempotent finalize, safe to replay.
+- **Outages.** A sink that strikes out on transient failures (three in a row,
+  each already retried) is paused for five minutes and then tried again, not
+  retired for the run: a platform deploy costs a multi-day run a window of
+  rows, never the rest of its curves. Records that arrive while a sink is
+  paused are counted in `run.failed_records` for that sink.
 - **No config update.** `config=` is registered once as `run_config` and there
   is no summary document, so `finish(summary=...)` is not sent for training
   runs — log final numbers with `log_metrics`.

--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -145,7 +145,8 @@ did by hand. Where it differs from an eval run:
   (prime-rl's cadence) for training-work episodes. Objects are additive: a
   step logged in several `log_episodes` calls (an off-policy episode landing
   in a later batch) gets one object per call, each numbering its `sample_id`s
-  in its own range, and the viewer shows their union. So "step N" in the
+  in its own range (a forked child draws its ranges apart from its parent's),
+  and the viewer shows their union. So "step N" in the
   sample viewer means dispatched at N, while the metrics logged at N describe
   the batch trained at N. Encoding needs pyarrow: `pip install
   'prime-runs[train]'`. Without it the table is skipped with a warning and

--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -141,8 +141,10 @@ did by hand. Where it differs from an eval run:
   table is one Parquet object per training step, uploaded every 10th step
   (prime-rl's cadence) for episodes whose `run.work` says *training* work at
   that step — verifiers' `TrainRunInfo`, which prime-rl stamps on every
-  dispatched episode. Encoding needs pyarrow: `pip install 'prime-runs[train]'`.
-  Without it the table is skipped with a warning and traces still flow.
+  dispatched episode. Log a step's episodes in one `log_episodes` call: the
+  platform keeps one object per step. Encoding needs pyarrow:
+  `pip install 'prime-runs[train]'`. Without it the table is skipped with a
+  warning and traces still flow.
 - **Attach.** `init(kind="train", id=os.environ["RUN_ID"])` joins a run a
   managed launch created: nothing is registered, the platform keeps the run's
   failure marking, and a clean `finish()` still completes it.

--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -1,6 +1,6 @@
 # Prime Runs SDK
 
-Track eval runs on the Prime Intellect platform.
+Track eval and training runs on the Prime Intellect platform.
 
 ```bash
 pip install prime-runs
@@ -105,6 +105,54 @@ disables the run with a warning — it never silently writes somewhere else.
   block — is `cancelled`; one that stopped without saying — an exit that never
   reached `finish()` — is `crashed`.
 
+## Training runs
+
+```python
+import prime_runs as pr
+
+run = pr.init(
+    kind="train",
+    name="qwen3-8b-gsm8k-rl",
+    model="Qwen/Qwen3-8B",                  # the base model
+    environments=["primeintellect/gsm8k"],  # hub ids, passed through as given
+    training=pr.TrainingSpec(max_steps=1000, batch_size=64, rollouts_per_example=8),
+    config=train_config.model_dump(),       # or the path to the launched TOML
+    team_id="team_...",                     # external runs are created for a team
+)
+
+for step, (episodes, metrics) in enumerate(training_loop):
+    run.log_episodes(episodes)              # carry run.work.step (verifiers TrainRunInfo)
+    run.log_metrics(metrics, step=step)
+
+run.finish()
+```
+
+A training run lives on `/api/v1/rft/external-runs` — what prime-rl's monitor
+did by hand. Where it differs from an eval run:
+
+- **A team is required.** The platform enables external runs per team. A team
+  outside the allowlist gets a `ForbiddenError` from `init()` with the
+  platform's reason; the producer decides whether that means "run locally".
+- **Metrics.** `log_metrics(values, step=...)` streams one row per call on its
+  own uploader, so a slow sample upload never holds a step's metrics back.
+  `_timestamp` is stamped on every row; non-finite values are dropped. The
+  endpoint allows 60 rows a minute per token.
+- **Samples.** Every record reaches Prime Traces. The training viewer's sample
+  table is one Parquet object per training step, uploaded every 10th step
+  (prime-rl's cadence) for episodes whose `run.work` says *training* work at
+  that step — verifiers' `TrainRunInfo`, which prime-rl stamps on every
+  dispatched episode. Encoding needs pyarrow: `pip install 'prime-runs[train]'`.
+  Without it the table is skipped with a warning and traces still flow.
+- **Attach.** `init(kind="train", id=os.environ["RUN_ID"])` joins a run a
+  managed launch created: nothing is registered, the platform keeps the run's
+  failure marking, and a clean `finish()` still completes it.
+- **Status.** The RFT vocabulary is `completed | failed`. `cancelled` and
+  `crashed` are reported as `failed` with the reason in `error_message`; a
+  clean `finish()` is an idempotent finalize, safe to replay.
+- **No config update.** `config=` is registered once as `run_config` and there
+  is no summary document, so `finish(summary=...)` is not sent for training
+  runs — log final numbers with `log_metrics`.
+
 ## From async code
 
 `log_traces()` / `log_episodes()` are a queue put, not a request, so they are
@@ -144,8 +192,8 @@ package is imported — this is a leaf package, because the `prime` CLI depends 
 
 ## Status
 
-Eval runs only. Training runs will arrive with a backend over
-`/api/v1/rft/external-runs`, designed against prime-rl's actual needs.
+Eval runs over `/api/v1/evaluations`, training runs over
+`/api/v1/rft/external-runs` (see "Training runs").
 
 The evaluations API this version targets has no producer-facing way to mark an
 evaluation **failed** or **cancelled**: the SDK records the terminal state under

--- a/packages/prime-runs/pyproject.toml
+++ b/packages/prime-runs/pyproject.toml
@@ -43,6 +43,11 @@ Documentation = "https://github.com/PrimeIntellect-ai/prime/tree/main/packages/p
 Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 
 [project.optional-dependencies]
+# The training sample table is Parquet. Optional: an eval producer never needs
+# it, and prime-rl already carries pyarrow.
+train = [
+    "pyarrow>=15.0.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.23.0",

--- a/packages/prime-runs/src/prime_runs/__init__.py
+++ b/packages/prime-runs/src/prime_runs/__init__.py
@@ -1,6 +1,6 @@
 """Prime Intellect Runs SDK.
 
-Track eval runs on the Prime platform::
+Track eval and training runs on the Prime platform::
 
     import prime_runs as pr
 
@@ -31,7 +31,14 @@ from .exceptions import (
     TransportError,
     UnauthorizedError,
 )
-from .models import CONFIG_SOURCE_KEY, ConfigSource, EnvironmentRef, RunStatus
+from .models import (
+    CONFIG_SOURCE_KEY,
+    ConfigSource,
+    EnvironmentRef,
+    RunKind,
+    RunStatus,
+    TrainingSpec,
+)
 from .run import MODE_ENV, Run, init
 
 __version__ = "0.1.0"
@@ -40,6 +47,8 @@ __all__ = [
     "init",
     "Run",
     "RunStatus",
+    "RunKind",
+    "TrainingSpec",
     "ConfigSource",
     "CONFIG_SOURCE_KEY",
     "EnvironmentRef",

--- a/packages/prime-runs/src/prime_runs/backend.py
+++ b/packages/prime-runs/src/prime_runs/backend.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Protocol
 
 from ._http import PlatformClient
 from .exceptions import APIError, ConfigurationError, EnvironmentResolutionError
-from .models import EnvironmentRef, RunHandle, RunSpec, RunStatus
+from .models import EnvironmentRef, RunHandle, RunSpec, RunStatus, TrainingSpec
 
 logger = logging.getLogger(__name__)
 
@@ -267,3 +267,163 @@ class DisabledBackend:
 
     def close(self) -> None:
         return None
+
+
+# ------------------------------------------------------------------- rft
+
+#: The RFT API's status vocabulary is ``completed | failed``; the SDK's finer
+#: distinctions travel in ``error_message``.
+RFT_TERMINAL_STATUS = {
+    RunStatus.COMPLETED: "completed",
+    RunStatus.FAILED: "failed",
+    RunStatus.CANCELLED: "failed",
+    RunStatus.CRASHED: "failed",
+}
+
+
+class RftBackend:
+    """Lifecycle for external training runs over ``/api/v1/rft/*``.
+
+    What prime-rl's ``TrainRun`` did, in the SDK: register a run (or attach to
+    one a managed launch created), close it out. External runs are created
+    *for a team* and the platform enables them per team, so ``team_id`` is
+    required and a team outside the allowlist gets a 403 from :meth:`create`;
+    the producer decides whether that means "run locally" (the way verifiers
+    treats a missing key) or "stop".
+
+    The API has no config/summary update — ``run_config`` travels with
+    :meth:`create` and :meth:`update` is a no-op — and its status vocabulary
+    is ``completed | failed``: ``cancelled`` and ``crashed`` are reported as
+    ``failed`` with the reason in ``error_message``.
+    """
+
+    def __init__(
+        self,
+        client: PlatformClient,
+        *,
+        frontend_url: str,
+        team_id: Optional[str] = None,
+    ) -> None:
+        self._client = client
+        self._frontend_url = frontend_url.rstrip("/")
+        self._team_id = team_id
+
+    # ------------------------------------------------------------------ create
+
+    def create(self, spec: RunSpec) -> RunHandle:
+        if not spec.model:
+            raise ConfigurationError("A training run needs model= — the base model being trained.")
+        team_id = spec.team_id or self._team_id
+        if not team_id:
+            raise ConfigurationError(
+                "A training run needs a team: pass team_id= or set PRIME_TEAM_ID. "
+                "External training runs are created for a team, and the platform "
+                "enables them per team."
+            )
+        training = spec.training or TrainingSpec()
+        payload: Dict[str, Any] = {
+            "base_model": spec.model,
+            "max_steps": int(training.max_steps),
+            # Environment ids are passed through: training environments are
+            # named by hub id, and the RFT API does its own resolution.
+            "environments": [_training_environment(ref) for ref in spec.environments],
+            "team_id": team_id,
+        }
+        _set_if(payload, "name", spec.name)
+        _set_if(payload, "batch_size", training.batch_size)
+        _set_if(payload, "rollouts_per_example", training.rollouts_per_example)
+        _set_if(payload, "seq_len", training.seq_len)
+        _set_if(payload, "run_config", spec.config or None)
+        _set_if(payload, "wandb_project", training.wandb_project)
+        _set_if(payload, "wandb_entity", training.wandb_entity)
+        _set_if(payload, "wandb_run_name", training.wandb_run_name)
+
+        # Not replayable: a retry after a lost response would register a
+        # second run and only the second would be tracked.
+        response = self._client.post("/rft/external-runs", json_body=payload)
+        run = response.get("run") or {}
+        run_id = run.get("id")
+        if not run_id:
+            raise APIError(f"POST /rft/external-runs returned no run id (keys: {sorted(response)})")
+        return RunHandle(
+            id=str(run_id),
+            name=str(run.get("name") or spec.name or "") or None,
+            url=self.url_for(str(run_id)),
+        )
+
+    def attach(self, run_id: str) -> RunHandle:
+        """A handle for a run the platform already created — a managed launch
+        that injected its id. No request: the first write proves access."""
+        return RunHandle(id=run_id, url=self.url_for(run_id))
+
+    def url_for(self, run_id: str) -> str:
+        return f"{self._frontend_url}/dashboard/training/{run_id}"
+
+    # ------------------------------------------------------------------ update
+
+    def update(
+        self,
+        run_id: str,
+        *,
+        config: Optional[Dict[str, Any]] = None,
+        summary: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """No-op: an RFT run takes its config at creation and has no summary
+        document. Run-level outputs go through ``log_metrics``."""
+        if config or summary:
+            logger.debug("Run %s: the RFT API has no config/summary update; nothing sent", run_id)
+
+    # ---------------------------------------------------------------- finalize
+
+    def finalize(
+        self,
+        run_id: str,
+        *,
+        status: RunStatus,
+        summary: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if status is RunStatus.COMPLETED:
+            # Compare-and-set on the server, and "already finalized" is a
+            # success, so a lost response is safe to replay.
+            self._client.post(
+                "/rft/finalize",
+                json_body={"run_id": run_id, "exit_code": 0},
+                idempotent=True,
+            )
+            return
+
+        message = error or status.value
+        if status is not RunStatus.FAILED:
+            message = f"{status.value}: {message}"
+        try:
+            self._client.put(
+                f"/rft/external-runs/{run_id}/status",
+                json_body={"status": RFT_TERMINAL_STATUS[status], "error_message": message},
+            )
+        except APIError as exc:
+            if exc.status_code == 409:
+                # Already closed out (a managed launcher, or an earlier attempt
+                # whose response was lost). The outcome is recorded either way.
+                logger.info(
+                    "Run %s is already closed on the platform; not marking it %s",
+                    run_id,
+                    status.value,
+                )
+                return
+            raise
+
+    def log_metrics(self, run_id: str, metrics: Dict[str, Any]) -> None:
+        """One step's metrics, synchronously. The run handle batches these
+        through its uploader; this is the direct call."""
+        self._client.post("/rft/metrics", json_body={"run_id": run_id, "metrics": metrics})
+
+    def close(self) -> None:
+        self._client.close()
+
+
+def _training_environment(ref: EnvironmentRef) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {"id": ref.id or ref.slug or ref.name}
+    _set_if(entry, "version_id", ref.version_id)
+    return entry

--- a/packages/prime-runs/src/prime_runs/backend.py
+++ b/packages/prime-runs/src/prime_runs/backend.py
@@ -387,20 +387,41 @@ class RftBackend:
         if status is RunStatus.COMPLETED:
             # Compare-and-set on the server, and "already finalized" is a
             # success, so a lost response is safe to replay.
-            self._client.post(
-                "/rft/finalize",
-                json_body={"run_id": run_id, "exit_code": 0},
-                idempotent=True,
-            )
+            try:
+                self._client.post(
+                    "/rft/finalize",
+                    json_body={"run_id": run_id, "exit_code": 0},
+                    idempotent=True,
+                )
+            except APIError as exc:
+                # Preserve TrainRun's fallback: finalization may be unavailable
+                # even though the status endpoint can still close the run out.
+                logger.warning(
+                    "Run %s could not be finalized (%s); falling back to a status update",
+                    run_id,
+                    exc,
+                )
+                self._set_terminal_status(run_id, status=status)
             return
 
         message = error or status.value
         if status is not RunStatus.FAILED:
             message = f"{status.value}: {message}"
+        self._set_terminal_status(run_id, status=status, error_message=message)
+
+    def _set_terminal_status(
+        self,
+        run_id: str,
+        *,
+        status: RunStatus,
+        error_message: Optional[str] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {"status": RFT_TERMINAL_STATUS[status]}
+        _set_if(payload, "error_message", error_message)
         try:
             self._client.put(
                 f"/rft/external-runs/{run_id}/status",
-                json_body={"status": RFT_TERMINAL_STATUS[status], "error_message": message},
+                json_body=payload,
             )
         except APIError as exc:
             if exc.status_code == 409:

--- a/packages/prime-runs/src/prime_runs/backend.py
+++ b/packages/prime-runs/src/prime_runs/backend.py
@@ -352,8 +352,10 @@ class RftBackend:
         )
 
     def attach(self, run_id: str) -> RunHandle:
-        """A handle for a run the platform already created — a managed launch
-        that injected its id. No request: the first write proves access."""
+        """A handle for a run the platform already created — a launcher that
+        injected its id. No request: the first write proves access, and it
+        must be an *external* run (``POST /rft/external-runs``): the v1
+        monitoring endpoints answer 400 for a hosted run's id."""
         return RunHandle(id=run_id, url=self.url_for(run_id))
 
     def url_for(self, run_id: str) -> str:

--- a/packages/prime-runs/src/prime_runs/models.py
+++ b/packages/prime-runs/src/prime_runs/models.py
@@ -18,8 +18,14 @@ the same object shape."""
 
 OnError = Literal["warn", "raise"]
 
-RUN_KIND = "eval"
-"""Stamped as ``run.type`` on records and sent as upload provenance."""
+RunKind = Literal["eval", "train"]
+"""What a run is: a standalone evaluation (``/api/v1/evaluations``) or an
+external training run (``/api/v1/rft/external-runs``). Stamped as ``run.type``
+on records and sent as upload provenance — the traces service's vocabulary,
+which is also what verifiers' ``EvalRunInfo`` / ``TrainRunInfo`` carry."""
+
+RUN_KIND: RunKind = "eval"
+"""The default kind."""
 
 
 class RunStatus(str, Enum):
@@ -192,6 +198,26 @@ class ConfigSource:
 
 
 @dataclass
+class TrainingSpec:
+    """What a training run is registered with, beyond what every run has
+    (``model`` is the base model, ``environments`` the training environments,
+    ``config`` the run config). All of it is for display on the dashboard.
+    ``max_steps`` is required by the platform; ``0`` means unknown."""
+
+    max_steps: int = 0
+    batch_size: Optional[int] = None
+    rollouts_per_example: Optional[int] = None
+    seq_len: Optional[int] = None
+    wandb_project: Optional[str] = None
+    wandb_entity: Optional[str] = None
+    wandb_run_name: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.max_steps < 0:
+            raise ValueError("max_steps must be non-negative")
+
+
+@dataclass
 class RunSpec:
     """Everything a backend needs to open a run: ``init()``'s arguments after
     normalization. ``config`` is the run's inputs; outputs accumulate on the
@@ -205,6 +231,8 @@ class RunSpec:
     tags: List[str] = field(default_factory=list)
     team_id: Optional[str] = None
     config: Dict[str, Any] = field(default_factory=dict)
+    kind: RunKind = RUN_KIND
+    training: Optional[TrainingSpec] = None
 
 
 @dataclass

--- a/packages/prime-runs/src/prime_runs/projection.py
+++ b/packages/prime-runs/src/prime_runs/projection.py
@@ -222,7 +222,9 @@ def train_sample_schema() -> Any:
     )
 
 
-def episodes_to_parquet_bytes(episodes: Sequence[Any], run_id: str, step: int) -> Optional[bytes]:
+def episodes_to_parquet_bytes(
+    episodes: Sequence[Any], run_id: str, step: int, *, sample_id_offset: int = 0
+) -> Optional[bytes]:
     """One training step's episodes as the viewer's Parquet table, one row per
     episode. Moved here from prime-rl's ``monitors/prime.py``.
 
@@ -231,6 +233,11 @@ def episodes_to_parquet_bytes(episodes: Sequence[Any], run_id: str, step: int) -
     one trainable trace), so a training episode and an eval sample land on the
     platform identically; the RFT-only columns (run/step/advantage/problem_id/
     env_name) are layered on here. ``None`` when no episode has a trajectory.
+
+    ``sample_id`` numbers the rows from ``sample_id_offset``: the viewer looks
+    samples up by (step, sample_id), and a step uploaded as more than one
+    object (see :mod:`prime_runs.sinks.train_samples`) needs each object to
+    number its rows in its own range.
     """
     import io
     import json
@@ -251,7 +258,7 @@ def episodes_to_parquet_bytes(episodes: Sequence[Any], run_id: str, step: int) -
 
     now = datetime.now(timezone.utc)
     rows: List[Dict[str, Any]] = []
-    for sample_id, sample in enumerate(build_samples(episodes)):
+    for sample_id, sample in enumerate(build_samples(episodes), start=sample_id_offset):
         trajectory = sample["trajectory"]
         if not trajectory:  # no branches: an episode that errored before any message
             continue

--- a/packages/prime-runs/src/prime_runs/projection.py
+++ b/packages/prime-runs/src/prime_runs/projection.py
@@ -179,3 +179,117 @@ def batch_samples(samples: Sequence[Dict[str, Any]]) -> List[List[Dict[str, Any]
     if batch:
         batches.append(batch)
     return batches
+
+
+# ------------------------------------------------------------ training table
+
+
+def parquet_available() -> bool:
+    """Whether the training sample table can be encoded (``prime-runs[train]``)."""
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def train_sample_schema() -> Any:
+    """The training sample table's Parquet schema (prime-rl's ``SAMPLE_SCHEMA``)."""
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            ("run_id", pa.string()),
+            ("step", pa.int64()),
+            ("tag", pa.string()),
+            ("problem_id", pa.int64()),
+            ("sample_id", pa.int64()),
+            ("prompt", pa.string()),
+            ("completion", pa.string()),
+            ("trajectory", pa.string()),
+            ("answer", pa.string()),
+            ("env_name", pa.string()),
+            ("task", pa.string()),
+            ("info", pa.string()),
+            ("reward", pa.float64()),
+            ("advantage", pa.float64()),
+            ("metrics", pa.string()),
+            ("timing", pa.string()),
+            ("num_input_tokens", pa.int64()),
+            ("num_output_tokens", pa.int64()),
+            ("created_at", pa.timestamp("us", tz="UTC")),
+        ]
+    )
+
+
+def episodes_to_parquet_bytes(episodes: Sequence[Any], run_id: str, step: int) -> Optional[bytes]:
+    """One training step's episodes as the viewer's Parquet table, one row per
+    episode. Moved here from prime-rl's ``monitors/prime.py``.
+
+    Sample construction is shared with the eval projection (:func:`build_samples`:
+    the complete native episode in ``info.native_wrapper``, a flat summary from
+    one trainable trace), so a training episode and an eval sample land on the
+    platform identically; the RFT-only columns (run/step/advantage/problem_id/
+    env_name) are layered on here. ``None`` when no episode has a trajectory.
+    """
+    import io
+    import json
+    from datetime import datetime, timezone
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    advantages: Dict[Any, Optional[float]] = {}
+    env_names: Dict[Any, str] = {}
+    for episode in episodes:
+        if not episode.traces:
+            continue
+        summary_trace = episode.traces[summary_trace_index(episode)]
+        advantages[episode.id] = (summary_trace.info or {}).get("advantage")
+        env = getattr(episode, "env", None)
+        env_names[episode.id] = str(getattr(env, "id", None) or "")
+
+    now = datetime.now(timezone.utc)
+    rows: List[Dict[str, Any]] = []
+    for sample_id, sample in enumerate(build_samples(episodes)):
+        trajectory = sample["trajectory"]
+        if not trajectory:  # no branches: an episode that errored before any message
+            continue
+        advantage = advantages.get(sample["episode_id"])
+        trajectory = [{**branch, "advantage": advantage} for branch in trajectory]
+        try:
+            problem_id = (
+                int(sample["example_id"]) if sample["example_id"] is not None else sample_id
+            )
+        except (TypeError, ValueError):
+            problem_id = sample_id
+        rows.append(
+            {
+                "run_id": run_id,
+                "step": step,
+                "tag": "",
+                "problem_id": problem_id,
+                "sample_id": sample_id,
+                "prompt": "",
+                "completion": json.dumps(sample["completion"]),
+                "trajectory": json.dumps(trajectory),
+                "answer": "",
+                "env_name": env_names.get(sample["episode_id"], ""),
+                "task": json.dumps(sample["task"]),
+                "info": json.dumps(sample["info"]),
+                "reward": sample["reward"],
+                "advantage": advantage,
+                "metrics": json.dumps(sample["metrics"]),
+                "timing": json.dumps(sample["timing"]),
+                "num_input_tokens": trajectory[-1]["num_input_tokens"],
+                "num_output_tokens": trajectory[-1]["num_output_tokens"],
+                "created_at": now,
+            }
+        )
+    if not rows:
+        return None
+
+    table = pa.Table.from_pylist(rows, schema=train_sample_schema())
+    buffer = io.BytesIO()
+    pq.write_table(table, buffer, compression="snappy", use_dictionary=True, write_statistics=True)
+    return buffer.getvalue()

--- a/packages/prime-runs/src/prime_runs/run.py
+++ b/packages/prime-runs/src/prime_runs/run.py
@@ -654,20 +654,41 @@ def _describe(error: Union[str, BaseException]) -> str:
     return str(error)
 
 
-def _clean_metrics(metrics: Mapping[str, Any]) -> Dict[str, Any]:
-    """Drop NaN/infinity: strict JSON rejects them, and the failure would
-    surface as an opaque 400 on the whole request."""
+def _clean_metrics(metrics: Mapping[str, Any], *, _path: str = "") -> Dict[str, Any]:
+    """Recursively drop NaN/infinity: strict JSON rejects them, and the
+    failure would surface as an opaque 400 on the whole request."""
     cleaned: Dict[str, Any] = {}
     for key, value in metrics.items():
+        path = f"{_path}.{key}" if _path else str(key)
         if isinstance(value, float) and not math.isfinite(value):
-            logger.debug("Dropping non-finite metric %s=%r", key, value)
+            logger.debug("Dropping non-finite metric %s=%r", path, value)
             continue
         if isinstance(value, Mapping):
-            nested = _clean_metrics(value)
+            nested = _clean_metrics(value, _path=path)
             if nested:
                 cleaned[key] = nested
             continue
+        if isinstance(value, (list, tuple)):
+            cleaned[key] = _clean_metric_sequence(value, path)
+            continue
         cleaned[key] = value
+    return cleaned
+
+
+def _clean_metric_sequence(values: Sequence[Any], path: str) -> List[Any]:
+    """Clean JSON-array-shaped metric values while preserving their order."""
+    cleaned: List[Any] = []
+    for index, value in enumerate(values):
+        item_path = f"{path}[{index}]"
+        if isinstance(value, float) and not math.isfinite(value):
+            logger.debug("Dropping non-finite metric %s=%r", item_path, value)
+            continue
+        if isinstance(value, Mapping):
+            cleaned.append(_clean_metrics(value, _path=item_path))
+        elif isinstance(value, (list, tuple)):
+            cleaned.append(_clean_metric_sequence(value, item_path))
+        else:
+            cleaned.append(value)
     return cleaned
 
 

--- a/packages/prime-runs/src/prime_runs/run.py
+++ b/packages/prime-runs/src/prime_runs/run.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
 from . import _fork
 from ._http import DEFAULT_TIMEOUT, UPLOAD_TIMEOUT, PlatformClient
-from .backend import Backend, DisabledBackend, EvalsBackend, disabled_run_id
+from .backend import Backend, DisabledBackend, EvalsBackend, RftBackend, disabled_run_id
 from .config import Config
 from .exceptions import ConfigurationError, RunFinishedError
 from .models import (
@@ -31,10 +31,12 @@ from .models import (
     Mode,
     OnError,
     RunHandle,
+    RunKind,
     RunSpec,
     RunStatus,
+    TrainingSpec,
 )
-from .sinks import EvalSamplesSink, Sink, TracesSink
+from .sinks import EvalSamplesSink, RftMetricsSink, RftSamplesSink, Sink, TracesSink
 from .worker import UploadWorker
 
 logger = logging.getLogger(__name__)
@@ -64,6 +66,8 @@ class Run:
         mode: Mode = "online",
         on_error: OnError = "warn",
         finish_timeout: Optional[float] = None,
+        metrics_sinks: Optional[List[Sink]] = None,
+        attached: bool = False,
     ) -> None:
         self._backend = backend
         self._handle = handle
@@ -73,6 +77,10 @@ class Run:
         self._status = RunStatus.RUNNING
         # A forked child inherits this handle but must not close the parent's run.
         self._owns_lifecycle = True
+        # A run the platform created and handed to this process (a managed
+        # launch): the platform owns its failure marking, this process only
+        # completes it.
+        self._attached = attached
 
         self.config: Dict[str, Any] = dict(spec.config)
         self.summary: Dict[str, Any] = {}
@@ -95,9 +103,14 @@ class Run:
         _fork.register(self)
 
         sinks = sinks or []
+        metrics_sinks = metrics_sinks or []
+        # Records and metrics drain on separate uploaders: a metrics dict is
+        # not a record (no sink would take both), and a slow sample upload
+        # must not hold a step's metrics behind it.
         self._worker = UploadWorker(sinks, on_error=self._record_sink_error)
+        self._metrics_worker = UploadWorker(metrics_sinks, on_error=self._record_sink_error)
         context = _sink_context(spec)
-        for sink in sinks:
+        for sink in [*sinks, *metrics_sinks]:
             try:
                 sink.start(handle.id, context)
             except Exception as exc:  # noqa: BLE001 - a bad sink is not a bad run
@@ -147,15 +160,25 @@ class Run:
         return self._finished
 
     @property
+    def kind(self) -> RunKind:
+        """``eval`` or ``train``."""
+        return self._spec.kind
+
+    @property
+    def attached(self) -> bool:
+        """Whether this process joined a run the platform had already created."""
+        return self._attached
+
+    @property
     def dropped_records(self) -> int:
-        """Records that reached no sink because the queue was full."""
-        return self._worker.dropped
+        """Records (and metrics) that reached no sink because a queue was full."""
+        return self._worker.dropped + self._metrics_worker.dropped
 
     @property
     def failed_records(self) -> Dict[str, int]:
         """Records each sink could not store, by sink name. Per sink because
         another sink may still hold them."""
-        return dict(self._worker.failed_records)
+        return {**self._worker.failed_records, **self._metrics_worker.failed_records}
 
     def __repr__(self) -> str:
         return f"<Run id={self.id!r} mode={self._mode!r} status={self._status.value}>"
@@ -184,6 +207,24 @@ class Run:
         """
         self._submit("log_episodes", episodes)
 
+    def log_metrics(self, values: Mapping[str, Any], *, step: Optional[int] = None) -> None:
+        """Hand one step's metrics to the run. Returns immediately.
+
+        Training runs only (an eval run has no metrics sink; the call is a
+        no-op there). ``step`` is recorded as ``values["step"]`` unless the
+        mapping already carries one; every row is stamped with ``_timestamp``
+        so step-less rows (inference metrics) keep a time anchor. Non-finite
+        numbers are dropped, as they are for :meth:`update_summary`.
+        """
+        self._require_live("log_metrics")
+        record = _clean_metrics(values)
+        if step is not None:
+            record.setdefault("step", step)
+        record.setdefault("_timestamp", time.time())
+        with self._state_lock:
+            self._require_live("log_metrics")
+            self._metrics_worker.submit([record])
+
     def _submit(self, operation: str, records: Iterable[Any]) -> None:
         # Refuse an already-finished run without consuming a lazy iterable.
         self._require_live(operation)
@@ -209,7 +250,13 @@ class Run:
     def flush(self, timeout: Optional[float] = 30.0) -> bool:
         """Block until queued records have been written. Under
         ``on_error="raise"`` this is the first place an upload failure surfaces."""
-        flushed = self._worker.flush(timeout=timeout)
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
+
+        def remaining() -> Optional[float]:
+            return None if deadline is None else max(0.0, deadline - time.monotonic())
+
+        flushed = self._worker.flush(timeout=remaining())
+        flushed = self._metrics_worker.flush(timeout=remaining()) and flushed
         self._raise_deferred()
         return flushed
 
@@ -266,7 +313,9 @@ class Run:
 
         # Records first, so a dashboard reacting to the terminal status never
         # sees a finished run with samples still landing.
-        if not self._worker.flush(timeout=remaining()):
+        drained = self._worker.flush(timeout=remaining())
+        drained = self._metrics_worker.flush(timeout=remaining()) and drained
+        if not drained:
             logger.warning(
                 "Run %s: uploads did not drain within %ss; finalizing anyway. "
                 "Some records may be missing from this run.",
@@ -274,6 +323,7 @@ class Run:
                 budget,
             )
         self._worker.close(timeout=remaining())
+        self._metrics_worker.close(timeout=remaining())
 
         if self._owns_lifecycle:
             self._teardown_step(
@@ -282,27 +332,37 @@ class Run:
                     self.id, config=self.config or None, summary=self.summary or None
                 ),
             )
-            self._teardown_step(
-                "finalizing the run",
-                lambda: self._backend.finalize(
+            if self._attached and resolved is not RunStatus.COMPLETED:
+                # A managed launch marks its own run failed when this process
+                # goes away; reporting it from here would race that.
+                logger.info(
+                    "Run %s: %s, but the platform owns the status of an attached run; "
+                    "leaving it to the launcher",
                     self.id,
-                    status=resolved,
-                    summary=self.summary or None,
-                    error=error or (self.errors[0] if self.errors else None),
-                    config=self.config or None,
-                ),
-            )
+                    resolved.value,
+                )
+            else:
+                self._teardown_step(
+                    "finalizing the run",
+                    lambda: self._backend.finalize(
+                        self.id,
+                        status=resolved,
+                        summary=self.summary or None,
+                        error=error or (self.errors[0] if self.errors else None),
+                        config=self.config or None,
+                    ),
+                )
         self._teardown_step("closing the backend", self._backend.close)
         atexit.unregister(self._atexit_hook)
 
-        if self._worker.dropped:
+        if self.dropped_records:
             logger.warning(
                 "Run %s finished with %d record(s) that reached no sink; the producer "
                 "outran the uploader.",
                 self.id,
-                self._worker.dropped,
+                self.dropped_records,
             )
-        for sink_name, count in self._worker.failed_records.items():
+        for sink_name, count in self.failed_records.items():
             logger.warning(
                 "Run %s: the %s sink could not store %d record(s)", self.id, sink_name, count
             )
@@ -423,6 +483,9 @@ def init(
     base_url: Optional[str] = None,
     on_error: OnError = "warn",
     finish_timeout: Optional[float] = None,
+    kind: RunKind = "eval",
+    id: Optional[str] = None,
+    training: Optional[TrainingSpec] = None,
 ) -> Run:
     """Start a run and return a handle to it.
 
@@ -436,11 +499,28 @@ def init(
     ``finish_timeout`` is how long :meth:`Run.finish` lets queued uploads drain
     before closing the run out anyway (default: the upload timeout, 300 s);
     ``finish(timeout=...)`` overrides it per call.
+
+    ``kind="train"`` opens an external training run instead of an evaluation:
+    ``model`` is the base model, ``environments`` the training environments
+    (hub ids, passed through), ``training`` the rest of what the dashboard
+    shows, and a team is required. ``id`` attaches to a training run the
+    platform already created (a managed launch that injected ``$RUN_ID``):
+    nothing is registered, the platform keeps ownership of the run's failure
+    marking, and a clean :meth:`Run.finish` still completes it.
     """
     settings = Config()
     api_key = api_key if api_key is not None else settings.api_key
     base_url = base_url or settings.base_url
     team_id = team_id if team_id is not None else settings.team_id
+
+    if kind not in ("eval", "train"):
+        raise ConfigurationError(f"kind={kind!r} is not one of 'eval' or 'train'")
+    if id is not None and kind != "train":
+        raise ConfigurationError(
+            "id= attaches to an existing training run; an eval run is always created here."
+        )
+    if training is not None and kind != "train":
+        raise ConfigurationError("training= only applies to kind='train'")
 
     spec = RunSpec(
         name=name,
@@ -451,14 +531,18 @@ def init(
         tags=list(tags or []),
         team_id=team_id,
         config=_normalize_config(config),
+        kind=kind,
+        training=training,
     )
     resolved_mode = _resolve_mode(mode, api_key=api_key)
 
     backend: Backend
     sinks: List[Sink]
+    metrics_sinks: List[Sink] = []
+    attached = False
     if resolved_mode == "disabled":
         backend = DisabledBackend()
-        handle = RunHandle(id=disabled_run_id(), name=name)
+        handle = RunHandle(id=id or disabled_run_id(), name=name)
         sinks = []
     else:
         if not api_key:
@@ -467,9 +551,17 @@ def init(
                 'or pass mode="disabled".'
             )
         client = PlatformClient(api_key=api_key, base_url=base_url, timeout=DEFAULT_TIMEOUT)
-        backend = EvalsBackend(client, frontend_url=settings.frontend_url, team_id=team_id)
+        if kind == "train":
+            rft = RftBackend(client, frontend_url=settings.frontend_url, team_id=team_id)
+            backend = rft
+        else:
+            backend = EvalsBackend(client, frontend_url=settings.frontend_url, team_id=team_id)
         try:
-            handle = backend.create(spec)
+            if kind == "train" and id is not None:
+                handle = rft.attach(id)
+                attached = True
+            else:
+                handle = backend.create(spec)
         except BaseException:
             # Ownership has not reached a Run yet, so nothing else can release
             # the connection pool when environment resolution or creation fails.
@@ -483,7 +575,12 @@ def init(
             raise
         # Both transports run during the transition: traces is the system of
         # record, the sample table is what today's viewer reads.
-        sinks = [TracesSink(api_key=api_key, team_id=team_id), EvalSamplesSink(client)]
+        traces = TracesSink(api_key=api_key, team_id=team_id)
+        if kind == "train":
+            sinks = [traces, RftSamplesSink(client)]
+            metrics_sinks = [RftMetricsSink(client)]
+        else:
+            sinks = [traces, EvalSamplesSink(client)]
 
     run = Run(
         backend=backend,
@@ -493,6 +590,8 @@ def init(
         mode=resolved_mode,
         on_error=on_error,
         finish_timeout=finish_timeout,
+        metrics_sinks=metrics_sinks,
+        attached=attached,
     )
     if run.url:
         logger.info("Run %s: %s", run.id, run.url)
@@ -521,7 +620,7 @@ def _resolve_mode(mode: Optional[Mode], *, api_key: str) -> Mode:
 def _sink_context(spec: RunSpec) -> Dict[str, str]:
     """Upload-scoped provenance. Not the join key — that is ``run.id`` inside
     the trace document."""
-    context = {"source": "prime-runs", "run_type": RUN_KIND}
+    context = {"source": "prime-runs", "run_type": spec.kind or RUN_KIND}
     if spec.framework:
         context["framework"] = spec.framework
     if spec.model:

--- a/packages/prime-runs/src/prime_runs/run.py
+++ b/packages/prime-runs/src/prime_runs/run.py
@@ -46,6 +46,11 @@ MODE_ENV = "PRIME_RUNS_MODE"
 #: Derived from the upload timeout: a single in-flight sample POST may take
 #: this long, and a shorter budget would abandon an upload about to succeed.
 DEFAULT_FINISH_TIMEOUT = float(UPLOAD_TIMEOUT.read or 300.0)
+#: A training run lasts days and a platform deploy lasts minutes: a training
+#: sink that struck out on transient failures is tried again after this many
+#: seconds instead of being retired for the rest of the run. Eval runs are
+#: minutes long and keep the permanent retirement.
+TRAIN_RETIRE_COOLDOWN = 300.0
 
 
 class Run:
@@ -68,6 +73,7 @@ class Run:
         finish_timeout: Optional[float] = None,
         metrics_sinks: Optional[List[Sink]] = None,
         attached: bool = False,
+        retire_cooldown: Optional[float] = None,
     ) -> None:
         self._backend = backend
         self._handle = handle
@@ -107,8 +113,12 @@ class Run:
         # Records and metrics drain on separate uploaders: a metrics dict is
         # not a record (no sink would take both), and a slow sample upload
         # must not hold a step's metrics behind it.
-        self._worker = UploadWorker(sinks, on_error=self._record_sink_error)
-        self._metrics_worker = UploadWorker(metrics_sinks, on_error=self._record_sink_error)
+        self._worker = UploadWorker(
+            sinks, on_error=self._record_sink_error, retire_cooldown=retire_cooldown
+        )
+        self._metrics_worker = UploadWorker(
+            metrics_sinks, on_error=self._record_sink_error, retire_cooldown=retire_cooldown
+        )
         context = _sink_context(spec)
         for sink in [*sinks, *metrics_sinks]:
             try:
@@ -504,9 +514,13 @@ def init(
     ``model`` is the base model, ``environments`` the training environments
     (hub ids, passed through), ``training`` the rest of what the dashboard
     shows, and a team is required. ``id`` attaches to a training run the
-    platform already created (a managed launch that injected ``$RUN_ID``):
-    nothing is registered, the platform keeps ownership of the run's failure
-    marking, and a clean :meth:`Run.finish` still completes it.
+    platform already created (a launcher that injected ``$RUN_ID``): nothing
+    is registered, the platform keeps ownership of the run's failure marking,
+    and a clean :meth:`Run.finish` still completes it. The run must itself be
+    an external run — one created through ``POST /rft/external-runs`` — since
+    the platform's monitoring endpoints answer 400 for a hosted (managed) run.
+    Training sinks that strike out on transient failures are tried again after
+    ``TRAIN_RETIRE_COOLDOWN`` seconds rather than retired for the run.
     """
     settings = Config()
     api_key = api_key if api_key is not None else settings.api_key
@@ -592,6 +606,7 @@ def init(
         finish_timeout=finish_timeout,
         metrics_sinks=metrics_sinks,
         attached=attached,
+        retire_cooldown=TRAIN_RETIRE_COOLDOWN if kind == "train" else None,
     )
     if run.url:
         logger.info("Run %s: %s", run.id, run.url)

--- a/packages/prime-runs/src/prime_runs/sinks/__init__.py
+++ b/packages/prime-runs/src/prime_runs/sinks/__init__.py
@@ -1,8 +1,10 @@
 """Record transports. Independent of backends, and of each other."""
 
 from .base import Sink, is_episode, stamp_run, to_mapping
+from .metrics import RftMetricsSink
 from .samples import EvalSamplesSink
 from .traces import TracesSink
+from .train_samples import RftSamplesSink, training_step
 
 __all__ = [
     "Sink",
@@ -10,5 +12,8 @@ __all__ = [
     "stamp_run",
     "to_mapping",
     "EvalSamplesSink",
+    "RftMetricsSink",
+    "RftSamplesSink",
     "TracesSink",
+    "training_step",
 ]

--- a/packages/prime-runs/src/prime_runs/sinks/base.py
+++ b/packages/prime-runs/src/prime_runs/sinks/base.py
@@ -25,8 +25,7 @@ class SinkWriteError(Exception):
         self.cause = cause
         self.failed_records = failed_records
         super().__init__(
-            f"{failed_records} record(s) were not fully stored: "
-            f"{type(cause).__name__}: {cause}"
+            f"{failed_records} record(s) were not fully stored: {type(cause).__name__}: {cause}"
         )
 
 
@@ -74,7 +73,7 @@ def is_episode(record: Any) -> bool:
     return hasattr(record, "traces")
 
 
-def stamp_run(mapping: Mapping[str, Any], run_id: str) -> Dict[str, Any]:
+def stamp_run(mapping: Mapping[str, Any], run_id: str, run_type: str = RUN_KIND) -> Dict[str, Any]:
     """A copy of ``mapping`` carrying ``run`` at the top level, and on every
     member trace of an episode that lacks one.
 
@@ -86,7 +85,7 @@ def stamp_run(mapping: Mapping[str, Any], run_id: str) -> Dict[str, Any]:
     """
     stamped = dict(mapping)
     if not stamped.get("run"):
-        stamped["run"] = {"id": run_id, "type": RUN_KIND}
+        stamped["run"] = {"id": run_id, "type": run_type}
     members = stamped.get("traces")
     if isinstance(members, list):
         run = stamped["run"]

--- a/packages/prime-runs/src/prime_runs/sinks/metrics.py
+++ b/packages/prime-runs/src/prime_runs/sinks/metrics.py
@@ -4,6 +4,10 @@ The RFT metrics endpoint takes a single step's metrics per request, so a
 coalesced batch costs one request per record. The platform allows 60 a minute
 per token; a 429 is retried with the server's ``Retry-After`` before it counts
 as a strike.
+
+Requests are replayed after an ambiguous failure (a 502/504, a read timeout):
+the platform keeps one row per step, so a duplicate collapses on its side,
+while a lost row is a hole in the training curves for good.
 """
 
 import logging
@@ -45,10 +49,12 @@ class RftMetricsSink(Sink):
                     reported = TypeError(f"metrics must be a mapping, got {type(record).__name__}")
                 continue
             try:
-                # Appends a row; a lost response is not replayed (the POST default).
+                # Replayable: the platform merges rows by step, so a retry after
+                # a lost response cannot duplicate anything visible.
                 self._client.post(
                     "/rft/metrics",
                     json_body={"run_id": self._run_id, "metrics": dict(record)},
+                    idempotent=True,
                 )
             except Exception as exc:  # noqa: BLE001 - classified below
                 failed += 1

--- a/packages/prime-runs/src/prime_runs/sinks/metrics.py
+++ b/packages/prime-runs/src/prime_runs/sinks/metrics.py
@@ -1,0 +1,73 @@
+"""Training metrics sink: one ``POST /rft/metrics`` per logged step.
+
+The RFT metrics endpoint takes a single step's metrics per request, so a
+coalesced batch costs one request per record. The platform allows 60 a minute
+per token; a 429 is retried with the server's ``Retry-After`` before it counts
+as a strike.
+"""
+
+import logging
+from typing import Any, Mapping, Optional, Sequence
+
+from .._http import PlatformClient
+from ..exceptions import is_record_rejection, is_transient
+from .base import Sink, SinkWriteError
+
+logger = logging.getLogger(__name__)
+
+
+class RftMetricsSink(Sink):
+    """Posts per-step metrics dicts to the RFT metrics endpoint."""
+
+    name = "rft_metrics"
+
+    def __init__(self, client: PlatformClient) -> None:
+        self.enabled = True
+        self._client = client
+        self._run_id: Optional[str] = None
+        self.steps_written = 0
+
+    def start(self, run_id: str, context: Mapping[str, str]) -> None:
+        self._run_id = run_id
+
+    def write(self, records: Sequence[Any]) -> None:
+        if not self.enabled or not records:
+            return
+        if self._run_id is None:
+            raise RuntimeError("RftMetricsSink.write called before start()")
+
+        failed = 0
+        reported: Optional[Exception] = None
+        for index, record in enumerate(records):
+            if not isinstance(record, Mapping):
+                failed += 1
+                if reported is None:
+                    reported = TypeError(f"metrics must be a mapping, got {type(record).__name__}")
+                continue
+            try:
+                # Appends a row; a lost response is not replayed (the POST default).
+                self._client.post(
+                    "/rft/metrics",
+                    json_body={"run_id": self._run_id, "metrics": dict(record)},
+                )
+            except Exception as exc:  # noqa: BLE001 - classified below
+                failed += 1
+                if not (is_record_rejection(exc) or is_transient(exc)):
+                    # Sink-wide: the rest would fail the same way.
+                    failed += len(records) - index - 1
+                    reported = exc
+                    break
+                # Prefer a transient error for the worker's strike accounting.
+                if reported is None or is_transient(exc):
+                    reported = exc
+            else:
+                self.steps_written += 1
+
+        if reported is not None:
+            raise SinkWriteError(reported, failed_records=failed) from reported
+
+    def flush(self) -> None:
+        """Writes are synchronous; the uploader thread owns the asynchrony."""
+
+    def close(self) -> None:
+        """The client is shared with the backend, which closes it."""

--- a/packages/prime-runs/src/prime_runs/sinks/samples.py
+++ b/packages/prime-runs/src/prime_runs/sinks/samples.py
@@ -86,9 +86,7 @@ class EvalSamplesSink(Sink):
                 reported_error, failed_records=len(failed_owners)
             ) from reported_error
 
-    def _to_samples(
-        self, records: Sequence[Any]
-    ) -> Tuple[List[Dict[str, Any]], List[int]]:
+    def _to_samples(self, records: Sequence[Any]) -> Tuple[List[Dict[str, Any]], List[int]]:
         """Episode objects are projected; v0 sample dicts (``sample_id``) pass
         through. Anything else — a JSON episode, a bare trace — has no v0
         projection (it is attribute-based, see :mod:`prime_runs.projection`)

--- a/packages/prime-runs/src/prime_runs/sinks/traces.py
+++ b/packages/prime-runs/src/prime_runs/sinks/traces.py
@@ -14,6 +14,7 @@ from prime_traces import ErrorCode, LineFormat, TracesClient
 
 from .. import _fork
 from ..exceptions import ForbiddenError
+from ..models import RUN_KIND
 from .base import Sink, is_episode, stamp_run, to_mapping
 
 logger = logging.getLogger(__name__)
@@ -127,7 +128,7 @@ class TracesSink(Sink):
         but the members are reachable for stamping."""
         if self._run_id is None:
             return record
-        return stamp_run(to_mapping(record), self._run_id)
+        return stamp_run(to_mapping(record), self._run_id, self._context.get("run_type", RUN_KIND))
 
     def flush(self) -> None:
         """Uploads are synchronous; nothing is held back here."""

--- a/packages/prime-runs/src/prime_runs/sinks/train_samples.py
+++ b/packages/prime-runs/src/prime_runs/sinks/train_samples.py
@@ -22,6 +22,7 @@ Log a step in one call to keep it to one object.
 """
 
 import logging
+import secrets
 import time
 from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
 
@@ -47,10 +48,16 @@ DEFAULT_STEP_INTERVAL = 10
 #: Attempts for the object-storage PUT, which is idempotent.
 UPLOAD_ATTEMPTS = 3
 
-#: ``sample_id`` ranges are ``upload_index * SAMPLE_ID_STRIDE``: the first
-#: object for a step numbers its rows from 0 (what a single-object step always
-#: did), a straggler object from 2**32, and so on. No object holds that many rows.
+#: ``sample_id = range * SAMPLE_ID_STRIDE + row``. In the process that opened
+#: the run the range is the step's upload index: the first object numbers its
+#: rows from 0 (what a single-object step always did), a straggler object from
+#: 2**32, and so on; no object holds 2**32 rows. A forked child inherits a copy
+#: of those counters and would hand out the same ranges as its parent, so it
+#: draws its ranges at random from the upper half of the range space instead,
+#: which the parent's counter never reaches. Every id stays below 2**53: the
+#: viewer parses ``sample_id`` as a JSON number.
 SAMPLE_ID_STRIDE = 1 << 32
+SAMPLE_ID_RANGES = 1 << 21
 
 
 class Encoder(Protocol):
@@ -110,6 +117,8 @@ class RftSamplesSink(Sink):
         self.sampled_out = 0
         #: Uploads attempted per step; each numbers its rows in its own range.
         self._uploads_per_step: Dict[int, int] = {}
+        #: A forked child cannot share the parent's counters; see SAMPLE_ID_RANGES.
+        self._forked = False
         _fork.register(self)
 
     # ------------------------------------------------------------------ setup
@@ -117,11 +126,14 @@ class RftSamplesSink(Sink):
     def reset_after_fork(self) -> None:
         """Drop (not close) the inherited storage client: its socket is the
         parent's. An owned client is rebuilt on the next upload; an injected
-        one cannot be, so the child's uploads fail rather than share it."""
+        one cannot be, so the child's uploads fail rather than share it. The
+        inherited upload counters are the parent's too: from here on ranges
+        are drawn at random, apart from anything the parent hands out."""
         if self._owns_upload_client:
             self._upload_client = None
         else:
             self._forked_with_injected_client = True
+        self._forked = True
 
     def start(self, run_id: str, context: Mapping[str, str]) -> None:
         self._run_id = run_id
@@ -201,13 +213,11 @@ class RftSamplesSink(Sink):
         assert self._encoder is not None and self._run_id is not None
         # Every upload of a step numbers its rows in its own range, counted by
         # attempt: an upload whose confirm was lost may still have landed.
-        upload_index = self._uploads_per_step.get(step, 0)
         payload = self._encoder(
-            episodes, self._run_id, step, sample_id_offset=upload_index * SAMPLE_ID_STRIDE
+            episodes, self._run_id, step, sample_id_offset=self._next_range(step) * SAMPLE_ID_STRIDE
         )
         if payload is None:
             return False
-        self._uploads_per_step[step] = upload_index + 1
 
         # Replayable: a presign only mints a URL.
         presign = self._client.post(
@@ -234,6 +244,15 @@ class RftSamplesSink(Sink):
             idempotent=True,
         )
         return True
+
+    def _next_range(self, step: int) -> int:
+        """The ``sample_id`` range for the next upload of ``step``."""
+        if self._forked:
+            half = SAMPLE_ID_RANGES // 2
+            return half + secrets.randbelow(half)
+        upload_index = self._uploads_per_step.get(step, 0)
+        self._uploads_per_step[step] = upload_index + 1
+        return upload_index
 
     def _put_object(self, url: str, payload: bytes) -> None:
         """PUT the object to storage. Bare client: the presigned URL carries its

--- a/packages/prime-runs/src/prime_runs/sinks/train_samples.py
+++ b/packages/prime-runs/src/prime_runs/sinks/train_samples.py
@@ -1,0 +1,238 @@
+"""Training samples sink: the step-keyed Parquet table the training viewer reads.
+
+What prime-rl's ``TrainRun.upload_samples`` did, in the SDK: for each training
+step, encode the step's episodes to one Parquet object and send it through the
+platform's presign -> PUT to object storage -> confirm flow. Like the eval
+samples sink this serves *today's* viewer; Prime Traces is the system of record
+and this sink leaves the default list once the viewer reads traces natively.
+
+Which episodes to upload is read off the records: a verifiers episode carries
+``run.work`` (``TrainWorkInfo(step=...)``) once its producer has stamped it, and
+prime-rl stamps every dispatched episode. Episodes from eval work, bare traces
+and JSON episodes have no row here and go to Prime Traces only.
+"""
+
+import logging
+import time
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import httpx
+from prime_traces.core.client import retry_delay
+
+from .._http import UPLOAD_TIMEOUT, PlatformClient
+from ..exceptions import (
+    APIError,
+    RetryableAPIError,
+    TransportError,
+    is_record_rejection,
+    is_transient,
+)
+from .base import Sink, SinkWriteError, is_episode
+
+logger = logging.getLogger(__name__)
+
+#: Upload every Nth training step (prime-rl's cadence, chosen so the sample
+#: table does not receive every rollout of every step).
+DEFAULT_STEP_INTERVAL = 10
+#: Attempts for the object-storage PUT, which is idempotent.
+UPLOAD_ATTEMPTS = 3
+
+Encoder = Callable[[Sequence[Any], str, int], Optional[bytes]]
+"""``(episodes, run_id, step) -> parquet bytes``, or ``None`` when there is
+nothing to upload for the step."""
+
+
+def _field(obj: Any, name: str) -> Any:
+    return obj.get(name) if isinstance(obj, Mapping) else getattr(obj, name, None)
+
+
+def training_step(record: Any) -> Optional[int]:
+    """The training step an episode was dispatched at, from its ``run.work``
+    (verifiers ``TrainRunInfo`` / ``TrainWorkInfo``). ``None`` for anything
+    else: eval work, a record without provenance, a bare trace."""
+    run = _field(record, "run")
+    work = _field(run, "work") if run is not None else None
+    if _field(run, "type") != "train" or _field(work, "type") != "train":
+        return None
+    step = _field(work, "step")
+    return step if isinstance(step, int) and not isinstance(step, bool) else None
+
+
+class RftSamplesSink(Sink):
+    """Encodes each training step's episodes to Parquet and uploads it."""
+
+    name = "rft_samples"
+
+    def __init__(
+        self,
+        client: PlatformClient,
+        *,
+        encoder: Optional[Encoder] = None,
+        step_interval: int = DEFAULT_STEP_INTERVAL,
+        upload_client: Optional[httpx.Client] = None,
+    ) -> None:
+        if step_interval < 1:
+            raise ValueError("step_interval must be at least 1")
+        self.enabled = True
+        self._client = client
+        self._encoder = encoder
+        self._step_interval = step_interval
+        self._upload_client = upload_client
+        self._owns_upload_client = upload_client is None
+        self._run_id: Optional[str] = None
+        self.steps_written = 0
+        #: Records with no row in this table (eval work, bare traces, JSON).
+        self.skipped = 0
+        #: Training episodes left out by the step cadence. Not a loss.
+        self.sampled_out = 0
+
+    # ------------------------------------------------------------------ setup
+
+    def start(self, run_id: str, context: Mapping[str, str]) -> None:
+        self._run_id = run_id
+        if self._encoder is None:
+            from ..projection import episodes_to_parquet_bytes, parquet_available
+
+            if not parquet_available():
+                # Not a failure: nothing was lost, the episodes still reach
+                # Prime Traces. Say once how to turn the table on.
+                logger.warning(
+                    "Training samples sink off: pyarrow is not installed "
+                    "(pip install 'prime-runs[train]'); episodes reach Prime Traces only"
+                )
+                self.enabled = False
+                return
+            self._encoder = episodes_to_parquet_bytes
+
+    # ------------------------------------------------------------------ write
+
+    def write(self, records: Sequence[Any]) -> None:
+        if not self.enabled or not records:
+            return
+        if self._run_id is None:
+            raise RuntimeError("RftSamplesSink.write called before start()")
+        assert self._encoder is not None  # start() set it or disabled the sink
+
+        steps = self._group(records)
+        failed = 0
+        reported: Optional[Exception] = None
+        for position, (step, episodes) in enumerate(steps):
+            try:
+                uploaded = self._upload_step(step, episodes)
+            except Exception as exc:  # noqa: BLE001 - classified below
+                failed += len(episodes)
+                if not (is_record_rejection(exc) or is_transient(exc)):
+                    # Sink-wide: the remaining steps would fail the same way.
+                    failed += sum(len(rest) for _, rest in steps[position + 1 :])
+                    reported = exc
+                    break
+                if reported is None or is_transient(exc):
+                    reported = exc
+            else:
+                if uploaded:
+                    self.steps_written += 1
+
+        if reported is not None:
+            raise SinkWriteError(reported, failed_records=failed) from reported
+
+    def _group(self, records: Sequence[Any]) -> List[Tuple[int, List[Any]]]:
+        """Training episodes by step, on the upload cadence, in step order."""
+        by_step: Dict[int, List[Any]] = {}
+        skipped = 0
+        for record in records:
+            step = training_step(record)
+            # The encoder projects attributes (``build_samples``), so a JSON
+            # episode has no row here either.
+            if step is None or isinstance(record, Mapping) or not is_episode(record):
+                skipped += 1
+                continue
+            if step % self._step_interval:
+                self.sampled_out += 1
+                continue
+            by_step.setdefault(step, []).append(record)
+        if skipped:
+            if not self.skipped:
+                logger.info(
+                    "The training sample table holds training-work episodes only; %d "
+                    "record(s) in this batch have no row there and reach Prime Traces only.",
+                    skipped,
+                )
+            self.skipped += skipped
+        return sorted(by_step.items())
+
+    def _upload_step(self, step: int, episodes: List[Any]) -> bool:
+        """Encode and upload one step. ``False`` when the step had nothing to
+        show (no trajectories) and no request was made."""
+        assert self._encoder is not None and self._run_id is not None
+        payload = self._encoder(episodes, self._run_id, step)
+        if payload is None:
+            return False
+
+        # Replayable: a presign only mints a URL.
+        presign = self._client.post(
+            "/rft/samples/presign",
+            json_body={"run_id": self._run_id, "step": step},
+            idempotent=True,
+        )
+        data = presign.get("data") or presign
+        url = data.get("presignedUrl") or data.get("presigned_url")
+        key = data.get("s3Key") or data.get("s3_key")
+        if not url or not key:
+            raise APIError(
+                f"POST /rft/samples/presign returned no upload URL/key (keys: {sorted(data)})"
+            )
+
+        self._put_object(url, payload)
+
+        # Records the object under the step. A lost response is not replayed:
+        # the platform may have taken the first confirm.
+        self._client.post(
+            "/rft/samples/confirm",
+            json_body={"run_id": self._run_id, "step": step, "s3_key": key},
+        )
+        return True
+
+    def _put_object(self, url: str, payload: bytes) -> None:
+        """PUT the object to storage. Bare client: the presigned URL carries its
+        own credentials and rejects the platform's auth headers. Idempotent, so
+        transport failures and 5xx are retried."""
+        client = self._upload()
+        for attempt in range(UPLOAD_ATTEMPTS):
+            error: APIError
+            try:
+                response = client.put(
+                    url,
+                    content=payload,
+                    headers={"Content-Type": "application/parquet"},
+                    timeout=UPLOAD_TIMEOUT,
+                )
+            except httpx.RequestError as exc:
+                error = TransportError(f"uploading samples failed: {type(exc).__name__}: {exc}")
+            else:
+                if response.is_success:
+                    return
+                message = f"uploading samples failed: HTTP {response.status_code}"
+                if response.status_code >= 500 or response.status_code == 429:
+                    error = RetryableAPIError(message, status_code=response.status_code)
+                else:
+                    raise APIError(message, status_code=response.status_code)
+            if attempt == UPLOAD_ATTEMPTS - 1:
+                raise error
+            time.sleep(retry_delay(error, attempt))
+
+    def _upload(self) -> httpx.Client:
+        if self._upload_client is None:
+            self._upload_client = httpx.Client(follow_redirects=False)
+        return self._upload_client
+
+    def flush(self) -> None:
+        """Uploads are synchronous; nothing is held back here."""
+
+    def close(self) -> None:
+        client = self._upload_client
+        self._upload_client = None
+        if client is not None and self._owns_upload_client:
+            try:
+                client.close()
+            except Exception as exc:  # noqa: BLE001 - teardown must not raise
+                logger.debug("Error closing the upload client: %s", exc)

--- a/packages/prime-runs/src/prime_runs/sinks/train_samples.py
+++ b/packages/prime-runs/src/prime_runs/sinks/train_samples.py
@@ -10,6 +10,11 @@ Which episodes to upload is read off the records: a verifiers episode carries
 ``run.work`` (``TrainWorkInfo(step=...)``) once its producer has stamped it, and
 prime-rl stamps every dispatched episode. Episodes from eval work, bare traces
 and JSON episodes have no row here and go to Prime Traces only.
+
+One object per step: the platform records a single object key per (run, step),
+so a step's episodes must arrive in one ``log_episodes`` call — prime-rl hands
+over a whole step at a time. Logging a step in pieces would leave the table
+with the last piece only (the traces sink is unaffected).
 """
 
 import logging
@@ -19,6 +24,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 import httpx
 from prime_traces.core.client import retry_delay
 
+from .. import _fork
 from .._http import UPLOAD_TIMEOUT, PlatformClient
 from ..exceptions import (
     APIError,
@@ -79,14 +85,26 @@ class RftSamplesSink(Sink):
         self._step_interval = step_interval
         self._upload_client = upload_client
         self._owns_upload_client = upload_client is None
+        # An inherited socket belongs to the parent; see reset_after_fork.
+        self._forked_with_injected_client = False
         self._run_id: Optional[str] = None
         self.steps_written = 0
         #: Records with no row in this table (eval work, bare traces, JSON).
         self.skipped = 0
         #: Training episodes left out by the step cadence. Not a loss.
         self.sampled_out = 0
+        _fork.register(self)
 
     # ------------------------------------------------------------------ setup
+
+    def reset_after_fork(self) -> None:
+        """Drop (not close) the inherited storage client: its socket is the
+        parent's. An owned client is rebuilt on the next upload; an injected
+        one cannot be, so the child's uploads fail rather than share it."""
+        if self._owns_upload_client:
+            self._upload_client = None
+        else:
+            self._forked_with_injected_client = True
 
     def start(self, run_id: str, context: Mapping[str, str]) -> None:
         self._run_id = run_id
@@ -221,6 +239,8 @@ class RftSamplesSink(Sink):
             time.sleep(retry_delay(error, attempt))
 
     def _upload(self) -> httpx.Client:
+        if self._forked_with_injected_client:
+            raise RuntimeError("an injected upload client cannot be reused after a fork")
         if self._upload_client is None:
             self._upload_client = httpx.Client(follow_redirects=False)
         return self._upload_client

--- a/packages/prime-runs/src/prime_runs/sinks/train_samples.py
+++ b/packages/prime-runs/src/prime_runs/sinks/train_samples.py
@@ -11,15 +11,19 @@ Which episodes to upload is read off the records: a verifiers episode carries
 prime-rl stamps every dispatched episode. Episodes from eval work, bare traces
 and JSON episodes have no row here and go to Prime Traces only.
 
-One object per step: the platform records a single object key per (run, step),
-so a step's episodes must arrive in one ``log_episodes`` call — prime-rl hands
-over a whole step at a time. Logging a step in pieces would leave the table
-with the last piece only (the traces sink is unaffected).
+Objects are additive per step: every upload mints its own
+``step_{step}_{uuid}.parquet`` key and the viewer unions every object under a
+step, so a step's episodes may arrive across several ``log_episodes`` calls —
+prime-rl hands over a step's batch at ship time, and an off-policy episode
+dispatched at step N can land in a later batch. Each call becomes one more
+object; ``sample_id`` is numbered from a per-upload offset so (step,
+sample_id), which the viewer looks samples up by, stays unique across them.
+Log a step in one call to keep it to one object.
 """
 
 import logging
 import time
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
 
 import httpx
 from prime_traces.core.client import retry_delay
@@ -43,9 +47,20 @@ DEFAULT_STEP_INTERVAL = 10
 #: Attempts for the object-storage PUT, which is idempotent.
 UPLOAD_ATTEMPTS = 3
 
-Encoder = Callable[[Sequence[Any], str, int], Optional[bytes]]
-"""``(episodes, run_id, step) -> parquet bytes``, or ``None`` when there is
-nothing to upload for the step."""
+#: ``sample_id`` ranges are ``upload_index * SAMPLE_ID_STRIDE``: the first
+#: object for a step numbers its rows from 0 (what a single-object step always
+#: did), a straggler object from 2**32, and so on. No object holds that many rows.
+SAMPLE_ID_STRIDE = 1 << 32
+
+
+class Encoder(Protocol):
+    """``(episodes, run_id, step, sample_id_offset=...) -> parquet bytes``, or
+    ``None`` when there is nothing to upload for the step. Rows are numbered
+    from ``sample_id_offset``."""
+
+    def __call__(
+        self, episodes: Sequence[Any], run_id: str, step: int, *, sample_id_offset: int = 0
+    ) -> Optional[bytes]: ...
 
 
 def _field(obj: Any, name: str) -> Any:
@@ -93,6 +108,8 @@ class RftSamplesSink(Sink):
         self.skipped = 0
         #: Training episodes left out by the step cadence. Not a loss.
         self.sampled_out = 0
+        #: Uploads attempted per step; each numbers its rows in its own range.
+        self._uploads_per_step: Dict[int, int] = {}
         _fork.register(self)
 
     # ------------------------------------------------------------------ setup
@@ -182,9 +199,15 @@ class RftSamplesSink(Sink):
         """Encode and upload one step. ``False`` when the step had nothing to
         show (no trajectories) and no request was made."""
         assert self._encoder is not None and self._run_id is not None
-        payload = self._encoder(episodes, self._run_id, step)
+        # Every upload of a step numbers its rows in its own range, counted by
+        # attempt: an upload whose confirm was lost may still have landed.
+        upload_index = self._uploads_per_step.get(step, 0)
+        payload = self._encoder(
+            episodes, self._run_id, step, sample_id_offset=upload_index * SAMPLE_ID_STRIDE
+        )
         if payload is None:
             return False
+        self._uploads_per_step[step] = upload_index + 1
 
         # Replayable: a presign only mints a URL.
         presign = self._client.post(
@@ -202,11 +225,13 @@ class RftSamplesSink(Sink):
 
         self._put_object(url, payload)
 
-        # Records the object under the step. A lost response is not replayed:
-        # the platform may have taken the first confirm.
+        # Records the object under the step. Replayable: confirm checks the
+        # key and the object, then refreshes the run's progress; a second
+        # confirm of the same key changes nothing.
         self._client.post(
             "/rft/samples/confirm",
             json_body={"run_id": self._run_id, "step": step, "s3_key": key},
+            idempotent=True,
         )
         return True
 

--- a/packages/prime-runs/src/prime_runs/worker.py
+++ b/packages/prime-runs/src/prime_runs/worker.py
@@ -8,7 +8,9 @@ The child starts over empty; the queued records belong to the parent.
 
 Containment: record-specific failures drop only their batch. A sink-wide
 failure disables the sink, while transient failures get a few consecutive
-strikes first. The thread never dies on one bad batch.
+strikes first — and, with a ``retire_cooldown``, the sink is tried again once
+the cooldown has passed, so an outage costs a long run a window of records
+rather than the rest of the run. The thread never dies on one bad batch.
 """
 
 import logging
@@ -63,11 +65,15 @@ class UploadWorker:
         max_queue_size: int = DEFAULT_QUEUE_SIZE,
         put_timeout: float = DEFAULT_PUT_TIMEOUT,
         on_error: Optional[Callable[[str, Exception], None]] = None,
+        retire_cooldown: Optional[float] = None,
     ) -> None:
         self.sinks = sinks
         self.max_queue_size = max_queue_size
         self.put_timeout = put_timeout
         self._on_error = on_error
+        #: Seconds after which a sink retired on transient failures is tried
+        #: again; ``None`` retires it for the rest of the run.
+        self._retire_cooldown = retire_cooldown
         self._queue: "queue.Queue[Any]" = queue.Queue(maxsize=max_queue_size)
         self._thread: Optional[threading.Thread] = None
         self._stopping = threading.Event()
@@ -82,6 +88,8 @@ class UploadWorker:
         #: these are lost to it and counted; a sink that switched itself off
         #: without raising (nowhere for the records to go) is not in here.
         self._retired: set = set()
+        #: Sink name -> monotonic time at which a paused sink is tried again.
+        self._cooldowns: dict = {}
         _fork.register(self)
 
     # ----------------------------------------------------------------- thread
@@ -154,6 +162,7 @@ class UploadWorker:
 
     def _dispatch(self, records: Sequence[Any]) -> None:
         for sink in self.sinks:
+            self._maybe_revive(sink)
             if not sink.enabled:
                 if sink.name in self._retired:
                     count = self.failed_records.get(sink.name, 0)
@@ -167,6 +176,17 @@ class UploadWorker:
                 self._fail_sink(sink, exc, dropped=len(records))
             else:
                 self._transient_failures.pop(sink.name, None)
+
+    def _maybe_revive(self, sink: Sink) -> None:
+        """Re-enable a sink whose cooldown has passed. Its strikes start over."""
+        until = self._cooldowns.get(sink.name)
+        if until is None or time.monotonic() < until:
+            return
+        del self._cooldowns[sink.name]
+        self._retired.discard(sink.name)
+        self._transient_failures.pop(sink.name, None)
+        sink.enabled = True
+        logger.info("Sink %s re-enabled after its cooldown", sink.name)
 
     def _flush_sinks(self) -> None:
         for sink in self.sinks:
@@ -182,7 +202,8 @@ class UploadWorker:
 
         Record-specific failures drop only the current batch. Sink-wide
         permanent failures retire immediately; transient failures retire after
-        ``TRANSIENT_FAILURE_LIMIT`` consecutive strikes.
+        ``TRANSIENT_FAILURE_LIMIT`` consecutive strikes — for good, or until
+        the worker's ``retire_cooldown`` has passed.
         """
         name = sink.name
         if dropped:
@@ -218,13 +239,24 @@ class UploadWorker:
                 return
             sink.enabled = False
             self._retired.add(name)
-            logger.warning(
-                "Sink %s disabled after %d consecutive transient failures: %s: %s",
-                name,
-                strikes,
-                type(exc).__name__,
-                exc,
-            )
+            if self._retire_cooldown is None:
+                logger.warning(
+                    "Sink %s disabled after %d consecutive transient failures: %s: %s",
+                    name,
+                    strikes,
+                    type(exc).__name__,
+                    exc,
+                )
+            else:
+                self._cooldowns[name] = time.monotonic() + self._retire_cooldown
+                logger.warning(
+                    "Sink %s paused for %.0fs after %d consecutive transient failures: %s: %s",
+                    name,
+                    self._retire_cooldown,
+                    strikes,
+                    type(exc).__name__,
+                    exc,
+                )
         else:
             sink.enabled = False
             self._retired.add(name)

--- a/packages/prime-runs/tests/_fakes.py
+++ b/packages/prime-runs/tests/_fakes.py
@@ -75,10 +75,40 @@ class Trace:
 
 
 @dataclass
+class EnvInfo:
+    id: str = "gsm8k"
+    name: Optional[str] = None
+
+
+@dataclass
+class TrainWorkInfo:
+    step: int
+    type: str = "train"
+
+
+@dataclass
+class EvalWorkInfo:
+    step: int
+    type: str = "eval"
+
+
+@dataclass
+class TrainRunInfo:
+    """verifiers stamps this on every episode a training run dispatches."""
+
+    id: str
+    work: Any
+    type: str = "train"
+    name: Optional[str] = None
+
+
+@dataclass
 class Episode:
     id: str = "episode-1"
     traces: List[Trace] = field(default_factory=list)
     ok: bool = True
+    env: EnvInfo = field(default_factory=EnvInfo)
+    run: Optional[Any] = None
 
     def to_record(self) -> Dict[str, Any]:
         return {"id": self.id, "traces": [trace.to_record() for trace in self.traces]}
@@ -113,3 +143,28 @@ def make_episode(
     episode_id: str = "episode-1", traces: Optional[List[Trace]] = None, ok: bool = True
 ) -> Episode:
     return Episode(id=episode_id, traces=traces if traces is not None else [make_trace()], ok=ok)
+
+
+def make_train_episode(
+    episode_id: str = "episode-1",
+    *,
+    step: int = 10,
+    work: str = "train",
+    idx: int = 0,
+    reward: float = 1.0,
+    advantage: Optional[float] = None,
+    env_id: str = "gsm8k",
+    run_id: str = "run-1",
+) -> Episode:
+    """An episode the way prime-rl hands it over: stamped with the run and the
+    training step it was dispatched at, ``advantage`` in the trace's info."""
+    trace = make_trace(trace_id=f"{episode_id}-t", idx=idx, reward=reward)
+    if advantage is not None:
+        trace.info["advantage"] = advantage
+    work_info = TrainWorkInfo(step=step) if work == "train" else EvalWorkInfo(step=step)
+    return Episode(
+        id=episode_id,
+        traces=[trace],
+        env=EnvInfo(id=env_id),
+        run=TrainRunInfo(id=run_id, work=work_info),
+    )

--- a/packages/prime-runs/tests/conftest.py
+++ b/packages/prime-runs/tests/conftest.py
@@ -141,3 +141,55 @@ class FakeSink:
 @pytest.fixture
 def fake_sink() -> Callable[..., FakeSink]:
     return FakeSink
+
+
+@pytest.fixture
+def rft_routes() -> Dict[str, Any]:
+    """The happy path for a training run: register, metrics, samples, finalize."""
+
+    def presign(request: httpx.Request) -> httpx.Response:
+        import json
+
+        step = json.loads(request.content)["step"]
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "presignedUrl": f"http://storage.test/run-abc/step-{step}.parquet",
+                    "s3Key": f"runs/run-abc/step-{step}.parquet",
+                    "expiresIn": 900,
+                }
+            },
+        )
+
+    return {
+        "POST /api/v1/rft/external-runs": lambda request: httpx.Response(
+            201,
+            json={"run": {"id": "run-abc", "name": "test-run", "status": "RUNNING"}},
+        ),
+        "POST /api/v1/rft/metrics": {"data": {"status": "success"}},
+        "POST /api/v1/rft/samples/presign": presign,
+        "POST /api/v1/rft/samples/confirm": {"data": {"status": "success"}},
+        "POST /api/v1/rft/finalize": {
+            "data": {"status": "success", "message": "Run finalized successfully"}
+        },
+        "PUT /api/v1/rft/external-runs/run-abc/status": {
+            "run": {"id": "run-abc", "status": "FAILED"}
+        },
+    }
+
+
+class StorageHandler:
+    """Object storage for presigned PUTs: records every upload, answers 200."""
+
+    def __init__(self, status_codes: Sequence[int] = ()) -> None:
+        self.uploads: List[httpx.Request] = []
+        self._status_codes = list(status_codes)
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.uploads.append(request)
+        code = self._status_codes.pop(0) if self._status_codes else 200
+        return httpx.Response(code)
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(transport=httpx.MockTransport(self))

--- a/packages/prime-runs/tests/test_init.py
+++ b/packages/prime-runs/tests/test_init.py
@@ -112,6 +112,13 @@ def test_an_online_run_returns_the_platforms_id_and_viewer_url(online):
     run.finish()
 
 
+def test_eval_uploaders_keep_the_permanent_retirement(online):
+    run, _ = online()
+
+    assert run._worker._retire_cooldown is None
+    run.finish()
+
+
 def test_a_failed_create_closes_the_platform_client(monkeypatch):
     class FailingClient:
         def __init__(self):
@@ -275,7 +282,7 @@ def online_train(monkeypatch, make_platform_client, rft_routes):
     storage = StorageHandler()
     encoder_calls = []
 
-    def encoder(episodes, run_id, step):
+    def encoder(episodes, run_id, step, sample_id_offset=0):
         encoder_calls.append((len(episodes), run_id, step))
         return b"parquet"
 
@@ -358,6 +365,18 @@ def test_a_failed_training_run_is_marked_failed_with_the_reason(online_train):
     body = handler.bodies_for("/api/v1/rft/external-runs/run-abc/status")[0]
     assert body == {"status": "failed", "error_message": "ValueError: loss is NaN"}
     assert "POST /api/v1/rft/finalize" not in handler.paths()
+
+
+def test_training_uploaders_pause_rather_than_retire_after_an_outage(online_train):
+    """A training run lasts days; a sink that struck out on a platform blip
+    is tried again after a cooldown instead of losing the rest of the run."""
+    from prime_runs.run import TRAIN_RETIRE_COOLDOWN
+
+    run, _, _, _ = online_train()
+
+    assert run._worker._retire_cooldown == TRAIN_RETIRE_COOLDOWN == 300.0
+    assert run._metrics_worker._retire_cooldown == TRAIN_RETIRE_COOLDOWN
+    run.finish()
 
 
 def test_attaching_to_a_managed_run_registers_nothing(online_train):

--- a/packages/prime-runs/tests/test_init.py
+++ b/packages/prime-runs/tests/test_init.py
@@ -8,7 +8,7 @@ from conftest import RecordingHandler
 
 import prime_runs as pr
 from prime_runs.exceptions import ConfigurationError
-from prime_runs.models import RunStatus
+from prime_runs.models import RunSpec, RunStatus
 
 # -------------------------------------------------------------------- modes
 
@@ -259,3 +259,194 @@ def test_records_reject_nonfinite_json_instead_of_sending_an_opaque_400(online):
     with pytest.raises(ValueError, match="Out of range float values"):
         run.flush()
     run.finish()
+
+
+# ----------------------------------------------------------------- training
+
+
+@pytest.fixture
+def online_train(monkeypatch, make_platform_client, rft_routes):
+    """``init(kind="train", mode="online")`` wired to a MockTransport: traces
+    sink off, sample uploads to an in-memory store, a recording encoder."""
+    from conftest import StorageHandler
+
+    from prime_runs.sinks import RftSamplesSink
+
+    storage = StorageHandler()
+    encoder_calls = []
+
+    def encoder(episodes, run_id, step):
+        encoder_calls.append((len(episodes), run_id, step))
+        return b"parquet"
+
+    def samples_sink(client, **kwargs):
+        return RftSamplesSink(client, encoder=encoder, upload_client=storage.client(), **kwargs)
+
+    def _init(routes=None, **kwargs):
+        handler = RecordingHandler(routes or rft_routes)
+        monkeypatch.setattr(
+            "prime_runs.run.PlatformClient", lambda **_: make_platform_client(handler)
+        )
+        monkeypatch.setattr("prime_runs.run.TracesSink", lambda **_: _NullSink())
+        monkeypatch.setattr("prime_runs.run.RftSamplesSink", samples_sink)
+        # The RFT create response carries no viewer URL; the SDK builds one.
+        monkeypatch.setenv("PRIME_FRONTEND_URL", "https://app.example")
+        kwargs.setdefault("name", "test-run")
+        kwargs.setdefault("model", "Qwen/Qwen3-8B")
+        kwargs.setdefault("environments", ["primeintellect/vf-math"])
+        kwargs.setdefault("team_id", "team-1")
+        run = pr.init(kind="train", api_key="test-key", **kwargs)
+        return run, handler, storage, encoder_calls
+
+    return _init
+
+
+def test_a_training_run_registers_with_the_rft_api(online_train):
+    run, handler, _, _ = online_train(
+        training=pr.TrainingSpec(max_steps=50, batch_size=32),
+        config={"trainer": {"lr": 1e-6}},
+    )
+
+    assert run.kind == "train"
+    assert run.id == "run-abc"
+    assert run.url == "https://app.example/dashboard/training/run-abc"
+    assert run.attached is False
+    body = handler.bodies_for("/api/v1/rft/external-runs")[0]
+    assert body["base_model"] == "Qwen/Qwen3-8B"
+    assert body["max_steps"] == 50
+    assert body["batch_size"] == 32
+    assert body["environments"] == [{"id": "primeintellect/vf-math"}]
+    assert body["run_config"] == {"trainer": {"lr": 1e-6}}
+    assert body["team_id"] == "team-1"
+    assert [sink.name for sink in run._worker.sinks] == ["traces", "rft_samples"]
+    assert [sink.name for sink in run._metrics_worker.sinks] == ["rft_metrics"]
+    run.finish()
+
+
+def test_a_training_run_streams_metrics_and_step_samples(online_train):
+    from _fakes import make_train_episode
+
+    run, handler, storage, encoder_calls = online_train()
+
+    run.log_metrics({"loss": 0.5}, step=10)
+    run.log_episodes([make_train_episode("e1", step=10), make_train_episode("e2", step=10)])
+    run.finish()
+
+    metrics = handler.bodies_for("/api/v1/rft/metrics")
+    assert len(metrics) == 1
+    assert metrics[0]["run_id"] == "run-abc"
+    assert metrics[0]["metrics"]["loss"] == 0.5
+    assert metrics[0]["metrics"]["step"] == 10
+    assert "_timestamp" in metrics[0]["metrics"]
+    assert encoder_calls == [(2, "run-abc", 10)]
+    assert len(storage.uploads) == 1
+    assert handler.bodies_for("/api/v1/rft/samples/confirm")[0]["step"] == 10
+    # Closed out through the idempotent finalize, not the status PUT.
+    assert handler.bodies_for("/api/v1/rft/finalize") == [{"run_id": "run-abc", "exit_code": 0}]
+    assert "PUT /api/v1/rft/external-runs/run-abc/status" not in handler.paths()
+    assert run.status is RunStatus.COMPLETED
+    assert run.errors == []
+
+
+def test_a_failed_training_run_is_marked_failed_with_the_reason(online_train):
+    run, handler, _, _ = online_train()
+
+    with pytest.raises(ValueError):
+        with run:
+            raise ValueError("loss is NaN")
+
+    body = handler.bodies_for("/api/v1/rft/external-runs/run-abc/status")[0]
+    assert body == {"status": "failed", "error_message": "ValueError: loss is NaN"}
+    assert "POST /api/v1/rft/finalize" not in handler.paths()
+
+
+def test_attaching_to_a_managed_run_registers_nothing(online_train):
+    run, handler, _, _ = online_train(id="run-managed")
+
+    assert run.id == "run-managed"
+    assert run.attached is True
+    assert run.url == "https://app.example/dashboard/training/run-managed"
+    assert "POST /api/v1/rft/external-runs" not in handler.paths()
+    run.finish()
+    # A clean exit still completes it.
+    assert handler.bodies_for("/api/v1/rft/finalize") == [{"run_id": "run-managed", "exit_code": 0}]
+
+
+def test_an_attached_run_leaves_failure_marking_to_the_launcher(online_train, caplog):
+    """A managed launch marks its own run failed when the process goes away;
+    reporting it from here would race that (prime-rl's contract)."""
+    run, handler, _, _ = online_train(id="run-managed")
+
+    with caplog.at_level("INFO"):
+        run.fail("boom")
+
+    assert not any("status" in path for path in handler.paths())
+    assert "POST /api/v1/rft/finalize" not in handler.paths()
+    assert "leaving it to the launcher" in caplog.text
+    assert run.status is RunStatus.FAILED
+
+
+def test_a_training_run_needs_a_team(monkeypatch, make_platform_client, rft_routes):
+    handler = RecordingHandler(rft_routes)
+    monkeypatch.setattr("prime_runs.run.PlatformClient", lambda **_: make_platform_client(handler))
+
+    with pytest.raises(ConfigurationError, match="team"):
+        pr.init(kind="train", model="Qwen/Qwen3-8B", api_key="test-key", mode="online")
+    assert handler.paths() == []
+
+
+def test_a_team_outside_the_allowlist_surfaces_the_platforms_reason(
+    monkeypatch, make_platform_client, rft_routes
+):
+    import httpx
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/external-runs"] = lambda request: httpx.Response(
+        403, json={"detail": "External training runs are not enabled for this team"}
+    )
+    handler = RecordingHandler(routes)
+    monkeypatch.setattr("prime_runs.run.PlatformClient", lambda **_: make_platform_client(handler))
+
+    with pytest.raises(pr.ForbiddenError, match="not enabled for this team"):
+        pr.init(kind="train", model="m", team_id="team-1", api_key="test-key", mode="online")
+
+
+def test_a_disabled_training_run_keeps_an_attached_id(tmp_path):
+    run = pr.init(kind="train", mode="disabled", id="run-managed", model="m")
+
+    assert run.id == "run-managed"
+    assert run.kind == "train"
+    run.log_metrics({"loss": 0.1}, step=1)
+    assert run._metrics_worker._thread is None
+    run.finish()
+    assert run.status is RunStatus.COMPLETED
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"kind": "eval", "id": "eval-1"},
+        {"kind": "eval", "training": pr.TrainingSpec()},
+        {"kind": "serve"},
+    ],
+    ids=["eval-with-id", "eval-with-training", "unknown-kind"],
+)
+def test_kind_arguments_are_checked_before_anything_else(kwargs):
+    with pytest.raises(ConfigurationError):
+        pr.init(mode="disabled", **kwargs)
+
+
+def test_training_records_are_stamped_with_the_train_run_type():
+    """Bare dicts get ``run.type`` from the run's kind, matching what verifiers'
+    ``TrainRunInfo`` carries, so the traces service files them as training."""
+    from prime_runs.run import _sink_context
+    from prime_runs.sinks.base import stamp_run
+
+    spec = RunSpec(kind="train", model="m")
+    context = _sink_context(spec)
+
+    assert context["run_type"] == "train"
+    assert stamp_run({"id": "t1"}, "run-abc", context["run_type"])["run"] == {
+        "id": "run-abc",
+        "type": "train",
+    }

--- a/packages/prime-runs/tests/test_metrics_sink.py
+++ b/packages/prime-runs/tests/test_metrics_sink.py
@@ -28,7 +28,9 @@ def test_each_metrics_dict_is_one_request(make_platform_client, rft_routes):
     assert sink.steps_written == 2
 
 
-def test_a_transient_failure_loses_only_its_step(make_platform_client, rft_routes):
+def test_an_ambiguous_failure_is_replayed(make_platform_client, rft_routes, no_sleep):
+    """The platform keeps one row per step, so a retry after a lost response
+    cannot double anything, while a lost row is a hole in the curves for good."""
     calls = []
 
     def flaky(request: httpx.Request) -> httpx.Response:
@@ -39,6 +41,26 @@ def test_a_transient_failure_loses_only_its_step(make_platform_client, rft_route
 
     routes = dict(rft_routes)
     routes["POST /api/v1/rft/metrics"] = flaky
+    sink, handler = make_sink(make_platform_client, routes)
+
+    sink.write([{"step": 1}, {"step": 2}])
+
+    assert len(calls) == 3
+    assert sink.steps_written == 2
+
+
+def test_a_persistent_transient_failure_loses_only_its_step(
+    make_platform_client, rft_routes, no_sleep
+):
+    import json
+
+    def down_for_step_one(request: httpx.Request) -> httpx.Response:
+        if json.loads(request.content)["metrics"]["step"] == 1:
+            return httpx.Response(502)
+        return httpx.Response(200, json={"data": {"status": "success"}})
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/metrics"] = down_for_step_one
     sink, handler = make_sink(make_platform_client, routes)
 
     with pytest.raises(SinkWriteError) as info:

--- a/packages/prime-runs/tests/test_metrics_sink.py
+++ b/packages/prime-runs/tests/test_metrics_sink.py
@@ -1,0 +1,80 @@
+"""The training metrics sink: one request per logged step."""
+
+import httpx
+import pytest
+from conftest import RecordingHandler
+
+from prime_runs.exceptions import RetryableAPIError, UnauthorizedError
+from prime_runs.sinks import RftMetricsSink
+from prime_runs.sinks.base import SinkWriteError
+
+
+def make_sink(make_platform_client, routes):
+    handler = RecordingHandler(routes)
+    sink = RftMetricsSink(make_platform_client(handler))
+    sink.start("run-abc", {})
+    return sink, handler
+
+
+def test_each_metrics_dict_is_one_request(make_platform_client, rft_routes):
+    sink, handler = make_sink(make_platform_client, rft_routes)
+
+    sink.write([{"step": 1, "loss": 0.9}, {"step": 2, "loss": 0.8}])
+
+    assert handler.bodies_for("/api/v1/rft/metrics") == [
+        {"run_id": "run-abc", "metrics": {"step": 1, "loss": 0.9}},
+        {"run_id": "run-abc", "metrics": {"step": 2, "loss": 0.8}},
+    ]
+    assert sink.steps_written == 2
+
+
+def test_a_transient_failure_loses_only_its_step(make_platform_client, rft_routes):
+    calls = []
+
+    def flaky(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if len(calls) == 1:
+            return httpx.Response(502)
+        return httpx.Response(200, json={"data": {"status": "success"}})
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/metrics"] = flaky
+    sink, handler = make_sink(make_platform_client, routes)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([{"step": 1}, {"step": 2}])
+
+    assert info.value.failed_records == 1
+    assert isinstance(info.value.cause, RetryableAPIError)
+    assert sink.steps_written == 1
+
+
+def test_a_sink_wide_failure_stops_the_batch_and_counts_the_rest(make_platform_client, rft_routes):
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/metrics"] = lambda request: httpx.Response(401)
+    sink, handler = make_sink(make_platform_client, routes)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([{"step": 1}, {"step": 2}, {"step": 3}])
+
+    assert info.value.failed_records == 3
+    assert isinstance(info.value.cause, UnauthorizedError)
+    assert len(handler.paths()) == 1
+
+
+def test_a_record_that_is_not_a_mapping_is_counted_not_sent(make_platform_client, rft_routes):
+    sink, handler = make_sink(make_platform_client, rft_routes)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write(["loss=0.5", {"step": 1}])
+
+    assert info.value.failed_records == 1
+    assert isinstance(info.value.cause, TypeError)
+    assert len(handler.bodies_for("/api/v1/rft/metrics")) == 1
+
+
+def test_write_before_start_is_a_producer_bug(make_platform_client, rft_routes):
+    sink = RftMetricsSink(make_platform_client(RecordingHandler(rft_routes)))
+
+    with pytest.raises(RuntimeError, match="before start"):
+        sink.write([{"step": 1}])

--- a/packages/prime-runs/tests/test_rft_backend.py
+++ b/packages/prime-runs/tests/test_rft_backend.py
@@ -170,6 +170,25 @@ def test_finalize_is_replayed_after_an_ambiguous_failure(make_platform_client, r
     assert len(attempts) == 2
 
 
+def test_finalize_falls_back_to_a_completed_status_update(make_platform_client, rft_routes):
+    """A finalize-specific failure must not strand an otherwise completed run."""
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/finalize"] = lambda request: httpx.Response(
+        400, json={"detail": "finalize unavailable"}
+    )
+    backend, handler = make_backend(make_platform_client, routes)
+
+    backend.finalize("run-abc", status=RunStatus.COMPLETED)
+
+    assert handler.paths() == [
+        "POST /api/v1/rft/finalize",
+        "PUT /api/v1/rft/external-runs/run-abc/status",
+    ]
+    assert handler.bodies_for("/api/v1/rft/external-runs/run-abc/status") == [
+        {"status": "completed"}
+    ]
+
+
 @pytest.mark.parametrize(
     ("status", "error", "expected_message"),
     [

--- a/packages/prime-runs/tests/test_rft_backend.py
+++ b/packages/prime-runs/tests/test_rft_backend.py
@@ -1,0 +1,221 @@
+"""Training run lifecycle against ``/api/v1/rft/*``."""
+
+import httpx
+import pytest
+from conftest import RecordingHandler
+
+from prime_runs.backend import RftBackend
+from prime_runs.exceptions import ConfigurationError, ForbiddenError, RetryableAPIError
+from prime_runs.models import EnvironmentRef, RunSpec, RunStatus, TrainingSpec
+
+
+def make_backend(make_platform_client, routes, **kwargs):
+    handler = RecordingHandler(routes)
+    client = make_platform_client(handler)
+    kwargs.setdefault("team_id", "team-1")
+    backend = RftBackend(client, frontend_url="https://app.example", **kwargs)
+    return backend, handler
+
+
+def train_spec(**overrides) -> RunSpec:
+    values = dict(
+        name="test-run",
+        kind="train",
+        model="Qwen/Qwen3-8B",
+        environments=[EnvironmentRef.coerce("primeintellect/vf-math")],
+        training=TrainingSpec(max_steps=100, batch_size=64, rollouts_per_example=8, seq_len=4096),
+        config={"trainer": {"lr": 1e-6}},
+    )
+    values.update(overrides)
+    return RunSpec(**values)
+
+
+def test_create_registers_an_external_run_for_the_team(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    handle = backend.create(train_spec())
+
+    assert handler.paths() == ["POST /api/v1/rft/external-runs"]
+    body = handler.bodies_for("/api/v1/rft/external-runs")[0]
+    assert body["base_model"] == "Qwen/Qwen3-8B"
+    assert body["max_steps"] == 100
+    assert body["batch_size"] == 64
+    assert body["rollouts_per_example"] == 8
+    assert body["seq_len"] == 4096
+    assert body["run_config"] == {"trainer": {"lr": 1e-6}}
+    assert body["team_id"] == "team-1"
+    assert body["name"] == "test-run"
+    assert handle.id == "run-abc"
+    assert handle.url == "https://app.example/dashboard/training/run-abc"
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ("primeintellect/vf-math", {"id": "primeintellect/vf-math"}),
+        ("agentic-judge+gsm8k", {"id": "agentic-judge+gsm8k"}),
+        ({"id": "env-123", "version_id": "v7"}, {"id": "env-123", "version_id": "v7"}),
+    ],
+    ids=["slug", "name", "id"],
+)
+def test_training_environments_are_passed_through_not_resolved(
+    make_platform_client, rft_routes, environment, expected
+):
+    """The RFT API names environments by hub id and resolves them itself; a
+    hub round-trip here would be a second opinion."""
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    backend.create(train_spec(environments=[EnvironmentRef.coerce(environment)]))
+
+    assert handler.bodies_for("/api/v1/rft/external-runs")[0]["environments"] == [expected]
+    assert "POST /api/v1/environmentshub/resolve" not in handler.paths()
+
+
+def test_the_spec_team_wins_over_the_backend_default(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes, team_id="team-default")
+
+    backend.create(train_spec(team_id="team-explicit"))
+
+    assert handler.bodies_for("/api/v1/rft/external-runs")[0]["team_id"] == "team-explicit"
+
+
+def test_create_needs_a_base_model(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    with pytest.raises(ConfigurationError, match="model="):
+        backend.create(train_spec(model=None))
+    assert handler.paths() == []
+
+
+def test_create_needs_a_team(make_platform_client, rft_routes):
+    """External runs are created for a team; the API refuses without one, so
+    say so before the request rather than surfacing its 403."""
+    backend, handler = make_backend(make_platform_client, rft_routes, team_id=None)
+
+    with pytest.raises(ConfigurationError, match="team"):
+        backend.create(train_spec())
+    assert handler.paths() == []
+
+
+def test_a_team_outside_the_allowlist_is_a_forbidden_error(make_platform_client, rft_routes):
+    """The platform enables external runs per team. The producer decides what
+    a refusal means; the SDK passes the platform's reason through."""
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/external-runs"] = lambda request: httpx.Response(
+        403, json={"detail": "External training runs are not enabled for this team"}
+    )
+    backend, handler = make_backend(make_platform_client, routes)
+
+    with pytest.raises(ForbiddenError, match="not enabled for this team"):
+        backend.create(train_spec())
+    assert len(handler.paths()) == 1
+
+
+def test_create_is_not_replayed_after_an_ambiguous_failure(make_platform_client, rft_routes):
+    """A retry after a lost response would register a second run."""
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/external-runs"] = lambda request: httpx.Response(502)
+    backend, handler = make_backend(make_platform_client, routes)
+
+    with pytest.raises(RetryableAPIError):
+        backend.create(train_spec())
+    assert handler.paths() == ["POST /api/v1/rft/external-runs"]
+
+
+def test_attach_makes_no_request(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    handle = backend.attach("run-managed")
+
+    assert handle.id == "run-managed"
+    assert handle.url == "https://app.example/dashboard/training/run-managed"
+    assert handler.paths() == []
+
+
+def test_update_is_a_no_op(make_platform_client, rft_routes):
+    """The RFT API takes the config at creation and has no summary document."""
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    backend.update("run-abc", config={"a": 1}, summary={"loss": 0.1})
+
+    assert handler.paths() == []
+
+
+def test_a_completed_run_is_finalized_with_exit_code_zero(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    backend.finalize("run-abc", status=RunStatus.COMPLETED, summary={"loss": 0.1})
+
+    assert handler.paths() == ["POST /api/v1/rft/finalize"]
+    assert handler.bodies_for("/api/v1/rft/finalize")[0] == {"run_id": "run-abc", "exit_code": 0}
+
+
+def test_finalize_is_replayed_after_an_ambiguous_failure(make_platform_client, rft_routes):
+    """Compare-and-set on the server, and "already finalized" is a success:
+    a lost response costs nothing to replay, unlike the eval finalize."""
+    attempts = []
+
+    def flaky(request: httpx.Request) -> httpx.Response:
+        attempts.append(request)
+        if len(attempts) == 1:
+            return httpx.Response(504)
+        return httpx.Response(200, json={"data": {"status": "success"}})
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/finalize"] = flaky
+    backend, handler = make_backend(make_platform_client, routes)
+
+    backend.finalize("run-abc", status=RunStatus.COMPLETED)
+
+    assert len(attempts) == 2
+
+
+@pytest.mark.parametrize(
+    ("status", "error", "expected_message"),
+    [
+        (RunStatus.FAILED, "ValueError: boom", "ValueError: boom"),
+        (RunStatus.CANCELLED, "interrupted", "cancelled: interrupted"),
+        (RunStatus.CRASHED, "process exited without finishing the run", "crashed: process exited"),
+        (RunStatus.FAILED, None, "failed"),
+    ],
+    ids=["failed", "cancelled", "crashed", "failed-no-reason"],
+)
+def test_other_terminal_states_are_reported_as_failed_with_the_reason(
+    make_platform_client, rft_routes, status, error, expected_message
+):
+    """The RFT vocabulary is completed | failed; the finer distinction rides
+    in error_message so an operator can still tell a Ctrl-C from a crash."""
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    backend.finalize("run-abc", status=status, error=error)
+
+    assert handler.paths() == ["PUT /api/v1/rft/external-runs/run-abc/status"]
+    body = handler.bodies_for("/api/v1/rft/external-runs/run-abc/status")[0]
+    assert body["status"] == "failed"
+    assert body["error_message"].startswith(expected_message)
+    assert "POST /api/v1/rft/finalize" not in handler.paths()
+
+
+def test_marking_an_already_closed_run_failed_is_not_an_error(make_platform_client, rft_routes):
+    """409: a managed launcher or an earlier attempt got there first. The
+    outcome is recorded either way, so teardown must not raise over it."""
+    routes = dict(rft_routes)
+    routes["PUT /api/v1/rft/external-runs/run-abc/status"] = lambda request: httpx.Response(
+        409, json={"detail": "Cannot update status of run in 'COMPLETED' state."}
+    )
+    backend, handler = make_backend(make_platform_client, routes)
+
+    backend.finalize("run-abc", status=RunStatus.FAILED, error="boom")
+
+    assert handler.paths() == ["PUT /api/v1/rft/external-runs/run-abc/status"]
+
+
+def test_log_metrics_posts_one_step(make_platform_client, rft_routes):
+    backend, handler = make_backend(make_platform_client, rft_routes)
+
+    backend.log_metrics("run-abc", {"step": 3, "loss": 0.5})
+
+    assert handler.bodies_for("/api/v1/rft/metrics")[0] == {
+        "run_id": "run-abc",
+        "metrics": {"step": 3, "loss": 0.5},
+    }

--- a/packages/prime-runs/tests/test_run.py
+++ b/packages/prime-runs/tests/test_run.py
@@ -639,3 +639,75 @@ def test_a_credential_without_the_traces_scope_reaches_strict_callers_and_loss_a
         run.finish()
 
     assert run.failed_records == {"traces": 1}
+
+
+# ------------------------------------------------------------------ metrics
+
+
+def test_log_metrics_goes_to_the_metrics_sinks_only():
+    records, metrics = FakeSink("records"), FakeSink("metrics")
+    run = make_run(sinks=[records], metrics_sinks=[metrics])
+
+    run.log_metrics({"loss": 0.5, "nan": float("nan")}, step=3)
+    run.log_traces([{"id": "t1"}])
+    run.flush()
+
+    assert records.batches == [[{"id": "t1"}]]
+    (batch,) = metrics.batches
+    (row,) = batch
+    assert row["loss"] == 0.5
+    assert row["step"] == 3
+    assert "nan" not in row
+    assert isinstance(row["_timestamp"], float)
+    run.finish()
+
+
+def test_log_metrics_keeps_a_step_the_producer_already_set():
+    metrics = FakeSink("metrics")
+    run = make_run(metrics_sinks=[metrics])
+
+    run.log_metrics({"step": 7, "loss": 0.5}, step=8)
+    run.flush()
+
+    assert metrics.batches[0][0]["step"] == 7
+    run.finish()
+
+
+def test_log_metrics_without_a_metrics_sink_is_a_no_op():
+    run = make_run()
+
+    run.log_metrics({"loss": 0.5}, step=1)
+
+    assert run._metrics_worker._thread is None
+    assert run.dropped_records == 0
+    run.finish()
+
+
+def test_log_metrics_on_a_finished_run_is_a_producer_bug():
+    run = make_run(metrics_sinks=[FakeSink("metrics")])
+    run.finish()
+
+    with pytest.raises(RunFinishedError):
+        run.log_metrics({"loss": 0.5})
+
+
+def test_finish_drains_and_closes_the_metrics_uploader_too():
+    metrics = FakeSink("metrics")
+    run = make_run(metrics_sinks=[metrics])
+
+    run.log_metrics({"loss": 0.5}, step=1)
+    run.finish()
+
+    assert len(metrics.batches) == 1
+    assert metrics.closed is True
+
+
+def test_losses_are_reported_across_both_uploaders():
+    broken = FakeSink("metrics", fail_on_write=True)
+    run = make_run(metrics_sinks=[broken])
+
+    run.log_metrics({"loss": 0.5}, step=1)
+    run.flush()
+
+    assert run.failed_records == {"metrics": 1}
+    run.finish()

--- a/packages/prime-runs/tests/test_run.py
+++ b/packages/prime-runs/tests/test_run.py
@@ -662,6 +662,24 @@ def test_log_metrics_goes_to_the_metrics_sinks_only():
     run.finish()
 
 
+def test_log_metrics_drops_non_finite_values_inside_sequences():
+    metrics = FakeSink("metrics")
+    run = make_run(metrics_sinks=[metrics])
+
+    run.log_metrics(
+        {
+            "quantiles": [0.1, float("nan"), 0.9],
+            "nested": [{"loss": float("inf"), "reward": 1.0}, [float("-inf"), 2.0]],
+        }
+    )
+    run.flush()
+
+    row = metrics.batches[0][0]
+    assert row["quantiles"] == [0.1, 0.9]
+    assert row["nested"] == [{"reward": 1.0}, [2.0]]
+    run.finish()
+
+
 def test_log_metrics_keeps_a_step_the_producer_already_set():
     metrics = FakeSink("metrics")
     run = make_run(metrics_sinks=[metrics])

--- a/packages/prime-runs/tests/test_samples_sink.py
+++ b/packages/prime-runs/tests/test_samples_sink.py
@@ -69,9 +69,7 @@ def test_records_this_sink_cannot_project_are_skipped_not_fatal(
     assert sink.skipped == 2
     assert sink.enabled is True
     warnings = [
-        record.getMessage()
-        for record in caplog.records
-        if "no projection" in record.getMessage()
+        record.getMessage() for record in caplog.records if "no projection" in record.getMessage()
     ]
     assert len(warnings) == 1
     assert "(dict)" in warnings[0]

--- a/packages/prime-runs/tests/test_train_samples_sink.py
+++ b/packages/prime-runs/tests/test_train_samples_sink.py
@@ -1,0 +1,313 @@
+"""The training samples sink: step-keyed Parquet through presign -> PUT -> confirm."""
+
+import httpx
+import pytest
+from _fakes import make_episode, make_trace, make_train_episode
+from conftest import RecordingHandler, StorageHandler
+
+from prime_runs.exceptions import APIError, RetryableAPIError, TransportError
+from prime_runs.sinks import RftSamplesSink, training_step
+from prime_runs.sinks.base import SinkWriteError
+
+
+class Encoder:
+    """Records what it was asked to encode; returns a recognizable payload."""
+
+    def __init__(self, payload=b"parquet-bytes"):
+        self.calls = []
+        self.payload = payload
+
+    def __call__(self, episodes, run_id, step):
+        self.calls.append((list(episodes), run_id, step))
+        return self.payload
+
+
+def make_sink(make_platform_client, routes, *, encoder=None, storage=None, **kwargs):
+    handler = RecordingHandler(routes)
+    storage = storage or StorageHandler()
+    encoder = encoder or Encoder()
+    sink = RftSamplesSink(
+        make_platform_client(handler), encoder=encoder, upload_client=storage.client(), **kwargs
+    )
+    sink.start("run-abc", {})
+    return sink, handler, storage, encoder
+
+
+def test_each_step_on_the_cadence_is_one_upload(make_platform_client, rft_routes):
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes)
+    episodes = [
+        make_train_episode("e1", step=10),
+        make_train_episode("e2", step=20),
+        make_train_episode("e3", step=10),
+        make_train_episode("e4", step=11),  # off-cadence: not a loss
+    ]
+
+    sink.write(episodes)
+
+    assert [(step, [e.id for e in eps]) for eps, _, step in encoder.calls] == [
+        (10, ["e1", "e3"]),
+        (20, ["e2"]),
+    ]
+    assert [body["step"] for body in handler.bodies_for("/api/v1/rft/samples/presign")] == [10, 20]
+    assert [str(u.url) for u in storage.uploads] == [
+        "http://storage.test/run-abc/step-10.parquet",
+        "http://storage.test/run-abc/step-20.parquet",
+    ]
+    assert storage.uploads[0].content == b"parquet-bytes"
+    assert storage.uploads[0].headers["content-type"] == "application/parquet"
+    confirms = handler.bodies_for("/api/v1/rft/samples/confirm")
+    assert confirms[0] == {
+        "run_id": "run-abc",
+        "step": 10,
+        "s3_key": "runs/run-abc/step-10.parquet",
+    }
+    assert sink.steps_written == 2
+    assert sink.sampled_out == 1
+    assert sink.skipped == 0
+
+
+def test_the_cadence_is_configurable(make_platform_client, rft_routes):
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, step_interval=1)
+
+    sink.write([make_train_episode("e1", step=7)])
+
+    assert [step for _, _, step in encoder.calls] == [7]
+    with pytest.raises(ValueError):
+        RftSamplesSink(sink._client, step_interval=0)
+
+
+def test_records_without_training_work_have_no_row_here(make_platform_client, rft_routes):
+    """Eval-work episodes, bare traces and JSON episodes reach Prime Traces
+    only; here they are counted, not uploaded, and not a loss."""
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes)
+
+    sink.write(
+        [
+            make_train_episode("eval-work", step=10, work="eval"),
+            make_episode("unstamped", [make_trace()]),
+            make_trace(),
+            {
+                "id": "json-episode",
+                "traces": [],
+                "run": {"type": "train", "work": {"type": "train", "step": 10}},
+            },
+        ]
+    )
+
+    assert encoder.calls == []
+    assert handler.paths() == []
+    assert sink.skipped == 4
+
+
+def test_nothing_to_encode_makes_no_request(make_platform_client, rft_routes):
+    sink, handler, storage, encoder = make_sink(
+        make_platform_client, rft_routes, encoder=Encoder(payload=None)
+    )
+
+    sink.write([make_train_episode("e1", step=10)])
+
+    assert encoder.calls and handler.paths() == []
+    assert sink.steps_written == 0
+
+
+def test_a_failed_presign_loses_that_step_only(make_platform_client, rft_routes):
+    """Presign is replayable (it only mints a URL), so a blip is retried; a
+    step whose presign keeps failing is lost on its own, not the batch."""
+    import json
+
+    def flaky(request: httpx.Request) -> httpx.Response:
+        if json.loads(request.content)["step"] == 10:
+            return httpx.Response(502)
+        return rft_routes["POST /api/v1/rft/samples/presign"](request)
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/samples/presign"] = flaky
+    sink, handler, storage, encoder = make_sink(make_platform_client, routes)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write(
+            [
+                make_train_episode("e1", step=10),
+                make_train_episode("e2", step=10),
+                make_train_episode("e3", step=20),
+            ]
+        )
+
+    # Step 10 (two episodes) was lost; step 20 went through.
+    assert info.value.failed_records == 2
+    assert isinstance(info.value.cause, RetryableAPIError)
+    assert sink.steps_written == 1
+    assert [str(u.url) for u in storage.uploads] == ["http://storage.test/run-abc/step-20.parquet"]
+
+
+def test_the_storage_put_is_retried_then_reported_as_transient(
+    make_platform_client, rft_routes, no_sleep
+):
+    storage = StorageHandler(status_codes=[503, 503, 503])
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, storage=storage)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([make_train_episode("e1", step=10)])
+
+    assert len(storage.uploads) == 3
+    assert isinstance(info.value.cause, RetryableAPIError)
+    assert handler.paths() == ["POST /api/v1/rft/samples/presign"]  # never confirmed
+
+
+def test_a_storage_put_that_recovers_is_confirmed(make_platform_client, rft_routes, no_sleep):
+    storage = StorageHandler(status_codes=[500, 200])
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, storage=storage)
+
+    sink.write([make_train_episode("e1", step=10)])
+
+    assert len(storage.uploads) == 2
+    assert "POST /api/v1/rft/samples/confirm" in handler.paths()
+
+
+def test_a_storage_rejection_is_not_retried(make_platform_client, rft_routes):
+    storage = StorageHandler(status_codes=[403])
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, storage=storage)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([make_train_episode("e1", step=10)])
+
+    assert len(storage.uploads) == 1
+    assert isinstance(info.value.cause, APIError)
+    assert not isinstance(info.value.cause, RetryableAPIError)
+
+
+def test_a_dropped_connection_to_storage_is_transient(make_platform_client, rft_routes, no_sleep):
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    storage = StorageHandler()
+    storage.__call__ = refuse  # type: ignore[method-assign]
+    upload = httpx.Client(transport=httpx.MockTransport(refuse))
+    handler = RecordingHandler(rft_routes)
+    sink = RftSamplesSink(make_platform_client(handler), encoder=Encoder(), upload_client=upload)
+    sink.start("run-abc", {})
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([make_train_episode("e1", step=10)])
+
+    assert isinstance(info.value.cause, TransportError)
+
+
+def test_an_encoder_failure_is_a_record_rejection(make_platform_client, rft_routes):
+    def broken(episodes, run_id, step):
+        raise ValueError("cannot serialize")
+
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, encoder=broken)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([make_train_episode("e1", step=10)])
+
+    assert isinstance(info.value.cause, ValueError)
+    assert handler.paths() == []
+
+
+def test_a_presign_without_a_url_is_an_api_error(make_platform_client, rft_routes):
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/samples/presign"] = {"data": {"expiresIn": 900}}
+    sink, handler, storage, encoder = make_sink(make_platform_client, routes)
+
+    with pytest.raises(SinkWriteError) as info:
+        sink.write([make_train_episode("e1", step=10)])
+
+    assert isinstance(info.value.cause, APIError)
+    assert "presign" in str(info.value.cause)
+
+
+def test_without_pyarrow_the_sink_turns_itself_off_quietly(
+    make_platform_client, rft_routes, monkeypatch, caplog
+):
+    """No loss: the episodes still reach Prime Traces. Say how to turn it on."""
+    monkeypatch.setattr("prime_runs.projection.parquet_available", lambda: False)
+    handler = RecordingHandler(rft_routes)
+    sink = RftSamplesSink(make_platform_client(handler))
+
+    with caplog.at_level("WARNING"):
+        sink.start("run-abc", {})
+
+    assert sink.enabled is False
+    assert "prime-runs[train]" in caplog.text
+    sink.write([make_train_episode("e1", step=10)])
+    assert handler.paths() == []
+
+
+def test_close_releases_only_an_owned_upload_client(make_platform_client, rft_routes):
+    handler = RecordingHandler(rft_routes)
+    injected = StorageHandler().client()
+    sink = RftSamplesSink(make_platform_client(handler), encoder=Encoder(), upload_client=injected)
+    sink.close()
+    assert not injected.is_closed
+
+    owned = RftSamplesSink(make_platform_client(handler), encoder=Encoder())
+    owned.start("run-abc", {})
+    client = owned._upload()
+    owned.close()
+    assert client.is_closed
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        (make_train_episode("e", step=12), 12),
+        (make_train_episode("e", step=12, work="eval"), None),
+        (make_episode("e"), None),
+        ({"run": {"type": "train", "work": {"type": "train", "step": 3}}}, 3),
+        ({"run": {"type": "eval"}}, None),
+        ({"run": {"type": "train", "work": {"type": "train", "step": True}}}, None),
+        ("not a record", None),
+    ],
+    ids=["train", "eval-work", "unstamped", "json", "json-eval", "bool-step", "string"],
+)
+def test_training_step_reads_the_episode_provenance(record, expected):
+    assert training_step(record) == expected
+
+
+def test_the_default_encoder_writes_the_viewer_table():
+    """The real Parquet encoder, when pyarrow is installed: one row per episode
+    with the RFT-only columns layered on the shared sample projection."""
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    import io
+    import json
+
+    from prime_runs.projection import episodes_to_parquet_bytes, train_sample_schema
+
+    episodes = [
+        make_train_episode("e1", step=10, idx=3, reward=1.0, advantage=0.25, env_id="gsm8k"),
+        make_train_episode("e2", step=10, idx=4, reward=0.0, advantage=-0.25, env_id="gsm8k"),
+    ]
+
+    payload = episodes_to_parquet_bytes(episodes, "run-abc", 10)
+
+    assert payload is not None
+    table = pq.read_table(io.BytesIO(payload))
+    assert table.schema.equals(train_sample_schema())
+    rows = table.to_pylist()
+    assert [row["run_id"] for row in rows] == ["run-abc", "run-abc"]
+    assert [row["step"] for row in rows] == [10, 10]
+    assert [row["problem_id"] for row in rows] == [3, 4]
+    assert [row["sample_id"] for row in rows] == [0, 1]
+    assert [row["reward"] for row in rows] == [1.0, 0.0]
+    assert [row["advantage"] for row in rows] == [0.25, -0.25]
+    assert [row["env_name"] for row in rows] == ["gsm8k", "gsm8k"]
+    trajectory = json.loads(rows[0]["trajectory"])
+    assert trajectory[-1]["advantage"] == 0.25
+    assert rows[0]["num_output_tokens"] == 5
+    info = json.loads(rows[0]["info"])
+    assert info["native_wrapper"]["id"] == "e1"
+    assert isinstance(pa.Table, type)
+
+
+def test_the_default_encoder_skips_episodes_without_a_trajectory():
+    pytest.importorskip("pyarrow")
+    from _fakes import Episode, Trace
+
+    from prime_runs.projection import episodes_to_parquet_bytes
+
+    bare = Episode(id="no-branches", traces=[Trace(id="t", branches=[])])
+    assert episodes_to_parquet_bytes([bare], "run-abc", 10) is None
+    assert episodes_to_parquet_bytes([], "run-abc", 10) is None

--- a/packages/prime-runs/tests/test_train_samples_sink.py
+++ b/packages/prime-runs/tests/test_train_samples_sink.py
@@ -311,3 +311,38 @@ def test_the_default_encoder_skips_episodes_without_a_trajectory():
     bare = Episode(id="no-branches", traces=[Trace(id="t", branches=[])])
     assert episodes_to_parquet_bytes([bare], "run-abc", 10) is None
     assert episodes_to_parquet_bytes([], "run-abc", 10) is None
+
+
+def test_a_forked_child_drops_the_inherited_storage_client(make_platform_client, rft_routes):
+    """The socket belongs to the parent: the child must neither reuse it nor
+    close it (a close would send close_notify on the parent's connection)."""
+    handler = RecordingHandler(rft_routes)
+    owned = RftSamplesSink(make_platform_client(handler), encoder=Encoder())
+    owned.start("run-abc", {})
+    inherited = owned._upload()
+
+    owned.reset_after_fork()
+
+    assert owned._upload_client is None
+    assert not inherited.is_closed  # dropped, not closed
+    assert owned._upload() is not inherited
+    owned.close()
+
+    injected = RftSamplesSink(
+        make_platform_client(handler), encoder=Encoder(), upload_client=StorageHandler().client()
+    )
+    injected.start("run-abc", {})
+    injected.reset_after_fork()
+    with pytest.raises(SinkWriteError) as info:
+        injected.write([make_train_episode("e1", step=10)])
+    assert isinstance(info.value.cause, RuntimeError)
+    assert "after a fork" in str(info.value.cause)
+
+
+def test_the_sink_is_registered_for_fork_resets():
+    from prime_runs import _fork
+    from prime_runs.sinks import RftSamplesSink
+
+    sink = RftSamplesSink(object(), encoder=Encoder())  # type: ignore[arg-type]
+
+    assert sink in _fork._registry

--- a/packages/prime-runs/tests/test_train_samples_sink.py
+++ b/packages/prime-runs/tests/test_train_samples_sink.py
@@ -253,6 +253,31 @@ def test_an_upload_that_failed_still_advances_the_sample_id_range(make_platform_
     assert encoder.offsets == [0, SAMPLE_ID_STRIDE]
 
 
+def test_a_forked_child_numbers_its_rows_apart_from_the_parent(make_platform_client, rft_routes):
+    """The child inherits a copy of the parent's upload counters; continuing
+    them would hand out the parent's next range. The child's ranges come from
+    a band the parent's counter never reaches, and every id stays a JSON-safe
+    integer for the viewer."""
+    from prime_runs.sinks.train_samples import SAMPLE_ID_RANGES, SAMPLE_ID_STRIDE
+
+    assert SAMPLE_ID_RANGES * SAMPLE_ID_STRIDE <= 2**53
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes)
+    sink.write([make_train_episode("e1", step=10)])
+
+    sink.reset_after_fork()  # the child's copy of the sink...
+    # ...with its own storage client, as an owned one is rebuilt on the next upload.
+    sink._upload_client, sink._forked_with_injected_client = storage.client(), False
+    sink.write([make_train_episode("e2", step=10)])
+    sink.write([make_train_episode("e3", step=10)])
+
+    parent, first, second = encoder.offsets
+    assert parent == 0
+    band = range(SAMPLE_ID_RANGES // 2 * SAMPLE_ID_STRIDE, SAMPLE_ID_RANGES * SAMPLE_ID_STRIDE)
+    assert first in band and second in band and first != second
+    assert first % SAMPLE_ID_STRIDE == 0
+    assert sink._uploads_per_step == {10: 1}, "the inherited counters are left to the parent"
+
+
 def test_a_confirm_whose_response_was_lost_is_replayed(make_platform_client, rft_routes, no_sleep):
     """Confirm validates the key and refreshes progress; a second confirm of
     the same key changes nothing, so an ambiguous failure is retried rather

--- a/packages/prime-runs/tests/test_train_samples_sink.py
+++ b/packages/prime-runs/tests/test_train_samples_sink.py
@@ -15,10 +15,12 @@ class Encoder:
 
     def __init__(self, payload=b"parquet-bytes"):
         self.calls = []
+        self.offsets = []
         self.payload = payload
 
-    def __call__(self, episodes, run_id, step):
+    def __call__(self, episodes, run_id, step, sample_id_offset=0):
         self.calls.append((list(episodes), run_id, step))
+        self.offsets.append(sample_id_offset)
         return self.payload
 
 
@@ -194,7 +196,7 @@ def test_a_dropped_connection_to_storage_is_transient(make_platform_client, rft_
 
 
 def test_an_encoder_failure_is_a_record_rejection(make_platform_client, rft_routes):
-    def broken(episodes, run_id, step):
+    def broken(episodes, run_id, step, sample_id_offset=0):
         raise ValueError("cannot serialize")
 
     sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, encoder=broken)
@@ -216,6 +218,62 @@ def test_a_presign_without_a_url_is_an_api_error(make_platform_client, rft_route
 
     assert isinstance(info.value.cause, APIError)
     assert "presign" in str(info.value.cause)
+
+
+def test_a_step_logged_again_gets_its_own_sample_id_range(make_platform_client, rft_routes):
+    """Objects are additive per step on the platform (each presign mints a new
+    key and the viewer unions them), and the viewer looks samples up by
+    (step, sample_id): a straggler batch must not reuse the first object's ids."""
+    from prime_runs.sinks.train_samples import SAMPLE_ID_STRIDE
+
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes)
+
+    sink.write([make_train_episode("e1", step=10), make_train_episode("e2", step=20)])
+    sink.write([make_train_episode("e3", step=10)])  # dispatched at 10, shipped later
+
+    assert [step for _, _, step in encoder.calls] == [10, 20, 10]
+    assert encoder.offsets == [0, 0, SAMPLE_ID_STRIDE]
+    presigned = [body["step"] for body in handler.bodies_for("/api/v1/rft/samples/presign")]
+    assert presigned == [10, 20, 10]
+    assert sink.steps_written == 3
+
+
+def test_an_upload_that_failed_still_advances_the_sample_id_range(make_platform_client, rft_routes):
+    """An attempt that failed late may still have landed an object; the next
+    one for the step must not overlap it."""
+    from prime_runs.sinks.train_samples import SAMPLE_ID_STRIDE
+
+    storage = StorageHandler(status_codes=[403])
+    sink, handler, storage, encoder = make_sink(make_platform_client, rft_routes, storage=storage)
+
+    with pytest.raises(SinkWriteError):
+        sink.write([make_train_episode("e1", step=10)])
+    sink.write([make_train_episode("e2", step=10)])
+
+    assert encoder.offsets == [0, SAMPLE_ID_STRIDE]
+
+
+def test_a_confirm_whose_response_was_lost_is_replayed(make_platform_client, rft_routes, no_sleep):
+    """Confirm validates the key and refreshes progress; a second confirm of
+    the same key changes nothing, so an ambiguous failure is retried rather
+    than costing the step."""
+    attempts = []
+
+    def flaky(request: httpx.Request) -> httpx.Response:
+        attempts.append(request)
+        if len(attempts) == 1:
+            return httpx.Response(504)
+        return httpx.Response(200, json={"data": {"status": "success"}})
+
+    routes = dict(rft_routes)
+    routes["POST /api/v1/rft/samples/confirm"] = flaky
+    sink, handler, storage, encoder = make_sink(make_platform_client, routes)
+
+    sink.write([make_train_episode("e1", step=10)])
+
+    assert len(attempts) == 2
+    assert len(storage.uploads) == 1
+    assert sink.steps_written == 1
 
 
 def test_without_pyarrow_the_sink_turns_itself_off_quietly(
@@ -300,6 +358,23 @@ def test_the_default_encoder_writes_the_viewer_table():
     info = json.loads(rows[0]["info"])
     assert info["native_wrapper"]["id"] == "e1"
     assert isinstance(pa.Table, type)
+
+
+def test_the_default_encoder_numbers_rows_from_the_offset():
+    pytest.importorskip("pyarrow")
+    import io
+
+    import pyarrow.parquet as pq
+
+    from prime_runs.projection import episodes_to_parquet_bytes
+
+    episodes = [make_train_episode("e1", step=10, idx=3), make_train_episode("e2", step=10, idx=4)]
+
+    payload = episodes_to_parquet_bytes(episodes, "run-abc", 10, sample_id_offset=7)
+
+    rows = pq.read_table(io.BytesIO(payload)).to_pylist()
+    assert [row["sample_id"] for row in rows] == [7, 8]
+    assert [row["problem_id"] for row in rows] == [3, 4]
 
 
 def test_the_default_encoder_skips_episodes_without_a_trajectory():

--- a/packages/prime-runs/tests/test_worker.py
+++ b/packages/prime-runs/tests/test_worker.py
@@ -373,6 +373,67 @@ def test_a_sustained_outage_eventually_retires_the_sink():
     worker.close()
 
 
+def test_a_cooldown_gives_a_retired_sink_another_chance():
+    """A training run outlives any platform deploy: after the cooldown the
+    sink is tried again, and records that arrived meanwhile are counted as
+    lost to it, not silently forgotten."""
+    from prime_runs.exceptions import TransportError
+    from prime_runs.worker import TRANSIENT_FAILURE_LIMIT
+
+    class OutageSink(FakeSink):
+        def __init__(self) -> None:
+            super().__init__("outage")
+            self.down = True
+
+        def write(self, records) -> None:
+            if self.down:
+                raise TransportError("connection refused")
+            super().write(records)
+
+    sink = OutageSink()
+    worker = UploadWorker([sink], retire_cooldown=0.05)
+
+    for _ in range(TRANSIENT_FAILURE_LIMIT):
+        worker.submit([{"id": "lost"}])
+        drain(worker)
+    assert sink.enabled is False
+    worker.submit([{"id": "during"}])
+    drain(worker)
+    assert sink.batches == []
+
+    # A real wait: the autouse no_sleep fixture stubs out time.sleep.
+    threading.Event().wait(0.06)
+    sink.down = False
+    worker.submit([{"id": "after"}])
+    drain(worker)
+
+    assert sink.enabled is True
+    assert sink.batches == [[{"id": "after"}]]
+    assert worker.failed_records == {"outage": TRANSIENT_FAILURE_LIMIT + 1}
+    worker.close()
+
+
+def test_a_permanent_failure_is_not_revived_by_the_cooldown():
+    from prime_runs.exceptions import UnauthorizedError
+
+    class DeniedSink(FakeSink):
+        def write(self, records) -> None:
+            raise UnauthorizedError("nope", status_code=401)
+
+    sink = DeniedSink("denied")
+    worker = UploadWorker([sink], retire_cooldown=0.01)
+
+    worker.submit([{"id": 1}])
+    drain(worker)
+    threading.Event().wait(0.02)
+    worker.submit([{"id": 2}])
+    drain(worker)
+
+    assert sink.enabled is False
+    assert worker.failed_records == {"denied": 2}
+    worker.close()
+
+
 def test_a_success_forgives_earlier_blips():
     """Strikes are consecutive: an intermittent gateway must never accumulate
     its way to a retirement across an otherwise healthy run."""

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-12T18:00:50.512194Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1461,16 +1461,20 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+train = [
+    { name = "pyarrow" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "prime-traces", editable = "packages/prime-traces" },
+    { name = "pyarrow", marker = "extra == 'train'", specifier = ">=15.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "train"]
 
 [[package]]
 name = "prime-sandboxes"


### PR DESCRIPTION
> **Stacked on #856** (`feature/prime-runs-sdk`). This PR targets that branch and must merge **after** it; once #856 is on `main`, retarget this PR to `main` and re-run CI. Compare against the parent branch, not `main`. Merging this does not publish anything: `prime-runs-v0.1.0` will already be tagged, so `release-runs.yml` skips — this ships in the release after 0.1.0 (on a `release/*` branch, with the eval FAILED-status adoption).

## What

The training half of the SDK: `pr.init(kind="train", ...)` opens an external training run over `/api/v1/rft/external-runs` — what prime-rl's [`monitors/prime.py::TrainRun`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/src/prime_rl/monitors/prime.py) does by hand today (its docstring calls itself "the natural seam to be subsumed by the train SDK"). Additive: the eval path is unchanged apart from `run.type` following the run's kind.

```python
run = pr.init(
    kind="train",
    model="Qwen/Qwen3-8B",                  # base model
    environments=["primeintellect/gsm8k"],  # hub ids, passed through
    training=pr.TrainingSpec(max_steps=1000, batch_size=64, rollouts_per_example=8),
    config=train_config.model_dump(),
    team_id="team_...",                     # required: external runs are per team
)
run.log_episodes(episodes)                  # carry run.work.step (verifiers TrainRunInfo)
run.log_metrics(metrics, step=step)
run.finish()
```

| piece | where | notes |
|---|---|---|
| `RftBackend` | `backend.py` | create / attach / finalize; `update()` is a no-op (no config/summary document on RFT runs) |
| `Run.log_metrics(values, step=)` | `run.py` | second `UploadWorker` so a slow sample upload never holds metrics back; `_timestamp` stamped, non-finite dropped |
| `RftMetricsSink` | `sinks/metrics.py` | one `POST /rft/metrics` per row (endpoint takes one step; 60/min, Retry-After honoured) |
| `RftSamplesSink` | `sinks/train_samples.py` | training-work episodes grouped by `run.work.step`, every 10th step (prime-rl's cadence, configurable), presign → PUT → confirm |
| `episodes_to_parquet_bytes` | `projection.py` | prime-rl's encoder moved here, duck-typed; pyarrow behind `prime-runs[train]`, sink turns itself off with a warning without it |
| `TrainingSpec`, `RunKind`, `RunSpec.kind/training` | `models.py` | |
| `init(kind=, id=, training=)` | `run.py` | `id=` attaches to a managed launch's run |

## Decisions worth a look

- **Terminal status.** `completed` → `POST /rft/finalize {exit_code: 0}`: a server-side compare-and-set with "already finalized" as success, so it is **replayed** on an ambiguous failure (unlike the eval finalize). `failed` / `cancelled` / `crashed` → `PUT /external-runs/{id}/status {status: "failed", error_message}` with the finer reason in the message, since the RFT vocabulary is `completed | failed`. A 409 there means someone closed it first — logged, not raised.
- **Team allowlist.** `POST /external-runs` refuses without a `team_id` and returns 403 for teams outside `rft_external_runs_allowed_team_ids`. The SDK raises `ConfigurationError` before the request when there is no team, and passes the platform's 403 reason through as `ForbiddenError` from `init()`. The producer decides whether that means "run locally" (the way verifiers treats a missing key) — same contract as evals, no silent downgrade inside `init()`.
- **Attach (`id=$RUN_ID`).** Mirrors prime-rl: nothing registered, a non-completed `finish()` is logged and left to the launcher (which marks its own run failed when the process goes away), a clean `finish()` still finalizes.
- **Samples cadence lives in the sink, not the producer.** prime-rl uploads every 10th `train`/`effective` step; the SDK applies the step cadence (`step_interval=10`) and reads the work kind off the episode, so the producer just logs everything and Prime Traces gets it all. The `effective`-subset filter stays in prime-rl (the SDK cannot know it).
- **`finish(summary=)` is not sent for training runs** — there is nowhere to put it (prime-rl sends `summary: {}` and the backend ignores it). Documented; final numbers go through `log_metrics`.

## Not in this PR

- The prime-rl branch that replaces `TrainRun` with this (after `prime-runs` is on PyPI; prime-rl also needs its `deps/verifiers` submodule past verifiers#2415, which makes `import prime_runs` part of its import path anyway).
- `dashboard/training/[id]/ConfigTab.tsx` rendering `run_config.config_source` verbatim (platform follow-up, same shape as platform#4740's eval Config tab).
- A version bump (CI gate; `release/*` only).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches run lifecycle, multi-day training uploads, and external RFT APIs (team allowlist, metrics rate limits, object storage); eval path is largely unchanged but shared upload/metrics plumbing grew more complex.
> 
> **Overview**
> **Adds training runs** to `prime-runs` alongside eval: `pr.init(kind="train", ...)` registers or attaches to external runs on `/api/v1/rft/external-runs`, with `TrainingSpec`, required `team_id`, and `Run.log_metrics` on a **separate upload worker** so metrics are not blocked by sample uploads.
> 
> **New platform plumbing:** `RftBackend` handles create/attach/finalize (RFT `completed|failed` mapping, idempotent finalize); `RftMetricsSink` posts per-step metrics; `RftSamplesSink` groups training-work episodes by `run.work.step`, uploads Parquet on a configurable cadence (default every 10th step) via presign/PUT/confirm, with fork-safe `sample_id` ranges. Parquet encoding lives in `projection.episodes_to_parquet_bytes` behind optional **`prime-runs[train]`** (pyarrow).
> 
> **Resilience for long runs:** training sinks use a **5-minute pause-and-retry** after transient failures instead of permanent retirement; attached runs (`id=`) skip registration and non-success terminal status updates so launchers own failure marking. Eval behavior stays the same aside from stamping `run.type` from kind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c000e196b6b832906e1488e73cab24b3219747f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->