### PR TITLE
release: cli 0.6.30

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.29"
+__version__ = "0.6.30"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Releases the verifiers 0.2.0 pin ahead of the upstream legacy-path removal (#879).

## Included since 0.6.29

- Published dependency pinned to `verifiers==0.2.0` (last frozen legacy reference; the CLI's CI and lockfile already test against it).
- `prime lab` no longer pulls verifiers `main` at runtime: config downloads track the same pinned commit as the lab assets, and workspace setup adds `verifiers==0.2.0` instead of unconstrained latest.

## Verified

- Wheel built from main installs in a fresh venv with deps resolved from PyPI; `verifiers==0.2.0` (present on PyPI, not yanked) resolves and all legacy imports the CLI uses (`verifiers.cli.commands.eval`, `verifiers.utils.eval_utils`, `verifiers.scripts.eval`) plus `verifiers.v1` import cleanly.
- Pinned-SHA config/asset URLs (raw + git trees API) return 200; `configs/{rl,gepa,eval}` content at the pin is byte-identical to current verifiers main.
- Full `packages/prime` test suite: 1025 passed, 5 skipped.

## User-facing notes

- Fresh installs now get verifiers 0.2.0 (previously resolved 0.3.1). Environments that co-install a package requiring `verifiers>0.2.0` will see a resolver conflict.
- Lab workspaces are pinned to verifiers 0.2.0. If you built environments against 0.3.x-only v1 APIs, re-running `prime lab setup` will downgrade the workspace — hold off until the v1 migration lands.

Merging this triggers the Release prime workflow (tags `v0.6.30`, publishes to PyPI). The required `prime-sandboxes>=0.2.40` floor is already live, so no release coordination is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199UaBWhe5Nb1ky6RV7oiZS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version string change with no behavioral code changes in the diff.
> 
> **Overview**
> **Bumps the published Prime CLI version** from `0.6.29` to `0.6.30` by updating `__version__` in `prime_cli/__init__.py`.
> 
> This is a release-only change (no runtime logic in the diff). Merging is intended to tag and publish **prime 0.6.30** to PyPI per the release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b380983d4c96dd2f234d8683a36753c8f758a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->