### PR TITLE
Use GPT Luna for release E2E

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -29,7 +29,7 @@ on:
       model:
         description: "Prime Inference model for one-example eval smoke tests"
         required: true
-        default: "deepseek/deepseek-chat"
+        default: "openai/gpt-5.6-luna"
         type: string
       sandbox_region:
         description: "Optional Prime sandbox region"
@@ -83,7 +83,7 @@ jobs:
       - name: Run release e2e in a Prime sandbox
         env:
           HOSTED_MODE: ${{ inputs.hosted_mode || 'submit' }}
-          MODEL: ${{ inputs.model || 'deepseek/deepseek-chat' }}
+          MODEL: ${{ inputs.model || 'openai/gpt-5.6-luna' }}
           REGION: ${{ inputs.sandbox_region || '' }}
           KEEP_SANDBOX: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_sandbox || false }}
           CLEANUP_REMOTE_ENV: ${{ github.event_name != 'workflow_dispatch' || inputs.cleanup_remote_env }}

--- a/packages/prime/scripts/release_e2e.py
+++ b/packages/prime/scripts/release_e2e.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from prime_sandboxes import APIClient, CreateSandboxRequest, SandboxClient
 
-DEFAULT_MODEL = "deepseek/deepseek-chat"
+DEFAULT_MODEL = "openai/gpt-5.6-luna"
 DEFAULT_HOSTED_TIMEOUT_MINUTES = "120"
 DEFAULT_SANDBOX_IMAGE = "python:3.11-bookworm"
 

--- a/packages/prime/tests/test_release_e2e_script.py
+++ b/packages/prime/tests/test_release_e2e_script.py
@@ -152,7 +152,7 @@ def test_release_e2e_workflow_uses_standard_name_and_safe_inputs():
     assert '"packages/prime-tunnel/**"' in workflow
     assert '".github/workflows/release-e2e.yml"' in workflow
     assert "HOSTED_MODE: ${{ inputs.hosted_mode || 'submit' }}" in workflow
-    assert "MODEL: ${{ inputs.model || 'deepseek/deepseek-chat' }}" in workflow
+    assert "MODEL: ${{ inputs.model || 'openai/gpt-5.6-luna' }}" in workflow
     assert 'HOSTED_MODE="${{ inputs.hosted_mode' not in workflow
     assert 'MODEL="${{ inputs.model' not in workflow
     assert 'REGION="${{ inputs.sandbox_region' not in workflow


### PR DESCRIPTION
## Overview

Use `openai/gpt-5.6-luna` as the default inference model for the sandbox-backed release E2E.

## Details

- Align the pull-request workflow fallback and workflow-dispatch default.
- Keep the standalone release E2E script on the same default.
- Update the workflow contract assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only default model change for release E2E; no production app logic or auth paths affected.
> 
> **Overview**
> Switches the **default Prime Inference model** for sandbox-backed release E2E from `deepseek/deepseek-chat` to **`openai/gpt-5.6-luna`**.
> 
> The workflow dispatch input default and the `MODEL` env fallback in **Release E2E Tests** now match **`DEFAULT_MODEL`** in `release_e2e.py`, so PR-triggered runs and manual workflow runs use the same smoke-test model unless overridden. The workflow contract test assertion was updated to lock in the new fallback string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7154321da7bb3bb6178a415051c04bf510bf27c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->