### PR TITLE
release: cli 0.6.31

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.30"
+__version__ = "0.6.31"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Releases server-side pagination for `prime train list` and hardens against backend/CLI version skew.

## Included since 0.6.30

- `GET /rft/runs` (backend, platform#4830) now paginates at the database level instead of fetching a user/team's entire run history on every call.
- `prime train list` and `prime lab`'s training panel now request paginated pages server-side (`--page`/`--num`/`--mine`) instead of fetching everything and sorting/filtering/slicing client-side.
- Backward-compat: if the CLI talks to a backend that hasn't deployed pagination support yet, it falls back to the old full-fetch client-side behavior instead of crashing (this was hit live during rollout and fixed before release).

## Verified

- `packages/prime` test suite: 248 passed (test_lab_view, test_rl_api, test_rl_logs, test_train_cli).
- ruff check/format, ty check clean.
- CI on #880 green across test-prime/test-traces/test-sandboxes (3.11/3.12/3.13), type-check, lint-format, lock-check, CodeQL.

Merging this triggers the Release prime workflow (tags `v0.6.31`, publishes to PyPI).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the package version string with no runtime or API logic in this diff.
> 
> **Overview**
> **Bumps the `prime_cli` release version** from `0.6.30` to `0.6.31` by updating `__version__` in `packages/prime/src/prime_cli/__init__.py`.
> 
> This is a version-only change in the diff; merging is intended to tag and publish the `0.6.31` CLI release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f22b5628caffaf80bb7eca7adc715e04ff6a332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->