### PR TITLE
fix: prevent sandbox poll teardown races

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -190,8 +190,13 @@ class _SyncPollLeaseRegistry:
             while any(scope in self._draining for scope in scopes):
                 self._condition.wait()
             self._draining.update(scopes)
-            while any(self._active.get(scope, 0) for scope in scopes):
-                self._condition.wait()
+            try:
+                while any(self._active.get(scope, 0) for scope in scopes):
+                    self._condition.wait()
+            except BaseException:
+                self._draining.difference_update(scopes)
+                self._condition.notify_all()
+                raise
         return scopes
 
     def end_drain(self, sandbox_ids: List[str]) -> None:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -307,7 +307,19 @@ class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
         self._pending.setdefault(key, []).append(future)
         if self._dispatch_task is None:
             self._dispatch_task = asyncio.create_task(self._dispatch())
-        return await future
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            # The shared dispatch outlives one caller. Settle this lookup before
+            # its caller can tear down resources that the dispatch still uses.
+            while not future.done():
+                try:
+                    await asyncio.shield(future)
+                except asyncio.CancelledError:
+                    pass
+            if not future.cancelled():
+                future.exception()
+            raise
 
     async def _dispatch(self) -> None:
         """Drain all currently pending lookups in bounded chunks."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -138,6 +138,151 @@ class _BatchItemError:
     error: Exception
 
 
+class _BatcherClosedError(RuntimeError):
+    """Raised when a lookup is interrupted by client shutdown."""
+
+
+class _SyncPollLease:
+    def __init__(self, registry: "_SyncPollLeaseRegistry", sandbox_id: str) -> None:
+        self._registry = registry
+        self.sandbox_id = sandbox_id
+        self._released = False
+
+    def release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._registry._release(self.sandbox_id)
+
+
+class _SyncPollLeaseRegistry:
+    """Coordinate sync polls with sandbox deletion across caller threads."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._active: Dict[str, int] = {}
+        self._draining: set[str] = set()
+
+    def acquire(self, sandbox_id: str) -> _SyncPollLease:
+        return self.acquire_many([sandbox_id])[0]
+
+    def acquire_many(self, sandbox_ids: List[str]) -> List[_SyncPollLease]:
+        scopes = list(dict.fromkeys(sandbox_ids))
+        with self._condition:
+            blocked = next((scope for scope in scopes if scope in self._draining), None)
+            if blocked is not None:
+                raise APIError(f"Sandbox {blocked} is being deleted")
+            for scope in scopes:
+                self._active[scope] = self._active.get(scope, 0) + 1
+        return [_SyncPollLease(self, scope) for scope in scopes]
+
+    def _release(self, sandbox_id: str) -> None:
+        with self._condition:
+            remaining = self._active[sandbox_id] - 1
+            if remaining:
+                self._active[sandbox_id] = remaining
+            else:
+                del self._active[sandbox_id]
+            self._condition.notify_all()
+
+    def begin_drain(self, sandbox_ids: List[str]) -> List[str]:
+        scopes = list(dict.fromkeys(sandbox_ids))
+        with self._condition:
+            while any(scope in self._draining for scope in scopes):
+                self._condition.wait()
+            self._draining.update(scopes)
+            while any(self._active.get(scope, 0) for scope in scopes):
+                self._condition.wait()
+        return scopes
+
+    def end_drain(self, sandbox_ids: List[str]) -> None:
+        with self._condition:
+            self._draining.difference_update(sandbox_ids)
+            self._condition.notify_all()
+
+
+class _AsyncPollLease:
+    def __init__(self, registry: "_AsyncPollLeaseRegistry", sandbox_id: str) -> None:
+        self._registry = registry
+        self.sandbox_id = sandbox_id
+        self._released = False
+
+    def release(self) -> None:
+        if not self._released:
+            self._released = True
+            self._registry._release(self.sandbox_id)
+
+
+class _AsyncPollLeaseRegistry:
+    """Coordinate async polls, deletion, and client shutdown on one event loop."""
+
+    def __init__(self) -> None:
+        self._active: Dict[str, int] = {}
+        self._draining: set[str] = set()
+        self._closing = False
+        self._changed = asyncio.Event()
+
+    def acquire(self, sandbox_id: str) -> _AsyncPollLease:
+        return self.acquire_many([sandbox_id])[0]
+
+    def acquire_many(self, sandbox_ids: List[str]) -> List[_AsyncPollLease]:
+        scopes = list(dict.fromkeys(sandbox_ids))
+        if self._closing:
+            raise _BatcherClosedError("Sandbox client is closing")
+        blocked = next((scope for scope in scopes if scope in self._draining), None)
+        if blocked is not None:
+            raise APIError(f"Sandbox {blocked} is being deleted")
+        for scope in scopes:
+            self._active[scope] = self._active.get(scope, 0) + 1
+        return [_AsyncPollLease(self, scope) for scope in scopes]
+
+    def _notify_changed(self) -> None:
+        changed = self._changed
+        self._changed = asyncio.Event()
+        changed.set()
+
+    def _release(self, sandbox_id: str) -> None:
+        remaining = self._active[sandbox_id] - 1
+        if remaining:
+            self._active[sandbox_id] = remaining
+        else:
+            del self._active[sandbox_id]
+        self._notify_changed()
+
+    async def begin_drain(self, sandbox_ids: List[str]) -> List[str]:
+        scopes = list(dict.fromkeys(sandbox_ids))
+        if self._closing:
+            raise _BatcherClosedError("Sandbox client is closing")
+        while any(scope in self._draining for scope in scopes):
+            changed = self._changed
+            await changed.wait()
+            if self._closing:
+                raise _BatcherClosedError("Sandbox client is closing")
+        self._draining.update(scopes)
+        self._notify_changed()
+        try:
+            while any(self._active.get(scope, 0) for scope in scopes):
+                changed = self._changed
+                await changed.wait()
+        except BaseException:
+            self._draining.difference_update(scopes)
+            self._notify_changed()
+            raise
+        return scopes
+
+    def end_drain(self, sandbox_ids: List[str]) -> None:
+        self._draining.difference_update(sandbox_ids)
+        self._notify_changed()
+
+    def begin_close(self) -> None:
+        self._closing = True
+        self._notify_changed()
+
+    async def wait_for_idle(self) -> None:
+        while self._active:
+            changed = self._changed
+            await changed.wait()
+
+
 @functools.lru_cache(maxsize=1)
 def _ca_bundle() -> bytes:
     with open(certifi.where(), "rb") as ca_file:
