### PR TITLE
fix(cli): apply temporary contexts to all commands

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -18,7 +19,9 @@ class Config:
     def __init__(self) -> None:
         self.config_dir = Path.home() / ".prime"
         self.config_file = self.config_dir / "config.json"
+        self.environments_dir = self.config_dir / "environments"
         self._load_config()
+        self._load_context()
 
     def _load_config(self) -> None:
         """Load configuration from file"""
@@ -30,6 +33,36 @@ class Config:
                 self.config = {}
         else:
             self.config = {}
+
+    def _load_context(self) -> None:
+        """Overlay the profile selected by the Prime CLI for this process."""
+        context = os.getenv("PRIME_CONTEXT")
+        if not context:
+            return
+
+        if context.casefold() == "production":
+            self.config.update(
+                {
+                    "base_url": self.DEFAULT_BASE_URL,
+                    "team_id": None,
+                    "team_name": None,
+                    "team_role": None,
+                }
+            )
+            return
+
+        if re.fullmatch(r"[a-zA-Z0-9_-]+", context) is None:
+            return
+
+        environment_file = self.environments_dir / f"{context}.json"
+        if not environment_file.exists():
+            return
+        try:
+            environment_config = json.loads(environment_file.read_text())
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            return
+        if isinstance(environment_config, dict):
+            self.config.update(environment_config)
 
     @staticmethod
     def _strip_api_v1(url: str) -> str:

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/config.py
@@ -52,17 +52,18 @@ class Config:
             return
 
         if re.fullmatch(r"[a-zA-Z0-9_-]+", context) is None:
-            return
+            raise ValueError(f"Invalid context name: {context!r}")
 
         environment_file = self.environments_dir / f"{context}.json"
         if not environment_file.exists():
-            return
+            raise ValueError(f"Context file not found: {environment_file}")
         try:
             environment_config = json.loads(environment_file.read_text())
-        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-            return
-        if isinstance(environment_config, dict):
-            self.config.update(environment_config)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+            raise ValueError(f"Failed to load context '{context}': {e}") from e
+        if not isinstance(environment_config, dict):
+            raise ValueError(f"Invalid context '{context}': expected a JSON object")
+        self.config.update(environment_config)
 
     @staticmethod
     def _strip_api_v1(url: str) -> str:

--- a/packages/prime-sandboxes/tests/test_sdk_config.py
+++ b/packages/prime-sandboxes/tests/test_sdk_config.py
@@ -1,8 +1,24 @@
 import json
