### PR TITLE
Redact credentials before trace and eval uploads

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -44,7 +44,7 @@ from .preflight import (
     secret_values,
 )
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -33,6 +33,16 @@ from .models import (
     Sample,
     SamplesResponse,
 )
+from .preflight import (
+    PreparedJSONLUpload,
+    PreparedUpload,
+    ScanReport,
+    UploadScanError,
+    prepare_jsonl_upload,
+    prepare_upload,
+    scan_upload,
+    secret_values,
+)
 
 __version__ = "0.2.3"
 
@@ -65,4 +75,13 @@ __all__ = [
     "EvaluationNotFoundError",
     "InvalidEvaluationError",
     "InvalidSampleError",
+    # Upload preflight
+    "PreparedJSONLUpload",
+    "PreparedUpload",
+    "ScanReport",
+    "UploadScanError",
+    "prepare_jsonl_upload",
+    "prepare_upload",
+    "scan_upload",
+    "secret_values",
 ]

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -7,6 +7,7 @@ import os
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,8 @@ _PLACEHOLDER = re.compile(
     re.IGNORECASE,
 )
 _SECRET_ENV = re.compile(
-    r"API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTHORIZATION|COOKIE|"
+    r"(?:^|_)AUTH(?:$|_)|API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|"
+    r"AUTHORIZATION|COOKIE|"
     r"PRIVATE_?KEY|CONNECTION_STRING|DATABASE_URL|REDIS_URL",
     re.IGNORECASE,
 )
@@ -50,10 +52,9 @@ _SENSITIVE_FIELDS = {
     "secret_key",
     "session_token",
     "signature",
-    "team_id",
     "token",
 }
-_SCHEMA_VALUES = {"const", "default", "example", "examples"}
+_SCHEMA_VALUES = {"const", "default", "enum", "example", "examples"}
 _SCHEMA_MARKERS = {
     "$defs",
     "$ref",
@@ -74,7 +75,7 @@ _SCHEMA_MARKERS = {
     "type",
 }
 _SAFE_PATH_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]{0,63}")
