### PR TITLE
release: prime-traces 0.0.4

### DIFF
--- a/packages/prime-traces/src/prime_traces/__init__.py
+++ b/packages/prime-traces/src/prime_traces/__init__.py
@@ -49,7 +49,7 @@ from .models import (
 )
 from .traces import SupportsToRecord, TraceRecord, TracesClient
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 __all__ = [
     # Clients & config


### PR DESCRIPTION
Bumps `prime-traces` to 0.0.4 so `release-traces.yml` publishes the one change since 0.0.3:

- #875 `fix(traces): keep the server's reason on 401 responses` — a 401 now reads `API key unauthorized (<server detail>). Check PRIME_API_KEY and its scopes.` instead of the canned message. That is the error a key without `environments:write` produces through `prime-runs` (`POST /environmentshub/resolve` answers 401 for a missing scope), and the detail names the scope to fix.

Version-only change; the workspace lock is unaffected. Merging publishes 0.0.4 through OIDC and tags `prime-traces-v0.0.4`.

Follow-up once 0.0.4 is on PyPI: raise the floor in `packages/prime-runs/pyproject.toml` to `prime-traces>=0.0.4` on #856 before it merges, so every `prime-runs` install carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fk5fBAAaTiPfJ5UpNyqxXR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only diff with no runtime logic changes; publishing risk is limited to release automation.
> 
> **Overview**
> **Bumps `prime-traces` from 0.0.3 to 0.0.4** in `packages/prime-traces/src/prime_traces/__init__.py` so CI can publish the package and tag `prime-traces-v0.0.4`.
> 
> This release cut carries the already-merged **401 handling fix** (#875): unauthorized responses now surface the server’s detail in `UnauthorizedError` (e.g. missing scope on `environments:write`) instead of a generic message—relevant for `prime-runs` callers hitting `POST /environmentshub/resolve`.
> 
> No other code changes in this PR; follow-up is to raise `prime-runs`’ `prime-traces` floor to `>=0.0.4` after PyPI publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b2a2ae19f959901ae12a21d6a5026a13ae7649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->