+from pathlib import Path
 
 import pytest
 
 from prime_sandboxes import Config
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_environment(monkeypatch, tmp_path) -> None:
+    """Keep config tests independent from CI credentials and shared SDK fixtures."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for variable in (
+        "PRIME_CONTEXT",
+        "PRIME_API_KEY",
+        "PRIME_API_BASE_URL",
+        "PRIME_BASE_URL",
+        "PRIME_TEAM_ID",
+        "PRIME_USER_ID",
+    ):
+        monkeypatch.delenv(variable, raising=False)
 
 
 def _write_configs(tmp_path) -> None:
@@ -33,7 +49,6 @@ def _write_configs(tmp_path) -> None:
 
 def test_config_loads_temporary_context(monkeypatch, tmp_path) -> None:
     _write_configs(tmp_path)
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "dev")
 
     config = Config()
@@ -46,7 +61,6 @@ def test_config_loads_temporary_context(monkeypatch, tmp_path) -> None:
 
 def test_environment_variables_override_temporary_context(monkeypatch, tmp_path) -> None:
     _write_configs(tmp_path)
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "dev")
     monkeypatch.setenv("PRIME_API_KEY", "environment-key")
     monkeypatch.setenv("PRIME_API_BASE_URL", "https://api.environment.example/api/v1")
@@ -63,7 +77,6 @@ def test_environment_variables_override_temporary_context(monkeypatch, tmp_path)
 
 def test_production_context_restores_builtin_scope(monkeypatch, tmp_path) -> None:
     _write_configs(tmp_path)
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "production")
 
     config = Config()
@@ -78,7 +91,6 @@ def test_production_context_restores_builtin_scope(monkeypatch, tmp_path) -> Non
 def test_broken_temporary_context_never_falls_back(monkeypatch, tmp_path, content) -> None:
     _write_configs(tmp_path)
     (tmp_path / ".prime" / "environments" / "dev.json").write_text(content)
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "dev")
 
     with pytest.raises(ValueError, match="context|JSON object"):
@@ -88,7 +100,6 @@ def test_broken_temporary_context_never_falls_back(monkeypatch, tmp_path, conten
 def test_missing_temporary_context_never_falls_back(monkeypatch, tmp_path) -> None:
     _write_configs(tmp_path)
     (tmp_path / ".prime" / "environments" / "dev.json").unlink()
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "dev")
 
     with pytest.raises(ValueError, match="Context file not found"):
@@ -106,7 +117,6 @@ def test_unreadable_temporary_context_never_falls_back(monkeypatch, tmp_path) ->
         return original_read_text(path, *args, **kwargs)
 
     monkeypatch.setattr(type(environment_file), "read_text", fail_for_context)
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_CONTEXT", "dev")
 
     with pytest.raises(ValueError, match="Failed to load context 'dev'"):

--- a/packages/prime-sandboxes/tests/test_sdk_config.py
+++ b/packages/prime-sandboxes/tests/test_sdk_config.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from prime_sandboxes import Config
 
 
@@ -70,3 +72,42 @@ def test_production_context_restores_builtin_scope(monkeypatch, tmp_path) -> Non
     assert config.base_url == Config.DEFAULT_BASE_URL
     assert config.team_id is None
     assert config.user_id == "production-user"
+
+
+@pytest.mark.parametrize("content", ["{", "[]", '"not-an-object"'])
+def test_broken_temporary_context_never_falls_back(monkeypatch, tmp_path, content) -> None:
+    _write_configs(tmp_path)
+    (tmp_path / ".prime" / "environments" / "dev.json").write_text(content)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    with pytest.raises(ValueError, match="context|JSON object"):
+        Config()
+
+
+def test_missing_temporary_context_never_falls_back(monkeypatch, tmp_path) -> None:
+    _write_configs(tmp_path)
+    (tmp_path / ".prime" / "environments" / "dev.json").unlink()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    with pytest.raises(ValueError, match="Context file not found"):
+        Config()
+
+
+def test_unreadable_temporary_context_never_falls_back(monkeypatch, tmp_path) -> None:
+    _write_configs(tmp_path)
+    environment_file = tmp_path / ".prime" / "environments" / "dev.json"
+    original_read_text = type(environment_file).read_text
+
+    def fail_for_context(path, *args, **kwargs):
+        if path == environment_file:
+            raise PermissionError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(environment_file), "read_text", fail_for_context)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    with pytest.raises(ValueError, match="Failed to load context 'dev'"):
+        Config()

--- a/packages/prime-sandboxes/tests/test_sdk_config.py
+++ b/packages/prime-sandboxes/tests/test_sdk_config.py
@@ -1,0 +1,72 @@
+import json
+
+from prime_sandboxes import Config
+
+
+def _write_configs(tmp_path) -> None:
+    config_dir = tmp_path / ".prime"
+    environments_dir = config_dir / "environments"
+    environments_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "production-key",
+                "base_url": "https://api.production.example",
+                "team_id": "production-team",
+                "user_id": "production-user",
+            }
+        )
+    )
+    (environments_dir / "dev.json").write_text(
+        json.dumps(
+            {
+                "api_key": "dev-key",
+                "base_url": "https://api.dev.example/api/v1",
+                "team_id": "dev-team",
+                "user_id": "dev-user",
+            }
+        )
+    )
+
+
+def test_config_loads_temporary_context(monkeypatch, tmp_path) -> None:
+    _write_configs(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    config = Config()
+
+    assert config.api_key == "dev-key"
+    assert config.base_url == "https://api.dev.example"
+    assert config.team_id == "dev-team"
+    assert config.user_id == "dev-user"
+
+
+def test_environment_variables_override_temporary_context(monkeypatch, tmp_path) -> None:
+    _write_configs(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+    monkeypatch.setenv("PRIME_API_KEY", "environment-key")
+    monkeypatch.setenv("PRIME_API_BASE_URL", "https://api.environment.example/api/v1")
+    monkeypatch.setenv("PRIME_TEAM_ID", "environment-team")
+    monkeypatch.setenv("PRIME_USER_ID", "environment-user")
+
+    config = Config()
+
+    assert config.api_key == "environment-key"
+    assert config.base_url == "https://api.environment.example"
+    assert config.team_id == "environment-team"
+    assert config.user_id == "environment-user"
+
+
+def test_production_context_restores_builtin_scope(monkeypatch, tmp_path) -> None:
+    _write_configs(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "production")
+
+    config = Config()
+
+    assert config.api_key == "production-key"
+    assert config.base_url == Config.DEFAULT_BASE_URL
+    assert config.team_id is None
+    assert config.user_id == "production-user"

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -16,7 +17,9 @@ class Config:
     def __init__(self) -> None:
         self.config_dir = Path.home() / ".prime"
         self.config_file = self.config_dir / "config.json"
+        self.environments_dir = self.config_dir / "environments"
         self._load_config()
+        self._load_context()
 
     def _load_config(self) -> None:
         """Load configuration from file."""
@@ -28,6 +31,36 @@ class Config:
                 self.config = {}
         else:
             self.config = {}
+
+    def _load_context(self) -> None:
+        """Overlay the profile selected by the Prime CLI for this process."""
+        context = os.getenv("PRIME_CONTEXT")
+        if not context:
+            return
+
+        if context.casefold() == "production":
+            self.config.update(
+                {
+                    "base_url": self.DEFAULT_BASE_URL,
+                    "team_id": None,
+                    "team_name": None,
+                    "team_role": None,
+                }
+            )
+            return
+
+        if re.fullmatch(r"[a-zA-Z0-9_-]+", context) is None:
+            return
+
+        environment_file = self.environments_dir / f"{context}.json"
+        if not environment_file.exists():
+            return
+        try:
+            environment_config = json.loads(environment_file.read_text())
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            return
+        if isinstance(environment_config, dict):
+            self.config.update(environment_config)
 
     @staticmethod
     def _strip_api_v1(url: str) -> str:

--- a/packages/prime-tunnel/src/prime_tunnel/core/config.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/config.py
@@ -50,17 +50,18 @@ class Config:
             return
 
         if re.fullmatch(r"[a-zA-Z0-9_-]+", context) is None:
-            return
+            raise ValueError(f"Invalid context name: {context!r}")
 
         environment_file = self.environments_dir / f"{context}.json"
         if not environment_file.exists():
-            return
+            raise ValueError(f"Context file not found: {environment_file}")
         try:
             environment_config = json.loads(environment_file.read_text())
-        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-            return
-        if isinstance(environment_config, dict):
-            self.config.update(environment_config)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
+            raise ValueError(f"Failed to load context '{context}': {e}") from e
+        if not isinstance(environment_config, dict):
+            raise ValueError(f"Invalid context '{context}': expected a JSON object")
+        self.config.update(environment_config)
 
     @staticmethod
     def _strip_api_v1(url: str) -> str:

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -118,6 +118,27 @@ def test_config_loads_temporary_context(monkeypatch, tmp_path):
     assert config.user_id == "dev-user"
 
 
+@pytest.mark.parametrize("content", ["{", "[]", '"not-an-object"'])
+def test_config_rejects_broken_temporary_context(monkeypatch, tmp_path, content):
+    config_dir = tmp_path / ".prime"
+    environments_dir = config_dir / "environments"
+    environments_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "production-key",
+                "base_url": "https://api.production.example",
+            }
+        )
+    )
+    (environments_dir / "dev.json").write_text(content)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    with pytest.raises(ValueError, match="context|JSON object"):
+        Config()
+
+
 def test_config_bin_dir():
     """Test Config bin_dir property."""
     config = Config()

--- a/packages/prime-tunnel/tests/test_tunnel.py
+++ b/packages/prime-tunnel/tests/test_tunnel.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -80,6 +81,41 @@ def test_config_api_key_from_env(monkeypatch):
     monkeypatch.setenv("PRIME_API_KEY", "test-key-123")
     config = Config()
     assert config.api_key == "test-key-123"
+
+
+def test_config_loads_temporary_context(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".prime"
+    environments_dir = config_dir / "environments"
+    environments_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "production-key",
+                "base_url": "https://api.production.example",
+                "team_id": "production-team",
+                "user_id": "production-user",
+            }
+        )
+    )
+    (environments_dir / "dev.json").write_text(
+        json.dumps(
+            {
+                "api_key": "dev-key",
+                "base_url": "https://api.dev.example/api/v1",
+                "team_id": "dev-team",
+                "user_id": "dev-user",
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_CONTEXT", "dev")
+
+    config = Config()
+
+    assert config.api_key == "dev-key"
+    assert config.base_url == "https://api.dev.example"
+    assert config.team_id == "dev-team"
+    assert config.user_id == "dev-user"
 
 
 def test_config_bin_dir():

--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -10,7 +10,7 @@ from rich.text import Text
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, get_console, require_persistent_context
 from .teams import fetch_teams
 
 app = PlainTyper(help="Configure the CLI", no_args_is_help=True)
@@ -124,6 +124,8 @@ def set_api_key(
     ),
 ) -> None:
     """Set your API key (prompts securely if not provided)"""
+    require_persistent_context()
+
     if api_key is None:
         # Interactive mode with secure prompt
         api_key = typer.prompt(
@@ -169,6 +171,7 @@ def set_team_id(
     ),
 ) -> None:
     """Set your team ID."""
+    require_persistent_context()
     config = Config()
 
     # Validate team ID format
@@ -207,6 +210,7 @@ def set_team_id(
 @app.command()
 def remove_team_id() -> None:
     """Remove team ID to use personal account"""
+    require_persistent_context()
     config = Config()
     config.set_team(None)
     console.print("[green]Team ID removed. Using personal account.[/green]")
@@ -220,6 +224,8 @@ def set_base_url(
     ),
 ) -> None:
     """Set the API base URL (prompts if not provided)"""
+    require_persistent_context()
+
     if not url:
         config = Config()
         url = typer.prompt(
@@ -243,6 +249,8 @@ def set_frontend_url(
     ),
 ) -> None:
     """Set the frontend URL (prompts if not provided)"""
+    require_persistent_context()
+
     if not url:
         config = Config()
         url = typer.prompt(
@@ -266,6 +274,8 @@ def set_inference_url(
     ),
 ) -> None:
     """Set the inference URL (prompts if not provided)"""
+    require_persistent_context()
+
     if not url:
         config = Config()
         url = typer.prompt(
@@ -292,6 +302,8 @@ def set_traces_url(
     ),
 ) -> None:
     """Set the Prime Traces service URL (prompts if not provided)"""
+    require_persistent_context()
+
     if url is None:
         config = Config()
         url = typer.prompt(
@@ -319,6 +331,7 @@ def _set_environment(
     env: str,
 ) -> None:
     """Set URLs for a specific environment"""
+    require_persistent_context()
     config = Config()
 
     # Try to load the environment (handles both built-in and custom)
@@ -342,6 +355,7 @@ def _save_environment(
     name: str,
 ) -> None:
     """Save current configuration as a named environment (including API key)"""
+    require_persistent_context()
     try:
         config = Config()
         config.save_environment(name)
@@ -373,6 +387,7 @@ def _delete_environment(
     name: str,
 ) -> None:
     """Delete a named saved environment."""
+    require_persistent_context()
     try:
         config = Config()
         config.delete_environment(name)
@@ -390,6 +405,7 @@ def set_share_resources_with_team(
     ),
 ) -> None:
     """Set whether to automatically share new resources with all team members"""
+    require_persistent_context()
     value = enabled.lower()
     if value not in ("true", "false"):
         console.print("[red]Error: Value must be 'true' or 'false'[/red]")
@@ -408,6 +424,7 @@ def set_ssh_key_path(
     ),
 ) -> None:
     """Set the SSH private key path"""
+    require_persistent_context()
     config = Config()
     config.set_ssh_key_path(path)
     console.print("[green]SSH key path configured successfully![/green]")
@@ -418,6 +435,7 @@ def reset(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Reset configuration to defaults"""
+    require_persistent_context()
     if yes or typer.confirm("Are you sure you want to reset all settings?"):
         config = Config()
         config.set_api_key("")