@@ -227,27 +372,47 @@ CREATION_POLL_JITTER = 0.25
 _LEGACY_FAST_POLLS = 5
 
 
+@dataclass
+class _SyncBatchEntry(Generic[_BatchKey, _BatchValue]):
+    key: _BatchKey
+    lease: _SyncPollLease
+    waiters: List[Future[_BatchValue]]
+
+
 class _SyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
     """Coalesce concurrent sync lookups into bounded calls."""
 
     def __init__(
         self,
         fetch: Callable[[List[_BatchKey]], Dict[_BatchKey, _BatchValue | _BatchItemError]],
+        sandbox_id_for_key: Callable[[_BatchKey], str],
+        leases: _SyncPollLeaseRegistry,
     ) -> None:
         self._fetch = fetch
+        self._sandbox_id_for_key = sandbox_id_for_key
+        self._leases = leases
         self._lock = threading.Lock()
-        self._pending: Dict[_BatchKey, List[Future[_BatchValue]]] = {}
+        self._pending: Dict[_BatchKey, _SyncBatchEntry[_BatchKey, _BatchValue]] = {}
         self._dispatching = False
 
     def get(self, key: _BatchKey) -> _BatchValue:
         """Return one result, sharing a batch with concurrent callers."""
         future: Future[_BatchValue] = Future()
+        lease = self._leases.acquire(self._sandbox_id_for_key(key))
+        redundant_lease: Optional[_SyncPollLease] = None
         with self._lock:
-            self._pending.setdefault(key, []).append(future)
+            entry = self._pending.get(key)
+            if entry is None:
+                self._pending[key] = _SyncBatchEntry(key, lease, [future])
+            else:
+                entry.waiters.append(future)
+                redundant_lease = lease
             leader = not self._dispatching
             if leader:
                 self._dispatching = True
 
+        if redundant_lease is not None:
+            redundant_lease.release()
         if leader:
             time.sleep(STATUS_BATCH_WINDOW_SECONDS)
             self._dispatch()
@@ -262,29 +427,64 @@ class _SyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
                 if not keys:
                     self._dispatching = False
                     return
-                waiters = {key: self._pending.pop(key) for key in keys}
+                entries = {key: self._pending.pop(key) for key in keys}
 
             try:
                 results = self._fetch(keys)
-            except Exception as exc:
-                for key_waiters in waiters.values():
-                    for waiter in key_waiters:
-                        waiter.set_exception(exc)
+            except BaseException as exc:
+                for entry in entries.values():
+                    for waiter in entry.waiters:
+                        if not waiter.done():
+                            waiter.set_exception(exc)
+                    entry.lease.release()
+                if not isinstance(exc, Exception):
+                    raise
                 continue
 
-            for key, key_waiters in waiters.items():
+            for key, entry in entries.items():
                 if key not in results:
                     exc = APIError(f"Batch status response omitted {key!r}")
-                    for waiter in key_waiters:
-                        waiter.set_exception(exc)
+                    for waiter in entry.waiters:
+                        if not waiter.done():
+                            waiter.set_exception(exc)
+                    entry.lease.release()
                     continue
                 result = results[key]
                 if isinstance(result, _BatchItemError):
-                    for waiter in key_waiters:
-                        waiter.set_exception(result.error)
+                    for waiter in entry.waiters:
+                        if not waiter.done():
+                            waiter.set_exception(result.error)
+                    entry.lease.release()
                     continue
-                for waiter in key_waiters:
-                    waiter.set_result(result)
+                for waiter in entry.waiters:
+                    if not waiter.done():
+                        waiter.set_result(result)
+                entry.lease.release()
+
+
+class _AsyncBatchEntry(Generic[_BatchKey, _BatchValue]):
+    def __init__(
+        self,
+        key: _BatchKey,
+        lease: _AsyncPollLease,
+        waiter: asyncio.Future[_BatchValue],
+    ) -> None:
+        self.key = key
+        self.lease = lease
+        self.waiters = [waiter]
+        self.batch: Optional[_AsyncBatch[_BatchKey, _BatchValue]] = None
+
+
+class _AsyncBatch(Generic[_BatchKey, _BatchValue]):
+    def __init__(self, entries: List[_AsyncBatchEntry[_BatchKey, _BatchValue]]) -> None:
+        self.entries = entries
+        self.fetch_task: Optional[asyncio.Task[Dict[_BatchKey, _BatchValue | _BatchItemError]]] = (
+            None
+        )
+        self.done = asyncio.Event()
+
+    def has_waiters(self) -> bool:
+        return any(entry.waiters for entry in self.entries)
 
 
 class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
@@ -296,67 +496,228 @@ class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
             [List[_BatchKey]],
             Awaitable[Dict[_BatchKey, _BatchValue | _BatchItemError]],
         ],
+        sandbox_id_for_key: Callable[[_BatchKey], str],
+        leases: _AsyncPollLeaseRegistry,
     ) -> None:
         self._fetch = fetch
