### PR TITLE
pin verifiers to 0.2.0

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "textual>=6.1.0",
     "textual-plot>=0.10.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.2.0",
+    "verifiers==0.2.0",
     "build>=1.0.0",
     "gitignore-parser>=0.1.13",
     "pyyaml>=6.0.0",

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -43,7 +43,11 @@ from .lab_hygiene import (
 
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
 VERIFIERS_REF = "6c64ce6a3a01e8edde7c3c0e8e5315fb236e9faa"
-VERIFIERS_CONFIG_REF = "main"
+# Lab configs must match the pinned legacy-stack verifiers below; main is
+# moving to a v1-only layout that the pinned stack cannot consume.
+VERIFIERS_CONFIG_REF = VERIFIERS_REF
+# Keep in sync with the verifiers pin in packages/prime/pyproject.toml.
+VERIFIERS_REQUIREMENT = "verifiers==0.2.0"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
 LAB_CONFIG_FOLDERS = ("rl", "gepa", "eval", "sft", "opd", "fft")
@@ -1387,7 +1391,7 @@ def _ensure_uv_project(workspace: Path, emit: Emit, runner: Runner) -> None:
         emit("Found pyproject.toml\n")
 
     emit("Adding verifiers dependency\n")
-    _check_command(["uv", "add", "verifiers"], workspace, emit, runner)
+    _check_command(["uv", "add", VERIFIERS_REQUIREMENT], workspace, emit, runner)
 
 
 def _post_setup_call_to_action(options: LabSetupOptions) -> Panel:

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -616,7 +616,7 @@ def test_lab_setup_uses_existing_verifiers_sources(
 
     assert result.exit_code == 0
     assert _is_pinned_ref(lab_setup.VERIFIERS_REF)
-    assert lab_setup.VERIFIERS_CONFIG_REF == "main"
+    assert lab_setup.VERIFIERS_CONFIG_REF == lab_setup.VERIFIERS_REF
     assert any(
         url.endswith(
             f"/primeintellect-ai/verifiers/{lab_setup.VERIFIERS_REF}/skills/create-environments/SKILL.md"


### PR DESCRIPTION
## Context

Verifiers is fully deprecating the legacy (v0) path, the next verifiers release will ship only the v1 API. Several prime CLI commands still consume the legacy surface: `prime eval` (`verifiers.cli.commands.eval` helpers, `verifiers.utils.eval_utils`), `prime lab` (`lab_setup`, `verifiers_bridge`, `prime_lab_app`), plus `prime env`, `prime rl`, and `prime gepa`.

## Changes

**Pin the published dependency to `verifiers==0.2.0`** — the last frozen legacy reference (nothing has changed in legacy since). The workspace `[tool.uv.sources]` already pins the `v0.2.0` git tag, but that only governs local dev/lockfile resolution; the published metadata was `verifiers>=0.2.0`, so end users installing from PyPI would resolve to the first legacy-free release and break. `uv lock` is a no-op since resolution already lands on v0.2.0.

**Stop pulling verifiers `main` at runtime in `prime lab`** — two spots survived the dependency pin:

- `VERIFIERS_CONFIG_REF` was `"main"`: lab downloads `configs/{rl,gepa,eval,...}` from the verifiers repo at runtime. Once main's configs are reworked for the v1 stack, a pinned CLI would fetch configs its stack can't parse (or silently fetch nothing — `missing_ok=True`). Now tracks the same pinned commit as the lab assets/skills (`VERIFIERS_REF`, an ancestor of `v0.2.0` — immutable and durably reachable).
- `_ensure_uv_project` ran an unconstrained `uv add verifiers`, resolving the latest PyPI release into every lab workspace regardless of the CLI's own pin. Now adds `verifiers==0.2.0` to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and asset-source pinning to avoid breakage when verifiers drops legacy APIs; no runtime auth or data-path changes.
> 
> **Overview**
> **Pins `verifiers` to exactly `0.2.0`** in the prime package and Lab setup so installs cannot float onto a future v1-only release while Prime CLI still depends on the legacy verifiers API.
> 
> Lab setup now downloads config templates from the same **pinned git ref** as skills/assets (`VERIFIERS_REF`), not `main`, because upstream `main` is moving to layouts the pinned stack cannot use. New workspaces get **`uv add verifiers==0.2.0`** via a shared `VERIFIERS_REQUIREMENT` constant documented to stay aligned with `pyproject.toml`. Tests assert config URLs use the pinned ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7255fcb3f9e10214cf636927ce1fc4833263ab82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->