### PR TITLE
feat(train): paginate 'prime train list' server-side

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -148,6 +148,18 @@ class EnvServerInfo(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class RLRunPage(BaseModel):
+    """One page of GET /rft/runs, as returned by the backend."""
+
+    runs: List[RLRun] = Field(default_factory=list)
+    total: int = Field(..., description="Total number of matching runs")
+    page: int = Field(..., description="Current page number")
+    limit: int = Field(..., description="Runs per page")
+    total_pages: int = Field(..., alias="total_pages")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class RLClient:
     """Client for the Hosted Training API."""
 
@@ -168,15 +180,26 @@ class RLClient:
                 raise APIError(f"Failed to list Hosted Training models: {e.response.text}")
             raise APIError(f"Failed to list Hosted Training models: {str(e)}")
 
-    def list_runs(self, team_id: Optional[str] = None) -> List[RLRun]:
-        """List Hosted Training runs for the authenticated user."""
+    def list_runs(
+        self,
+        team_id: Optional[str] = None,
+        *,
+        mine: bool = False,
+        page: int = 1,
+        limit: int = 20,
+    ) -> RLRunPage:
+        """List Hosted Training runs for the authenticated user, one page
+        at a time - pagination and the `mine` filter are applied
+        server-side rather than fetched-in-full-then-sliced locally.
+        """
         try:
-            params = {}
+            params: Dict[str, Any] = {"page": page, "limit": limit}
             if team_id:
                 params["team_id"] = team_id
-            response = self.client.get("/rft/runs", params=params if params else None)
-            runs_data = response.get("runs", [])
-            return [RLRun.model_validate(run) for run in runs_data]
+            if mine:
+                params["mine"] = "true"
+            response = self.client.get("/rft/runs", params=params)
+            return RLRunPage.model_validate(response)
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to list Hosted Training runs: {e.response.text}")

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -149,13 +149,21 @@ class EnvServerInfo(BaseModel):
 
 
 class RLRunPage(BaseModel):
-    """One page of GET /rft/runs, as returned by the backend."""
+    """One page of GET /rft/runs, as returned by the backend.
+
+    The pagination metadata fields are Optional: a backend that hasn't
+    deployed pagination support yet silently ignores the page/limit/mine
+    query params (FastAPI drops undeclared query params rather than
+    erroring) and returns the old `{"runs": [...]}` shape - the caller
+    must detect that (via `total is None`) and fall back to client-side
+    filtering/pagination over the full list it got back.
+    """
 
     runs: List[RLRun] = Field(default_factory=list)
-    total: int = Field(..., description="Total number of matching runs")
-    page: int = Field(..., description="Current page number")
-    limit: int = Field(..., description="Runs per page")
-    total_pages: int = Field(..., alias="total_pages")
+    total: Optional[int] = Field(None, description="Total number of matching runs")
+    page: Optional[int] = Field(None, description="Current page number")
+    limit: Optional[int] = Field(None, description="Runs per page")
+    total_pages: Optional[int] = Field(None, alias="total_pages")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -2150,12 +2150,33 @@ def _list_runs_impl(
 
         team_id = team or config.team_id
 
-        # Pagination and the `mine` filter are applied server-side, so this
-        # fetches exactly the requested page instead of the caller's whole
-        # run history sorted/sliced locally.
+        # Pagination and the `mine` filter are applied server-side when the
+        # backend supports it, so this normally fetches exactly the
+        # requested page instead of the caller's whole run history sorted/
+        # sliced locally.
         run_page = rl_client.list_runs(team_id=team_id, mine=mine, page=page, limit=num)
         runs = run_page.runs
-        total_count = run_page.total
+
+        if run_page.total is None:
+            # Backend predates pagination support: it silently ignored
+            # page/limit/mine and returned the full history. Fall back to
+            # the old client-side filter/sort/slice behavior.
+            if mine:
+                current_user_id = config.user_id
+                if not current_user_id:
+                    console.print(
+                        "[red]Error:[/red] Cannot filter by user - no user_id configured. "
+                        "Run [bold]prime whoami[/bold] to refresh your config."
+                    )
+                    raise typer.Exit(1)
+                runs = [r for r in runs if r.user_id == current_user_id]
+
+            total_count = len(runs)
+            runs = sorted(runs, key=lambda r: r.created_at, reverse=True)
+            start = (page - 1) * num
+            runs = runs[start : start + num]
+        else:
+            total_count = run_page.total
 
         if output == "json":
             output_data_as_json(

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -2150,24 +2150,12 @@ def _list_runs_impl(
 
         team_id = team or config.team_id
 
-        all_runs = rl_client.list_runs(team_id=team_id)
-
-        if mine:
-            current_user_id = config.user_id
-            if not current_user_id:
-                console.print(
-                    "[red]Error:[/red] Cannot filter by user - no user_id configured. "
-                    "Run [bold]prime whoami[/bold] to refresh your config."
-                )
-                raise typer.Exit(1)
-            all_runs = [r for r in all_runs if r.user_id == current_user_id]
-
-        total_count = len(all_runs)
-
-        # Sort by created_at descending and paginate
-        all_runs.sort(key=lambda r: r.created_at, reverse=True)
-        start = (page - 1) * num
-        runs = all_runs[start : start + num]
+        # Pagination and the `mine` filter are applied server-side, so this
+        # fetches exactly the requested page instead of the caller's whole
+        # run history sorted/sliced locally.
+        run_page = rl_client.list_runs(team_id=team_id, mine=mine, page=page, limit=num)
+        runs = run_page.runs
+        total_count = run_page.total
 
         if output == "json":
             output_data_as_json(

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -454,8 +454,7 @@ class LabDataSource:
         try:
             api_client = self._api_client_factory()
             client = self._rl_client_factory(api_client)
-            runs = client.list_runs(team_id=config.team_id)
-            runs = sorted(runs, key=lambda run: run.created_at, reverse=True)[: options.limit]
+            runs = client.list_runs(team_id=config.team_id, limit=options.limit).runs
             items = tuple(_rl_run_item(run, idx) for idx, run in enumerate(runs))
             return LabSection(
                 key="training",

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -454,7 +454,12 @@ class LabDataSource:
         try:
             api_client = self._api_client_factory()
             client = self._rl_client_factory(api_client)
-            runs = client.list_runs(team_id=config.team_id, limit=options.limit).runs
+            run_page = client.list_runs(team_id=config.team_id, limit=options.limit)
+            runs = run_page.runs
+            if run_page.total is None:
+                # Backend predates pagination support and ignored `limit`,
+                # returning the full (already createdAt-desc sorted) history.
+                runs = runs[: options.limit]
             items = tuple(_rl_run_item(run, idx) for idx, run in enumerate(runs))
             return LabSection(
                 key="training",

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -457,9 +457,10 @@ class LabDataSource:
             run_page = client.list_runs(team_id=config.team_id, limit=options.limit)
             runs = run_page.runs
             if run_page.total is None:
-                # Backend predates pagination support and ignored `limit`,
-                # returning the full (already createdAt-desc sorted) history.
-                runs = runs[: options.limit]
+                # Backend predates pagination support and ignored `limit`.
+                # Re-sort defensively (mirrors the CLI's fallback) rather
+                # than trusting response order, then take the newest N.
+                runs = sorted(runs, key=lambda run: run.created_at, reverse=True)[: options.limit]
             items = tuple(_rl_run_item(run, idx) for idx, run in enumerate(runs))
             return LabSection(
                 key="training",

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -398,13 +398,18 @@ class FakeRun:
         }
 
 
+@dataclass
+class FakeRunPage:
+    runs: list[FakeRun]
+
+
 class FakeRLClient:
     def __init__(self, _api_client: Any) -> None:
         pass
 
-    def list_runs(self, team_id: str | None = None) -> list[FakeRun]:
+    def list_runs(self, team_id: str | None = None, *, limit: int = 20) -> FakeRunPage:
         assert team_id == "team-123"
-        return [FakeRun()]
+        return FakeRunPage(runs=[FakeRun()])
 
     def get_run(self, run_id: str) -> FakeRun:
         assert run_id == "run-1"
@@ -479,7 +484,7 @@ class FailingEvalsClient(FakeEvalsClient):
 
 
 class FailingRLClient(FakeRLClient):
-    def list_runs(self, team_id: str | None = None) -> list[FakeRun]:
+    def list_runs(self, team_id: str | None = None, *, limit: int = 20) -> FakeRunPage:
         raise RuntimeError("training unavailable")
 
 

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -401,6 +401,7 @@ class FakeRun:
 @dataclass
 class FakeRunPage:
     runs: list[FakeRun]
+    total: int | None = None
 
 
 class FakeRLClient:


### PR DESCRIPTION
## Summary
- `prime train list` used to fetch a user/team's *entire* run history from the backend on every call, then sort/slice/filter it client-side to build the requested page. Threads real server-side pagination through instead (backend PR: PrimeIntellect-ai/platform#4834, `GET /rft/runs` now takes `page`/`limit`/`mine` and returns `total`/`page`/`limit`/`total_pages`).
- `--mine` no longer requires a local `user_id` in config - the backend already knows the caller's identity from the API token, so it's filtered server-side now.
- Fixes the Lab TUI's training panel to request only the runs it displays instead of pulling the full history and slicing locally.

## Depends on
Backend pagination support in PrimeIntellect-ai/platform#4834 (itself stacked on #4830). This CLI change is backwards-incompatible with pre-#4834 backends for the new `mine`/`page`/`limit` query params - fine since the CLI always talks to the latest deployed backend.

## Test plan
- `uv run pytest tests/test_lab_view.py tests/test_rl_api.py tests/test_rl_logs.py tests/test_train_cli.py` - 248 passed
- `ruff check`, `ruff format --check`, `ty check` all clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `RLClient.list_runs` return type and listing behavior across CLI and Lab; backward compatibility depends on detecting missing pagination fields on older backends.
> 
> **Overview**
> **`prime train list` and the Lab training panel** no longer download the full run history on every refresh. The Hosted Training client now calls `GET /rft/runs` with **`page`**, **`limit`**, and optional **`mine`**, and parses a paginated **`RLRunPage`** (`runs` plus optional `total` / `page` / `limit` / `total_pages`).
> 
> When the backend returns pagination metadata (`total` is set), the CLI uses **`run_page.total`** for counts and relies on the server for **`--mine`** filtering (no local `user_id` needed on that path). If **`total` is missing** (pre-pagination API), behavior falls back to the old flow: client-side **`mine`** filter (still needs `user_id`), sort by **`created_at`**, and slice for **`--page`** / **`--num`**. The Lab TUI applies the same **`limit`**-only request with an analogous fallback sort-and-truncate.
> 
> Tests update fakes to return **`FakeRunPage`** instead of a bare run list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0e9901dd8b54d136af95f591fba4bc5bfa6aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->