-        self._pending: Dict[_BatchKey, List[asyncio.Future[_BatchValue]]] = {}
+        self._sandbox_id_for_key = sandbox_id_for_key
+        self._leases = leases
+        self._pending: Dict[_BatchKey, _AsyncBatchEntry[_BatchKey, _BatchValue]] = {}
         self._dispatch_task: Optional[asyncio.Task[None]] = None
+        self._active_batch: Optional[_AsyncBatch[_BatchKey, _BatchValue]] = None
+        self._closed = False
+        self._close_task: Optional[asyncio.Task[None]] = None
+
+    def _fail_pending(self, error: Exception) -> None:
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for entry in pending:
+            for waiter in entry.waiters:
+                if not waiter.done():
+                    waiter.set_exception(error)
+            entry.waiters.clear()
+            entry.lease.release()
+
+    def _start_dispatch(self) -> None:
+        task = asyncio.create_task(self._dispatch())
+        self._dispatch_task = task
+        task.add_done_callback(self._dispatch_done)
+
+    def _dispatch_done(self, task: asyncio.Task[None]) -> None:
+        # A task cancelled before its coroutine starts never executes its
+        # ``finally`` block, so settle pending work from the completion hook.
+        if self._dispatch_task is not task:
+            return
+        self._dispatch_task = None
+        if task.cancelled():
+            self._fail_pending(
+                _BatcherClosedError("Request batcher is closed")
+                if self._closed
+                else RuntimeError("Request batch dispatch cancelled")
+            )
+            return
+        error = task.exception()
+        if error is not None:
+            self._fail_pending(
+                error if isinstance(error, Exception) else RuntimeError("Request batch aborted")
+            )
+            return
+        if self._pending and not self._closed:
+            self._start_dispatch()
 
     async def get(self, key: _BatchKey) -> _BatchValue:
         """Return one result, sharing a batch with concurrent callers."""
+        if self._closed:
+            raise _BatcherClosedError("Request batcher is closed")
         future = asyncio.get_running_loop().create_future()
-        self._pending.setdefault(key, []).append(future)
+        lease = self._leases.acquire(self._sandbox_id_for_key(key))
+        entry = self._pending.get(key)
+        if entry is None:
+            entry = _AsyncBatchEntry(key, lease, future)
+            self._pending[key] = entry
+        else:
+            entry.waiters.append(future)
+            lease.release()
         if self._dispatch_task is None:
-            self._dispatch_task = asyncio.create_task(self._dispatch())
+            self._start_dispatch()
         try:
             return await asyncio.shield(future)
         except asyncio.CancelledError:
-            # The shared dispatch outlives one caller. Settle this lookup before
-            # its caller can tear down resources that the dispatch still uses.
-            while not future.done():
-                try:
-                    await asyncio.shield(future)
-                except asyncio.CancelledError:
-                    pass
-            if not future.cancelled():
-                future.exception()
+            await self._cancel_waiter(entry, future)
             raise
+
+    async def _cancel_waiter(
+        self,
+        entry: _AsyncBatchEntry[_BatchKey, _BatchValue],
+        future: asyncio.Future[_BatchValue],
+    ) -> None:
+        if future in entry.waiters:
+            entry.waiters.remove(future)
+        if not future.done():
+            future.cancel()
+
+        if entry.batch is None:
+            if not entry.waiters and self._pending.get(entry.key) is entry:
+                del self._pending[entry.key]
+                entry.lease.release()
+            return
+
+        batch = entry.batch
+        fetch_task = batch.fetch_task
+        if batch.has_waiters() or fetch_task is None or fetch_task.done():
+            return
+
+        fetch_task.cancel()
+        completion = asyncio.create_task(batch.done.wait())
+        while not completion.done():
+            try:
+                await asyncio.shield(completion)
+            except asyncio.CancelledError:
+                pass
+
+    def _finish_batch(
+        self,
+        batch: _AsyncBatch[_BatchKey, _BatchValue],
+        results: Optional[Dict[_BatchKey, _BatchValue | _BatchItemError]],
+        error: Optional[BaseException],
+    ) -> None:
+        for entry in batch.entries:
+            if error is not None:
+                for waiter in entry.waiters:
+                    if waiter.done():
+                        continue
+                    if isinstance(error, asyncio.CancelledError):
+                        if self._closed:
+                            waiter.set_exception(_BatcherClosedError("Request batcher is closed"))
+                        else:
+                            waiter.cancel()
+                    elif isinstance(error, Exception):
+                        waiter.set_exception(error)
+                    else:
+                        waiter.set_exception(RuntimeError("Request batch dispatch aborted"))
+            elif results is not None and entry.key not in results:
+                exc = APIError(f"Batch status response omitted {entry.key!r}")
+                for waiter in entry.waiters:
+                    if not waiter.done():
+                        waiter.set_exception(exc)
+            elif results is not None:
+                result = results[entry.key]
+                for waiter in entry.waiters:
+                    if waiter.done():
+                        continue
+                    if isinstance(result, _BatchItemError):
+                        waiter.set_exception(result.error)
+                    else:
+                        waiter.set_result(result)
+            entry.waiters.clear()
+            entry.lease.release()
+        batch.done.set()
 
     async def _dispatch(self) -> None:
         """Drain all currently pending lookups in bounded chunks."""
-        await asyncio.sleep(STATUS_BATCH_WINDOW_SECONDS)
         try:
-            while self._pending:
+            await asyncio.sleep(STATUS_BATCH_WINDOW_SECONDS)
+            while self._pending and not self._closed:
                 keys = list(self._pending)[:MAX_STATUS_BATCH_SIZE]