-_AUTH_VALUE = re.compile(r"^(?:bearer|basic)\s+(.+)$", re.IGNORECASE)
+_AUTH_VALUE = re.compile(r"^(?:bearer|basic|token)\s+(.+)$", re.IGNORECASE)
 
 # Every shape names only the credential. The same match drives reporting and redaction.
 _PATTERNS = (
@@ -113,7 +114,7 @@ _PATTERNS = (
         "authorization_header",
         re.compile(
             r"(?<![A-Za-z0-9_])[\"']?(?:authorization|proxy-authorization)"
-            r"[\"']?\s*[:=]\s*[\"']?(?:(?:bearer|basic)\s+)?"
+            r"[\"']?\s*[:=]\s*[\"']?(?:(?:bearer|basic|token)\s+)?"
             r"(?P<secret>[^\s,;\"']{8,})",
             re.IGNORECASE,
         ),
@@ -136,8 +137,10 @@ _PATTERNS = (
             r"AUTH_?TOKEN|SESSION_?TOKEN|TOKEN|CLIENT_?SECRET|SECRET(?:_ACCESS_?KEY)?|"
             r"PASSWORD|PASSWD|CREDENTIAL|PRIVATE_?KEY)\s*=\s*|"
             r"--(?:api-key|access-token|auth-token|client-secret|password|private-key|"
-            r"secret|token)(?:=|\s+))[\"']?(?:(?:bearer|basic)\s+)?[\"']?"
-            r"(?P<secret>[^\s,;\"']{16,})",
+            r"secret|token)(?:=|\s+))"
+            r"(?:\"(?P<secret_double>(?:\\.|[^\"\\\r\n]){16,})\"|"
+            r"'(?P<secret_single>(?:\\.|[^'\\\r\n]){16,})'|"
+            r"(?:(?:bearer|basic|token)\s+)?(?P<secret>[^\s,;\"']{16,}))",
             re.IGNORECASE,
         ),
     ),
@@ -335,7 +338,11 @@ def _redact_text(text: str, secrets: Mapping[str, str]) -> tuple[str, set[str]]:
     for category, pattern in _PATTERNS:
 
         def replace_shape(match: re.Match[str], category: str = category) -> str:
-            group = "secret" if match.groupdict().get("secret") is not None else "secret_query"
+            group = next(
+                name
+                for name, value in match.groupdict().items()
+                if name.startswith("secret") and value is not None
+            )
             secret = match.group(group)
             if not _is_secret(secret):
                 return match.group(0)
@@ -363,7 +370,11 @@ def _reduce(
         object_schema = schema_context or any(field in value for field in _SCHEMA_MARKERS)
         for key, child in value.items():
             safe_key, categories = (
-                _redact_text(key, secrets) if isinstance(key, str) else (key, set())
+                (REDACTED, {"structured_secret"})
+                if structured_secret and _is_secret(key)
+                else _redact_text(key, secrets)
+                if isinstance(key, str)
+                else (key, set())
             )
             findings.update((_path((*path, "[key]")), category) for category in categories)
             if safe_key in reduced:
@@ -516,28 +527,40 @@ def prepare_jsonl_upload(
     findings = _prefix(context_prepared.report, "$.context") if context_prepared else set()
     file_findings: set[Finding] = set()
 
+    redacted.unlink(missing_ok=True)
+    output_file = None
     try:
-        with snapshot.open("rb") as input_file, redacted.open("wb") as output_file:
-            for number, raw in enumerate(input_file, 1):
+        with snapshot.open("rb") as input_file, ExitStack() as stack:
+            offset = 0
+            number = 0
+            while raw := input_file.readline():
+                number += 1
                 if raw.isspace():
-                    output_file.write(raw)
+                    if output_file:
+                        output_file.write(raw)
+                    offset += len(raw)
                     continue
                 value = _prepare(_load_line(raw.decode(), number), secrets)
                 file_findings.update(_prefix(value.report, f"$.lines[{number}]"))
-                output_file.write(
-                    json.dumps(value.data, ensure_ascii=False, separators=(",", ":")).encode()
-                    + b"\n"
-                    if value.report
-                    else raw
-                )
+                if value.report and output_file is None:
+                    output_file = stack.enter_context(redacted.open("wb"))
+                    with snapshot.open("rb") as prefix:
+                        output_file.write(prefix.read(offset))
+                if output_file:
+                    output_file.write(
+                        json.dumps(value.data, ensure_ascii=False, separators=(",", ":")).encode()
+                        + b"\n"
+                        if value.report
+                        else raw
+                    )
+                offset += len(raw)
     except UnicodeDecodeError as error:
         raise UploadScanError("trace JSONL must be UTF-8") from error
 
-    if file_findings:
+    if output_file:
         snapshot.unlink()
         upload_path = redacted
     else:
-        redacted.unlink()
         upload_path = snapshot
     return PreparedJSONLUpload(
         upload_path,

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -55,8 +55,8 @@ _PATTERNS = (
     (
         "private_key",
         re.compile(
-            r"(?P<secret>-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?"
-            r"-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----)",
+            r"(?P<secret>-----BEGIN (?P<label>(?:(?:RSA|EC|OPENSSH|DSA|ENCRYPTED) )?"
+            r"PRIVATE KEY)-----.*?-----END (?P=label)-----)",
             re.DOTALL,
         ),
     ),

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -30,6 +30,7 @@ _SENSITIVE_FIELDS = {
     "api_key",
     "access_token",
     "auth_token",
+    "auth",
     "authorization",
     "client_secret",
     "connection_string",
@@ -48,10 +49,28 @@ _SENSITIVE_FIELDS = {
     "secret_key",
     "session_token",
     "signature",
+    "team_id",
     "token",
 }
 _SCHEMA_VALUES = {"const", "default", "example", "examples"}
-_SCHEMA_TYPES = {"array", "boolean", "integer", "null", "number", "object", "string"}
+_SCHEMA_FIELDS = {
+    "$ref",
+    "allOf",
+    "anyOf",
+    "const",
+    "default",
+    "description",
+    "enum",
+    "examples",
+    "format",
+    "items",
+    "oneOf",
+    "pattern",
+    "properties",
+    "required",
+    "title",
+    "type",
+}
 _SAFE_PATH_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]{0,63}")
 _AUTH_VALUE = re.compile(r"^(?:bearer|basic)\s+(.+)$", re.IGNORECASE)
 
@@ -214,10 +233,10 @@ def secret_values(*values: str | None, secrets_file: str | Path | None = None) -
 
 
 def _remember(value: Any, secrets: dict[str, str], category: str) -> None:
-    if isinstance(value, str) and bool(value.strip()) and not _PLACEHOLDER.fullmatch(value.strip()):
+    if _is_secret(value):
         secrets.setdefault(value, category)
-        if match := _AUTH_VALUE.fullmatch(value.strip()):
-            _remember(match.group(1), secrets, category)
+        if (match := _AUTH_VALUE.fullmatch(value.strip())) and _is_secret(token := match.group(1)):
+            secrets.setdefault(token, category)
     elif isinstance(value, Mapping):
         for child in value.values():
             _remember(child, secrets, category)
@@ -234,8 +253,7 @@ def _discover(value: Any, secrets: dict[str, str]) -> None:
                 normalized = _normalize(name)
                 if properties:
                     schema = isinstance(nested, Mapping) and (
-                        nested.get("type") in _SCHEMA_TYPES
-                        or any(field in nested for field in ("$ref", "allOf", "anyOf", "oneOf"))
+                        not nested or any(field in nested for field in _SCHEMA_FIELDS)
                     )
                     if schema:
                         visit(nested, _sensitive(name))
@@ -313,6 +331,9 @@ def _reduce(
     secrets: Mapping[str, str],
     findings: set[Finding],
     path: tuple[str | int, ...] = (),
+    structured_secret: bool = False,
+    schema_secret: bool = False,
+    properties: bool = False,
 ) -> Any:
     if isinstance(value, Mapping):
         reduced = {}
@@ -323,20 +344,57 @@ def _reduce(
             findings.update((_path((*path, "[key]")), category) for category in categories)
             if safe_key in reduced:
                 raise UploadScanError("credential reduction would create duplicate object keys")
+            normalized = _normalize(str(key))
+            schema = (
+                properties
+                and isinstance(child, Mapping)
+                and (not child or any(field in child for field in _SCHEMA_FIELDS))
+            )
+            child_secret = structured_secret or (
+                not schema
+                and (_sensitive(str(key)) or schema_secret and normalized in _SCHEMA_VALUES)
+            )
             reduced[safe_key] = _reduce(
-                child, secrets, findings, (*path, "[key]" if categories else str(key))
+                child,
+                secrets,
+                findings,
+                (*path, "[key]" if categories else str(key)),
+                child_secret,
+                _sensitive(str(key)) if schema else schema_secret,
+                not structured_secret and normalized == "properties",
             )
         return reduced
     if isinstance(value, list):
         return [
-            _reduce(child, secrets, findings, (*path, index)) for index, child in enumerate(value)
+            _reduce(
+                child,
+                secrets,
+                findings,
+                (*path, index),
+                structured_secret,
+                schema_secret,
+                properties,
+            )
+            for index, child in enumerate(value)
         ]
     if isinstance(value, tuple):
         return tuple(
-            _reduce(child, secrets, findings, (*path, index)) for index, child in enumerate(value)
+            _reduce(
+                child,
+                secrets,
+                findings,
+                (*path, index),
+                structured_secret,
+                schema_secret,
+                properties,
+            )
+            for index, child in enumerate(value)
         )
     if not isinstance(value, str):
         return value
+    if structured_secret and value.strip() and not _PLACEHOLDER.fullmatch(value.strip()):
+        findings.add((_path(path), "structured_secret"))
+        return REDACTED
     reduced, categories = _redact_text(value, secrets)
     findings.update((_path(path), category) for category in categories)
     return reduced

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -75,6 +75,7 @@ _PATTERNS = (
             r"gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
             r"hf_[A-Za-z0-9]{20,}|gsk_[A-Za-z0-9]{20,}|"
             r"glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|"
+            r"x(?:wfp|app)-[A-Za-z0-9-]{10,}|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{20,}|"
             r"npm_[A-Za-z0-9]{20,}|pypi-[A-Za-z0-9_-]{30,}|"
             r"SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,})"
         ),
@@ -86,6 +87,10 @@ _PATTERNS = (
             r"discord(?:app)?\.com/api/webhooks)/[^\s\"']+)",
             re.IGNORECASE,
         ),
+    ),
+    (
+        "cookie_header",
+        re.compile(r"^\s*cookie\s*:\s*(?P<secret>[^\r\n]{8,})", re.IGNORECASE | re.MULTILINE),
     ),
     (
         "credential_assignment",

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -87,14 +87,15 @@ _PATTERNS = (
     (
         "credential_assignment",
         re.compile(
-            r"(?:\b(?:authorization|proxy-authorization|x-api-key|api[_ -]?key|"
+            r"(?:(?<![A-Za-z0-9_])[\"']?(?:authorization|proxy-authorization|"
+            r"x-api-key|api[_ -]?key|"
             r"access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|"
-            r"secret|password|passwd|cookie|private[_ -]?key|signature)\b\s*[:=]\s*|"
+            r"secret|password|passwd|cookie|private[_ -]?key|signature)\b[\"']?\s*[:=]\s*|"
             r"\b(?:[A-Z][A-Z0-9_]*_)?(?:API_?KEY|ACCESS_?TOKEN|REFRESH_?TOKEN|"
             r"AUTH_?TOKEN|SESSION_?TOKEN|TOKEN|CLIENT_?SECRET|SECRET(?:_ACCESS_?KEY)?|"
             r"PASSWORD|PASSWD|CREDENTIAL|PRIVATE_?KEY)\s*=\s*|"
             r"--(?:api-key|access-token|auth-token|client-secret|password|private-key|"
-            r"secret|token)(?:=|\s+))(?:(?:bearer|basic)\s+)?[\"']?"
+            r"secret|token)(?:=|\s+))[\"']?(?:(?:bearer|basic)\s+)?[\"']?"
             r"(?P<secret>[^\s,;\"']{8,})",
             re.IGNORECASE,
         ),
@@ -202,11 +203,10 @@ def secret_values(*values: str | None, secrets_file: str | Path | None = None) -
 
 
 def _remember(value: Any, secrets: dict[str, str], category: str) -> None:
-    if _is_secret(value):
+    if isinstance(value, str) and bool(value.strip()) and not _PLACEHOLDER.fullmatch(value.strip()):
         secrets.setdefault(value, category)
         if match := _AUTH_VALUE.fullmatch(value.strip()):
-            if _is_secret(token := match.group(1)):
-                secrets.setdefault(token, category)
+            _remember(match.group(1), secrets, category)
     elif isinstance(value, Mapping):
         for child in value.values():
             _remember(child, secrets, category)
@@ -246,7 +246,9 @@ def _discover(value: Any, secrets: dict[str, str]) -> None:
 
 
 def _secrets(value: Any, known_secrets: Iterable[str]) -> dict[str, str]:
-    secrets = {secret: "known_secret" for secret in known_secrets if _is_secret(secret)}
+    secrets: dict[str, str] = {}
+    for secret in known_secrets:
+        _remember(secret, secrets, "known_secret")
     _discover(value, secrets)
     return secrets
 

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -47,6 +47,7 @@ _SENSITIVE_FIELDS = {
     "signature",
 }
 _SCHEMA_VALUES = {"const", "default", "example", "examples"}
+_SCHEMA_TYPES = {"array", "boolean", "integer", "null", "number", "object", "string"}
 _SAFE_PATH_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]{0,63}")
 _AUTH_VALUE = re.compile(r"^(?:bearer|basic)\s+(.+)$", re.IGNORECASE)
 
@@ -197,6 +198,9 @@ def _remember(value: Any, secrets: dict[str, str], category: str) -> None:
         if match := _AUTH_VALUE.fullmatch(value.strip()):
             if _is_secret(token := match.group(1)):
                 secrets.setdefault(token, category)
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            _remember(child, secrets, category)
     elif isinstance(value, (list, tuple)):
         for child in value:
             _remember(child, secrets, category)
@@ -209,7 +213,16 @@ def _discover(value: Any, secrets: dict[str, str]) -> None:
                 name = str(key)
                 normalized = _normalize(name)
                 if properties:
-                    visit(nested, _sensitive(name))
+                    schema = isinstance(nested, Mapping) and (
+                        nested.get("type") in _SCHEMA_TYPES
+                        or any(field in nested for field in ("$ref", "allOf", "anyOf", "oneOf"))
+                    )
+                    if schema:
+                        visit(nested, _sensitive(name))
+                    else:
+                        if _sensitive(name):
+                            _remember(nested, secrets, "structured_secret")
+                        visit(nested)
                     continue
                 if _sensitive(name):
                     _remember(nested, secrets, "structured_secret")

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -15,7 +15,7 @@ from typing import Any
 REDACTED = "[REDACTED]"
 
 _PLACEHOLDER = re.compile(
-    r"^(?:\[?redacted\]?|masked|dummy|example|test|none|null|empty|changeme|"
+    r"^(?:\[?redacted(?:[_ -]?\d+)?\]?|masked|dummy|example|test|none|null|empty|changeme|"
     r"replace[_ -]?me|x{4,}|\*{4,}|<[^>]+>|\$\{?[A-Z][A-Z0-9_]*\}?)$",
     re.IGNORECASE,
 )
@@ -131,9 +131,11 @@ _PATTERNS = (
     (
         "credential_assignment",
         re.compile(
-            r"(?:(?<![A-Za-z0-9_])[\"']?(?:x-api-key|api[_ -]?key|"
+            r"(?:(?<![A-Za-z0-9_])[\"']?(?:[A-Za-z][A-Za-z0-9]*[_-]+)*"
+            r"(?:x-api-key|api[_ -]?key|"
             r"access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|"
-            r"secret|password|passwd|cookie|private[_ -]?key|signature)\b[\"']?\s*[:=]\s*|"
+            r"access[_ -]?key(?:[_ -]?id)?|secret(?:[_ -]?access[_ -]?key)?|"
+            r"password|passwd|cookie|private[_ -]?key|signature)\b[\"']?\s*[:=]\s*|"
             r"\b(?:[A-Z][A-Z0-9_]*_)?(?:API_?KEY|ACCESS_?TOKEN|REFRESH_?TOKEN|"
             r"AUTH_?TOKEN|SESSION_?TOKEN|TOKEN|CLIENT_?SECRET|SECRET(?:_ACCESS_?KEY)?|"
             r"PASSWORD|PASSWD|CREDENTIAL|PRIVATE_?KEY)\s*=\s*|"
@@ -301,6 +303,16 @@ def _discover(value: Any, secrets: dict[str, str]) -> None:
         elif isinstance(child, (list, tuple)):
             for nested in child:
                 visit(nested, schema_secret, schema_context, properties)
+        elif isinstance(child, str):
+            for category, pattern in _PATTERNS:
+                for match in pattern.finditer(child):
+                    secret = next(
+                        value
+                        for name, value in match.groupdict().items()
+                        if name.startswith("secret") and value is not None
+                    )
+                    if _is_secret(secret):
+                        secrets.setdefault(secret, category)
 
     visit(value)
 
@@ -383,6 +395,11 @@ def _reduce(
                 else (key, set())
             )
             findings.update((_path((*path, "[key]")), category) for category in categories)
+            if structured_secret and safe_key == REDACTED:
+                suffix = 2
+                while safe_key in reduced:
+                    safe_key = f"[REDACTED {suffix}]"
+                    suffix += 1
             if safe_key in reduced:
                 raise UploadScanError("credential reduction would create duplicate object keys")
             normalized = _normalize(str(key))

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -99,7 +99,7 @@ _PATTERNS = (
             r"PASSWORD|PASSWD|CREDENTIAL|PRIVATE_?KEY)\s*=\s*|"
             r"--(?:api-key|access-token|auth-token|client-secret|password|private-key|"
             r"secret|token)(?:=|\s+))[\"']?(?:(?:bearer|basic)\s+)?[\"']?"
-            r"(?P<secret>[^\s,;\"']{8,})",
+            r"(?P<secret>[^\s,;\"']{16,})",
             re.IGNORECASE,
         ),
     ),

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -413,11 +413,20 @@ def _reduce(
             )
             for index, child in enumerate(value)
         )
-    if not isinstance(value, str):
-        return value
-    if structured_secret and value.strip() and not _PLACEHOLDER.fullmatch(value.strip()):
+    if (
+        structured_secret
+        and value is not None
+        and not isinstance(value, bool)
+        and (
+            not isinstance(value, str)
+            or value.strip()
+            and not _PLACEHOLDER.fullmatch(value.strip())
+        )
+    ):
         findings.add((_path(path), "structured_secret"))
         return REDACTED
+    if not isinstance(value, str):
+        return value
     reduced, categories = _redact_text(value, secrets)
     findings.update((_path(path), category) for category in categories)
     return reduced
@@ -482,7 +491,12 @@ def prepare_jsonl_upload(
     """Return a safe snapshot or redacted JSONL path without changing the source."""
     source, snapshot = Path(source), Path(destination)
     redacted = snapshot.with_name(f"redacted-{snapshot.name}")
-    if source.resolve() in {snapshot.resolve(), redacted.resolve()}:
+    outputs = (snapshot, redacted)
+    if (
+        source.resolve() in {output.resolve() for output in outputs}
+        or source.exists()
+        and any(output.exists() and source.samefile(output) for output in outputs)
+    ):
         raise UploadScanError("upload outputs must not alias the source JSONL")
     secrets: dict[str, str] = {}
     for secret in known_secrets:

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -1,0 +1,412 @@
+"""Credential scanning and reduction for data leaving the local machine."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REDACTED = "[REDACTED]"
+
+_PLACEHOLDER = re.compile(
+    r"^(?:\[?redacted\]?|masked|dummy|example|test|none|null|empty|changeme|"
+    r"replace[_ -]?me|x{4,}|\*{4,}|<[^>]+>|\$\{?[A-Z][A-Z0-9_]*\}?)$",
+    re.IGNORECASE,
+)
+_SECRET_ENV = re.compile(
+    r"API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTHORIZATION|COOKIE|"
+    r"PRIVATE_?KEY|CONNECTION_STRING|DATABASE_URL|REDIS_URL",
+    re.IGNORECASE,
+)
+_REFERENCE_SUFFIXES = ("_env", "_env_var", "_file", "_name", "_path", "_var", "_variable")
+_SENSITIVE_FIELDS = {
+    "api_key",
+    "access_token",
+    "auth_token",
+    "authorization",
+    "client_secret",
+    "connection_string",
+    "cookie",
+    "credential",
+    "database_url",
+    "password",
+    "passwd",
+    "private_key",
+    "proxy_authorization",
+    "redis_url",
+    "refresh_token",
+    "sas_token",
+    "secret",
+    "secret_key",
+    "session_token",
+    "signature",
+}
+_SCHEMA_VALUES = {"const", "default", "example", "examples"}
+_SAFE_PATH_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]{0,63}")
+_AUTH_VALUE = re.compile(r"^(?:bearer|basic)\s+(.+)$", re.IGNORECASE)
+
+# Every shape names only the credential. The same match drives reporting and redaction.
+_PATTERNS = (
+    (
+        "private_key",
+        re.compile(
+            r"(?P<secret>-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?"
+            r"-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----)",
+            re.DOTALL,
+        ),
+    ),
+    (
+        "provider_credential",
+        re.compile(
+            r"(?<![A-Za-z0-9])(?P<secret>"
+            r"sk-(?:ant-|or-v1-)?[A-Za-z0-9_-]{20,}|"
+            r"AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|"
+            r"AIza[0-9A-Za-z_-]{30,}|"
+            r"gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
+            r"hf_[A-Za-z0-9]{20,}|gsk_[A-Za-z0-9]{20,}|"
+            r"glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|"
+            r"npm_[A-Za-z0-9]{20,}|pypi-[A-Za-z0-9_-]{30,}|"
+            r"SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,})"
+        ),
+    ),
+    (
+        "webhook_credential",
+        re.compile(
+            r"(?P<secret>https://(?:hooks\.slack\.com/services|"
+            r"discord(?:app)?\.com/api/webhooks)/[^\s\"']+)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "credential_assignment",
+        re.compile(
+            r"(?:\b(?:authorization|proxy-authorization|x-api-key|api[_ -]?key|"
+            r"access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|"
+            r"secret|password|passwd|cookie|private[_ -]?key|signature)\b\s*[:=]\s*|"
+            r"\b(?:[A-Z][A-Z0-9_]*_)?(?:API_?KEY|ACCESS_?TOKEN|REFRESH_?TOKEN|"
+            r"AUTH_?TOKEN|SESSION_?TOKEN|TOKEN|CLIENT_?SECRET|SECRET(?:_ACCESS_?KEY)?|"
+            r"PASSWORD|PASSWD|CREDENTIAL|PRIVATE_?KEY)\s*=\s*|"
+            r"--(?:api-key|access-token|auth-token|client-secret|password|private-key|"
+            r"secret|token)(?:=|\s+))(?:(?:bearer|basic)\s+)?[\"']?"
+            r"(?P<secret>[^\s,;\"']{8,})",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "credential_url",
+        re.compile(
+            r"[A-Za-z][A-Za-z0-9+.-]*://(?:[^:/@\s]+:)?"
+            r"(?P<secret>[^/@\s]{8,})@|"
+            r"[?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|sig|"
+            r"signature|credential|authorization|auth|password)="
+            r"(?P<secret_query>[^&#\s\"']{8,})",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+Finding = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class ScanReport:
+    findings: tuple[Finding, ...]
+
+    def __bool__(self) -> bool:
+        return bool(self.findings)
+
+    @property
+    def locations(self) -> int:
+        return len({path for path, _ in self.findings})
+
+    @property
+    def categories(self) -> dict[str, int]:
+        return dict(sorted(Counter(category for _, category in self.findings).items()))
+
+    def __str__(self) -> str:
+        categories = ", ".join(f"{name}: {count}" for name, count in self.categories.items())
+        return f"{self.locations} credential-bearing location(s) ({categories})"
+
+
+@dataclass(frozen=True)
+class PreparedUpload:
+    data: Any
+    report: ScanReport
+
+
+@dataclass(frozen=True)
+class PreparedJSONLUpload:
+    path: Path
+    context: dict[str, str] | None
+    report: ScanReport
+
+
+class UploadScanError(ValueError):
+    """The upload could not be safely reduced before network access."""
+
+
+def _normalize(name: str) -> str:
+    return (
+        re.sub(r"[^A-Za-z0-9]+", "_", re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name))
+        .strip("_")
+        .lower()
+    )
+
+
+def _sensitive(name: str) -> bool:
+    name = _normalize(name)
+    return not name.endswith(_REFERENCE_SUFFIXES) and any(
+        name == field or name.endswith(f"_{field}") for field in _SENSITIVE_FIELDS
+    )
+
+
+def _is_secret(value: Any) -> bool:
+    return isinstance(value, str) and len(value) >= 8 and not _PLACEHOLDER.fullmatch(value.strip())
+
+
+def secret_values(*values: str | None, secrets_file: str | Path | None = None) -> tuple[str, ...]:
+    """Combine environment, configured, and optional file secrets."""
+    candidates = [
+        value
+        for name, value in os.environ.items()
+        if _SECRET_ENV.search(name) and _is_secret(value)
+    ]
+    candidates.extend(values)
+    if secrets_file:
+        for line_number, line in enumerate(Path(secrets_file).read_text().splitlines(), 1):
+            value = line.strip()
+            if not value or value.startswith("#"):
+                continue
+            if not _is_secret(value):
+                raise ValueError(
+                    f"secret file line {line_number} must contain at least 8 "
+                    "non-placeholder characters"
+                )
+            candidates.append(value)
+    return tuple(dict.fromkeys(value for value in candidates if _is_secret(value)))
+
+
+def _remember(value: Any, secrets: dict[str, str], category: str) -> None:
+    if _is_secret(value):
+        secrets.setdefault(value, category)
+        if match := _AUTH_VALUE.fullmatch(value.strip()):
+            if _is_secret(token := match.group(1)):
+                secrets.setdefault(token, category)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            _remember(child, secrets, category)
+
+
+def _discover(value: Any, secrets: dict[str, str]) -> None:
+    def visit(child: Any, schema_secret: bool = False, properties: bool = False) -> None:
+        if isinstance(child, Mapping):
+            for key, nested in child.items():
+                name = str(key)
+                normalized = _normalize(name)
+                if properties:
+                    visit(nested, _sensitive(name))
+                    continue
+                if _sensitive(name):
+                    _remember(nested, secrets, "structured_secret")
+                if schema_secret and normalized in _SCHEMA_VALUES:
+                    _remember(nested, secrets, "structured_secret")
+                visit(nested, schema_secret, normalized == "properties")
+        elif isinstance(child, (list, tuple)):
+            for nested in child:
+                visit(nested, schema_secret)
+
+    visit(value)
+
+
+def _secrets(value: Any, known_secrets: Iterable[str]) -> dict[str, str]:
+    secrets = {secret: "known_secret" for secret in known_secrets if _is_secret(secret)}
+    _discover(value, secrets)
+    return secrets
+
+
+def _exact_pattern(secrets: Mapping[str, str]) -> re.Pattern[str] | None:
+    if not secrets:
+        return None
+    alternatives = "|".join(re.escape(secret) for secret in sorted(secrets, key=len, reverse=True))
+    return re.compile(f"(?P<secret>{alternatives})")
+
+
+def _path(parts: tuple[str | int, ...]) -> str:
+    result = "$"
+    for part in parts:
+        if isinstance(part, int):
+            result += f"[{part}]"
+        elif part == "[key]" or not _SAFE_PATH_KEY.fullmatch(part):
+            result += ".[key]"
+        else:
+            result += f".{part}"
+    return result
+
+
+def _redact_text(text: str, secrets: Mapping[str, str]) -> tuple[str, set[str]]:
+    categories = set()
+    if exact := _exact_pattern(secrets):
+
+        def replace_exact(match: re.Match[str]) -> str:
+            categories.add(secrets[match.group("secret")])
+            return REDACTED
+
+        text = exact.sub(replace_exact, text)
+    for category, pattern in _PATTERNS:
+
+        def replace_shape(match: re.Match[str], category: str = category) -> str:
+            group = "secret" if match.groupdict().get("secret") is not None else "secret_query"
+            secret = match.group(group)
+            if not _is_secret(secret):
+                return match.group(0)
+            categories.add(category)
+            start, end = match.span(group)
+            offset = match.start()
+            return f"{match.group(0)[: start - offset]}{REDACTED}{match.group(0)[end - offset :]}"
+
+        text = pattern.sub(replace_shape, text)
+    return text, categories
+
+
+def _reduce(
+    value: Any,
+    secrets: Mapping[str, str],
+    findings: set[Finding],
+    path: tuple[str | int, ...] = (),
+) -> Any:
+    if isinstance(value, Mapping):
+        reduced = {}
+        for key, child in value.items():
+            safe_key, categories = (
+                _redact_text(key, secrets) if isinstance(key, str) else (key, set())
+            )
+            findings.update((_path((*path, "[key]")), category) for category in categories)
+            if safe_key in reduced:
+                raise UploadScanError("credential reduction would create duplicate object keys")
+            reduced[safe_key] = _reduce(
+                child, secrets, findings, (*path, "[key]" if categories else str(key))
+            )
+        return reduced
+    if isinstance(value, list):
+        return [
+            _reduce(child, secrets, findings, (*path, index)) for index, child in enumerate(value)
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _reduce(child, secrets, findings, (*path, index)) for index, child in enumerate(value)
+        )
+    if not isinstance(value, str):
+        return value
+    reduced, categories = _redact_text(value, secrets)
+    findings.update((_path(path), category) for category in categories)
+    return reduced
+
+
+def _prepare(value: Any, secrets: Mapping[str, str]) -> PreparedUpload:
+    findings: set[Finding] = set()
+    data = _reduce(value, secrets, findings)
+    residual: set[Finding] = set()
+    _reduce(data, secrets, residual)
+    if residual:
+        paths = ", ".join(path for path, _ in sorted(residual)[:10])
+        raise UploadScanError(f"reduced upload still contains credentials at {paths}")
+    return PreparedUpload(data, ScanReport(tuple(sorted(findings))))
+
+
+def scan_upload(value: Any, known_secrets: Iterable[str] = ()) -> ScanReport:
+    """Classify credential locations without returning their values."""
+    return _prepare(value, _secrets(value, known_secrets)).report
+
+
+def prepare_upload(value: Any, known_secrets: Iterable[str] = ()) -> PreparedUpload:
+    """Reduce a copy, then rescan it before any caller starts an upload."""
+    return _prepare(value, _secrets(value, known_secrets))
+
+
+class _DuplicateKeyError(ValueError):
+    pass
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value = {}
+    for key, child in pairs:
+        if key in value:
+            raise _DuplicateKeyError
+        value[key] = child
+    return value
+
+
+def _load_line(line: str, number: int) -> Any:
+    try:
+        return json.loads(line, object_pairs_hook=_unique_object)
+    except _DuplicateKeyError as error:
+        raise UploadScanError(f"duplicate object key on JSONL line {number}") from error
+    except json.JSONDecodeError as error:
+        raise UploadScanError(
+            f"invalid JSON on JSONL line {number} at column {error.colno}"
+        ) from error
+
+
+def _prefix(report: ScanReport, prefix: str) -> set[Finding]:
+    return {(f"{prefix}{path[1:]}", category) for path, category in report.findings}
+
+
+def prepare_jsonl_upload(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    context: Mapping[str, str] | None = None,
+    known_secrets: Iterable[str] = (),
+) -> PreparedJSONLUpload:
+    """Return a safe snapshot or redacted JSONL path without changing the source."""
+    source, snapshot = Path(source), Path(destination)
+    redacted = snapshot.with_name(f"redacted-{snapshot.name}")
+    secrets = {secret: "known_secret" for secret in known_secrets if _is_secret(secret)}
+    _discover(context, secrets)
+
+    try:
+        with source.open("rb") as input_file, snapshot.open("wb") as output_file:
+            for number, raw in enumerate(input_file, 1):
+                output_file.write(raw)
+                if not raw.isspace():
+                    _discover(_load_line(raw.decode(), number), secrets)
+    except UnicodeDecodeError as error:
+        raise UploadScanError("trace JSONL must be UTF-8") from error
+
+    context_prepared = _prepare(context, secrets) if context is not None else None
+    findings = _prefix(context_prepared.report, "$.context") if context_prepared else set()
+    file_findings: set[Finding] = set()
+
+    try:
+        with snapshot.open("rb") as input_file, redacted.open("wb") as output_file:
+            for number, raw in enumerate(input_file, 1):
+                if raw.isspace():
+                    output_file.write(raw)
+                    continue
+                value = _prepare(_load_line(raw.decode(), number), secrets)
+                file_findings.update(_prefix(value.report, f"$.lines[{number}]"))
+                output_file.write(
+                    json.dumps(value.data, ensure_ascii=False, separators=(",", ":")).encode()
+                    + b"\n"
+                    if value.report
+                    else raw
+                )
+    except UnicodeDecodeError as error:
+        raise UploadScanError("trace JSONL must be UTF-8") from error
+
+    if file_findings:
+        snapshot.unlink()
+        upload_path = redacted
+    else:
+        redacted.unlink()
+        upload_path = snapshot
+    return PreparedJSONLUpload(
+        upload_path,
+        context_prepared.data if context_prepared else None,
+        ScanReport(tuple(sorted(findings | file_findings))),
+    )

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -31,6 +31,7 @@ _SENSITIVE_FIELDS = {
     "access_token",
     "auth_token",
     "auth",
+    "authentication",
     "authorization",
     "client_secret",
     "connection_string",
@@ -53,8 +54,10 @@ _SENSITIVE_FIELDS = {
     "token",
 }
 _SCHEMA_VALUES = {"const", "default", "example", "examples"}
-_SCHEMA_FIELDS = {
+_SCHEMA_MARKERS = {
+    "$defs",
     "$ref",
+    "$schema",
     "allOf",
     "anyOf",
     "const",
@@ -66,7 +69,6 @@ _SCHEMA_FIELDS = {
     "items",
     "oneOf",
     "pattern",
-    "properties",
     "required",
     "title",
     "type",
@@ -108,14 +110,26 @@ _PATTERNS = (
         ),
     ),
     (
+        "authorization_header",
+        re.compile(
+            r"(?<![A-Za-z0-9_])[\"']?(?:authorization|proxy-authorization)"
+            r"[\"']?\s*[:=]\s*[\"']?(?:(?:bearer|basic)\s+)?"
+            r"(?P<secret>[^\s,;\"']{8,})",
+            re.IGNORECASE,
+        ),
+    ),
+    (
         "cookie_header",
-        re.compile(r"^\s*cookie\s*:\s*(?P<secret>[^\r\n]{8,})", re.IGNORECASE | re.MULTILINE),
+        re.compile(
+            r"(?<![A-Za-z0-9_-])[\"']?cookie[\"']?\s*:\s*[\"']?"
+            r"(?P<secret>[^\r\n\"']{8,})",
+            re.IGNORECASE,
+        ),
     ),
     (
         "credential_assignment",
         re.compile(
-            r"(?:(?<![A-Za-z0-9_])[\"']?(?:authorization|proxy-authorization|"
-            r"x-api-key|api[_ -]?key|"
+            r"(?:(?<![A-Za-z0-9_])[\"']?(?:x-api-key|api[_ -]?key|"
             r"access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|"
             r"secret|password|passwd|cookie|private[_ -]?key|signature)\b[\"']?\s*[:=]\s*|"
             r"\b(?:[A-Z][A-Z0-9_]*_)?(?:API_?KEY|ACCESS_?TOKEN|REFRESH_?TOKEN|"
@@ -246,17 +260,20 @@ def _remember(value: Any, secrets: dict[str, str], category: str) -> None:
 
 
 def _discover(value: Any, secrets: dict[str, str]) -> None:
-    def visit(child: Any, schema_secret: bool = False, properties: bool = False) -> None:
+    def visit(
+        child: Any,
+        schema_secret: bool = False,
+        schema_context: bool = False,
+        properties: bool = False,
+    ) -> None:
         if isinstance(child, Mapping):
+            object_schema = schema_context or any(field in child for field in _SCHEMA_MARKERS)
             for key, nested in child.items():
                 name = str(key)
                 normalized = _normalize(name)
                 if properties:
-                    schema = isinstance(nested, Mapping) and (
-                        not nested or any(field in nested for field in _SCHEMA_FIELDS)
-                    )
-                    if schema:
-                        visit(nested, _sensitive(name))
+                    if isinstance(nested, (Mapping, bool)):
+                        visit(nested, _sensitive(name), True)
                     else:
                         if _sensitive(name):
                             _remember(nested, secrets, "structured_secret")
@@ -266,10 +283,15 @@ def _discover(value: Any, secrets: dict[str, str]) -> None:
                     _remember(nested, secrets, "structured_secret")
                 if schema_secret and normalized in _SCHEMA_VALUES:
                     _remember(nested, secrets, "structured_secret")
-                visit(nested, schema_secret, normalized == "properties")
+                visit(
+                    nested,
+                    schema_secret,
+                    object_schema or normalized in {"schema", "json_schema"},
+                    object_schema and normalized == "properties",
+                )
         elif isinstance(child, (list, tuple)):
             for nested in child:
-                visit(nested, schema_secret)
+                visit(nested, schema_secret, schema_context, properties)
 
     visit(value)
 
@@ -333,10 +355,12 @@ def _reduce(
     path: tuple[str | int, ...] = (),
     structured_secret: bool = False,
     schema_secret: bool = False,
+    schema_context: bool = False,
     properties: bool = False,
 ) -> Any:
     if isinstance(value, Mapping):
         reduced = {}
+        object_schema = schema_context or any(field in value for field in _SCHEMA_MARKERS)
         for key, child in value.items():
             safe_key, categories = (
                 _redact_text(key, secrets) if isinstance(key, str) else (key, set())
@@ -345,13 +369,9 @@ def _reduce(
             if safe_key in reduced:
                 raise UploadScanError("credential reduction would create duplicate object keys")
             normalized = _normalize(str(key))
-            schema = (
-                properties
-                and isinstance(child, Mapping)
-                and (not child or any(field in child for field in _SCHEMA_FIELDS))
-            )
+            property_schema = properties and isinstance(child, (Mapping, bool))
             child_secret = structured_secret or (
-                not schema
+                not property_schema
                 and (_sensitive(str(key)) or schema_secret and normalized in _SCHEMA_VALUES)
             )
             reduced[safe_key] = _reduce(
@@ -360,8 +380,9 @@ def _reduce(
                 findings,
                 (*path, "[key]" if categories else str(key)),
                 child_secret,
-                _sensitive(str(key)) if schema else schema_secret,
-                not structured_secret and normalized == "properties",
+                _sensitive(str(key)) if property_schema else schema_secret,
+                property_schema or object_schema or normalized in {"schema", "json_schema"},
+                not structured_secret and object_schema and normalized == "properties",
             )
         return reduced
     if isinstance(value, list):
@@ -373,6 +394,7 @@ def _reduce(
                 (*path, index),
                 structured_secret,
                 schema_secret,
+                schema_context,
                 properties,
             )
             for index, child in enumerate(value)
@@ -386,6 +408,7 @@ def _reduce(
                 (*path, index),
                 structured_secret,
                 schema_secret,
+                schema_context,
                 properties,
             )
             for index, child in enumerate(value)

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -25,6 +25,8 @@ _SECRET_ENV = re.compile(
 )
 _REFERENCE_SUFFIXES = ("_env", "_env_var", "_file", "_name", "_path", "_var", "_variable")
 _SENSITIVE_FIELDS = {
+    "access_key",
+    "access_key_id",
     "api_key",
     "access_token",
     "auth_token",
@@ -42,6 +44,7 @@ _SENSITIVE_FIELDS = {
     "refresh_token",
     "sas_token",
     "secret",
+    "secret_access_key",
     "secret_key",
     "session_token",
     "signature",
@@ -171,8 +174,11 @@ def _normalize(name: str) -> str:
 
 def _sensitive(name: str) -> bool:
     name = _normalize(name)
-    return not name.endswith(_REFERENCE_SUFFIXES) and any(
-        name == field or name.endswith(f"_{field}") for field in _SENSITIVE_FIELDS
+    names = (name, name.removesuffix("s"))
+    return not any(candidate.endswith(_REFERENCE_SUFFIXES) for candidate in names) and any(
+        candidate == field or candidate.endswith(f"_{field}")
+        for candidate in names
+        for field in _SENSITIVE_FIELDS
     )
 
 
@@ -390,7 +396,11 @@ def prepare_jsonl_upload(
     """Return a safe snapshot or redacted JSONL path without changing the source."""
     source, snapshot = Path(source), Path(destination)
     redacted = snapshot.with_name(f"redacted-{snapshot.name}")
-    secrets = {secret: "known_secret" for secret in known_secrets if _is_secret(secret)}
+    if source.resolve() in {snapshot.resolve(), redacted.resolve()}:
+        raise UploadScanError("upload outputs must not alias the source JSONL")
+    secrets: dict[str, str] = {}
+    for secret in known_secrets:
+        _remember(secret, secrets, "known_secret")
     _discover(context, secrets)
 
     try:

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -29,6 +29,7 @@ _REFERENCE_SUFFIXES = ("_env", "_env_var", "_file", "_name", "_path", "_var", "_
 _SENSITIVE_FIELDS = {
     "access_key",
     "access_key_id",
+    "account_key",
     "api_key",
     "api_token",
     "access_token",
@@ -132,7 +133,7 @@ _PATTERNS = (
         "credential_assignment",
         re.compile(
             r"(?:(?<![A-Za-z0-9_])[\"']?(?:[A-Za-z][A-Za-z0-9]*[_-]+)*"
-            r"(?:x-api-key|api[_ -]?key|"
+            r"(?:x-api-key|api[_ -]?key|account[_ -]?key|"
             r"access[_ -]?token|refresh[_ -]?token|auth[_ -]?token|client[_ -]?secret|"
             r"access[_ -]?key(?:[_ -]?id)?|secret(?:[_ -]?access[_ -]?key)?|"
             r"password|passwd|cookie|private[_ -]?key|signature)\b[\"']?\s*[:=]\s*|"
@@ -344,9 +345,13 @@ def _path(parts: tuple[str | int, ...]) -> str:
     return result
 
 
-def _redact_text(text: str, secrets: Mapping[str, str]) -> tuple[str, set[str]]:
+def _redact_text(
+    text: str,
+    secrets: Mapping[str, str],
+    exact: re.Pattern[str] | None,
+) -> tuple[str, set[str]]:
     categories = set()
-    if exact := _exact_pattern(secrets):
+    if exact:
 
         def replace_exact(match: re.Match[str]) -> str:
             categories.add(secrets[match.group("secret")])
@@ -376,6 +381,7 @@ def _redact_text(text: str, secrets: Mapping[str, str]) -> tuple[str, set[str]]:
 def _reduce(
     value: Any,
     secrets: Mapping[str, str],
+    exact: re.Pattern[str] | None,
     findings: set[Finding],
     path: tuple[str | int, ...] = (),
     structured_secret: bool = False,
@@ -390,7 +396,7 @@ def _reduce(
             safe_key, categories = (
                 (REDACTED, {"structured_secret"})
                 if structured_secret and _is_secret(key)
-                else _redact_text(key, secrets)
+                else _redact_text(key, secrets, exact)
                 if isinstance(key, str)
                 else (key, set())
             )
@@ -411,6 +417,7 @@ def _reduce(
             reduced[safe_key] = _reduce(
                 child,
                 secrets,
+                exact,
                 findings,
                 (*path, "[key]" if categories else str(key)),
                 child_secret,
@@ -424,6 +431,7 @@ def _reduce(
             _reduce(
                 child,
                 secrets,
+                exact,
                 findings,
                 (*path, index),
                 structured_secret,
@@ -438,6 +446,7 @@ def _reduce(
             _reduce(
                 child,
                 secrets,
+                exact,
                 findings,
                 (*path, index),
                 structured_secret,
@@ -461,16 +470,21 @@ def _reduce(
         return REDACTED
     if not isinstance(value, str):
         return value
-    reduced, categories = _redact_text(value, secrets)
+    reduced, categories = _redact_text(value, secrets, exact)
     findings.update((_path(path), category) for category in categories)
     return reduced
 
 
-def _prepare(value: Any, secrets: Mapping[str, str]) -> PreparedUpload:
+def _prepare(
+    value: Any,
+    secrets: Mapping[str, str],
+    exact: re.Pattern[str] | None = None,
+) -> PreparedUpload:
+    exact = exact or _exact_pattern(secrets)
     findings: set[Finding] = set()
-    data = _reduce(value, secrets, findings)
+    data = _reduce(value, secrets, exact, findings)
     residual: set[Finding] = set()
-    _reduce(data, secrets, residual)
+    _reduce(data, secrets, exact, residual)
     if residual:
         paths = ", ".join(path for path, _ in sorted(residual)[:10])
         raise UploadScanError(f"reduced upload still contains credentials at {paths}")
@@ -546,7 +560,8 @@ def prepare_jsonl_upload(
     except UnicodeDecodeError as error:
         raise UploadScanError("trace JSONL must be UTF-8") from error
 
-    context_prepared = _prepare(context, secrets) if context is not None else None
+    exact = _exact_pattern(secrets)
+    context_prepared = _prepare(context, secrets, exact) if context is not None else None
     findings = _prefix(context_prepared.report, "$.context") if context_prepared else set()
     file_findings: set[Finding] = set()
 
@@ -563,7 +578,7 @@ def prepare_jsonl_upload(
                         output_file.write(raw)
                     offset += len(raw)
                     continue
-                value = _prepare(_load_line(raw.decode(), number), secrets)
+                value = _prepare(_load_line(raw.decode(), number), secrets, exact)
                 file_findings.update(_prefix(value.report, f"$.lines[{number}]"))
                 if value.report and output_file is None:
                     output_file = stack.enter_context(redacted.open("wb"))

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -30,6 +30,7 @@ _SENSITIVE_FIELDS = {
     "access_key",
     "access_key_id",
     "api_key",
+    "api_token",
     "access_token",
     "auth_token",
     "auth",
@@ -215,7 +216,12 @@ def _normalize(name: str) -> str:
 
 def _sensitive(name: str) -> bool:
     name = _normalize(name)
-    names = (name, name.removesuffix("s"))
+    singular = name.removesuffix("s")
+    plural_secret = singular != name and any(
+        singular == field or singular.endswith(f"_{field}")
+        for field in _SENSITIVE_FIELDS - {"token"}
+    )
+    names = (name, singular) if plural_secret else (name,)
     return not any(candidate.endswith(_REFERENCE_SUFFIXES) for candidate in names) and any(
         candidate == field or candidate.endswith(f"_{field}")
         for candidate in names

--- a/packages/prime-evals/src/prime_evals/preflight.py
+++ b/packages/prime-evals/src/prime_evals/preflight.py
@@ -45,6 +45,7 @@ _SENSITIVE_FIELDS = {
     "secret_key",
     "session_token",
     "signature",
+    "token",
 }
 _SCHEMA_VALUES = {"const", "default", "example", "examples"}
 _SCHEMA_TYPES = {"array", "boolean", "integer", "null", "number", "object", "string"}
@@ -153,7 +154,15 @@ class UploadScanError(ValueError):
 
 def _normalize(name: str) -> str:
     return (
-        re.sub(r"[^A-Za-z0-9]+", "_", re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name))
+        re.sub(
+            r"[^A-Za-z0-9]+",
+            "_",
+            re.sub(
+                r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])",
+                "_",
+                name,
+            ),
+        )
         .strip("_")
         .lower()
     )

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -97,6 +97,13 @@ def test_preflight_catches_assignments_flags_urls_webhooks_and_private_keys():
     }
 
 
+@pytest.mark.parametrize("label", ["DSA PRIVATE KEY", "ENCRYPTED PRIVATE KEY"])
+def test_preflight_catches_private_key_pem_variants(label):
+    private_key = f"-----BEGIN {label}-----\nopaque-key-material\n-----END {label}-----"
+
+    assert prepare_upload({"completion": private_key}).data["completion"] == REDACTED
+
+
 def test_structured_authorization_redacts_the_repeated_bearer_token():
     token = "opaque-bearer-token-0123456789"
     prepared = prepare_upload(

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -140,18 +140,32 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
 
 
 def test_preflight_catches_quoted_assignments_and_sensitive_mapping_keys():
-    secret = "opaque-map-key-0123456789"
+    secrets = ["opaque-map-key-0123456789", "second-map-key-0123456789"]
+    aws_secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
     prepared = prepare_upload(
         {
-            "completion": 'password="correct horse battery staple"',
-            "api_keys": {secret: {"owner": "alice"}},
+            "completion": (
+                'password="correct horse battery staple" '
+                f'{{"aws_secret_access_key":"{aws_secret}"}}'
+            ),
+            "api_keys": {secret: {"owner": "alice"} for secret in secrets},
             "team_id": "team-0123456789",
         }
     )
 
     assert "correct horse battery staple" not in prepared.data["completion"]
-    assert list(prepared.data["api_keys"]) == [REDACTED]
+    assert aws_secret not in prepared.data["completion"]
+    assert list(prepared.data["api_keys"]) == [REDACTED, "[REDACTED 2]"]
     assert prepared.data["team_id"] == "team-0123456789"
+    assert scan_upload(prepared.data).findings == ()
+
+
+def test_pattern_discovered_secrets_are_redacted_everywhere():
+    secret = "opaque-password-value-0123456789"
+    prepared = prepare_upload({"prompt": f"model repeated {secret}", "log": f"password={secret}"})
+
+    assert secret not in json.dumps(prepared.data)
+    assert prepared.data["prompt"] == f"model repeated {REDACTED}"
 
 
 def test_preflight_redacts_numeric_structured_secrets():

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -166,6 +166,9 @@ def test_preflight_redacts_numeric_structured_secrets():
         "auth": False,
     }
 
+    usage = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+    assert prepare_upload({"usage": usage}).data["usage"] == usage
+
 
 @pytest.mark.parametrize("label", ["DSA PRIVATE KEY", "ENCRYPTED PRIVATE KEY"])
 def test_preflight_catches_private_key_pem_variants(label):

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -97,6 +97,21 @@ def test_preflight_catches_assignments_flags_urls_webhooks_and_private_keys():
     }
 
 
+def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets():
+    token = "opaque-json-token-0123456789"
+    payload = {
+        "completion": json.dumps({"Authorization": f"Bearer {token}"}),
+        "password": "s3cr3t",
+        "api_key": "abc123",
+    }
+
+    prepared = prepare_upload(payload)
+
+    assert token not in prepared.data["completion"]
+    assert prepared.data["password"] == REDACTED
+    assert prepared.data["api_key"] == REDACTED
+
+
 @pytest.mark.parametrize("label", ["DSA PRIVATE KEY", "ENCRYPTED PRIVATE KEY"])
 def test_preflight_catches_private_key_pem_variants(label):
     private_key = f"-----BEGIN {label}-----\nopaque-key-material\n-----END {label}-----"

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -135,8 +135,12 @@ def test_structured_authorization_redacts_the_repeated_bearer_token():
 def test_nested_and_properties_credentials_do_not_bypass_discovery():
     secret = "opaque-nested-secret-0123456789"
     token = "opaque-generic-token-0123456789"
+    access_key = "opaque-aws-secret-access-key-0123456789"
+    plural_key = "opaque-plural-key-0123456789"
     payload = {
         "APIKey": secret,
+        "apiKeys": [plural_key],
+        "awsSecretAccessKey": access_key,
         "secret": {"value": secret},
         "token": token,
         "properties": {"password": secret},
@@ -146,6 +150,8 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
     prepared = prepare_upload(payload)
 
     assert prepared.data["APIKey"] == REDACTED
+    assert prepared.data["apiKeys"] == [REDACTED]
+    assert prepared.data["awsSecretAccessKey"] == REDACTED
     assert prepared.data["secret"]["value"] == REDACTED
     assert prepared.data["token"] == REDACTED
     assert prepared.data["properties"]["password"] == REDACTED
@@ -190,6 +196,17 @@ def test_jsonl_preflight_uploads_an_exact_snapshot_when_clean(tmp_path):
     assert prepared.path == destination
     assert destination.read_bytes() == source.read_bytes()
     assert prepared.report.findings == ()
+
+
+@pytest.mark.parametrize("source_name", ["safe.jsonl", "redacted-safe.jsonl"])
+def test_jsonl_preflight_rejects_output_paths_that_alias_the_source(tmp_path, source_name):
+    source = tmp_path / source_name
+    source.write_text('{"answer":"keep"}\n')
+
+    with pytest.raises(UploadScanError, match="must not alias"):
+        prepare_jsonl_upload(source, tmp_path / "safe.jsonl")
+
+    assert source.read_text() == '{"answer":"keep"}\n'
 
 
 @pytest.mark.parametrize(

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -123,7 +123,7 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     token = "opaque-json-token-0123456789"
     payload = {
         "completion": json.dumps({"Authorization": f"Bearer {token}"}),
-        "answer": "Use token=version-123 for the example.",
+        "answer": "Use abc123 and token=version-123 for the example.",
         "password": "s3cr3t",
         "api_key": "abc123",
     }
@@ -165,10 +165,17 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
         "APIKey": secret,
         "apiKeys": [plural_key],
         "awsSecretAccessKey": access_key,
+        "credential": {"value": "pin"},
+        "rubric": "keep the pin label",
         "secret": {"value": secret},
         "token": token,
         "properties": {"password": secret},
-        "schema": {"properties": {"password": {"type": "string", "description": "keep this"}}},
+        "schema": {
+            "properties": {
+                "password": {"type": ["string", "null"], "description": "keep this"},
+                "apiKey": {"description": "typeless schema"},
+            }
+        },
     }
 
     prepared = prepare_upload(payload)
@@ -176,6 +183,8 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
     assert prepared.data["APIKey"] == REDACTED
     assert prepared.data["apiKeys"] == [REDACTED]
     assert prepared.data["awsSecretAccessKey"] == REDACTED
+    assert prepared.data["credential"]["value"] == REDACTED
+    assert prepared.data["rubric"] == payload["rubric"]
     assert prepared.data["secret"]["value"] == REDACTED
     assert prepared.data["token"] == REDACTED
     assert prepared.data["properties"]["password"] == REDACTED

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -97,6 +97,18 @@ def test_preflight_catches_assignments_flags_urls_webhooks_and_private_keys():
     }
 
 
+def test_preflight_catches_azure_storage_account_keys():
+    secret = "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+    connection = (
+        "DefaultEndpointsProtocol=https;AccountName=example;"
+        f"AccountKey={secret};EndpointSuffix=core.windows.net"
+    )
+
+    prepared = prepare_upload({"completion": connection})
+
+    assert secret not in prepared.data["completion"]
+
+
 @pytest.mark.parametrize(
     "token",
     [

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -113,7 +113,8 @@ def test_preflight_catches_additional_provider_credentials(token):
 def test_preflight_redacts_every_value_in_a_raw_cookie_header():
     session = "opaque-cookie-session-0123456789"
     refresh = "opaque-cookie-refresh-0123456789"
-    prepared = prepare_upload({"completion": f"Cookie: session={session}; refresh={refresh}"})
+    header = json.dumps({"Cookie": f"session={session}; refresh={refresh}"})
+    prepared = prepare_upload({"completion": f"request: {header}"})
 
     assert session not in prepared.data["completion"]
     assert refresh not in prepared.data["completion"]
@@ -123,6 +124,7 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     token = "opaque-json-token-0123456789"
     payload = {
         "completion": json.dumps({"Authorization": f"Bearer {token}"}),
+        "error": "Authorization: Basic dXNlcjpwYXNz",
         "answer": "Use abc123 and token=version-123 for the example.",
         "password": "s3cr3t",
         "api_key": "abc123",
@@ -131,6 +133,7 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     prepared = prepare_upload(payload)
 
     assert token not in prepared.data["completion"]
+    assert "dXNlcjpwYXNz" not in prepared.data["error"]
     assert prepared.data["answer"] == payload["answer"]
     assert prepared.data["password"] == REDACTED
     assert prepared.data["api_key"] == REDACTED
@@ -161,15 +164,17 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
     token = "opaque-generic-token-0123456789"
     access_key = "opaque-aws-secret-access-key-0123456789"
     plural_key = "opaque-plural-key-0123456789"
+    property_key = "opaque-property-key-0123456789"
     payload = {
         "APIKey": secret,
         "apiKeys": [plural_key],
         "awsSecretAccessKey": access_key,
         "credential": {"value": "pin"},
+        "authentication": "opaque-authentication-0123456789",
         "rubric": "keep the pin label",
         "secret": {"value": secret},
         "token": token,
-        "properties": {"password": secret},
+        "properties": {"password": {"type": "string", "value": property_key}},
         "schema": {
             "properties": {
                 "password": {"type": ["string", "null"], "description": "keep this"},
@@ -184,10 +189,11 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
     assert prepared.data["apiKeys"] == [REDACTED]
     assert prepared.data["awsSecretAccessKey"] == REDACTED
     assert prepared.data["credential"]["value"] == REDACTED
+    assert prepared.data["authentication"] == REDACTED
     assert prepared.data["rubric"] == payload["rubric"]
     assert prepared.data["secret"]["value"] == REDACTED
     assert prepared.data["token"] == REDACTED
-    assert prepared.data["properties"]["password"] == REDACTED
+    assert prepared.data["properties"]["password"]["value"] == REDACTED
     assert prepared.data["schema"] == payload["schema"]
 
 

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -117,6 +117,21 @@ def test_structured_authorization_redacts_the_repeated_bearer_token():
     assert token not in prepared.data["completion"]
 
 
+def test_nested_and_properties_credentials_do_not_bypass_discovery():
+    secret = "opaque-nested-secret-0123456789"
+    payload = {
+        "secret": {"value": secret},
+        "properties": {"password": secret},
+        "schema": {"properties": {"password": {"type": "string", "description": "keep this"}}},
+    }
+
+    prepared = prepare_upload(payload)
+
+    assert prepared.data["secret"]["value"] == REDACTED
+    assert prepared.data["properties"]["password"] == REDACTED
+    assert prepared.data["schema"] == payload["schema"]
+
+
 def test_jsonl_preflight_uses_secrets_discovered_in_later_lines(tmp_path):
     secret = "opaque-later-line-secret-0123456789"
     source = tmp_path / "traces.jsonl"

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -97,6 +97,28 @@ def test_preflight_catches_assignments_flags_urls_webhooks_and_private_keys():
     }
 
 
+@pytest.mark.parametrize(
+    "token",
+    [
+        "xwfp-0123456789-abcdefghijklmnop",
+        "xapp-0123456789-abcdefghijklmnop",
+        "rk_" + "live_" + "0" * 24,
+        "sk_" + "test_" + "0" * 24,
+    ],
+)
+def test_preflight_catches_additional_provider_credentials(token):
+    assert prepare_upload({"completion": token}).data["completion"] == REDACTED
+
+
+def test_preflight_redacts_every_value_in_a_raw_cookie_header():
+    session = "opaque-cookie-session-0123456789"
+    refresh = "opaque-cookie-refresh-0123456789"
+    prepared = prepare_upload({"completion": f"Cookie: session={session}; refresh={refresh}"})
+
+    assert session not in prepared.data["completion"]
+    assert refresh not in prepared.data["completion"]
+
+
 def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets():
     token = "opaque-json-token-0123456789"
     payload = {

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -1,0 +1,178 @@
+import json
+
+import pytest
+
+from prime_evals.preflight import (
+    REDACTED,
+    UploadScanError,
+    prepare_jsonl_upload,
+    prepare_upload,
+    scan_upload,
+    secret_values,
+)
+
+
+def test_preflight_reduces_credentials_without_reducing_trace_review_data():
+    provider_key = "sk-test-0123456789abcdefghijklmnopqrstuv"
+    opaque_key = "opaque-judge-key-0123456789"
+    upload_key = "opaque-prime-key-0123456789"
+    payload = {
+        "metadata": {
+            "judgeApiKey": opaque_key,
+            "api_key_var": "JUDGE_API_KEY",
+        },
+        "results": [
+            {
+                "prompt": f"The leaked provider key is {provider_key}",
+                "completion": f"Repeated judge key: {opaque_key}; upload key: {upload_key}",
+                "answer": "reference answer",
+                "rubric": "award one point for the reference answer",
+                "traceback": "/Users/alice/project failed on 10.0.0.4",
+                "tool_defs": [
+                    {
+                        "name": "login",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"password": {"type": "string"}},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    prepared = prepare_upload(payload, [upload_key])
+    serialized = json.dumps(prepared.data)
+
+    assert provider_key not in serialized
+    assert opaque_key not in serialized
+    assert upload_key not in serialized
+    assert payload["metadata"]["judgeApiKey"] == opaque_key
+    assert prepared.data["metadata"] == {
+        "judgeApiKey": REDACTED,
+        "api_key_var": "JUDGE_API_KEY",
+    }
+    result = prepared.data["results"][0]
+    assert result["answer"] == "reference answer"
+    assert result["rubric"].startswith("award one point")
+    assert result["traceback"] == "/Users/alice/project failed on 10.0.0.4"
+    assert result["tool_defs"][0]["parameters"]["properties"] == {"password": {"type": "string"}}
+    assert prepared.report.locations == 3
+    assert prepared.report.categories == {
+        "known_secret": 1,
+        "provider_credential": 1,
+        "structured_secret": 2,
+    }
+    assert scan_upload(prepared.data).findings == ()
+
+
+def test_preflight_catches_assignments_flags_urls_webhooks_and_private_keys():
+    private_key = (
+        "-----BEGIN PRIVATE KEY-----\n0123456789abcdefghijklmnopqrstuv\n-----END PRIVATE KEY-----"
+    )
+    webhook = "https://hooks.slack.com/" + "services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    payload = {
+        "text": (
+            "TOKEN=opaque-token-0123456789 "
+            "--api-key cli-token-0123456789 "
+            "redis://user:password@example.com/0?access_token=query-token-0123456789\n"
+            f"{webhook}\n"
+            f"{private_key}"
+        )
+    }
+
+    prepared = prepare_upload(payload)
+
+    assert "opaque-token" not in prepared.data["text"]
+    assert "cli-token" not in prepared.data["text"]
+    assert "user:password" not in prepared.data["text"]
+    assert "query-token" not in prepared.data["text"]
+    assert "hooks.slack.com" not in prepared.data["text"]
+    assert "BEGIN PRIVATE KEY" not in prepared.data["text"]
+    assert prepared.report.categories == {
+        "credential_assignment": 1,
+        "credential_url": 1,
+        "private_key": 1,
+        "webhook_credential": 1,
+    }
+
+
+def test_structured_authorization_redacts_the_repeated_bearer_token():
+    token = "opaque-bearer-token-0123456789"
+    prepared = prepare_upload(
+        {
+            "headers": {"Authorization": f"Bearer {token}"},
+            "completion": f"the model repeated {token}",
+        }
+    )
+
+    assert prepared.data["headers"]["Authorization"] == REDACTED
+    assert token not in prepared.data["completion"]
+
+
+def test_jsonl_preflight_uses_secrets_discovered_in_later_lines(tmp_path):
+    secret = "opaque-later-line-secret-0123456789"
+    source = tmp_path / "traces.jsonl"
+    destination = tmp_path / "safe.jsonl"
+    original = (
+        json.dumps({"prompt": f"the model repeated {secret}", "answer": "keep me"})
+        + "\n"
+        + json.dumps({"config": {"apiKey": secret}, "rubric": "keep this too"})
+        + "\n"
+    )
+    source.write_text(original)
+
+    prepared = prepare_jsonl_upload(
+        source,
+        destination,
+        context={"password": secret, "source": "local-eval"},
+    )
+
+    assert source.read_text() == original
+    assert prepared.path == tmp_path / "redacted-safe.jsonl"
+    assert prepared.context == {"password": REDACTED, "source": "local-eval"}
+    assert secret not in prepared.path.read_text()
+    records = [json.loads(line) for line in prepared.path.read_text().splitlines()]
+    assert records[0]["answer"] == "keep me"
+    assert records[1]["rubric"] == "keep this too"
+    assert prepared.report.locations == 3
+
+
+def test_jsonl_preflight_uploads_an_exact_snapshot_when_clean(tmp_path):
+    source = tmp_path / "traces.jsonl"
+    destination = tmp_path / "safe.jsonl"
+    source.write_bytes(b'{ "answer": "reference" }\n\n')
+
+    prepared = prepare_jsonl_upload(source, destination)
+
+    assert prepared.path == destination
+    assert destination.read_bytes() == source.read_bytes()
+    assert prepared.report.findings == ()
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ('{"id":}\n', "invalid JSON"),
+        ('{"password":"first-secret", "password":"second-secret"}\n', "duplicate object key"),
+    ],
+)
+def test_jsonl_preflight_fails_closed_on_ambiguous_input(tmp_path, content, message):
+    source = tmp_path / "traces.jsonl"
+    source.write_text(content)
+
+    with pytest.raises(UploadScanError, match=message):
+        prepare_jsonl_upload(source, tmp_path / "safe.jsonl")
+
+
+def test_secret_values_file(tmp_path):
+    path = tmp_path / "secrets.txt"
+    path.write_text("# exact values\nopaque-secret-0123456789\n\nsecond-secret-0123456789\n")
+
+    values = secret_values(secrets_file=path)
+    assert "opaque-secret-0123456789" in values
+    assert "second-secret-0123456789" in values
+
+    path.write_text("short\n")
+    with pytest.raises(ValueError, match="line 1"):
+        secret_values(secrets_file=path)

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -139,6 +139,21 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     assert prepared.data["api_key"] == REDACTED
 
 
+def test_preflight_catches_quoted_assignments_and_sensitive_mapping_keys():
+    secret = "opaque-map-key-0123456789"
+    prepared = prepare_upload(
+        {
+            "completion": 'password="correct horse battery staple"',
+            "api_keys": {secret: {"owner": "alice"}},
+            "team_id": "team-0123456789",
+        }
+    )
+
+    assert "correct horse battery staple" not in prepared.data["completion"]
+    assert list(prepared.data["api_keys"]) == [REDACTED]
+    assert prepared.data["team_id"] == "team-0123456789"
+
+
 def test_preflight_redacts_numeric_structured_secrets():
     prepared = prepare_upload(
         {"password": 12345678, "token": 987654321, "secret": None, "auth": False}
@@ -159,11 +174,12 @@ def test_preflight_catches_private_key_pem_variants(label):
     assert prepare_upload({"completion": private_key}).data["completion"] == REDACTED
 
 
-def test_structured_authorization_redacts_the_repeated_bearer_token():
+@pytest.mark.parametrize("scheme", ["Bearer", "Token"])
+def test_structured_authorization_redacts_the_repeated_token(scheme):
     token = "opaque-bearer-token-0123456789"
     prepared = prepare_upload(
         {
-            "headers": {"Authorization": f"Bearer {token}"},
+            "headers": {"Authorization": f"{scheme} {token}"},
             "completion": f"the model repeated {token}",
         }
     )
@@ -208,6 +224,18 @@ def test_nested_and_properties_credentials_do_not_bypass_discovery():
     assert prepared.data["token"] == REDACTED
     assert prepared.data["properties"]["password"]["value"] == REDACTED
     assert prepared.data["schema"] == payload["schema"]
+
+
+def test_sensitive_schema_enums_are_redacted():
+    secret = "opaque-schema-secret-0123456789"
+    schema = {
+        "type": "object",
+        "properties": {"api_key": {"type": "string", "enum": [secret]}},
+    }
+
+    prepared = prepare_upload({"schema": schema})
+
+    assert prepared.data["schema"]["properties"]["api_key"]["enum"] == [REDACTED]
 
 
 def test_jsonl_preflight_uses_secrets_discovered_in_later_lines(tmp_path):
@@ -299,3 +327,10 @@ def test_secret_values_file(tmp_path):
     path.write_text("short\n")
     with pytest.raises(ValueError, match="line 1"):
         secret_values(secrets_file=path)
+
+
+def test_secret_values_includes_auth_environment_variables(monkeypatch):
+    secret = "opaque-auth-secret-0123456789"
+    monkeypatch.setenv("AUTH", secret)
+
+    assert secret in secret_values()

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -139,6 +139,19 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     assert prepared.data["api_key"] == REDACTED
 
 
+def test_preflight_redacts_numeric_structured_secrets():
+    prepared = prepare_upload(
+        {"password": 12345678, "token": 987654321, "secret": None, "auth": False}
+    )
+
+    assert prepared.data == {
+        "password": REDACTED,
+        "token": REDACTED,
+        "secret": None,
+        "auth": False,
+    }
+
+
 @pytest.mark.parametrize("label", ["DSA PRIVATE KEY", "ENCRYPTED PRIVATE KEY"])
 def test_preflight_catches_private_key_pem_variants(label):
     private_key = f"-----BEGIN {label}-----\nopaque-key-material\n-----END {label}-----"
@@ -244,6 +257,18 @@ def test_jsonl_preflight_rejects_output_paths_that_alias_the_source(tmp_path, so
 
     with pytest.raises(UploadScanError, match="must not alias"):
         prepare_jsonl_upload(source, tmp_path / "safe.jsonl")
+
+    assert source.read_text() == '{"answer":"keep"}\n'
+
+
+def test_jsonl_preflight_rejects_a_hard_link_to_the_source(tmp_path):
+    source = tmp_path / "traces.jsonl"
+    destination = tmp_path / "safe.jsonl"
+    source.write_text('{"answer":"keep"}\n')
+    destination.hardlink_to(source)
+
+    with pytest.raises(UploadScanError, match="must not alias"):
+        prepare_jsonl_upload(source, destination)
 
     assert source.read_text() == '{"answer":"keep"}\n'
 

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -119,15 +119,20 @@ def test_structured_authorization_redacts_the_repeated_bearer_token():
 
 def test_nested_and_properties_credentials_do_not_bypass_discovery():
     secret = "opaque-nested-secret-0123456789"
+    token = "opaque-generic-token-0123456789"
     payload = {
+        "APIKey": secret,
         "secret": {"value": secret},
+        "token": token,
         "properties": {"password": secret},
         "schema": {"properties": {"password": {"type": "string", "description": "keep this"}}},
     }
 
     prepared = prepare_upload(payload)
 
+    assert prepared.data["APIKey"] == REDACTED
     assert prepared.data["secret"]["value"] == REDACTED
+    assert prepared.data["token"] == REDACTED
     assert prepared.data["properties"]["password"] == REDACTED
     assert prepared.data["schema"] == payload["schema"]
 

--- a/packages/prime-evals/tests/test_preflight.py
+++ b/packages/prime-evals/tests/test_preflight.py
@@ -101,6 +101,7 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     token = "opaque-json-token-0123456789"
     payload = {
         "completion": json.dumps({"Authorization": f"Bearer {token}"}),
+        "answer": "Use token=version-123 for the example.",
         "password": "s3cr3t",
         "api_key": "abc123",
     }
@@ -108,6 +109,7 @@ def test_preflight_catches_quoted_json_assignments_and_short_structured_secrets(
     prepared = prepare_upload(payload)
 
     assert token not in prepared.data["completion"]
+    assert prepared.data["answer"] == payload["answer"]
     assert prepared.data["password"] == REDACTED
     assert prepared.data["api_key"] == REDACTED
 

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 dependencies = [
     "prime-sandboxes>=0.2.40",
-    "prime-evals>=0.2.3",
+    "prime-evals>=0.2.4",
     "prime-traces>=0.0.1",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",
@@ -62,10 +62,10 @@ dev = [
 
 [tool.uv.sources]
 prime-sandboxes = { workspace = true }
-prime-evals = { workspace = true }
 prime-traces = { workspace = true }
 prime-tunnel = { workspace = true }
 verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.2.0" }
+prime-evals = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1069,22 +1069,31 @@ def _push_single_eval(
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
 
+    detected_env = eval_data.get("env_id") or eval_data.get("env")
+    if not env_slug and detected_env and not run_id and not eval_id:
+        env_slug = detected_env
+
     api_client = APIClient()
     prepared = prepare_upload(
-        {"eval_name": eval_name, "eval_data": eval_data},
+        {
+            "eval_name": eval_name,
+            "eval_data": eval_data,
+            "env_slug": env_slug,
+            "run_id": run_id,
+            "eval_id": eval_id,
+        },
         secret_values(getattr(api_client, "api_key", None), secrets_file=secrets_file),
     )
     eval_name = prepared.data["eval_name"]
     eval_data = prepared.data["eval_data"]
+    env_slug = prepared.data["env_slug"]
+    run_id = prepared.data["run_id"]
+    eval_id = prepared.data["eval_id"]
     if prepared.report:
         console.print(
             f"[yellow]Upload preflight redacted {prepared.report}. "
             "Local files were not changed.[/yellow]"
         )
-
-    detected_env = eval_data.get("env_id") or eval_data.get("env")
-    if not env_slug and detected_env and not run_id and not eval_id:
-        env_slug = detected_env
 
     environments = None
     if env_slug and not run_id and not eval_id:

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -9,7 +9,13 @@ from typing import Any, Optional
 
 import typer
 from click.core import ParameterSource
-from prime_evals import EvalsAPIError, EvalsClient, InvalidEvaluationError
+from prime_evals import (
+    EvalsAPIError,
+    EvalsClient,
+    InvalidEvaluationError,
+    prepare_upload,
+    secret_values,
+)
 from rich.progress import Progress
 from rich.syntax import Syntax
 from rich.table import Table
@@ -1056,11 +1062,25 @@ def _push_single_eval(
     eval_id: Optional[str],
     is_public: bool = False,
     name: Optional[str] = None,
+    secrets_file: Optional[str] = None,
 ) -> str:
     path = _validate_eval_path(config_path)
     eval_data = _load_eval_directory(path)
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
+
+    api_client = APIClient()
+    prepared = prepare_upload(
+        {"eval_name": eval_name, "eval_data": eval_data},
+        secret_values(getattr(api_client, "api_key", None), secrets_file=secrets_file),
+    )
+    eval_name = prepared.data["eval_name"]
+    eval_data = prepared.data["eval_data"]
+    if prepared.report:
+        console.print(
+            f"[yellow]Upload preflight redacted {prepared.report}. "
+            "Local files were not changed.[/yellow]"
+        )
 
     detected_env = eval_data.get("env_id") or eval_data.get("env")
     if not env_slug and detected_env and not run_id and not eval_id:
@@ -1074,7 +1094,6 @@ def _push_single_eval(
 
     console.print()
 
-    api_client = APIClient()
     client = EvalsClient(api_client)
 
     if eval_id:
@@ -1222,6 +1241,11 @@ def push_eval(
         "--public",
         help="Make the pushed evaluation public. Evaluations are private by default.",
     ),
+    secrets_file: Optional[str] = typer.Option(
+        None,
+        "--secrets-file",
+        help="Local newline-delimited secrets to remove from the upload copy.",
+    ),
 ) -> None:
     """Push evaluation data to Prime Evals.
 
@@ -1255,7 +1279,9 @@ def push_eval(
         if config_path is None:
             current_dir = Path(".")
             if _has_eval_files(current_dir):
-                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id, is_public, name)
+                result_eval_id = _push_single_eval(
+                    ".", env_id, run_id, eval_id, is_public, name, secrets_file
+                )
                 if output == "json":
                     console.print()
                     output_data_as_json({"evaluation_id": result_eval_id}, console)
@@ -1279,7 +1305,13 @@ def push_eval(
             for eval_dir in eval_dirs:
                 try:
                     result_eval_id = _push_single_eval(
-                        str(eval_dir), env_id, run_id, eval_id, is_public, name
+                        str(eval_dir),
+                        env_id,
+                        run_id,
+                        eval_id,
+                        is_public,
+                        name,
+                        secrets_file,
                     )
                     results.append(
                         {"path": str(eval_dir), "eval_id": result_eval_id, "status": "success"}
@@ -1303,7 +1335,9 @@ def push_eval(
 
             return
 
-        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id, is_public, name)
+        result_eval_id = _push_single_eval(
+            config_path, env_id, run_id, eval_id, is_public, name, secrets_file
+        )
 
         if output == "json":
             console.print()

--- a/packages/prime/src/prime_cli/commands/traces.py
+++ b/packages/prime/src/prime_cli/commands/traces.py
@@ -1,8 +1,14 @@
+import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import click
 import typer
+from prime_evals import (
+    UploadScanError,
+    prepare_jsonl_upload,
+    secret_values,
+)
 from prime_traces import (
     APIError,
     Batch,
@@ -93,6 +99,14 @@ def upload_traces(
     no_compress: bool = typer.Option(
         False, "--no-compress", help="Skip gzip transport compression"
     ),
+    secrets_file: Optional[Path] = typer.Option(
+        None,
+        "--secrets-file",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Local newline-delimited secrets to redact in addition to detected credentials",
+    ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """Upload a JSONL file of traces. Safe to rerun after interruption:
@@ -109,14 +123,39 @@ def upload_traces(
             )
 
     try:
-        client = _traces_client()
-        receipts = client.upload_file(
-            file,
-            line_format=line_format,
-            context=_parse_context(context),
-            compress=not no_compress,
-            on_batch=on_batch,
-        )
+        parsed_context = _parse_context(context)
+        known_secrets = secret_values(Config().api_key, secrets_file=secrets_file)
+    except typer.Exit:
+        raise
+    except (UnicodeError, ValueError) as e:
+        error_console.print(f"[red]Preflight failed:[/red] {escape(str(e))}")
+        raise typer.Exit(1)
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="prime-traces-upload-") as directory:
+            try:
+                prepared = prepare_jsonl_upload(
+                    file,
+                    Path(directory) / "traces.jsonl",
+                    context=parsed_context,
+                    known_secrets=known_secrets,
+                )
+            except UploadScanError as e:
+                error_console.print(f"[red]Preflight failed:[/red] {escape(str(e))}")
+                raise typer.Exit(1)
+            if prepared.report:
+                error_console.print(
+                    f"[yellow]Preflight redacted {prepared.report}; "
+                    "the source file was not changed[/yellow]"
+                )
+            client = _traces_client()
+            receipts = client.upload_file(
+                prepared.path,
+                line_format=line_format,
+                context=prepared.context,
+                compress=not no_compress,
+                on_batch=on_batch,
+            )
     except typer.Exit:
         raise
     except UnauthorizedError as e:

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -3,7 +3,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from prime_evals import EvalsAPIError, EvalsClient
+from prime_evals import (
+    EvalsAPIError,
+    EvalsClient,
+    prepare_upload,
+    secret_values,
+)
 
 from prime_cli.core import APIClient
 
@@ -157,7 +162,37 @@ def push_eval_results_to_hub(
     env_identifier = resolved_env_slug or resolved_env_id
     console.print(f"\n[blue]Uploading evaluation results, using upstream: {env_identifier}[/blue]")
 
+    metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
+    eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
+    converted_results = [
+        {
+            "example_id": sample.get("id", 0),
+            "reward": sample.get("reward", 0.0),
+            **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
+        }
+        for sample in results_samples
+    ]
+    eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
     api_client = APIClient()
+    prepared = prepare_upload(
+        {
+            "eval_name": eval_name,
+            "metadata": eval_metadata,
+            "metrics": metrics,
+            "results": converted_results,
+        },
+        secret_values(getattr(api_client, "api_key", None)),
+    )
+    eval_name = prepared.data["eval_name"]
+    eval_metadata = prepared.data["metadata"]
+    metrics = prepared.data["metrics"]
+    converted_results = prepared.data["results"]
+    if prepared.report:
+        console.print(
+            f"[yellow]Upload preflight redacted {prepared.report}. "
+            "Local files were not changed.[/yellow]"
+        )
 
     if resolved_env_id:
         environments = [{"id": resolved_env_id}]
@@ -175,21 +210,6 @@ def push_eval_results_to_hub(
             environments = [{"slug": resolved_env_slug}]
     else:
         raise ValueError("No valid environment identifier found")
-    metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
-
-    eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
-
-    converted_results = [
-        {
-            "example_id": sample.get("id", 0),
-            "reward": sample.get("reward", 0.0),
-            **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
-        }
-        for sample in results_samples
-    ]
-
-    eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-
     evals_client = EvalsClient(api_client)
 
     create_response = evals_client.create_evaluation(

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -178,6 +178,11 @@ def push_eval_results_to_hub(
     prepared = prepare_upload(
         {
             "eval_name": eval_name,
+            "model": model,
+            "env_name": env_name,
+            "task_type": metadata.get("task_type"),
+            "resolved_env_slug": resolved_env_slug,
+            "resolved_env_id": resolved_env_id,
             "metadata": eval_metadata,
             "metrics": metrics,
             "results": converted_results,
@@ -185,6 +190,11 @@ def push_eval_results_to_hub(
         secret_values(getattr(api_client, "api_key", None)),
     )
     eval_name = prepared.data["eval_name"]
+    model = prepared.data["model"]
+    env_name = prepared.data["env_name"]
+    task_type = prepared.data["task_type"]
+    resolved_env_slug = prepared.data["resolved_env_slug"]
+    resolved_env_id = prepared.data["resolved_env_id"]
     eval_metadata = prepared.data["metadata"]
     metrics = prepared.data["metrics"]
     converted_results = prepared.data["results"]
@@ -218,7 +228,7 @@ def push_eval_results_to_hub(
         model_name=model,
         dataset=env_name,
         framework="verifiers",
-        task_type=metadata.get("task_type"),
+        task_type=task_type,
         metadata=eval_metadata,
         metrics=metrics,
         is_public=False,  # Private by default - only visible to the user who created it

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -151,7 +151,9 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_push_single_eval(config_path, env_slug, run_id, eval_id, is_public, name):
+    def fake_push_single_eval(
+        config_path, env_slug, run_id, eval_id, is_public, name, secrets_file
+    ):
         captured.update(
             {
                 "config_path": config_path,
@@ -160,6 +162,7 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
                 "eval_id": eval_id,
                 "is_public": is_public,
                 "name": name,
+                "secrets_file": secrets_file,
             }
         )
         return "eval-123"
@@ -171,7 +174,17 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
 
     result = runner.invoke(
         app,
-        ["eval", "push", ".", "--eval-id", "eval-123", "--name", "custom eval"],
+        [
+            "eval",
+            "push",
+            ".",
+            "--eval-id",
+            "eval-123",
+            "--name",
+            "custom eval",
+            "--secrets-file",
+            "secret-values.txt",
+        ],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
 
@@ -183,6 +196,7 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
         "eval_id": "eval-123",
         "is_public": False,
         "name": "custom eval",
+        "secrets_file": "secret-values.txt",
     }
 
 
@@ -284,6 +298,57 @@ def test_push_samples_with_progress_skips_callback_when_signature_is_uninspectab
 
 
 class TestPushSingleEval:
+    def test_preflight_redacts_upload_copy_and_preserves_local_trace(self, tmp_path, monkeypatch):
+        provider_key = "sk-test-0123456789abcdefghijklmnopqrstuv"
+        opaque_key = "opaque-judge-key-0123456789"
+        metadata = {
+            "env": "owner/gsm8k",
+            "model": "gpt-4",
+            "judge_api_key": opaque_key,
+        }
+        result = {
+            "id": 1,
+            "completion": f"leaked twice: {opaque_key} and {provider_key}",
+            "answer": "reference answer",
+            "rubric": "compare with the reference answer",
+        }
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text(json.dumps(result) + "\n")
+        captured = {}
+
+        class DummyAPIClient:
+            api_key = provider_key
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured["create"] = kwargs
+                return {"evaluation_id": "eval-123"}
+
+            def push_samples(self, evaluation_id, samples):
+                captured["samples"] = samples
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                return {}
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, None)
+
+        assert eval_id == "eval-123"
+        uploaded = json.dumps(captured)
+        assert provider_key not in uploaded
+        assert opaque_key not in uploaded
+        assert captured["create"]["metadata"]["judge_api_key"] == "[REDACTED]"
+        uploaded_result = captured["samples"][0]
+        assert uploaded_result["answer"] == "reference answer"
+        assert uploaded_result["rubric"] == "compare with the reference answer"
+        assert opaque_key in (tmp_path / "metadata.json").read_text()
+        assert provider_key in (tmp_path / "results.jsonl").read_text()
+
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
         metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -10,10 +10,59 @@ from prime_cli.commands.evals import (
     _validate_eval_path,
 )
 from prime_cli.main import app
+from prime_cli.utils.eval_push import push_eval_results_to_hub
 from typer.testing import CliRunner
 from typing_extensions import cast
 
 runner = CliRunner()
+
+
+def test_automatic_eval_push_preflights_every_outbound_field(tmp_path, monkeypatch):
+    env_name = "sk-env-0123456789abcdefghijklmnopqrstuv"
+    model = "sk-model-0123456789abcdefghijklmnopqrstuv"
+    task_type = "sk-task-0123456789abcdefghijklmnopqrstuv"
+    output = tmp_path / "outputs" / "evals" / f"{env_name}--{model}" / "run"
+    output.mkdir(parents=True)
+    (output / "metadata.json").write_text(json.dumps({"task_type": task_type}))
+    (output / "results.jsonl").write_text("{}\n")
+    captured = {}
+
+    class DummyAPIClient:
+        api_key = "prime-api-key-0123456789"
+
+        def get(self, _path):
+            return {"data": {"id": "environment-id"}}
+
+    class DummyEvalsClient:
+        def __init__(self, _api_client):
+            pass
+
+        def create_evaluation(self, **kwargs):
+            captured["create"] = kwargs
+            return {"evaluation_id": "eval-id"}
+
+        def push_samples(self, _evaluation_id, samples):
+            captured["samples"] = samples
+
+        def finalize_evaluation(self, _evaluation_id, metrics=None):
+            captured["finalize"] = metrics
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.utils.eval_push.APIClient", DummyAPIClient)
+    monkeypatch.setattr("prime_cli.utils.eval_push.EvalsClient", DummyEvalsClient)
+
+    push_eval_results_to_hub(
+        env_name,
+        model,
+        "job-id",
+        upstream_slug="owner/environment",
+    )
+
+    serialized = json.dumps(captured)
+    assert all(secret not in serialized for secret in (env_name, model, task_type))
+    assert captured["create"]["model_name"] == "[REDACTED]"
+    assert captured["create"]["dataset"] == "[REDACTED]"
+    assert captured["create"]["task_type"] == "[REDACTED]"
 
 
 class TestHasEvalFiles:

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -398,6 +398,70 @@ class TestPushSingleEval:
         assert opaque_key in (tmp_path / "metadata.json").read_text()
         assert provider_key in (tmp_path / "results.jsonl").read_text()
 
+    def test_preflight_covers_manual_upload_identifiers(self, tmp_path, monkeypatch):
+        secret = "opaque-cli-identifier-0123456789"
+        (tmp_path / "metadata.json").write_text(
+            json.dumps({"env": "owner/gsm8k", "model": "gpt-4"})
+        )
+        (tmp_path / "results.jsonl").write_text("")
+        secrets_file = tmp_path / "secrets.txt"
+        secrets_file.write_text(secret + "\n")
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def get_evaluation(self, evaluation_id):
+                captured["checked_evaluation_id"] = evaluation_id
+
+            def update_evaluation(self, **kwargs):
+                captured.update(kwargs)
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        _push_single_eval(
+            str(tmp_path),
+            f"owner/{secret}",
+            None,
+            None,
+            secrets_file=str(secrets_file),
+        )
+        assert captured["environments"] == [{"slug": "owner/[REDACTED]"}]
+
+        captured.clear()
+        _push_single_eval(
+            str(tmp_path),
+            None,
+            secret,
+            None,
+            secrets_file=str(secrets_file),
+        )
+        assert secret not in json.dumps(captured)
+        assert captured["environments"] is None
+        assert captured["run_id"] == "[REDACTED]"
+
+        captured.clear()
+        _push_single_eval(
+            str(tmp_path),
+            None,
+            None,
+            secret,
+            secrets_file=str(secrets_file),
+        )
+        assert secret not in json.dumps(captured)
+        assert captured["checked_evaluation_id"] == "[REDACTED]"
+        assert captured["evaluation_id"] == "[REDACTED]"
+        assert captured["finalized_evaluation_id"] == "[REDACTED]"
+
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
         metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -295,7 +295,7 @@ class FakeTracesClient:
         self.receipt = UploadReceipt(upload_id="a" * 64, status="committed")
 
     def upload_file(self, path, **kwargs):
-        self.calls["upload_file"] = {"path": path, **kwargs}
+        self.calls["upload_file"] = {"path": path, "data": path.read_bytes(), **kwargs}
         on_batch = kwargs.get("on_batch")
         batch = Batch(data=b"{}\n", digest="a" * 64, num_lines=1, first_line_number=1)
         if on_batch is not None:
@@ -376,6 +376,61 @@ def test_upload_command_rejects_malformed_context(fake_client, tmp_path):
 
     assert result.exit_code == 1
     assert "upload_file" not in fake_client.calls
+
+
+def test_upload_command_redacts_a_copy_and_keeps_review_data(fake_client, tmp_path):
+    secret = "opaque-user-key-0123456789"
+    traces_file = tmp_path / "traces.jsonl"
+    original = (
+        json.dumps(
+            {
+                "prompt": f"accidentally repeated {secret}",
+                "answer": "reference answer",
+                "rubric": "compare against the reference answer",
+            }
+        ).encode()
+        + b"\n"
+    )
+    traces_file.write_bytes(original)
+    secrets_file = tmp_path / "secrets.txt"
+    secrets_file.write_text(secret + "\n")
+
+    result = runner.invoke(
+        main_app,
+        [
+            "traces",
+            "upload",
+            str(traces_file),
+            "-c",
+            f"authorization={secret}",
+            "--secrets-file",
+            str(secrets_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Preflight redacted 2 credential-bearing location(s)" in result.output
+    assert secret not in fake_client.calls["upload_file"]["data"].decode()
+    assert fake_client.calls["upload_file"]["context"] == {"authorization": "[REDACTED]"}
+    uploaded = json.loads(fake_client.calls["upload_file"]["data"])
+    assert uploaded["answer"] == "reference answer"
+    assert uploaded["rubric"] == "compare against the reference answer"
+    assert traces_file.read_bytes() == original
+
+
+def test_upload_command_fails_before_client_creation_on_invalid_json(tmp_path, monkeypatch):
+    traces_file = tmp_path / "traces.jsonl"
+    traces_file.write_text('{"password":}\n')
+
+    def fail_if_called():
+        raise AssertionError("client must not be created before preflight succeeds")
+
+    monkeypatch.setattr(traces_cmd, "_traces_client", fail_if_called)
+    result = runner.invoke(main_app, ["traces", "upload", str(traces_file)])
+
+    assert result.exit_code == 1
+    assert "Preflight failed: invalid JSON on JSONL line 1" in result.output
+    assert not isinstance(result.exception, AssertionError)
 
 
 def test_unexpected_error_does_not_dump_sdk_locals(fake_client, tmp_path):

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -22,7 +22,7 @@ def test_prime_requires_runtime_sdks_with_cli_feature_support() -> None:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
-    assert "prime-evals>=0.2.3" in pyproject["project"]["dependencies"]
+    assert "prime-evals>=0.2.4" in pyproject["project"]["dependencies"]
     assert "prime-traces>=0.0.1" in pyproject["project"]["dependencies"]
     assert "prime-tunnel>=0.1.9" in pyproject["project"]["dependencies"]
 


### PR DESCRIPTION
## Summary

- add a shared upload preflight that discovers configured, environment, structured, and high-confidence credential shapes
- redact only the upload copy and fail closed by rescanning before any network request
- apply the boundary to prime traces upload, prime eval push, and automatic eval publication
- preserve clean JSONL byte-for-byte and keep reference answers, rubrics, and other review data unless they contain an actual detected credential
- support an optional local --secrets-file for exact values

## Validation

- UV_FROZEN=1 uv run pytest packages/prime-evals/tests packages/prime/tests/test_eval_push.py packages/prime/tests/test_traces_command.py -q (91 passed)
- UV_FROZEN=1 uv run pytest packages/prime/tests -q (1028 passed, 5 skipped)
- UV_FROZEN=1 uv run ruff check on touched files
- UV_FROZEN=1 uv run ty check on touched packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what data leaves the client for evals/traces; overly aggressive redaction could strip useful fields, while missed patterns could still leak secrets.
> 
> **Overview**
> Adds **upload preflight** in `prime-evals` (v0.2.4): scan and redact credentials in outbound payloads before any network call, without mutating local files.
> 
> The new `preflight` module discovers secrets from env vars, optional `--secrets-file`, sensitive JSON keys, and regex shapes (API keys, PEM private keys, webhooks, auth headers, URLs). It returns redacted copies via `prepare_upload` / `prepare_jsonl_upload`, reports findings in `ScanReport`, and **fails closed** if redaction is incomplete or JSONL is ambiguous.
> 
> **Prime CLI** runs preflight on `prime eval push`, automatic hub publication (`eval_push`), and `prime traces upload` (temp copy for JSONL; byte-identical snapshot when clean). Users get a yellow warning when redaction occurs; eval push accepts `--secrets-file`.
> 
> Tests cover the scanner and all three CLI paths; `prime` depends on `prime-evals>=0.2.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e1947d1e9d456943ded909150832840d98730f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->