--- a/packages/prime/src/prime_cli/commands/disks.py
+++ b/packages/prime/src/prime_cli/commands/disks.py
@@ -10,7 +10,7 @@ from rich.table import Table
 from rich.text import Text
 
 from prime_cli.api.availability import AvailabilityClient
-from prime_cli.core import APIClient, APIError, Config
+from prime_cli.core import APIClient, APIError
 from prime_cli.helper.short_id import generate_short_id_disk
 
 from ..api.disks import Disk, DisksClient
@@ -30,7 +30,6 @@ from ..utils.display import DISK_STATUS_COLORS
 
 app = PlainTyper(help="Manage storage", no_args_is_help=True)
 console = get_console()
-config = Config()
 
 LIST_DISKS_JSON_HELP = json_output_help(
     ".disks[] = {id, name, size, status, provider, location, created_at, price_hr}",

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -51,7 +51,16 @@ from .images_update_helpers import format_image_coordinate
 app = PlainTyper(help="Manage Docker images in Prime Intellect registry", no_args_is_help=True)
 console = get_console()
 
-config = Config()
+
+class _ConfigProxy:
+    """Resolve configuration lazily after the root callback selects a context."""
+
+    @property
+    def team_id(self) -> Optional[str]:
+        return Config().team_id
+
+
+config = _ConfigProxy()
 
 
 LIST_IMAGES_JSON_HELP = json_output_help(
@@ -1054,8 +1063,9 @@ def _update_source_for_parsed_reference(
 
 def _current_scope_owner() -> Any:
     """Owner object for the configured personal/team context."""
-    if config.team_id:
-        return TeamImageOwner(team_id=config.team_id)
+    team_id = config.team_id
+    if team_id:
+        return TeamImageOwner(team_id=team_id)
     return PersonalImageOwner()
 
 

--- a/packages/prime/src/prime_cli/commands/login.py
+++ b/packages/prime/src/prime_cli/commands/login.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, get_console, require_persistent_context
 from .teams import fetch_teams
 
 app = PlainTyper(help="Login to Prime Intellect")
@@ -127,6 +127,7 @@ def login(
     headless: bool = typer.Option(False, "--headless", help="Don't attempt to open browser"),
 ) -> None:
     """Login to Prime Intellect"""
+    require_persistent_context()
     config = Config()
     settings = config.view()
 

--- a/packages/prime/src/prime_cli/commands/logout.py
+++ b/packages/prime/src/prime_cli/commands/logout.py
@@ -5,7 +5,7 @@ import typer
 
 from prime_cli.core import Config
 
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, get_console, require_persistent_context
 
 app = PlainTyper(help="Log out of Prime Intellect", no_args_is_help=False)
 console = get_console()
@@ -53,6 +53,7 @@ def logout(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Clear the stored API key, team selection, and user id."""
+    require_persistent_context()
     config = Config()
 
     raw = config.config

--- a/packages/prime/src/prime_cli/commands/registry.py
+++ b/packages/prime/src/prime_cli/commands/registry.py
@@ -4,7 +4,6 @@ import typer
 from prime_sandboxes import (
     APIClient,
     APIError,
-    Config,
     DockerImageCheckResponse,
     RegistryCredentialSummary,
     TemplateClient,
@@ -25,7 +24,6 @@ from ..utils import (
 
 app = PlainTyper(help="Manage registry credentials and private images", no_args_is_help=True)
 console = get_console()
-config = Config()
 
 LIST_REGISTRY_JSON_HELP = json_output_help(
     ".credentials[] = {id, name, server, scope, team_id, user_id, created_at, updated_at, age}",

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -55,8 +55,6 @@ app = PlainTyper(help="Manage sandboxes", no_args_is_help=True)
 console = get_console()
 
 
-config = Config()
-
 LIST_SANDBOXES_JSON_HELP = json_output_help(
     ".sandboxes[] = {id, name, image, status, resources, labels[], created_at, "
     "timeout_minutes, expires_at?}",
@@ -1027,6 +1025,7 @@ def delete(
             raise typer.Exit(1)
 
         if all or labels:
+            config = Config()
             team_id = config.team_id
 
             if target_user_id and not only_mine:

--- a/packages/prime/src/prime_cli/commands/switch.py
+++ b/packages/prime/src/prime_cli/commands/switch.py
@@ -6,7 +6,7 @@ from click.exceptions import Abort
 from prime_cli.core import Config
 
 from ..client import APIClient, APIError
-from ..utils import PlainTyper, get_console
+from ..utils import PlainTyper, get_console, require_persistent_context
 from .teams import fetch_teams
 
 app = PlainTyper(
@@ -67,6 +67,7 @@ def switch(
     ),
 ) -> None:
     """Switch the active account context."""
+    require_persistent_context()
     config = Config()
 
     if config.team_id_from_env:

--- a/packages/prime/src/prime_cli/commands/whoami.py
+++ b/packages/prime/src/prime_cli/commands/whoami.py
@@ -31,7 +31,7 @@ def whoami() -> None:
 
         # Update config
         config = Config()
-        if user_id:
+        if user_id and config.context_override is None:
             config.set_user_id(user_id)
             config.update_current_environment_file()
 

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -30,7 +30,7 @@ class Config:
     DEFAULT_INFERENCE_URL: str = "https://api.pinference.ai/api/v1"
     DEFAULT_SSH_KEY_PATH: str = str(Path.home() / ".ssh" / "id_rsa")
 
-    def __init__(self) -> None:
+    def __init__(self, use_context: bool = True) -> None:
         self.config_dir = Path.home() / ".prime"
         self.config_file = self.config_dir / "config.json"
         self.environments_dir = self.config_dir / "environments"
@@ -38,7 +38,7 @@ class Config:
         self._load_config()
 
         # Check for PRIME_CONTEXT env var to temporarily override config
-        context = os.getenv("PRIME_CONTEXT")
+        context = os.getenv("PRIME_CONTEXT") if use_context else None
         if context:
             self.load_environment(context, persist=False)
 
@@ -390,6 +390,15 @@ class Config:
                     env_config = json.loads(env_file.read_text())
                 except json.JSONDecodeError as e:
                     raise ValueError(f"Invalid JSON in environment file {sanitized_name}.json: {e}")
+                except (OSError, UnicodeDecodeError) as e:
+                    raise ValueError(
+                        f"Cannot read environment file {sanitized_name}.json: {e}"
+                    ) from e
+
+                if not isinstance(env_config, dict):
+                    raise ValueError(
+                        f"Invalid environment file {sanitized_name}.json: expected a JSON object"
+                    )
 
                 if persist:
                     if "api_key" in env_config:

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -42,6 +42,12 @@ class Config:
         if context:
             self.load_environment(context, persist=False)
 
+    @property
+    def context_override(self) -> str | None:
+        """Return the temporary context selected for this invocation, if any."""
+        context = os.getenv("PRIME_CONTEXT")
+        return context if context else None
+
     @staticmethod
     def _strip_api_v1(url: str) -> str:
         # make base_url consistent even if user passed a /api/v1 variant
@@ -224,8 +230,7 @@ class Config:
             )
 
         update_root = (
-            not context_override
-            or root_environment.casefold() == selected_environment.casefold()
+            not context_override or root_environment.casefold() == selected_environment.casefold()
         )
 
         if update_root:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -115,8 +115,19 @@ def callback(
                 typer.echo(f"  - {env_name}", err=True)
             raise typer.Exit(1)
 
-        # Set environment variable so Config instances in subcommands pick it up
+        # Set the environment variable so Config instances in subcommands and
+        # SDK packages pick it up. Restore it when Click closes the context so
+        # embedded/CliRunner invocations in the same process do not leak state.
+        previous_context = os.environ.get("PRIME_CONTEXT")
         os.environ["PRIME_CONTEXT"] = context
+
+        def restore_context() -> None:
+            if previous_context is None:
+                os.environ.pop("PRIME_CONTEXT", None)
+            else:
+                os.environ["PRIME_CONTEXT"] = previous_context
+
+        ctx.call_on_close(restore_context)
 
     # Check for updates (only when a subcommand is being executed)
     if ctx.invoked_subcommand is not None:

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -106,9 +106,17 @@ def callback(
     if context:
         import os
 
-        config = Config()
-        # Check if the context exists
-        if context.lower() != "production" and context not in config.list_environments():
+        # Ignore any inherited PRIME_CONTEXT while validating the explicit
+        # selector, then fully load it before any command can construct a
+        # client. A filename alone is not proof that a context is usable.
+        config = Config(use_context=False)
+        try:
+            context_loaded = config.load_environment(context, persist=False)
+        except (ValueError, TypeError, AttributeError) as e:
+            typer.echo(f"Error: Failed to load context '{context}': {e}", err=True)
+            raise typer.Exit(1)
+
+        if not context_loaded:
             typer.echo(f"Error: Unknown context '{context}'", err=True)
             typer.echo("Available contexts:", err=True)
             for env_name in config.list_environments():

--- a/packages/prime/src/prime_cli/utils/__init__.py
+++ b/packages/prime/src/prime_cli/utils/__init__.py
@@ -2,6 +2,7 @@
 
 # Re-export the most commonly used functions
 from .config import BaseConfig, load_toml
+from .context import require_persistent_context
 from .display import (
     build_table,
     get_eval_viewer_url,
@@ -56,6 +57,7 @@ __all__ = [
     "load_toml",
     "BaseConfig",
     "optional_team_params",
+    "require_persistent_context",
     "DefaultCommandGroup",
     "PlainAwareTyperGroup",
     "PlainTyper",

--- a/packages/prime/src/prime_cli/utils/context.py
+++ b/packages/prime/src/prime_cli/utils/context.py
@@ -1,0 +1,21 @@
+"""Helpers for commands that persist CLI configuration."""
+
+import typer
+from rich.markup import escape
+
+from prime_cli.core import Config
+
+from .plain import get_console
+
+
+def require_persistent_context() -> None:
+    """Reject config writes while a temporary ``--context`` is selected."""
+    context = Config().context_override
+    if context is None:
+        return
+
+    console = get_console(stderr=True)
+    safe_context = escape(context)
+    console.print(f"[red]Error:[/red] Temporary context '{safe_context}' is read-only.")
+    console.print(f"[dim]First run: prime config use {safe_context}; then retry without -c.[/dim]")
+    raise typer.Exit(1)

--- a/packages/prime/tests/test_context.py
+++ b/packages/prime/tests/test_context.py
@@ -87,3 +87,57 @@ def test_whoami_does_not_cache_user_id_in_temporary_context(
     assert "fresh-user" in result.output
     assert json.loads(root_file.read_text()) == root_before
     assert json.loads(dev_file.read_text()) == dev_before
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("{", "Invalid JSON"),
+        ("[]", "expected a JSON object"),
+        ('"not-an-object"', "expected a JSON object"),
+    ],
+)
+def test_broken_context_aborts_before_command_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    content: str,
+    expected: str,
+) -> None:
+    _, dev_file = _create_dev_context(monkeypatch, tmp_path)
+    dev_file.write_text(content)
+    monkeypatch.setattr(
+        "prime_cli.commands.sandbox.SandboxClient.list",
+        lambda *args, **kwargs: pytest.fail("sandbox command must not execute"),
+    )
+
+    result = runner.invoke(app, ["-c", "dev", "sandbox", "list"])
+
+    assert result.exit_code == 1, result.output
+    assert "Failed to load context 'dev'" in result.output
+    assert expected in result.output
+    assert os.getenv("PRIME_CONTEXT") is None
+
+
+def test_unreadable_context_aborts_before_command_execution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _, dev_file = _create_dev_context(monkeypatch, tmp_path)
+    original_read_text = Path.read_text
+
+    def fail_for_context(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == dev_file:
+            raise PermissionError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_for_context)
+    monkeypatch.setattr(
+        "prime_cli.commands.sandbox.SandboxClient.list",
+        lambda *args, **kwargs: pytest.fail("sandbox command must not execute"),
+    )
+
+    result = runner.invoke(app, ["-c", "dev", "sandbox", "list"])
+
+    assert result.exit_code == 1, result.output
+    assert "Failed to load context 'dev'" in result.output
+    assert "Cannot read environment file dev.json" in result.output
+    assert os.getenv("PRIME_CONTEXT") is None

--- a/packages/prime/tests/test_context.py
+++ b/packages/prime/tests/test_context.py
@@ -1,0 +1,89 @@
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from prime_cli.core import Config
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _create_dev_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.delenv("PRIME_CONTEXT", raising=False)
+    config = Config()
+    config.set_api_key("root-key")
+    config.set_user_id("root-user")
+    config.save_environment("dev")
+    return config.config_file, config.environments_dir / "dev.json"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["config", "set-api-key", "replacement-key"],
+        ["config", "set-team-id", ""],
+        ["config", "set-base-url", "https://replacement.example"],
+        ["config", "set-frontend-url", "https://frontend.example"],
+        ["config", "set-inference-url", "https://inference.example"],
+        ["config", "set-traces-url", "https://traces.example"],
+        ["config", "set-share-resources-with-team", "true"],
+        ["config", "set-ssh-key-path", "/tmp/id_test"],
+        ["config", "reset", "--yes"],
+        ["config", "use", "production"],
+        ["config", "save", "copy"],
+        ["config", "delete", "dev"],
+        ["login", "--headless"],
+        ["logout", "--yes"],
+        ["switch", "personal"],
+    ],
+)
+def test_temporary_context_rejects_config_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command: list[str],
+) -> None:
+    root_file, dev_file = _create_dev_context(monkeypatch, tmp_path)
+    root_before = root_file.read_text()
+    dev_before = dev_file.read_text()
+
+    result = runner.invoke(app, ["-c", "dev", *command])
+
+    assert result.exit_code == 1, result.output
+    assert "Temporary context 'dev' is read-only" in result.output
+    assert root_file.read_text() == root_before
+    assert dev_file.read_text() == dev_before
+    assert os.getenv("PRIME_CONTEXT") is None
+
+
+def test_whoami_does_not_cache_user_id_in_temporary_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root_file, dev_file = _create_dev_context(monkeypatch, tmp_path)
+    root_before = json.loads(root_file.read_text())
+    dev_before = json.loads(dev_file.read_text())
+
+    def mock_get(self: Any, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        assert endpoint == "/user/whoami"
+        return {
+            "data": {
+                "id": "fresh-user",
+                "email": "dev@example.com",
+                "name": "Dev User",
+                "slug": "dev-user",
+                "scope": {},
+            }
+        }
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = runner.invoke(app, ["-c", "dev", "whoami"])
+
+    assert result.exit_code == 0, result.output
+    assert "fresh-user" in result.output
+    assert json.loads(root_file.read_text()) == root_before
+    assert json.loads(dev_file.read_text()) == dev_before

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -85,6 +85,68 @@ def _configure_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
 
 
+def test_list_uses_temporary_context_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    config_dir = tmp_path / ".prime"
+    environments_dir = config_dir / "environments"
+    environments_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "production-key",
+                "base_url": "https://api.production.example",
+                "team_id": "production-team",
+                "user_id": "production-user",
+            }
+        )
+    )
+    (environments_dir / "dev.json").write_text(
+        json.dumps(
+            {
+                "api_key": "dev-key",
+                "base_url": "https://api.dev.example",
+                "team_id": "dev-team",
+                "user_id": "dev-user",
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    for name in (
+        "PRIME_CONTEXT",
+        "PRIME_API_KEY",
+        "PRIME_API_BASE_URL",
+        "PRIME_BASE_URL",
+        "PRIME_TEAM_ID",
+        "PRIME_USER_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def mock_list(self: Any, **kwargs: Any) -> SimpleNamespace:
+        captured.update(
+            {
+                "api_key": self.client.api_key,
+                "base_url": self.client.base_url,
+                "team_id": self.client.config.team_id,
+                "user_id": self.client.config.user_id,
+            }
+        )
+        return SimpleNamespace(sandboxes=[], total=0, page=1, per_page=50, has_next=False)
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
+
+    result = runner.invoke(app, ["-c", "dev", "sandbox", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "api_key": "dev-key",
+        "base_url": "https://api.dev.example",
+        "team_id": "dev-team",
+        "user_id": "dev-user",
+    }
+
+
 def test_sandbox_network_without_flags_shows_current_rules(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -158,7 +158,7 @@ def test_set_traces_url_does_not_persist_env_override(monkeypatch, tmp_path):
     assert config.traces_url == traces_url
 
 
-def test_set_traces_url_with_context_does_not_replace_default_config(monkeypatch, tmp_path):
+def test_set_traces_url_with_context_is_read_only(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     # The CLI callback sets this directly; record the pre-test value so the
@@ -181,12 +181,10 @@ def test_set_traces_url_with_context_does_not_replace_default_config(monkeypatch
         ["--context", "staging", "config", "set-traces-url", traces_url],
     )
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
+    assert "Temporary context 'staging' is read-only" in result.output
     assert json.loads(config.config_file.read_text()) == root_before
-    assert json.loads(staging_file.read_text()) == {
-        **staging_before,
-        "traces_url": traces_url,
-    }
+    assert json.loads(staging_file.read_text()) == staging_before
 
 
 def test_set_traces_url_does_not_persist_unrelated_env_overrides(monkeypatch, tmp_path):
@@ -236,7 +234,7 @@ def test_set_traces_url_rejects_unstored_production_context(monkeypatch, tmp_pat
     )
 
     assert result.exit_code == 1
-    assert "run 'prime config use production' first" in result.output
+    assert "prime config use production" in result.output
     assert json.loads(config.config_file.read_text()) == root_before
 
 

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -226,6 +226,79 @@ def test_tunnel_list_passes_label_filters(monkeypatch: pytest.MonkeyPatch) -> No
     assert captured["sort_by"] == "name"
 
 
+def test_tunnel_list_uses_temporary_context_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / ".prime"
+    environments_dir = config_dir / "environments"
+    environments_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "production-key",
+                "base_url": "https://api.production.example",
+                "team_id": "production-team",
+                "user_id": "production-user",
+            }
+        )
+    )
+    (environments_dir / "dev.json").write_text(
+        json.dumps(
+            {
+                "api_key": "dev-key",
+                "base_url": "https://api.dev.example",
+                "team_id": "dev-team",
+                "user_id": "dev-user",
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    for name in (
+        "PRIME_CONTEXT",
+        "PRIME_API_KEY",
+        "PRIME_API_BASE_URL",
+        "PRIME_BASE_URL",
+        "PRIME_TEAM_ID",
+        "PRIME_USER_ID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    class FakeTunnelClient:
+        def __init__(self) -> None:
+            from prime_tunnel import Config
+
+            config = Config()
+            captured.update(
+                {
+                    "api_key": config.api_key,
+                    "base_url": config.base_url,
+                    "team_id": config.team_id,
+                    "user_id": config.user_id,
+                }
+            )
+
+        async def list_tunnels_page(self, **kwargs: Any) -> Any:
+            return SimpleNamespace(tunnels=[], total=0, page=1, per_page=50, has_next=False)
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("prime_tunnel.core.client.TunnelClient", FakeTunnelClient)
+
+    result = runner.invoke(app, ["-c", "dev", "tunnel", "list", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "api_key": "dev-key",
+        "base_url": "https://api.dev.example",
+        "team_id": "dev-team",
+        "user_id": "dev-user",
+    }
+
+
 def test_tunnel_list_json_outputs_empty_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- make sandbox and tunnel SDK clients honor the temporary PRIME_CONTEXT profile
- resolve image and sandbox configuration after the root CLI callback selects a context
- make temporary contexts read-only for persisted config changes while keeping whoami read-only
- restore PRIME_CONTEXT after embedded CLI invocations to prevent state leakage

## Testing
- uv run pytest -q packages/prime/tests/test_context.py packages/prime/tests/test_sandbox_cli.py packages/prime/tests/test_tunnel_cli.py packages/prime/tests/test_traces_command.py packages/prime/tests/test_images_list.py packages/prime/tests/test_images_push.py packages/prime-sandboxes/tests/test_sdk_config.py packages/prime-tunnel/tests/test_tunnel.py
- uv run ruff check on affected CLI and SDK files
- uv run ty check src/ from packages/prime

The targeted suite passes 233 tests. The full CLI suite passes 1041 tests with 5 skipped; two unrelated Lab environment-detail tests fail in isolation on the base checkout behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how credentials, base URLs, and team scope are resolved for every command and SDK client; misconfigured context files now error instead of falling back, but behavior is intentional and well-tested.
> 
> **Overview**
> **Temporary `--context` / `PRIME_CONTEXT` now drives API clients end-to-end** instead of only partially applying saved profiles. The root CLI callback fully validates and loads the selected context (including broken or unreadable env files) before subcommands run, sets `PRIME_CONTEXT` for the process, and **restores the previous value on exit** so embedded `CliRunner` calls do not leak state.
> 
> **Sandboxes and tunnel SDK `Config`** mirror the CLI: they overlay `~/.prime/environments/{name}.json` when `PRIME_CONTEXT` is set, treat `production` as resetting team/base URL scope, and **fail hard** on invalid or missing context files (no silent fallback to root config). Env vars still win over file values.
> 
> **Read-only temporary contexts**: `require_persistent_context()` blocks login/logout/switch and all mutating `prime config` commands while `-c` is active; `whoami` no longer writes `user_id` back to disk in that mode. Module-level `Config()` was removed or deferred (e.g. lazy proxy in images) so team scope resolves **after** the context callback runs.
> 
> Tests cover SDK context loading, CLI integration for sandbox/tunnel list, config-write rejection, and abort-before-command on bad contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2f7ca162ddc4205f5c9a31c9281fbcbe579c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->