-                waiters = {key: self._pending.pop(key) for key in keys}
+                entries = [self._pending.pop(key) for key in keys]
+                batch = _AsyncBatch(entries)
+                self._active_batch = batch
+                for entry in entries:
+                    entry.batch = batch
+                batch.fetch_task = asyncio.create_task(self._fetch(keys))
+                results: Optional[Dict[_BatchKey, _BatchValue | _BatchItemError]] = None
+                error: Optional[BaseException] = None
+                dispatch_cancelled = False
                 try:
-                    results = await self._fetch(keys)
-                except Exception as exc:
-                    for key_waiters in waiters.values():
-                        for waiter in key_waiters:
-                            if not waiter.done():
-                                waiter.set_exception(exc)
-                    continue
+                    results = await batch.fetch_task
+                except BaseException as exc:
+                    error = exc
+                    task = asyncio.current_task()
+                    dispatch_cancelled = bool(task is not None and task.cancelling())
+                finally:
+                    self._finish_batch(batch, results, error)
+                    self._active_batch = None
 
-                for key, key_waiters in waiters.items():
-                    if key not in results:
-                        exc = APIError(f"Batch status response omitted {key!r}")
-                        for waiter in key_waiters:
-                            if not waiter.done():
-                                waiter.set_exception(exc)
-                        continue
-                    result = results[key]
-                    if isinstance(result, _BatchItemError):
-                        for waiter in key_waiters:
-                            if not waiter.done():
-                                waiter.set_exception(result.error)
-                        continue
-                    for waiter in key_waiters:
-                        if not waiter.done():
-                            waiter.set_result(result)
+                if dispatch_cancelled:
+                    raise asyncio.CancelledError
+                if error is not None and not isinstance(error, (Exception, asyncio.CancelledError)):
+                    raise error
         finally:
+            task = asyncio.current_task()
+            dispatch_cancelled = bool(task is not None and task.cancelling())
+            if dispatch_cancelled:
+                self._fail_pending(
+                    _BatcherClosedError("Request batcher is closed")
+                    if self._closed
+                    else RuntimeError("Request batch dispatch cancelled")
+                )
             self._dispatch_task = None
-            if self._pending:
-                self._dispatch_task = asyncio.create_task(self._dispatch())
+            if self._pending and not self._closed and not dispatch_cancelled:
+                self._start_dispatch()
+
+    async def _close(self) -> None:
+        self._closed = True
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for entry in pending:
+            for waiter in entry.waiters:
+                if not waiter.done():
+                    waiter.set_exception(_BatcherClosedError("Request batcher is closed"))
+            entry.waiters.clear()
+            entry.lease.release()
+
+        batch = self._active_batch
+        if batch is not None:
+            for entry in batch.entries:
+                for waiter in entry.waiters:
+                    if not waiter.done():
+                        waiter.set_exception(_BatcherClosedError("Request batcher is closed"))
+
+        dispatch_task = self._dispatch_task
+        if dispatch_task is not None and not dispatch_task.done():
+            dispatch_task.cancel()
+            try:
+                await dispatch_task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._dispatch_done(dispatch_task)
+
+    async def aclose(self) -> None:
+        """Cancel and join all work owned by this batcher."""
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._close())
+        try:
+            await asyncio.shield(self._close_task)
+        except asyncio.CancelledError:
+            while not self._close_task.done():
+                try:
+                    await asyncio.shield(self._close_task)
+                except asyncio.CancelledError:
+                    pass
+            if not self._close_task.cancelled():
+                self._close_task.exception()
+            raise
 
 
 def _creation_poll_delay(poll_index: int) -> float:
@@ -912,9 +1273,16 @@ class SandboxClient:
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
         )
-        self._sandbox_status_batcher = _SyncRequestBatcher(self._fetch_sandbox_statuses)
+        self._poll_leases = _SyncPollLeaseRegistry()
+        self._sandbox_status_batcher = _SyncRequestBatcher(
+            self._fetch_sandbox_statuses,
+            lambda sandbox_id: sandbox_id,
+            self._poll_leases,
+        )
         self._background_job_status_batcher = _SyncRequestBatcher(
-            self._fetch_background_job_statuses
+            self._fetch_background_job_statuses,
+            lambda key: key[0],
+            self._poll_leases,
         )
         self._sandbox_status_batch_supported: Optional[bool] = None
         self._background_job_status_batch_supported: Optional[bool] = None
@@ -1149,8 +1517,12 @@ class SandboxClient:
 
     def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
-        response = self.client.request("DELETE", f"/sandbox/{sandbox_id}")
-        return response
+        scopes = self._poll_leases.begin_drain([sandbox_id])
+        try:
+            response = self.client.request("DELETE", f"/sandbox/{sandbox_id}")
+            return response
+        finally:
+            self._poll_leases.end_drain(scopes)
 
     def get_network(self, sandbox_id: str) -> EgressPolicyStatus:
         """Get the desired and applied network rules of a VM sandbox."""
@@ -1197,12 +1569,16 @@ class SandboxClient:
             all_users=all_users,
         )
         payload = request.model_dump(by_alias=False, exclude_none=True)
-        response = self.client.request(
-            "DELETE",
-            "/sandbox",
-            json=payload,
-        )
-        return BulkDeleteSandboxResponse.model_validate(response)
+        scopes = self._poll_leases.begin_drain(sandbox_ids or [])
+        try:
+            response = self.client.request(
+                "DELETE",
+                "/sandbox",
+                json=payload,
+            )
+            return BulkDeleteSandboxResponse.model_validate(response)
+        finally:
+            self._poll_leases.end_drain(scopes)
 
     def get_logs(self, sandbox_id: str) -> str:
         """Get sandbox logs via backend"""
@@ -1774,7 +2150,11 @@ class SandboxClient:
             if use_batch_status:
                 status = self._background_job_status_batcher.get((sandbox_id, job.job_id))
             else:
