### PR TITLE
fix(traces): keep the server's reason on 401 responses

### DIFF
--- a/packages/prime-traces/src/prime_traces/core/client.py
+++ b/packages/prime-traces/src/prime_traces/core/client.py
@@ -193,10 +193,6 @@ def raise_for_response(response: httpx.Response) -> None:
     code, message = _extract_error(response)
 
     if status == 401:
-        # Carry the server's reason. The platform API answers a token that
-        # lacks a required *scope* with 401, not 403, and only the body names
-        # the scope; a canned line sends the caller to rotate a key that is
-        # valid but under-scoped.
         detail = message if message != f"HTTP {status}" else None
         text = (
             f"API key unauthorized ({detail}). Check PRIME_API_KEY and its scopes."

--- a/packages/prime-traces/src/prime_traces/core/client.py
+++ b/packages/prime-traces/src/prime_traces/core/client.py
@@ -193,9 +193,17 @@ def raise_for_response(response: httpx.Response) -> None:
     code, message = _extract_error(response)
 
     if status == 401:
-        raise UnauthorizedError(
-            "API key unauthorized. Check PRIME_API_KEY.", status_code=status, code=code
+        # Carry the server's reason. The platform API answers a token that
+        # lacks a required *scope* with 401, not 403, and only the body names
+        # the scope; a canned line sends the caller to rotate a key that is
+        # valid but under-scoped.
+        detail = message if message != f"HTTP {status}" else None
+        text = (
+            f"API key unauthorized ({detail}). Check PRIME_API_KEY and its scopes."
+            if detail
+            else "API key unauthorized. Check PRIME_API_KEY and its scopes."
         )
+        raise UnauthorizedError(text, status_code=status, code=code)
     if status == 402:
         raise PaymentRequiredError(
             "Payment required. Check billing status.", status_code=status, code=code

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -189,49 +189,6 @@ class TestPointReads:
         with pytest.raises(UnauthorizedError):
             make_client(handler).get("8d3f1a2b")
 
-    def test_unauthorized_keeps_server_detail(self, make_client):
-        """The platform API answers a token missing a required *scope* with
-        401 (not 403), and only the FastAPI ``detail`` names the scope. That
-        text must reach the caller: the key is valid, and "check
-        PRIME_API_KEY" alone sends them rotating it instead of granting the
-        scope."""
-        detail = "Token permission missing: scope 'environments', permission 'write'"
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(401, json={"detail": detail})
-
-        with pytest.raises(UnauthorizedError) as exc_info:
-            make_client(handler).get("8d3f1a2b")
-        assert detail in str(exc_info.value)
-        assert "PRIME_API_KEY" in str(exc_info.value)
-
-    def test_unauthorized_keeps_service_envelope_message(self, make_client):
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                401,
-                json={
-                    "error": {
-                        "code": "unauthenticated",
-                        "message": "Invalid or expired API token",
-                    }
-                },
-            )
-
-        with pytest.raises(UnauthorizedError) as exc_info:
-            make_client(handler).get("8d3f1a2b")
-        assert exc_info.value.code == "unauthenticated"
-        assert "Invalid or expired API token" in str(exc_info.value)
-
-    def test_unauthorized_without_body_stays_readable(self, make_client):
-        """An empty 401 (a gateway, say) must not render as "(HTTP 401)"."""
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(401)
-
-        with pytest.raises(UnauthorizedError) as exc_info:
-            make_client(handler).get("8d3f1a2b")
-        assert str(exc_info.value) == "API key unauthorized. Check PRIME_API_KEY and its scopes."
-
     def test_forbidden_is_typed_with_server_message(self, make_client):
         """403 is an expected path, not an edge case: hosted-eval worker
         tokens are write-only, so any read they attempt lands here. The

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -189,6 +189,49 @@ class TestPointReads:
         with pytest.raises(UnauthorizedError):
             make_client(handler).get("8d3f1a2b")
 
+    def test_unauthorized_keeps_server_detail(self, make_client):
+        """The platform API answers a token missing a required *scope* with
+        401 (not 403), and only the FastAPI ``detail`` names the scope. That
+        text must reach the caller: the key is valid, and "check
+        PRIME_API_KEY" alone sends them rotating it instead of granting the
+        scope."""
+        detail = "Token permission missing: scope 'environments', permission 'write'"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"detail": detail})
+
+        with pytest.raises(UnauthorizedError) as exc_info:
+            make_client(handler).get("8d3f1a2b")
+        assert detail in str(exc_info.value)
+        assert "PRIME_API_KEY" in str(exc_info.value)
+
+    def test_unauthorized_keeps_service_envelope_message(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                401,
+                json={
+                    "error": {
+                        "code": "unauthenticated",
+                        "message": "Invalid or expired API token",
+                    }
+                },
+            )
+
+        with pytest.raises(UnauthorizedError) as exc_info:
+            make_client(handler).get("8d3f1a2b")
+        assert exc_info.value.code == "unauthenticated"
+        assert "Invalid or expired API token" in str(exc_info.value)
+
+    def test_unauthorized_without_body_stays_readable(self, make_client):
+        """An empty 401 (a gateway, say) must not render as "(HTTP 401)"."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401)
+
+        with pytest.raises(UnauthorizedError) as exc_info:
+            make_client(handler).get("8d3f1a2b")
+        assert str(exc_info.value) == "API key unauthorized. Check PRIME_API_KEY and its scopes."
+
     def test_forbidden_is_typed_with_server_message(self, make_client):
         """403 is an expected path, not an edge case: hosted-eval worker
         tokens are write-only, so any read they attempt lands here. The


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes client-side exception text for 401 responses; no auth, retry, or request behavior changes.
> 
> **Overview**
> **401 handling** in `raise_for_response` no longer drops the API’s error text. When `_extract_error` returns something other than the generic `HTTP 401` placeholder, that reason is included in the `UnauthorizedError` message (e.g. `API key unauthorized (bad token). …`).
> 
> The fixed guidance string now also mentions checking **API key scopes**, aligning with how **403** already surfaces server messages for scope-related failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d47adc0015989f4bde80d8ccd82afd06f9a90f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

