### PR TITLE
feat(env): send a v0/v1 runtime hint on push

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -34,7 +34,11 @@ from ..utils import (
     validate_output_format,
 )
 from ..utils.env_metadata import find_environment_metadata
-from ..utils.environment_runtime import VERIFIERS_V1, detect_environment_runtime
+from ..utils.environment_runtime import (
+    VERIFIERS_V1,
+    classify_runtime_from_metadata,
+    parse_runtime_option,
+)
 from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
@@ -1070,6 +1074,14 @@ def push(
     visibility: Optional[str] = typer.Option(
         None, "--visibility", "-v", help="Environment visibility (PUBLIC/PRIVATE)"
     ),
+    runtime: Optional[str] = typer.Option(
+        None,
+        "--runtime",
+        help=(
+            "Verifiers API the package targets: v0 or v1. Defaults to the package's "
+            "verifiers requirement (a lower bound of 0.2.0 or newer means v1)."
+        ),
+    ),
     auto_bump: bool = typer.Option(
         False, "--auto-bump", help="Automatically bump patch version before push"
     ),
@@ -1083,6 +1095,12 @@ def push(
     """Push environment to registry"""
 
     try:
+        try:
+            declared_runtime = parse_runtime_option(runtime)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            raise typer.Exit(1)
+
         env_path = _resolve_push_environment_path(path, env_id)
         _run_env_push_lab_hygiene_preflight(env_path)
 
@@ -1345,22 +1363,18 @@ def push(
             # Extract Requires-Dist from wheel METADATA (includes URL dependencies)
             requires_dist = extract_requires_dist_from_wheel(wheel_path)
 
-            archive_files = _collect_archive_files(env_path)
-            runtime_hint = detect_environment_runtime(
-                env_path,
-                archive_files,
-                requires_dist=requires_dist,
-                dependencies=project_metadata.get("dependencies", []),
-                legacy_tags="tags" in project_metadata,
+            runtime_hint = declared_runtime or classify_runtime_from_metadata(
+                requires_dist or project_metadata.get("dependencies", [])
             )
             if runtime_hint is None:
                 console.print(
-                    "[dim]Could not tell v0 from v1 locally; the Hub will classify "
-                    "the package at unpack time.[/dim]"
+                    "[yellow]No verifiers requirement found, so the Hub will list this "
+                    "package as Unclassified; pass --runtime v0|v1 to declare it.[/yellow]"
                 )
             else:
                 label = "verifiers v1" if runtime_hint == VERIFIERS_V1 else "legacy verifiers v0"
-                console.print(f"Detected a {label} environment")
+                source = "--runtime" if declared_runtime else "the verifiers requirement"
+                console.print(f"Publishing as {label} (from {source})")
 
             wheel_data = {
                 "content_hash": content_hash,
@@ -1377,8 +1391,9 @@ def push(
                     "original_filename": wheel_path.name,
                     "requires_dist": requires_dist,  # Include full dependency specs from wheel
                 },
-                "runtime_hint": runtime_hint,
             }
+            if runtime_hint is not None:
+                wheel_data["runtime_hint"] = runtime_hint
 
             try:
                 response = client.post(f"/environmentshub/{env_id}/wheels", json=wheel_data)
@@ -1436,7 +1451,7 @@ def push(
                 with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
                     temp_file_path = tmp.name
                     with tarfile.open(tmp.name, "w:gz") as tar:
-                        for file_path in archive_files:
+                        for file_path in _collect_archive_files(env_path):
                             arcname = file_path.relative_to(env_path)
                             tar.add(file_path, arcname=str(arcname))
 
@@ -1481,8 +1496,9 @@ def push(
                             **wheel_data["metadata"],
                             "original_filename": f"{env_name}-{version}.tar.gz",
                         },
-                        "runtime_hint": runtime_hint,
                     }
+                    if runtime_hint is not None:
+                        source_data["runtime_hint"] = runtime_hint
 
                     try:
                         response = client.post(

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -1095,12 +1095,12 @@ def push(
     """Push environment to registry"""
 
     try:
-        try:
-            declared_runtime = parse_runtime_option(runtime)
-        except ValueError as e:
-            console.print(f"[red]Error: {e}[/red]")
-            raise typer.Exit(1)
+        declared_runtime = parse_runtime_option(runtime)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
 
+    try:
         env_path = _resolve_push_environment_path(path, env_id)
         _run_env_push_lab_hygiene_preflight(env_path)
 

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -34,6 +34,11 @@ from ..utils import (
     validate_output_format,
 )
 from ..utils.env_metadata import find_environment_metadata
+from ..utils.environment_runtime import (
+    VERIFIERS_V0,
+    VERIFIERS_V1,
+    detect_environment_runtime,
+)
 from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
@@ -1344,6 +1349,24 @@ def push(
             # Extract Requires-Dist from wheel METADATA (includes URL dependencies)
             requires_dist = extract_requires_dist_from_wheel(wheel_path)
 
+            runtime_hint = detect_environment_runtime(
+                env_path,
+                _collect_archive_files(env_path),
+                requires_dist=requires_dist,
+                dependencies=project_metadata.get("dependencies", []),
+            )
+            if runtime_hint == VERIFIERS_V1:
+                console.print("Detected a verifiers v1 environment (runtime_hint=VERIFIERS_V1)")
+            elif runtime_hint == VERIFIERS_V0:
+                console.print(
+                    "Detected a legacy verifiers v0 environment (runtime_hint=VERIFIERS_V0)"
+                )
+            else:
+                console.print(
+                    "[dim]Could not tell v0 from v1 locally; the Hub will classify "
+                    "the package at unpack time.[/dim]"
+                )
+
             wheel_data = {
                 "content_hash": content_hash,
                 "filename": unique_wheel_name,
@@ -1360,6 +1383,8 @@ def push(
                     "requires_dist": requires_dist,  # Include full dependency specs from wheel
                 },
             }
+            if runtime_hint is not None:
+                wheel_data["runtime_hint"] = runtime_hint
 
             try:
                 response = client.post(f"/environmentshub/{env_id}/wheels", json=wheel_data)
@@ -1463,6 +1488,8 @@ def push(
                             "original_filename": f"{env_name}-{version}.tar.gz",
                         },
                     }
+                    if runtime_hint is not None:
+                        source_data["runtime_hint"] = runtime_hint
 
                     try:
                         response = client.post(

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -34,11 +34,7 @@ from ..utils import (
     validate_output_format,
 )
 from ..utils.env_metadata import find_environment_metadata
-from ..utils.environment_runtime import (
-    VERIFIERS_V0,
-    VERIFIERS_V1,
-    detect_environment_runtime,
-)
+from ..utils.environment_runtime import VERIFIERS_V1, detect_environment_runtime
 from ..utils.formatters import format_file_size
 from ..utils.formatters import strip_ansi as _strip_ansi
 from ..utils.prompt import (
@@ -1349,23 +1345,22 @@ def push(
             # Extract Requires-Dist from wheel METADATA (includes URL dependencies)
             requires_dist = extract_requires_dist_from_wheel(wheel_path)
 
+            archive_files = _collect_archive_files(env_path)
             runtime_hint = detect_environment_runtime(
                 env_path,
-                _collect_archive_files(env_path),
+                archive_files,
                 requires_dist=requires_dist,
                 dependencies=project_metadata.get("dependencies", []),
+                legacy_tags="tags" in project_metadata,
             )
-            if runtime_hint == VERIFIERS_V1:
-                console.print("Detected a verifiers v1 environment (runtime_hint=VERIFIERS_V1)")
-            elif runtime_hint == VERIFIERS_V0:
-                console.print(
-                    "Detected a legacy verifiers v0 environment (runtime_hint=VERIFIERS_V0)"
-                )
-            else:
+            if runtime_hint is None:
                 console.print(
                     "[dim]Could not tell v0 from v1 locally; the Hub will classify "
                     "the package at unpack time.[/dim]"
                 )
+            else:
+                label = "verifiers v1" if runtime_hint == VERIFIERS_V1 else "legacy verifiers v0"
+                console.print(f"Detected a {label} environment")
 
             wheel_data = {
                 "content_hash": content_hash,
@@ -1382,9 +1377,8 @@ def push(
                     "original_filename": wheel_path.name,
                     "requires_dist": requires_dist,  # Include full dependency specs from wheel
                 },
+                "runtime_hint": runtime_hint,
             }
-            if runtime_hint is not None:
-                wheel_data["runtime_hint"] = runtime_hint
 
             try:
                 response = client.post(f"/environmentshub/{env_id}/wheels", json=wheel_data)
@@ -1442,7 +1436,7 @@ def push(
                 with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
                     temp_file_path = tmp.name
                     with tarfile.open(tmp.name, "w:gz") as tar:
-                        for file_path in _collect_archive_files(env_path):
+                        for file_path in archive_files:
                             arcname = file_path.relative_to(env_path)
                             tar.add(file_path, arcname=str(arcname))
 
@@ -1487,9 +1481,8 @@ def push(
                             **wheel_data["metadata"],
                             "original_filename": f"{env_name}-{version}.tar.gz",
                         },
+                        "runtime_hint": runtime_hint,
                     }
-                    if runtime_hint is not None:
-                        source_data["runtime_hint"] = runtime_hint
 
                     try:
                         response = client.post(

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -1,0 +1,273 @@
+"""Classify which verifiers API an environment package targets (v0 vs v1).
+
+Local mirror of the Hub's server-side classifier (platform
+``backend/app/utils/environment_runtime.py``), applied to the environment
+directory at push time. The result is sent as the optional ``runtime_hint``
+field on wheel and version uploads; the Hub stores it as authoritative, so the
+rules here must stay consistent with the server:
+
+* source evidence wins over the requirement heuristic — ``verifiers.v1``
+  imports are an unambiguous v1 marker, ``def load_environment`` an
+  unambiguous v0 one;
+* otherwise the ``verifiers`` requirement decides — v1 shipped as verifiers
+  0.2.0, so a lower bound at or above 0.2.0 is a v1 signal;
+* a package with neither signal returns ``None`` and the hint is omitted, in
+  which case the Hub classifies the package itself at unpack time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import InvalidVersion, Version
+
+VERIFIERS_V0 = "VERIFIERS_V0"
+VERIFIERS_V1 = "VERIFIERS_V1"
+
+# First verifiers release that shipped the v1 API (`verifiers.v1`).
+VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
+
+# Source files larger than this are skipped: markers live near the top of
+# small package modules, not in bundled data files.
+MAX_SOURCE_FILE_BYTES = 256 * 1024
+
+# Upper bound on source files read per push. Markers live in the package's
+# top-level modules, which `_source_scan_order` puts first.
+MAX_SOURCE_FILES = 40
+
+# Only scan Python modules and the project manifest; skip tests and vendored code.
+_SCANNABLE_SUFFIXES = (".py", "pyproject.toml")
+_SKIPPED_PATH_PARTS = {
+    "tests",
+    "test",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "site-packages",
+    "outputs",
+}
+
+# Anchored to real import statements / the conventional `vf.` alias so prose
+# mentions in docstrings are unlikely to match. A bare `class X(Taskset)` is
+# deliberately not a marker: nothing ties that name to verifiers.
+_V1_SOURCE_PATTERNS = (
+    re.compile(r"^\s*(?:from|import)\s+verifiers\.v1\b", re.MULTILINE),
+    re.compile(r"^\s*from\s+verifiers\s+import\s+(?:\([^)]*\b|[^\n]*\b)?v1\b", re.MULTILINE),
+    re.compile(r"\bvf\.(?:Taskset|Harness|TasksetConfig|HarnessConfig)\b"),
+)
+_V0_SOURCE_PATTERNS = (
+    re.compile(r"^\s*def\s+load_environment\s*\(", re.MULTILINE),
+    re.compile(r"^\s*(?:from|import)\s+verifiers\.legacy\b", re.MULTILINE),
+)
+
+
+def effective_requirement_strings(
+    requires_dist: Optional[Iterable[str]],
+    dependencies: Optional[Iterable[str]],
+) -> List[str]:
+    """Pick the richest requirement source: wheel metadata, then pyproject."""
+    for value in (requires_dist, dependencies):
+        if not value:
+            continue
+        entries = [entry for entry in value if isinstance(entry, str)]
+        if entries:
+            return entries
+    return []
+
+
+def _verifiers_requirements(requirement_strings: Iterable[str]) -> List[Requirement]:
+    requirements: List[Requirement] = []
+    for requirement_text in requirement_strings:
+        try:
+            requirement = Requirement(requirement_text.strip())
+        except InvalidRequirement:
+            continue
+        if requirement.name.lower() == "verifiers":
+            requirements.append(requirement)
+    return requirements
+
+
+def find_verifiers_requirement(
+    requirement_strings: Iterable[str],
+) -> Optional[Requirement]:
+    """Return the package's effective ``verifiers`` requirement, if any.
+
+    Unconditional entries take precedence over marker-guarded ones
+    (``verifiers>=0.2; python_version >= "3.11"``). Within the applicable set,
+    repeated entries intersect, so the one with the highest floor is the
+    effective requirement — a package that admits v1 in any of its
+    environments targets v1.
+    """
+    requirements = _verifiers_requirements(requirement_strings)
+    if not requirements:
+        return None
+    unconditional = [r for r in requirements if r.marker is None]
+    applicable = unconditional or requirements
+    return max(
+        applicable,
+        key=lambda requirement: _verifiers_lower_bound(requirement) or Version("0"),
+    )
+
+
+def _verifiers_lower_bound(requirement: Requirement) -> Optional[Version]:
+    """Effective lower bound of the specifier set, or None if it has no floor.
+
+    ``>=``, ``>``, ``~=``, ``==``/``===`` and ``==X.Y.*`` prefix pins all set a
+    floor; clauses intersect, so the highest floor is the effective one
+    (``>=0.1,>=0.2`` admits nothing below 0.2). ``>`` is treated as its
+    version — off by one patch level is irrelevant at the 0.2.0 cut.
+    """
+    floors: List[Version] = []
+    for spec in requirement.specifier:
+        if spec.operator not in {">=", ">", "==", "===", "~="}:
+            continue
+        version = spec.version
+        if "*" in version:
+            if spec.operator != "==" or not version.endswith(".*"):
+                continue
+            version = version[: -len(".*")]
+        try:
+            floors.append(Version(version))
+        except InvalidVersion:
+            continue
+    return max(floors) if floors else None
+
+
+def classify_runtime_from_metadata(
+    requirement_strings: Iterable[str],
+) -> Optional[str]:
+    """Heuristic classification from the verifiers requirement alone.
+
+    * floor ``>= 0.2.0`` → v1 (v1 shipped as verifiers 0.2.0);
+    * any other verifiers requirement (``>=0.1.x``, unbounded, ``<0.2``) → v0 —
+      every package published before v1 existed looks like this, and v0
+      packages that upgraded their pin are caught by the source scan;
+    * no verifiers requirement → ``None`` (no opinion).
+    """
+    requirement = find_verifiers_requirement(requirement_strings)
+    if requirement is None:
+        return None
+    if requirement.url:
+        # `verifiers @ git+https://...` — can't tell which API from a URL pin.
+        return None
+    floor = _verifiers_lower_bound(requirement)
+    if floor is not None and floor >= VERIFIERS_V1_MIN_VERSION:
+        return VERIFIERS_V1
+    return VERIFIERS_V0
+
+
+def _is_scannable_source_path(path: str, size: Optional[int] = None) -> bool:
+    """Whether a file is worth reading for classification."""
+    if size is not None and size > MAX_SOURCE_FILE_BYTES:
+        return False
+    normalized = path.strip("/")
+    if not normalized.endswith(_SCANNABLE_SUFFIXES):
+        return False
+    parts = normalized.split("/")
+    # Only skip on *directory* components so a `test_utils.py` module still scans.
+    return not any(part in _SKIPPED_PATH_PARTS for part in parts[:-1])
+
+
+def _pyproject_declares_legacy_tags(content: str) -> bool:
+    """True when ``[project].tags`` is set (only that table; ``[tool.*]`` tags
+    are unrelated)."""
+    try:
+        data = tomllib.loads(content)
+    except Exception:
+        return False
+    project = data.get("project")
+    return isinstance(project, dict) and "tags" in project
+
+
+def classify_runtime_from_source(sources: Mapping[str, str]) -> Optional[str]:
+    """Classify from source contents (relative path → text).
+
+    v1 markers win: a v1 package may keep a ``load_environment`` shim for old
+    callers, but nothing pre-v1 imports ``verifiers.v1``.
+    """
+    saw_v0 = False
+    for path, content in sources.items():
+        if not content:
+            continue
+        if path.endswith("pyproject.toml"):
+            # `[project].tags` is the non-PEP-621 field the old Actions CI
+            # asserted on; v1 packages don't need it but may still carry it,
+            # so it only counts as weak v0 evidence.
+            if _pyproject_declares_legacy_tags(content):
+                saw_v0 = True
+            continue
+        if any(pattern.search(content) for pattern in _V1_SOURCE_PATTERNS):
+            return VERIFIERS_V1
+        if any(pattern.search(content) for pattern in _V0_SOURCE_PATTERNS):
+            saw_v0 = True
+    return VERIFIERS_V0 if saw_v0 else None
+
+
+def _source_scan_order(path: str) -> Tuple[int, int, str]:
+    """Sort key: pyproject first, then shallow modules (``__init__`` before siblings)."""
+    if path.endswith("pyproject.toml"):
+        return (0, 0, path)
+    depth = path.count("/")
+    if path.endswith("__init__.py"):
+        return (1, depth, f"{path[: -len('__init__.py')]}!")
+    return (1, depth, path)
+
+
+def collect_sources(
+    env_path: Path,
+    files: Iterable[Path],
+    max_files: int = MAX_SOURCE_FILES,
+) -> Dict[str, str]:
+    """Read the scannable source files out of the push's archive file set.
+
+    ``files`` is the same collection that goes into the source tarball, so the
+    CLI scans exactly what the Hub would scan at unpack time. Reads stop early
+    once a v1 marker is seen — it is conclusive.
+    """
+    by_rel_path: Dict[str, Path] = {}
+    for file_path in files:
+        rel_path = str(file_path.relative_to(env_path)).replace("\\", "/")
+        try:
+            size = file_path.stat().st_size
+        except OSError:
+            continue
+        if _is_scannable_source_path(rel_path, size):
+            by_rel_path[rel_path] = file_path
+
+    sources: Dict[str, str] = {}
+    for rel_path in sorted(by_rel_path, key=_source_scan_order)[:max_files]:
+        try:
+            sources[rel_path] = by_rel_path[rel_path].read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if classify_runtime_from_source(sources) == VERIFIERS_V1:
+            break
+    return sources
+
+
+def detect_environment_runtime(
+    env_path: Path,
+    files: Iterable[Path],
+    requires_dist: Optional[Iterable[str]] = None,
+    dependencies: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """The ``runtime_hint`` to send with a push, or ``None`` to omit it.
+
+    Source markers beat the verifiers pin floor, matching the server-side
+    classifier; with no signal at all the hint is omitted and the Hub
+    classifies the package itself at unpack time.
+    """
+    from_source = classify_runtime_from_source(collect_sources(env_path, files))
+    if from_source is not None:
+        return from_source
+    return classify_runtime_from_metadata(
+        effective_requirement_strings(requires_dist, dependencies)
+    )

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -1,24 +1,18 @@
-"""Classify which verifiers API an environment package targets (v0 vs v1).
+"""Which verifiers API an environment package targets (v0 vs v1), for ``prime env push``.
 
-Local mirror of the Hub's server-side classifier (platform
-``backend/app/utils/environment_runtime.py``), applied to the environment
-directory at push time. The result is sent as ``runtime_hint`` on wheel and
-version uploads and the Hub stores it as authoritative, so the rules here must
-stay consistent with the server:
+The Hub stores whatever the CLI declares (``--runtime v0|v1``) as the package's
+runtime. Without the flag, the package's own ``verifiers`` requirement decides:
+v1 shipped as verifiers 0.2.0, so a lower bound at or above 0.2.0 declares v1
+and any other pin declares v0. No verifiers requirement (or a URL pin, which
+says nothing about the API) means no hint is sent and the Hub lists the
+package as Unclassified until its owner sets the runtime.
 
-* source evidence wins — ``verifiers.v1`` imports are an unambiguous v1 marker,
-  ``def load_environment`` an unambiguous v0 one, ``[project].tags`` weak v0;
-* otherwise the ``verifiers`` requirement decides — v1 shipped as verifiers
-  0.2.0, so a lower bound at or above 0.2.0 is a v1 signal;
-* neither signal → ``None``: the hint is omitted and the Hub classifies the
-  package itself at unpack time.
+Mirrors the server's fallback (platform ``backend/app/utils/environment_runtime.py``).
 """
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
@@ -29,34 +23,20 @@ VERIFIERS_V1 = "VERIFIERS_V1"
 # First verifiers release that shipped the v1 API (`verifiers.v1`).
 VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
-# Same scan bounds as the server: markers live near the top of small modules.
-MAX_SOURCE_FILE_BYTES = 256 * 1024
-MAX_SOURCE_FILES = 40
+_RUNTIME_OPTIONS = {"v0": VERIFIERS_V0, "v1": VERIFIERS_V1}
 
-# Skip tests and vendored code (directory components only, so `test_utils.py` still scans).
-_SKIPPED_DIRS = {
-    "tests",
-    "test",
-    ".venv",
-    "venv",
-    "node_modules",
-    "__pycache__",
-    "site-packages",
-    "outputs",
-}
 
-# Anchored to real import statements / the conventional `vf.` alias so prose
-# mentions in docstrings are unlikely to match. A bare `class X(Taskset)` is
-# deliberately not a marker: nothing ties that name to verifiers.
-_V1_SOURCE_PATTERNS = (
-    re.compile(r"^\s*(?:from|import)\s+verifiers\.v1\b", re.MULTILINE),
-    re.compile(r"^\s*from\s+verifiers\s+import\s+(?:\([^)]*\b|[^\n]*\b)?v1\b", re.MULTILINE),
-    re.compile(r"\bvf\.(?:Taskset|Harness|TasksetConfig|HarnessConfig)\b"),
-)
-_V0_SOURCE_PATTERNS = (
-    re.compile(r"^\s*def\s+load_environment\s*\(", re.MULTILINE),
-    re.compile(r"^\s*(?:from|import)\s+verifiers\.legacy\b", re.MULTILINE),
-)
+def parse_runtime_option(value: Optional[str]) -> Optional[str]:
+    """``--runtime`` value → Hub runtime, or None when the flag was not given.
+
+    Raises ``ValueError`` for anything other than ``v0`` / ``v1`` (case-insensitive).
+    """
+    if value is None:
+        return None
+    runtime = _RUNTIME_OPTIONS.get(value.strip().lower())
+    if runtime is None:
+        raise ValueError(f"--runtime must be 'v0' or 'v1', got {value!r}")
+    return runtime
 
 
 def find_verifiers_requirement(requirement_strings: Iterable[str]) -> Optional[Requirement]:
@@ -108,68 +88,3 @@ def classify_runtime_from_metadata(requirement_strings: Iterable[str]) -> Option
     if floor is not None and floor >= VERIFIERS_V1_MIN_VERSION:
         return VERIFIERS_V1
     return VERIFIERS_V0
-
-
-def classify_runtime_from_source(
-    sources: Iterable[str], legacy_tags: bool = False
-) -> Optional[str]:
-    """v1 markers win: a v1 package may keep a ``load_environment`` shim for old
-    callers, but nothing pre-v1 imports ``verifiers.v1``."""
-    saw_v0 = legacy_tags
-    for content in sources:
-        if any(pattern.search(content) for pattern in _V1_SOURCE_PATTERNS):
-            return VERIFIERS_V1
-        if any(pattern.search(content) for pattern in _V0_SOURCE_PATTERNS):
-            saw_v0 = True
-    return VERIFIERS_V0 if saw_v0 else None
-
-
-def _scan_order(rel_path: str) -> Tuple[int, str]:
-    """Shallow modules first, ``__init__`` before its siblings."""
-    depth = rel_path.count("/")
-    if rel_path.endswith("__init__.py"):
-        return (depth, f"{rel_path[: -len('__init__.py')]}!")
-    return (depth, rel_path)
-
-
-def collect_sources(
-    env_path: Path, files: Iterable[Path], max_files: int = MAX_SOURCE_FILES
-) -> List[str]:
-    """Contents of the scannable modules among the push's archive files — the same
-    set the Hub scans at unpack time, bounded the same way."""
-    candidates: Dict[str, Path] = {}
-    for file_path in files:
-        rel_path = str(file_path.relative_to(env_path)).replace("\\", "/")
-        if not rel_path.endswith(".py"):
-            continue
-        if any(part in _SKIPPED_DIRS for part in rel_path.split("/")[:-1]):
-            continue
-        try:
-            if file_path.stat().st_size > MAX_SOURCE_FILE_BYTES:
-                continue
-        except OSError:
-            continue
-        candidates[rel_path] = file_path
-
-    sources: List[str] = []
-    for rel_path in sorted(candidates, key=_scan_order)[:max_files]:
-        try:
-            sources.append(candidates[rel_path].read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            continue
-    return sources
-
-
-def detect_environment_runtime(
-    env_path: Path,
-    files: Iterable[Path],
-    requires_dist: Optional[Iterable[str]] = None,
-    dependencies: Optional[Iterable[str]] = None,
-    legacy_tags: bool = False,
-) -> Optional[str]:
-    """The ``runtime_hint`` to send with a push, or ``None`` to omit it."""
-    from_source = classify_runtime_from_source(collect_sources(env_path, files), legacy_tags)
-    if from_source is not None:
-        return from_source
-    requirements = [r for r in (requires_dist or dependencies or []) if isinstance(r, str)]
-    return classify_runtime_from_metadata(requirements)

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -2,29 +2,24 @@
 
 Local mirror of the Hub's server-side classifier (platform
 ``backend/app/utils/environment_runtime.py``), applied to the environment
-directory at push time. The result is sent as the optional ``runtime_hint``
-field on wheel and version uploads; the Hub stores it as authoritative, so the
-rules here must stay consistent with the server:
+directory at push time. The result is sent as ``runtime_hint`` on wheel and
+version uploads and the Hub stores it as authoritative, so the rules here must
+stay consistent with the server:
 
-* source evidence wins over the requirement heuristic — ``verifiers.v1``
-  imports are an unambiguous v1 marker, ``def load_environment`` an
-  unambiguous v0 one;
+* source evidence wins — ``verifiers.v1`` imports are an unambiguous v1 marker,
+  ``def load_environment`` an unambiguous v0 one, ``[project].tags`` weak v0;
 * otherwise the ``verifiers`` requirement decides — v1 shipped as verifiers
   0.2.0, so a lower bound at or above 0.2.0 is a v1 signal;
-* a package with neither signal returns ``None`` and the hint is omitted, in
-  which case the Hub classifies the package itself at unpack time.
+* neither signal → ``None``: the hint is omitted and the Hub classifies the
+  package itself at unpack time.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
 
@@ -34,17 +29,12 @@ VERIFIERS_V1 = "VERIFIERS_V1"
 # First verifiers release that shipped the v1 API (`verifiers.v1`).
 VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
-# Source files larger than this are skipped: markers live near the top of
-# small package modules, not in bundled data files.
+# Same scan bounds as the server: markers live near the top of small modules.
 MAX_SOURCE_FILE_BYTES = 256 * 1024
-
-# Upper bound on source files read per push. Markers live in the package's
-# top-level modules, which `_source_scan_order` puts first.
 MAX_SOURCE_FILES = 40
 
-# Only scan Python modules and the project manifest; skip tests and vendored code.
-_SCANNABLE_SUFFIXES = (".py", "pyproject.toml")
-_SKIPPED_PATH_PARTS = {
+# Skip tests and vendored code (directory components only, so `test_utils.py` still scans).
+_SKIPPED_DIRS = {
     "tests",
     "test",
     ".venv",
@@ -69,62 +59,29 @@ _V0_SOURCE_PATTERNS = (
 )
 
 
-def effective_requirement_strings(
-    requires_dist: Optional[Iterable[str]],
-    dependencies: Optional[Iterable[str]],
-) -> List[str]:
-    """Pick the richest requirement source: wheel metadata, then pyproject."""
-    for value in (requires_dist, dependencies):
-        if not value:
-            continue
-        entries = [entry for entry in value if isinstance(entry, str)]
-        if entries:
-            return entries
-    return []
-
-
-def _verifiers_requirements(requirement_strings: Iterable[str]) -> List[Requirement]:
+def find_verifiers_requirement(requirement_strings: Iterable[str]) -> Optional[Requirement]:
+    """Effective ``verifiers`` requirement: unconditional entries beat marker-guarded
+    ones, and among those the highest floor wins (repeated entries intersect)."""
     requirements: List[Requirement] = []
-    for requirement_text in requirement_strings:
+    for text in requirement_strings:
         try:
-            requirement = Requirement(requirement_text.strip())
+            requirement = Requirement(text.strip())
         except InvalidRequirement:
             continue
         if requirement.name.lower() == "verifiers":
             requirements.append(requirement)
-    return requirements
-
-
-def find_verifiers_requirement(
-    requirement_strings: Iterable[str],
-) -> Optional[Requirement]:
-    """Return the package's effective ``verifiers`` requirement, if any.
-
-    Unconditional entries take precedence over marker-guarded ones
-    (``verifiers>=0.2; python_version >= "3.11"``). Within the applicable set,
-    repeated entries intersect, so the one with the highest floor is the
-    effective requirement — a package that admits v1 in any of its
-    environments targets v1.
-    """
-    requirements = _verifiers_requirements(requirement_strings)
     if not requirements:
         return None
     unconditional = [r for r in requirements if r.marker is None]
-    applicable = unconditional or requirements
     return max(
-        applicable,
+        unconditional or requirements,
         key=lambda requirement: _verifiers_lower_bound(requirement) or Version("0"),
     )
 
 
 def _verifiers_lower_bound(requirement: Requirement) -> Optional[Version]:
-    """Effective lower bound of the specifier set, or None if it has no floor.
-
-    ``>=``, ``>``, ``~=``, ``==``/``===`` and ``==X.Y.*`` prefix pins all set a
-    floor; clauses intersect, so the highest floor is the effective one
-    (``>=0.1,>=0.2`` admits nothing below 0.2). ``>`` is treated as its
-    version — off by one patch level is irrelevant at the 0.2.0 cut.
-    """
+    """Highest floor set by ``>=``/``>``/``~=``/``==``/``===`` clauses (``==X.Y.*``
+    counts as ``X.Y``; ``>`` as its version — a patch level is irrelevant at 0.2.0)."""
     floors: List[Version] = []
     for spec in requirement.specifier:
         if spec.operator not in {">=", ">", "==", "===", "~="}:
@@ -141,22 +98,11 @@ def _verifiers_lower_bound(requirement: Requirement) -> Optional[Version]:
     return max(floors) if floors else None
 
 
-def classify_runtime_from_metadata(
-    requirement_strings: Iterable[str],
-) -> Optional[str]:
-    """Heuristic classification from the verifiers requirement alone.
-
-    * floor ``>= 0.2.0`` → v1 (v1 shipped as verifiers 0.2.0);
-    * any other verifiers requirement (``>=0.1.x``, unbounded, ``<0.2``) → v0 —
-      every package published before v1 existed looks like this, and v0
-      packages that upgraded their pin are caught by the source scan;
-    * no verifiers requirement → ``None`` (no opinion).
-    """
+def classify_runtime_from_metadata(requirement_strings: Iterable[str]) -> Optional[str]:
+    """v1 for a verifiers floor >= 0.2.0, v0 for any other pin, ``None`` without one
+    (a URL pin says nothing about the API)."""
     requirement = find_verifiers_requirement(requirement_strings)
-    if requirement is None:
-        return None
-    if requirement.url:
-        # `verifiers @ git+https://...` — can't tell which API from a URL pin.
+    if requirement is None or requirement.url:
         return None
     floor = _verifiers_lower_bound(requirement)
     if floor is not None and floor >= VERIFIERS_V1_MIN_VERSION:
@@ -164,46 +110,13 @@ def classify_runtime_from_metadata(
     return VERIFIERS_V0
 
 
-def _is_scannable_source_path(path: str, size: Optional[int] = None) -> bool:
-    """Whether a file is worth reading for classification."""
-    if size is not None and size > MAX_SOURCE_FILE_BYTES:
-        return False
-    normalized = path.strip("/")
-    if not normalized.endswith(_SCANNABLE_SUFFIXES):
-        return False
-    parts = normalized.split("/")
-    # Only skip on *directory* components so a `test_utils.py` module still scans.
-    return not any(part in _SKIPPED_PATH_PARTS for part in parts[:-1])
-
-
-def _pyproject_declares_legacy_tags(content: str) -> bool:
-    """True when ``[project].tags`` is set (only that table; ``[tool.*]`` tags
-    are unrelated)."""
-    try:
-        data = tomllib.loads(content)
-    except Exception:
-        return False
-    project = data.get("project")
-    return isinstance(project, dict) and "tags" in project
-
-
-def classify_runtime_from_source(sources: Mapping[str, str]) -> Optional[str]:
-    """Classify from source contents (relative path → text).
-
-    v1 markers win: a v1 package may keep a ``load_environment`` shim for old
-    callers, but nothing pre-v1 imports ``verifiers.v1``.
-    """
-    saw_v0 = False
-    for path, content in sources.items():
-        if not content:
-            continue
-        if path.endswith("pyproject.toml"):
-            # `[project].tags` is the non-PEP-621 field the old Actions CI
-            # asserted on; v1 packages don't need it but may still carry it,
-            # so it only counts as weak v0 evidence.
-            if _pyproject_declares_legacy_tags(content):
-                saw_v0 = True
-            continue
+def classify_runtime_from_source(
+    sources: Iterable[str], legacy_tags: bool = False
+) -> Optional[str]:
+    """v1 markers win: a v1 package may keep a ``load_environment`` shim for old
+    callers, but nothing pre-v1 imports ``verifiers.v1``."""
+    saw_v0 = legacy_tags
+    for content in sources:
         if any(pattern.search(content) for pattern in _V1_SOURCE_PATTERNS):
             return VERIFIERS_V1
         if any(pattern.search(content) for pattern in _V0_SOURCE_PATTERNS):
@@ -211,45 +124,39 @@ def classify_runtime_from_source(sources: Mapping[str, str]) -> Optional[str]:
     return VERIFIERS_V0 if saw_v0 else None
 
 
-def _source_scan_order(path: str) -> Tuple[int, int, str]:
-    """Sort key: pyproject first, then shallow modules (``__init__`` before siblings)."""
-    if path.endswith("pyproject.toml"):
-        return (0, 0, path)
-    depth = path.count("/")
-    if path.endswith("__init__.py"):
-        return (1, depth, f"{path[: -len('__init__.py')]}!")
-    return (1, depth, path)
+def _scan_order(rel_path: str) -> Tuple[int, str]:
+    """Shallow modules first, ``__init__`` before its siblings."""
+    depth = rel_path.count("/")
+    if rel_path.endswith("__init__.py"):
+        return (depth, f"{rel_path[: -len('__init__.py')]}!")
+    return (depth, rel_path)
 
 
 def collect_sources(
-    env_path: Path,
-    files: Iterable[Path],
-    max_files: int = MAX_SOURCE_FILES,
-) -> Dict[str, str]:
-    """Read the scannable source files out of the push's archive file set.
-
-    ``files`` is the same collection that goes into the source tarball, so the
-    CLI scans exactly what the Hub would scan at unpack time. Reads stop early
-    once a v1 marker is seen — it is conclusive.
-    """
-    by_rel_path: Dict[str, Path] = {}
+    env_path: Path, files: Iterable[Path], max_files: int = MAX_SOURCE_FILES
+) -> List[str]:
+    """Contents of the scannable modules among the push's archive files — the same
+    set the Hub scans at unpack time, bounded the same way."""
+    candidates: Dict[str, Path] = {}
     for file_path in files:
         rel_path = str(file_path.relative_to(env_path)).replace("\\", "/")
+        if not rel_path.endswith(".py"):
+            continue
+        if any(part in _SKIPPED_DIRS for part in rel_path.split("/")[:-1]):
+            continue
         try:
-            size = file_path.stat().st_size
+            if file_path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+                continue
         except OSError:
             continue
-        if _is_scannable_source_path(rel_path, size):
-            by_rel_path[rel_path] = file_path
+        candidates[rel_path] = file_path
 
-    sources: Dict[str, str] = {}
-    for rel_path in sorted(by_rel_path, key=_source_scan_order)[:max_files]:
+    sources: List[str] = []
+    for rel_path in sorted(candidates, key=_scan_order)[:max_files]:
         try:
-            sources[rel_path] = by_rel_path[rel_path].read_text(encoding="utf-8", errors="replace")
+            sources.append(candidates[rel_path].read_text(encoding="utf-8", errors="replace"))
         except OSError:
             continue
-        if classify_runtime_from_source(sources) == VERIFIERS_V1:
-            break
     return sources
 
 
@@ -258,16 +165,11 @@ def detect_environment_runtime(
     files: Iterable[Path],
     requires_dist: Optional[Iterable[str]] = None,
     dependencies: Optional[Iterable[str]] = None,
+    legacy_tags: bool = False,
 ) -> Optional[str]:
-    """The ``runtime_hint`` to send with a push, or ``None`` to omit it.
-
-    Source markers beat the verifiers pin floor, matching the server-side
-    classifier; with no signal at all the hint is omitted and the Hub
-    classifies the package itself at unpack time.
-    """
-    from_source = classify_runtime_from_source(collect_sources(env_path, files))
+    """The ``runtime_hint`` to send with a push, or ``None`` to omit it."""
+    from_source = classify_runtime_from_source(collect_sources(env_path, files), legacy_tags)
     if from_source is not None:
         return from_source
-    return classify_runtime_from_metadata(
-        effective_requirement_strings(requires_dist, dependencies)
-    )
+    requirements = [r for r in (requires_dist or dependencies or []) if isinstance(r, str)]
+    return classify_runtime_from_metadata(requirements)

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -1,139 +1,93 @@
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional
 
+import pytest
 from prime_cli.utils.environment_runtime import (
     MAX_SOURCE_FILE_BYTES,
     VERIFIERS_V0,
     VERIFIERS_V1,
     classify_runtime_from_metadata,
     detect_environment_runtime,
-    effective_requirement_strings,
 )
 
-PYPROJECT = "[project]\nname = 'demo'\nversion = '0.1.0'\n"
+NO_MARKERS = "print('no markers here')\n"
+V1_IMPORT = "from verifiers.v1 import Taskset\n"
 
 
 def _detect(
     env_path: Path,
+    files: Dict[str, str],
     requires_dist: Optional[Iterable[str]] = None,
-    dependencies: Optional[Iterable[str]] = None,
+    legacy_tags: bool = False,
 ) -> Optional[str]:
-    files = [path for path in env_path.rglob("*") if path.is_file()]
+    for rel_path, content in files.items():
+        file_path = env_path / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
     return detect_environment_runtime(
-        env_path, files, requires_dist=requires_dist, dependencies=dependencies
+        env_path,
+        [path for path in env_path.rglob("*") if path.is_file()],
+        requires_dist=requires_dist,
+        legacy_tags=legacy_tags,
     )
 
 
-def _write(env_path: Path, rel_path: str, content: str) -> None:
-    file_path = env_path / rel_path
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(content)
+@pytest.mark.parametrize(
+    ("requirements", "expected"),
+    [
+        (["verifiers>=0.2.0"], VERIFIERS_V1),
+        (["verifiers>=0.1.2"], VERIFIERS_V0),
+        (["verifiers"], VERIFIERS_V0),
+        (["httpx>=0.25"], None),
+        (["verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git"], None),
+        # Unconditional entries beat marker-guarded ones.
+        (['verifiers>=0.2.0; python_version >= "3.11"', "verifiers>=0.1.0"], VERIFIERS_V0),
+        # Repeated entries intersect, so the highest floor wins.
+        (["verifiers>=0.1", "verifiers>=0.2"], VERIFIERS_V1),
+    ],
+)
+def test_classify_from_metadata(requirements, expected):
+    assert classify_runtime_from_metadata(requirements) == expected
 
 
-def test_v1_pin_floor_classifies_v1(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-
-    assert _detect(tmp_path, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V1
-
-
-def test_old_pin_classifies_v0(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-
-    assert _detect(tmp_path, requires_dist=["verifiers>=0.1.2"]) == VERIFIERS_V0
-    assert _detect(tmp_path, requires_dist=["verifiers"]) == VERIFIERS_V0
-
-
-def test_no_verifiers_requirement_omits_hint(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-
-    assert _detect(tmp_path, requires_dist=["httpx>=0.25"]) is None
-
-
-def test_url_pin_gives_no_opinion(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-
-    requires = ["verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git"]
-    assert _detect(tmp_path, requires_dist=requires) is None
+def test_no_markers_fall_back_to_the_pin(tmp_path):
+    files = {"demo.py": NO_MARKERS}
+    assert _detect(tmp_path, files, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V1
+    assert _detect(tmp_path, files, requires_dist=["httpx>=0.25"]) is None
 
 
 def test_load_environment_beats_v1_pin(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "def load_environment(**kwargs):\n    return None\n")
-
-    assert _detect(tmp_path, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V0
+    files = {"demo.py": "def load_environment(**kwargs):\n    return None\n"}
+    assert _detect(tmp_path, files, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V0
 
 
 def test_v1_import_beats_old_pin(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "from verifiers.v1 import Taskset\n")
-
-    assert _detect(tmp_path, requires_dist=["verifiers>=0.1.0"]) == VERIFIERS_V1
+    assert _detect(tmp_path, {"demo.py": V1_IMPORT}, requires_dist=["verifiers>=0.1.0"]) == (
+        VERIFIERS_V1
+    )
 
 
 def test_v1_marker_beats_load_environment_shim(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(
-        tmp_path,
-        "demo.py",
-        "import verifiers.v1 as v1\n\ndef load_environment(**kwargs):\n    return None\n",
-    )
-
-    assert _detect(tmp_path) == VERIFIERS_V1
+    shim = "import verifiers.v1 as v1\n\ndef load_environment(**kwargs):\n    return None\n"
+    files = {"demo.py": shim}
+    assert _detect(tmp_path, files) == VERIFIERS_V1
 
 
 def test_vf_alias_marker_classifies_v1(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(
-        tmp_path,
-        "demo/__init__.py",
-        "import verifiers as vf\n\nclass Demo(vf.Taskset):\n    pass\n",
-    )
-
-    assert _detect(tmp_path) == VERIFIERS_V1
+    files = {"demo/__init__.py": "import verifiers as vf\n\nclass Demo(vf.Taskset):\n    pass\n"}
+    assert _detect(tmp_path, files) == VERIFIERS_V1
 
 
 def test_project_tags_count_as_weak_v0_evidence(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT + "tags = ['math']\n")
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-
-    assert _detect(tmp_path) == VERIFIERS_V0
+    assert _detect(tmp_path, {"demo.py": NO_MARKERS}, legacy_tags=True) == VERIFIERS_V0
+    assert _detect(tmp_path, {"demo.py": V1_IMPORT}, legacy_tags=True) == VERIFIERS_V1
 
 
 def test_markers_under_tests_directory_are_ignored(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
-    _write(tmp_path, "demo.py", "print('no markers here')\n")
-    _write(tmp_path, "tests/test_demo.py", "from verifiers.v1 import Taskset\n")
-
-    assert _detect(tmp_path) is None
+    files = {"demo.py": NO_MARKERS, "tests/test_demo.py": V1_IMPORT}
+    assert _detect(tmp_path, files) is None
 
 
 def test_oversized_files_are_skipped(tmp_path):
-    _write(tmp_path, "pyproject.toml", PYPROJECT)
     padding = "#" * (MAX_SOURCE_FILE_BYTES + 1) + "\n"
-    _write(tmp_path, "demo.py", padding + "from verifiers.v1 import Taskset\n")
-
-    assert _detect(tmp_path) is None
-
-
-def test_unconditional_requirement_beats_marker_guarded_one():
-    requires = [
-        'verifiers>=0.2.0; python_version >= "3.11"',
-        "verifiers>=0.1.0",
-    ]
-    assert classify_runtime_from_metadata(requires) == VERIFIERS_V0
-
-
-def test_repeated_requirements_take_the_highest_floor():
-    assert classify_runtime_from_metadata(["verifiers>=0.1", "verifiers>=0.2"]) == VERIFIERS_V1
-
-
-def test_effective_requirement_strings_prefers_requires_dist():
-    assert effective_requirement_strings(["verifiers>=0.2.0"], ["verifiers>=0.1.0"]) == [
-        "verifiers>=0.2.0"
-    ]
-    assert effective_requirement_strings([], ["verifiers>=0.1.0"]) == ["verifiers>=0.1.0"]
-    assert effective_requirement_strings(None, None) == []
+    assert _detect(tmp_path, {"demo.py": padding + V1_IMPORT}) is None

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -1,10 +1,12 @@
 import pytest
+from prime_cli.commands.env import app
 from prime_cli.utils.environment_runtime import (
     VERIFIERS_V0,
     VERIFIERS_V1,
     classify_runtime_from_metadata,
     parse_runtime_option,
 )
+from typer.testing import CliRunner
 
 
 @pytest.mark.parametrize(
@@ -46,3 +48,11 @@ def test_parse_runtime_option(value, expected):
 def test_parse_runtime_option_rejects_unknown_values(value):
     with pytest.raises(ValueError, match="--runtime must be 'v0' or 'v1'"):
         parse_runtime_option(value)
+
+
+def test_push_rejects_invalid_runtime_without_unexpected_error():
+    result = CliRunner().invoke(app, ["push", "--runtime", "v2"])
+
+    assert result.exit_code == 1
+    assert "--runtime must be 'v0' or 'v1'" in result.output
+    assert "Unexpected error" not in result.output

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -1,93 +1,48 @@
-from pathlib import Path
-from typing import Dict, Iterable, Optional
-
 import pytest
 from prime_cli.utils.environment_runtime import (
-    MAX_SOURCE_FILE_BYTES,
     VERIFIERS_V0,
     VERIFIERS_V1,
     classify_runtime_from_metadata,
-    detect_environment_runtime,
+    parse_runtime_option,
 )
-
-NO_MARKERS = "print('no markers here')\n"
-V1_IMPORT = "from verifiers.v1 import Taskset\n"
-
-
-def _detect(
-    env_path: Path,
-    files: Dict[str, str],
-    requires_dist: Optional[Iterable[str]] = None,
-    legacy_tags: bool = False,
-) -> Optional[str]:
-    for rel_path, content in files.items():
-        file_path = env_path / rel_path
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content)
-    return detect_environment_runtime(
-        env_path,
-        [path for path in env_path.rglob("*") if path.is_file()],
-        requires_dist=requires_dist,
-        legacy_tags=legacy_tags,
-    )
 
 
 @pytest.mark.parametrize(
     ("requirements", "expected"),
     [
         (["verifiers>=0.2.0"], VERIFIERS_V1),
+        (["verifiers[harbor]>=0.3.1"], VERIFIERS_V1),
         (["verifiers>=0.1.2"], VERIFIERS_V0),
         (["verifiers"], VERIFIERS_V0),
         (["httpx>=0.25"], None),
+        ([], None),
         (["verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git"], None),
         # Unconditional entries beat marker-guarded ones.
         (['verifiers>=0.2.0; python_version >= "3.11"', "verifiers>=0.1.0"], VERIFIERS_V0),
         # Repeated entries intersect, so the highest floor wins.
         (["verifiers>=0.1", "verifiers>=0.2"], VERIFIERS_V1),
+        (["verifiers==0.2.*"], VERIFIERS_V1),
+        (["not a requirement", "verifiers~=0.3.0"], VERIFIERS_V1),
     ],
 )
 def test_classify_from_metadata(requirements, expected):
     assert classify_runtime_from_metadata(requirements) == expected
 
 
-def test_no_markers_fall_back_to_the_pin(tmp_path):
-    files = {"demo.py": NO_MARKERS}
-    assert _detect(tmp_path, files, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V1
-    assert _detect(tmp_path, files, requires_dist=["httpx>=0.25"]) is None
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("v1", VERIFIERS_V1),
+        ("V0", VERIFIERS_V0),
+        (" v1 ", VERIFIERS_V1),
+    ],
+)
+def test_parse_runtime_option(value, expected):
+    assert parse_runtime_option(value) == expected
 
 
-def test_load_environment_beats_v1_pin(tmp_path):
-    files = {"demo.py": "def load_environment(**kwargs):\n    return None\n"}
-    assert _detect(tmp_path, files, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V0
-
-
-def test_v1_import_beats_old_pin(tmp_path):
-    assert _detect(tmp_path, {"demo.py": V1_IMPORT}, requires_dist=["verifiers>=0.1.0"]) == (
-        VERIFIERS_V1
-    )
-
-
-def test_v1_marker_beats_load_environment_shim(tmp_path):
-    shim = "import verifiers.v1 as v1\n\ndef load_environment(**kwargs):\n    return None\n"
-    files = {"demo.py": shim}
-    assert _detect(tmp_path, files) == VERIFIERS_V1
-
-
-def test_vf_alias_marker_classifies_v1(tmp_path):
-    files = {"demo/__init__.py": "import verifiers as vf\n\nclass Demo(vf.Taskset):\n    pass\n"}
-    assert _detect(tmp_path, files) == VERIFIERS_V1
-
-
-def test_project_tags_count_as_weak_v0_evidence(tmp_path):
-    assert _detect(tmp_path, {"demo.py": NO_MARKERS}, legacy_tags=True) == VERIFIERS_V0
-    assert _detect(tmp_path, {"demo.py": V1_IMPORT}, legacy_tags=True) == VERIFIERS_V1
-
-
-def test_markers_under_tests_directory_are_ignored(tmp_path):
-    files = {"demo.py": NO_MARKERS, "tests/test_demo.py": V1_IMPORT}
-    assert _detect(tmp_path, files) is None
-
-
-def test_oversized_files_are_skipped(tmp_path):
-    padding = "#" * (MAX_SOURCE_FILE_BYTES + 1) + "\n"
-    assert _detect(tmp_path, {"demo.py": padding + V1_IMPORT}) is None
+@pytest.mark.parametrize("value", ["v2", "verifiers_v1", "legacy", ""])
+def test_parse_runtime_option_rejects_unknown_values(value):
+    with pytest.raises(ValueError, match="--runtime must be 'v0' or 'v1'"):
+        parse_runtime_option(value)

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+from typing import Iterable, Optional
+
+from prime_cli.utils.environment_runtime import (
+    MAX_SOURCE_FILE_BYTES,
+    VERIFIERS_V0,
+    VERIFIERS_V1,
+    classify_runtime_from_metadata,
+    detect_environment_runtime,
+    effective_requirement_strings,
+)
+
+PYPROJECT = "[project]\nname = 'demo'\nversion = '0.1.0'\n"
+
+
+def _detect(
+    env_path: Path,
+    requires_dist: Optional[Iterable[str]] = None,
+    dependencies: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    files = [path for path in env_path.rglob("*") if path.is_file()]
+    return detect_environment_runtime(
+        env_path, files, requires_dist=requires_dist, dependencies=dependencies
+    )
+
+
+def _write(env_path: Path, rel_path: str, content: str) -> None:
+    file_path = env_path / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content)
+
+
+def test_v1_pin_floor_classifies_v1(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+
+    assert _detect(tmp_path, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V1
+
+
+def test_old_pin_classifies_v0(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+
+    assert _detect(tmp_path, requires_dist=["verifiers>=0.1.2"]) == VERIFIERS_V0
+    assert _detect(tmp_path, requires_dist=["verifiers"]) == VERIFIERS_V0
+
+
+def test_no_verifiers_requirement_omits_hint(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+
+    assert _detect(tmp_path, requires_dist=["httpx>=0.25"]) is None
+
+
+def test_url_pin_gives_no_opinion(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+
+    requires = ["verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git"]
+    assert _detect(tmp_path, requires_dist=requires) is None
+
+
+def test_load_environment_beats_v1_pin(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "def load_environment(**kwargs):\n    return None\n")
+
+    assert _detect(tmp_path, requires_dist=["verifiers>=0.2.0"]) == VERIFIERS_V0
+
+
+def test_v1_import_beats_old_pin(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "from verifiers.v1 import Taskset\n")
+
+    assert _detect(tmp_path, requires_dist=["verifiers>=0.1.0"]) == VERIFIERS_V1
+
+
+def test_v1_marker_beats_load_environment_shim(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(
+        tmp_path,
+        "demo.py",
+        "import verifiers.v1 as v1\n\ndef load_environment(**kwargs):\n    return None\n",
+    )
+
+    assert _detect(tmp_path) == VERIFIERS_V1
+
+
+def test_vf_alias_marker_classifies_v1(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(
+        tmp_path,
+        "demo/__init__.py",
+        "import verifiers as vf\n\nclass Demo(vf.Taskset):\n    pass\n",
+    )
+
+    assert _detect(tmp_path) == VERIFIERS_V1
+
+
+def test_project_tags_count_as_weak_v0_evidence(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT + "tags = ['math']\n")
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+
+    assert _detect(tmp_path) == VERIFIERS_V0
+
+
+def test_markers_under_tests_directory_are_ignored(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    _write(tmp_path, "demo.py", "print('no markers here')\n")
+    _write(tmp_path, "tests/test_demo.py", "from verifiers.v1 import Taskset\n")
+
+    assert _detect(tmp_path) is None
+
+
+def test_oversized_files_are_skipped(tmp_path):
+    _write(tmp_path, "pyproject.toml", PYPROJECT)
+    padding = "#" * (MAX_SOURCE_FILE_BYTES + 1) + "\n"
+    _write(tmp_path, "demo.py", padding + "from verifiers.v1 import Taskset\n")
+
+    assert _detect(tmp_path) is None
+
+
+def test_unconditional_requirement_beats_marker_guarded_one():
+    requires = [
+        'verifiers>=0.2.0; python_version >= "3.11"',
+        "verifiers>=0.1.0",
+    ]
+    assert classify_runtime_from_metadata(requires) == VERIFIERS_V0
+
+
+def test_repeated_requirements_take_the_highest_floor():
+    assert classify_runtime_from_metadata(["verifiers>=0.1", "verifiers>=0.2"]) == VERIFIERS_V1
+
+
+def test_effective_requirement_strings_prefers_requires_dist():
+    assert effective_requirement_strings(["verifiers>=0.2.0"], ["verifiers>=0.1.0"]) == [
+        "verifiers>=0.2.0"
+    ]
+    assert effective_requirement_strings([], ["verifiers>=0.1.0"]) == ["verifiers>=0.1.0"]
+    assert effective_requirement_strings(None, None) == []


### PR DESCRIPTION
## Summary

`prime env push` is v0/v1-blind today. This PR makes it declare which verifiers API the package targets and send that as a top-level `runtime_hint` on both Hub upload calls (`POST /environmentshub/{env_id}/wheels` and `POST /environmentshub/{env_id}/versions`).

- **`--runtime v0|v1`** declares it explicitly.
- Without the flag, the package's own `verifiers` requirement decides (wheel `Requires-Dist`, else pyproject `dependencies`): a lower bound at or above 0.2.0 means v1, any other pin means v0. This is the same fallback the Hub applies server-side to hint-less pushes (platform #4792), so old and new CLIs agree.
- No verifiers requirement, or a URL pin, means nothing is known: the field is **omitted** (not sent as `null`), push warns that the Hub will list the package as Unclassified, and suggests the flag.
- Push prints what it is publishing as, and where that came from, so a mislabel is visible locally.

No source scanning: runtime is declared, not detected. Old servers ignore the unknown field (pydantic default), so this can merge before #4792 deploys; the hint just starts mattering once it does. Needs a prime CLI release (ENG-5767).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI metadata on publish with omission when unknown; backward compatible with older Hub APIs, but mis-inferred runtime could mislabel packages once the server consumes the hint.
> 
> **Overview**
> **`prime env push`** now declares which verifiers API (v0 vs v1) a package targets and sends that as top-level **`runtime_hint`** on both Hub upload requests (wheel and source version).
> 
> Users can set it with **`--runtime v0|v1`**. If omitted, the CLI infers runtime from the package’s **`verifiers`** dependency (wheel `Requires-Dist`, else `pyproject` dependencies): a floor **≥ 0.2.0** → v1, any other pin → v0, matching the Hub’s server-side fallback. Missing or URL-only `verifiers` pins omit the field, warn that the Hub will show **Unclassified**, and suggest **`--runtime`**. Push also prints the chosen label and whether it came from the flag or metadata.
> 
> A new **`environment_runtime`** helper encapsulates parsing and classification; tests cover requirement edge cases and invalid **`--runtime`** handling on push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c12a43d7d7c5605cccaf20a3adbb9e09dd31d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