-                status = self.get_background_job(sandbox_id, job)
+                lease = self._poll_leases.acquire(sandbox_id)
+                try:
+                    status = self.get_background_job(sandbox_id, job)
+                finally:
+                    lease.release()
             if status.completed:
                 return status
             time.sleep(poll_interval)
@@ -1818,8 +2198,12 @@ class SandboxClient:
                     reachability_phase = True
                     deadline = time.monotonic() + timeout_seconds
                     poll_index = 0
+                lease = self._poll_leases.acquire(sandbox_id)
                 try:
-                    reachable = self._is_sandbox_reachable(sandbox_id)
+                    try:
+                        reachable = self._is_sandbox_reachable(sandbox_id)
+                    finally:
+                        lease.release()
                 except Exception as error:
                     if not _is_retryable_reachability_error(error):
                         raise
@@ -1899,19 +2283,25 @@ class SandboxClient:
         attempt = 0
         while attempt < max_attempts:
             try:
-                response = self.get_sandbox_statuses(sandbox_ids)
-            except BatchStatusUnsupportedError:
-                outcomes = self._fetch_sandbox_statuses(sandbox_ids)
-                snapshots = []
-                for sandbox_id in sandbox_ids:
-                    outcome = outcomes[sandbox_id]
-                    if isinstance(outcome, _BatchItemError):
-                        raise outcome.error
-                    snapshots.append(outcome)
-                response = BatchSandboxStatusResponse(
-                    statuses=snapshots,
-                    errors=[],
-                )
+                leases = self._poll_leases.acquire_many(sandbox_ids)
+                try:
+                    try:
+                        response = self.get_sandbox_statuses(sandbox_ids)
+                    except BatchStatusUnsupportedError:
+                        outcomes = self._fetch_sandbox_statuses(sandbox_ids)
+                        snapshots = []
+                        for sandbox_id in sandbox_ids:
+                            outcome = outcomes[sandbox_id]
+                            if isinstance(outcome, _BatchItemError):
+                                raise outcome.error
+                            snapshots.append(outcome)
+                        response = BatchSandboxStatusResponse(
+                            statuses=snapshots,
+                            errors=[],
+                        )
+                finally:
+                    for lease in leases:
+                        lease.release()
             except Exception as exc:
                 if "429" in str(exc) or "Too Many Requests" in str(exc):
                     time.sleep(min(2**attempt, 60))
@@ -1943,8 +2333,12 @@ class SandboxClient:
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
                     if final_statuses.get(sandbox_id) == "RUNNING":
+                        lease = self._poll_leases.acquire(sandbox_id)
                         try:
-                            reachable = self._is_sandbox_reachable(sandbox_id)
+                            try:
+                                reachable = self._is_sandbox_reachable(sandbox_id)
+                            finally:
+                                lease.release()
                         except Exception as error:
                             if not _is_retryable_reachability_error(error):
                                 raise
@@ -2317,12 +2711,20 @@ class AsyncSandboxClient:
         # Shared httpx client for gateway operations (upload/download/execute)
         # Initialized lazily to allow connection pooling and reuse
         self._gateway_client: Optional[httpx.AsyncClient] = None
-        self._sandbox_status_batcher = _AsyncRequestBatcher(self._fetch_sandbox_statuses)
+        self._poll_leases = _AsyncPollLeaseRegistry()
+        self._sandbox_status_batcher = _AsyncRequestBatcher(
+            self._fetch_sandbox_statuses,
+            lambda sandbox_id: sandbox_id,
+            self._poll_leases,
+        )
         self._background_job_status_batcher = _AsyncRequestBatcher(
-            self._fetch_background_job_statuses
+            self._fetch_background_job_statuses,
+            lambda key: key[0],
+            self._poll_leases,
         )
         self._sandbox_status_batch_supported: Optional[bool] = None
         self._background_job_status_batch_supported: Optional[bool] = None
+        self._close_task: Optional[asyncio.Task[None]] = None
 
     def _get_gateway_client(self) -> httpx.AsyncClient:
         """Get or create the shared gateway client for connection pooling
@@ -2574,8 +2976,12 @@ class AsyncSandboxClient:
 
     async def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
-        response = await self.client.request("DELETE", f"/sandbox/{sandbox_id}")
-        return response
+        scopes = await self._poll_leases.begin_drain([sandbox_id])
+        try:
+            response = await self.client.request("DELETE", f"/sandbox/{sandbox_id}")
+            return response
+        finally:
+            self._poll_leases.end_drain(scopes)
 
     async def get_network(self, sandbox_id: str) -> EgressPolicyStatus:
         """Get the desired and applied network rules of a VM sandbox."""
@@ -2622,12 +3028,16 @@ class AsyncSandboxClient:
             all_users=all_users,
         )
         payload = request.model_dump(by_alias=False, exclude_none=True)
-        response = await self.client.request(
-            "DELETE",
-            "/sandbox",
-            json=payload,
-        )
-        return BulkDeleteSandboxResponse.model_validate(response)
+        scopes = await self._poll_leases.begin_drain(sandbox_ids or [])
+        try:
+            response = await self.client.request(
+                "DELETE",
+                "/sandbox",
+                json=payload,
+            )
+            return BulkDeleteSandboxResponse.model_validate(response)
+        finally:
+            self._poll_leases.end_drain(scopes)
 
     async def get_logs(self, sandbox_id: str) -> str:
         """Get sandbox logs"""
@@ -3373,7 +3783,11 @@ class AsyncSandboxClient:
             if use_batch_status:
                 status = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
             else:
-                status = await self.get_background_job(sandbox_id, job)
+                lease = self._poll_leases.acquire(sandbox_id)
+                try:
+                    status = await self.get_background_job(sandbox_id, job)
+                finally:
+                    lease.release()
             if status.completed:
                 return status
             await asyncio.sleep(poll_interval)
@@ -3417,8 +3831,12 @@ class AsyncSandboxClient:
                     reachability_phase = True
                     deadline = time.monotonic() + timeout_seconds
                     poll_index = 0
+                lease = self._poll_leases.acquire(sandbox_id)
                 try:
-                    reachable = await self._is_sandbox_reachable(sandbox_id)
+                    try:
+                        reachable = await self._is_sandbox_reachable(sandbox_id)
+                    finally:
+                        lease.release()
                 except Exception as error:
                     if not _is_retryable_reachability_error(error):
                         raise
@@ -3499,19 +3917,25 @@ class AsyncSandboxClient:
         attempt = 0
         while attempt < max_attempts:
             try:
-                response = await self.get_sandbox_statuses(sandbox_ids)
-            except BatchStatusUnsupportedError:
-                outcomes = await self._fetch_sandbox_statuses(sandbox_ids)
-                snapshots = []
-                for sandbox_id in sandbox_ids:
-                    outcome = outcomes[sandbox_id]
-                    if isinstance(outcome, _BatchItemError):
-                        raise outcome.error
-                    snapshots.append(outcome)
-                response = BatchSandboxStatusResponse(
-                    statuses=snapshots,
-                    errors=[],
-                )
+                leases = self._poll_leases.acquire_many(sandbox_ids)
+                try:
+                    try:
+                        response = await self.get_sandbox_statuses(sandbox_ids)
+                    except BatchStatusUnsupportedError:
+                        outcomes = await self._fetch_sandbox_statuses(sandbox_ids)
+                        snapshots = []
+                        for sandbox_id in sandbox_ids:
+                            outcome = outcomes[sandbox_id]
+                            if isinstance(outcome, _BatchItemError):
+                                raise outcome.error
+                            snapshots.append(outcome)
+                        response = BatchSandboxStatusResponse(
+                            statuses=snapshots,
+                            errors=[],
+                        )
+                finally:
+                    for lease in leases:
+                        lease.release()
             except Exception as exc:
                 if "429" in str(exc) or "Too Many Requests" in str(exc):
                     await asyncio.sleep(min(2**attempt, 60))
@@ -3543,8 +3967,12 @@ class AsyncSandboxClient:
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
                     if final_statuses.get(sandbox_id) == "RUNNING":
+                        lease = self._poll_leases.acquire(sandbox_id)
                         try:
-                            reachable = await self._is_sandbox_reachable(sandbox_id)
+                            try:
+                                reachable = await self._is_sandbox_reachable(sandbox_id)
+                            finally:
+                                lease.release()
                         except Exception as error:
                             if not _is_retryable_reachability_error(error):
                                 raise
@@ -3854,11 +4282,37 @@ class AsyncSandboxClient:
 
         raise APIError("Read file failed after retries")
 
+    async def _close(self) -> None:
+        self._poll_leases.begin_close()
+        batchers = (
+            self._sandbox_status_batcher,
+            self._background_job_status_batcher,
+        )
+        await asyncio.gather(
+            *(batcher.aclose() for batcher in batchers if isinstance(batcher, _AsyncRequestBatcher))
+        )
+        await self._poll_leases.wait_for_idle()
+        try:
+            if self._gateway_client is not None:
+                await self._gateway_client.aclose()
+        finally:
+            await self.client.aclose()
+
     async def aclose(self) -> None:
-        """Close the async client and gateway client"""
-        if self._gateway_client is not None:
-            await self._gateway_client.aclose()
-        await self.client.aclose()
+        """Cancel owned poll tasks before closing async transports."""
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._close())
+        try:
+            await asyncio.shield(self._close_task)
+        except asyncio.CancelledError:
+            while not self._close_task.done():
+                try:
+                    await asyncio.shield(self._close_task)
+                except asyncio.CancelledError:
+                    pass
+            if not self._close_task.cancelled():
+                self._close_task.exception()
+            raise
 
     async def __aenter__(self) -> "AsyncSandboxClient":
         """Async context manager entry"""

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -1,6 +1,7 @@
 """Focused tests for platform lifecycle and VM background-job batch calls."""
 
 import asyncio
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import Any, Optional, cast
@@ -197,6 +198,55 @@ class _AsyncUnsupportedPlatformClient:
 
     async def aclose(self) -> None:
         return None
+
+
+class _SyncDeletePlatformClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.delete_called = threading.Event()
+
+    def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        if method == "DELETE":
+            self.delete_called.set()
+        if path == "/sandbox":
+            return {
+                "succeeded": kwargs["json"].get("sandbox_ids") or [],
+                "failed": [],
+                "message": "",
+            }
+        return {}
+
+
+class _AsyncDeletePlatformClient:
+    def __init__(self, close_order: Optional[list[str]] = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.delete_called = asyncio.Event()
+        self.close_order = close_order
+
+    async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        if method == "DELETE":
+            self.delete_called.set()
+        if path == "/sandbox":
+            return {
+                "succeeded": kwargs["json"].get("sandbox_ids") or [],
+                "failed": [],
+                "message": "",
+            }
+        return {}
+
+    async def aclose(self) -> None:
+        if self.close_order is not None:
+            self.close_order.append("platform-close")
+
+
+class _OrderedAsyncGatewayClient:
+    def __init__(self, close_order: list[str]) -> None:
+        self.close_order = close_order
+
+    async def aclose(self) -> None:
+        self.close_order.append("gateway-close")
 
 
 class _SyncVMAuthCache:
@@ -583,3 +633,224 @@ async def test_async_background_job_cancellation_settles_poll_before_teardown() 
 
     assert sandbox_deleted
     assert not polled_after_delete
+
+
+@pytest.mark.asyncio
+async def test_async_cancellation_before_dispatch_removes_lookup() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    fetch_calls = 0
+
+    async def fetch(_keys: list[tuple[str, str]]) -> dict[tuple[str, str], BackgroundJobStatus]:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return {}
+
+    batcher = cast(Any, client)._background_job_status_batcher
+    batcher._fetch = fetch
+    lookup = asyncio.create_task(batcher.get(("sandbox-a", "deadbeef")))
+    await asyncio.sleep(0)
+    lookup.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await lookup
+    await client.aclose()
+
+    assert fetch_calls == 0
+    assert not cast(Any, client)._poll_leases._active
+
+
+@pytest.mark.asyncio
+async def test_async_dispatch_cancellation_settles_pending_lookup() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    batcher = cast(Any, client)._background_job_status_batcher
+    lookup = asyncio.create_task(batcher.get(("sandbox-a", "deadbeef")))
+    await asyncio.sleep(0)
+
+    batcher._dispatch_task.cancel()
+    with pytest.raises(RuntimeError, match="dispatch cancelled"):
+        await lookup
+    assert not cast(Any, client)._poll_leases._active
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_last_waiter_cancels_and_joins_fetch_cleanup() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    fetch_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def fetch(_keys: list[tuple[str, str]]) -> dict[tuple[str, str], BackgroundJobStatus]:
+        fetch_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_started.set()
+            await release_cleanup.wait()
+
+    batcher = cast(Any, client)._background_job_status_batcher
+    batcher._fetch = fetch
+    lookup = asyncio.create_task(batcher.get(("sandbox-a", "deadbeef")))
+    await fetch_started.wait()
+
+    lookup.cancel()
+    await cleanup_started.wait()
+    await asyncio.sleep(0)
+    assert not lookup.done()
+
+    release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await lookup
+    assert not cast(Any, client)._poll_leases._active
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_shared_fetch_survives_one_cancellation_and_blocks_delete() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncDeletePlatformClient()
+    cast(Any, client).client = platform
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+    fetch_cancelled = False
+
+    async def fetch(
+        keys: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], BackgroundJobStatus]:
+        nonlocal fetch_cancelled
+        fetch_started.set()
+        try:
+            await release_fetch.wait()
+        except asyncio.CancelledError:
+            fetch_cancelled = True
+            raise
+        return {key: BackgroundJobStatus(job_id=key[1], completed=False) for key in keys}
+
+    batcher = cast(Any, client)._background_job_status_batcher
+    batcher._fetch = fetch
+    cancelled = asyncio.create_task(batcher.get(("sandbox-a", "deadbeef")))
+    surviving = asyncio.create_task(batcher.get(("sandbox-b", "cafebabe")))
+    await fetch_started.wait()
+
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(cancelled, timeout=1)
+    assert not fetch_cancelled
+
+    deleting = asyncio.create_task(client.delete("sandbox-a"))
+    while "sandbox-a" not in cast(Any, client)._poll_leases._draining:
+        await asyncio.sleep(0)
+    with pytest.raises(APIError, match="being deleted"):
+        await batcher.get(("sandbox-a", "feedface"))
+    assert not platform.delete_called.is_set()
+
+    release_fetch.set()
+    status = await surviving
+    await deleting
+    assert not status.completed
+    assert platform.delete_called.is_set()
+    await client.aclose()
+
+
+def test_sync_delete_waits_for_in_flight_poll() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncDeletePlatformClient()
+    cast(Any, client).client = platform
+    fetch_started = threading.Event()
+    release_fetch = threading.Event()
+
+    def fetch(
+        keys: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], BackgroundJobStatus]:
+        fetch_started.set()
+        assert release_fetch.wait(timeout=2)
+        return {key: BackgroundJobStatus(job_id=key[1], completed=False) for key in keys}
+
+    cast(Any, client)._background_job_status_batcher._fetch = fetch
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        lookup = executor.submit(
+            cast(Any, client)._background_job_status_batcher.get,
+            ("sandbox-a", "deadbeef"),
+        )
+        assert fetch_started.wait(timeout=2)
+        deleting = executor.submit(client.delete, "sandbox-a")
+        assert not platform.delete_called.wait(timeout=0.05)
+        release_fetch.set()
+        assert not lookup.result(timeout=2).completed
+        assert deleting.result(timeout=2) == {}
+
+    assert platform.delete_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_async_explicit_bulk_delete_drains_known_sandboxes() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncDeletePlatformClient()
+    cast(Any, client).client = platform
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    async def fetch(
+        keys: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], BackgroundJobStatus]:
+        fetch_started.set()
+        await release_fetch.wait()
+        return {key: BackgroundJobStatus(job_id=key[1], completed=False) for key in keys}
+
+    batcher = cast(Any, client)._background_job_status_batcher
+    batcher._fetch = fetch
+    lookup = asyncio.create_task(batcher.get(("sandbox-a", "deadbeef")))
+    await fetch_started.wait()
+    deleting = asyncio.create_task(client.bulk_delete(sandbox_ids=["sandbox-a"]))
+    await asyncio.sleep(0)
+    assert not platform.delete_called.is_set()
+
+    release_fetch.set()
+    await lookup
+    response = await deleting
+    assert response.succeeded == ["sandbox-a"]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_close_joins_fetch_before_transports_even_when_cancelled() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    close_order: list[str] = []
+    cast(Any, client).client = _AsyncDeletePlatformClient(close_order)
+    cast(Any, client)._gateway_client = _OrderedAsyncGatewayClient(close_order)
+    fetch_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def fetch(_keys: list[str]) -> dict[str, Any]:
+        fetch_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            close_order.append("fetch-close")
+
+    batcher = cast(Any, client)._sandbox_status_batcher
+    batcher._fetch = fetch
+    lookup = asyncio.create_task(batcher.get("sandbox-a"))
+    await fetch_started.wait()
+
+    closing = asyncio.create_task(client.aclose())
+    await cleanup_started.wait()
+    closing.cancel()
+    await asyncio.sleep(0)
+    assert not closing.done()
+    assert close_order == []
+
+    release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+    with pytest.raises(RuntimeError, match="closed"):
+        await lookup
+    assert close_order == ["fetch-close", "gateway-close", "platform-close"]
+
+    await client.aclose()

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -207,6 +207,14 @@ class _SyncVMAuthCache:
         return True
 
 
+class _AsyncVMAuthCache:
+    async def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
+        return {}
+
+    async def is_vm(self, _sandbox_id: str) -> bool:
+        return True
+
+
 def test_concurrent_sync_creation_waits_share_one_platform_batch() -> None:
     client = SandboxClient(APIClient(api_key="test-key"))
     client.client.client.close()
@@ -528,3 +536,50 @@ async def test_async_background_batch_errors_only_fail_the_matching_waiter() -> 
     assert isinstance(results[1], APIError)
     assert "sandbox-b/cafebabe" in str(results[1])
     assert len(platform.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_background_job_cancellation_settles_poll_before_teardown() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    cast(Any, client).client = _AsyncUnsupportedPlatformClient()
+    cast(Any, client)._auth_cache = _AsyncVMAuthCache()
+
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+    sandbox_deleted = False
+    polled_after_delete = False
+
+    async def start_background_job(*_args: Any, **_kwargs: Any) -> BackgroundJob:
+        return _job("sandbox-a", "deadbeef")
+
+    async def read_file(*_args: Any, **_kwargs: Any) -> ReadFileResponse:
+        nonlocal polled_after_delete
+        poll_started.set()
+        await release_poll.wait()
+        polled_after_delete = sandbox_deleted
+        return ReadFileResponse(content="", size=0)
+
+    cast(Any, client).start_background_job = start_background_job
+    cast(Any, client).read_file = read_file
+
+    run = asyncio.create_task(client.run_background_job("sandbox-a", "sleep 30"))
+    await poll_started.wait()
+
+    async def cancel_then_delete() -> None:
+        nonlocal sandbox_deleted
+        run.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run
+        sandbox_deleted = True
+
+    teardown = asyncio.create_task(cancel_then_delete())
+    await asyncio.sleep(0)
+    assert not sandbox_deleted
+
+    release_poll.set()
+    await teardown
+    await client.aclose()
+
+    assert sandbox_deleted
+    assert not polled_after_delete

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -783,6 +783,29 @@ def test_sync_delete_waits_for_in_flight_poll() -> None:
     assert platform.delete_called.is_set()
 
 
+def test_sync_interrupted_drain_rolls_back_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    registry = cast(Any, client)._poll_leases
+    active_lease = registry.acquire("sandbox-a")
+
+    def interrupt_wait() -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(registry._condition, "wait", interrupt_wait)
+    with pytest.raises(KeyboardInterrupt):
+        registry.begin_drain(["sandbox-a"])
+
+    assert "sandbox-a" not in registry._draining
+    next_lease = registry.acquire("sandbox-a")
+    next_lease.release()
+    active_lease.release()
+
+    scopes = registry.begin_drain(["sandbox-a"])
+    registry.end_drain(scopes)
+    assert "sandbox-a" not in registry._draining
+
+
 @pytest.mark.asyncio
 async def test_async_explicit_bulk_delete_drains_known_sandboxes() -> None:
     client = AsyncSandboxClient(api_key="test-key")


### PR DESCRIPTION
## Summary

- Wait for shared async status lookups to settle before propagating caller cancellation.
- Prevent sandbox teardown from overtaking in-flight VM background-job and creation polls.
- Add regression coverage for cancellation during legacy `.exit` file polling.

## Verification

Before:

- Reproduced with `prime-sandboxes==0.2.39` and a real Prime VM.
- Cancellation returned while the `/tmp/job_<id>.exit` read was paused.
- Sandbox deletion completed before the read resumed.
- The resumed read failed with HTTP 502 and `sandbox_not_found`.

After:

- Ran 220 non-live Prime Sandboxes tests: all passed.
- Ran the controlled cancellation ordering against a real Prime VM: the poll settled before deletion.
- Ran current verifiers `PrimeRuntime.run()` against a real Prime VM with this SDK: runtime stop waited for the poll, then deleted the VM.
- Ran Ruff check and format checks on the changed files: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sync/async polling, batching, and lifecycle teardown paths; behavior changes around cancellation and delete ordering could affect long-running VM workflows, but scope is confined to the sandbox client.
> 
> **Overview**
> Fixes teardown races where sandbox **delete** or **client close** could run while status/background-job polls (including batched VM lookups) were still in flight—e.g. cancellation returning before a legacy `.exit` file read finished, then deletion causing `sandbox_not_found` / 502.
> 
> Introduces **sync and async poll-lease registries** that refcount in-flight work per sandbox, **block new lookups** while a sandbox is draining for delete, and **wait for active polls** before DELETE runs. Status batchers now hold a lease per pending key and release it when batch results settle; the async batcher gains explicit **close/cancel** paths (`aclose`, shielded waits, fetch join) so pending lookups fail cleanly with `_BatcherClosedError` instead of leaking work. **Reachability checks**, non-batched background-job polls, and bulk creation status fetches are wrapped in the same lease model. **`AsyncSandboxClient.aclose`** drains batchers and waits for leases to go idle before closing gateway/platform HTTP clients.
> 
> Adds regression tests for delete ordering, bulk delete, dispatch/cancellation, and close ordering under cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b06986acff66418b24c97c68edaa4b5b122939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->