### PR TITLE
feat(cli): redact known secrets before trace and eval uploads

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1062,7 +1062,7 @@ def _push_single_eval(
     path = _validate_eval_path(config_path)
     api_client = APIClient()
     redactor = Redactor(known_secrets(api_client.api_key, secret_args=secrets))
-    eval_data = redactor.value(_load_eval_directory(path))
+    eval_data, name = redactor.value([_load_eval_directory(path), name])
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
     if redactor.count:

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1062,7 +1062,11 @@ def _push_single_eval(
     path = _validate_eval_path(config_path)
     api_client = APIClient()
     redactor = Redactor(known_secrets(api_client.api_key, secret_args=secrets))
-    eval_data, name = redactor.value([_load_eval_directory(path), name])
+    # Everything from here on is what the platform receives: redact it all up front. A
+    # secret inside an identifier makes the request fail rather than leak it.
+    eval_data, env_slug, run_id, eval_id, name = redactor.value(
+        [_load_eval_directory(path), env_slug, run_id, eval_id, name]
+    )
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
     if redactor.count:

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -5,7 +5,7 @@ import re
 import time
 from functools import wraps
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 import typer
 from click.core import ParameterSource
@@ -32,6 +32,7 @@ from ..utils.hosted_eval import (
     clean_logs,
     get_new_log_lines,
 )
+from ..utils.redact import Redactor, known_secrets
 from ..verifiers_bridge import (
     DEFAULT_ENV_DIR_PATH,
     DEFAULT_MODEL,
@@ -1056,11 +1057,19 @@ def _push_single_eval(
     eval_id: Optional[str],
     is_public: bool = False,
     name: Optional[str] = None,
+    secrets: Iterable[str] = (),
 ) -> str:
     path = _validate_eval_path(config_path)
-    eval_data = _load_eval_directory(path)
+    api_client = APIClient()
+    redactor = Redactor(known_secrets(api_client.api_key, secret_args=secrets))
+    eval_data = redactor.value(_load_eval_directory(path))
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
+    if redactor.count:
+        console.print(
+            f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
+            "local files are unchanged[/yellow]"
+        )
 
     detected_env = eval_data.get("env_id") or eval_data.get("env")
     if not env_slug and detected_env and not run_id and not eval_id:
@@ -1074,7 +1083,6 @@ def _push_single_eval(
 
     console.print()
 
-    api_client = APIClient()
     client = EvalsClient(api_client)
 
     if eval_id:
@@ -1222,6 +1230,14 @@ def push_eval(
         "--public",
         help="Make the pushed evaluation public. Evaluations are private by default.",
     ),
+    secret: list[str] = typer.Option(
+        [],
+        "--secret",
+        help=(
+            "Value to redact before upload, or a file with one per line; repeatable. "
+            "Credential-named environment variables and the API key are always redacted."
+        ),
+    ),
 ) -> None:
     """Push evaluation data to Prime Evals.
 
@@ -1255,7 +1271,9 @@ def push_eval(
         if config_path is None:
             current_dir = Path(".")
             if _has_eval_files(current_dir):
-                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id, is_public, name)
+                result_eval_id = _push_single_eval(
+                    ".", env_id, run_id, eval_id, is_public, name, secret
+                )
                 if output == "json":
                     console.print()
                     output_data_as_json({"evaluation_id": result_eval_id}, console)
@@ -1279,7 +1297,7 @@ def push_eval(
             for eval_dir in eval_dirs:
                 try:
                     result_eval_id = _push_single_eval(
-                        str(eval_dir), env_id, run_id, eval_id, is_public, name
+                        str(eval_dir), env_id, run_id, eval_id, is_public, name, secret
                     )
                     results.append(
                         {"path": str(eval_dir), "eval_id": result_eval_id, "status": "success"}
@@ -1303,7 +1321,9 @@ def push_eval(
 
             return
 
-        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id, is_public, name)
+        result_eval_id = _push_single_eval(
+            config_path, env_id, run_id, eval_id, is_public, name, secret
+        )
 
         if output == "json":
             console.print()

--- a/packages/prime/src/prime_cli/commands/traces.py
+++ b/packages/prime/src/prime_cli/commands/traces.py
@@ -126,7 +126,7 @@ def upload_traces(
         receipts = client.upload_lines(
             (redactor.json(line.decode()).encode() for line in read_jsonl_lines(file)),
             line_format=line_format,
-            context=_parse_context(context),
+            context=redactor.value(_parse_context(context)),
             compress=not no_compress,
             on_batch=on_batch,
         )

--- a/packages/prime/src/prime_cli/commands/traces.py
+++ b/packages/prime/src/prime_cli/commands/traces.py
@@ -13,6 +13,7 @@ from prime_traces import (
     TracesClient,
     UnauthorizedError,
     UploadReceipt,
+    read_jsonl_lines,
 )
 from rich.markup import escape
 from rich.table import Table
@@ -25,6 +26,7 @@ from ..utils import (
     output_data_as_json,
     validate_output_format,
 )
+from ..utils.redact import Redactor, known_secrets
 
 app = PlainTyper(help="Upload and query traces (Prime Traces)", no_args_is_help=True)
 console = get_console()
@@ -44,6 +46,7 @@ def _traces_client() -> TracesClient:
 UPLOAD_JSON_HELP = json_output_help(
     ".receipts[] = {upload_id, status}",
     ".num_batches = number",
+    ".redacted = number of secret occurrences replaced before upload",
 )
 
 LIST_TRACES_JSON_HELP = json_output_help(
@@ -90,13 +93,22 @@ def upload_traces(
         "-c",
         help="Batch context as key=value, repeatable (e.g. -c source=hosted_eval)",
     ),
+    secret: List[str] = typer.Option(
+        [],
+        "--secret",
+        help=(
+            "Value to redact before upload, or a file with one per line; repeatable. "
+            "Credential-named environment variables and the API key are always redacted."
+        ),
+    ),
     no_compress: bool = typer.Option(
         False, "--no-compress", help="Skip gzip transport compression"
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """Upload a JSONL file of traces. Safe to rerun after interruption:
-    identical bytes replay their committed receipts without re-storing."""
+    identical bytes replay their committed receipts without re-storing.
+    Known secrets are replaced with [REDACTED] on the way out; the file is unchanged."""
     validate_output_format(output, error_console)
     line_format = LineFormat.EPISODE if episodes else LineFormat.TRACE
 
@@ -110,8 +122,9 @@ def upload_traces(
 
     try:
         client = _traces_client()
-        receipts = client.upload_file(
-            file,
+        redactor = Redactor(known_secrets(client.client.api_key, secret_args=secret))
+        receipts = client.upload_lines(
+            (redactor.json(line.decode()).encode() for line in read_jsonl_lines(file)),
             line_format=line_format,
             context=_parse_context(context),
             compress=not no_compress,
@@ -138,11 +151,17 @@ def upload_traces(
             {
                 "receipts": [r.model_dump() for r in receipts],
                 "num_batches": len(receipts),
+                "redacted": redactor.count,
             },
             console,
         )
-    else:
-        console.print(f"[green]Uploaded {len(receipts)} batch(es) from {escape(str(file))}[/green]")
+        return
+    if redactor.count:
+        console.print(
+            f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
+            f"{escape(str(file))} is unchanged[/yellow]"
+        )
+    console.print(f"[green]Uploaded {len(receipts)} batch(es) from {escape(str(file))}[/green]")
 
 
 @app.command("list", epilog=LIST_TRACES_JSON_HELP)

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -189,7 +189,9 @@ def push_eval_results_to_hub(
         }
         for sample in results_samples
     ]
-    eval_metadata, converted_results = redactor.value([eval_metadata, converted_results])
+    eval_metadata, metrics, converted_results = redactor.value(
+        [eval_metadata, metrics, converted_results]
+    )
     if redactor.count:
         console.print(
             f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
@@ -206,7 +208,7 @@ def push_eval_results_to_hub(
         model_name=model,
         dataset=env_name,
         framework="verifiers",
-        task_type=metadata.get("task_type"),
+        task_type=eval_metadata.get("task_type"),
         metadata=eval_metadata,
         metrics=metrics,
         is_public=False,  # Private by default - only visible to the user who created it

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -10,6 +10,7 @@ from prime_cli.core import APIClient
 from .display import get_eval_viewer_url
 from .env_metadata import find_environment_metadata
 from .plain import get_console
+from .redact import Redactor, known_secrets
 
 console = get_console()
 
@@ -158,6 +159,7 @@ def push_eval_results_to_hub(
     console.print(f"\n[blue]Uploading evaluation results, using upstream: {env_identifier}[/blue]")
 
     api_client = APIClient()
+    redactor = Redactor(known_secrets(api_client.api_key))
 
     if resolved_env_id:
         environments = [{"id": resolved_env_id}]
@@ -187,6 +189,12 @@ def push_eval_results_to_hub(
         }
         for sample in results_samples
     ]
+    eval_metadata, converted_results = redactor.value([eval_metadata, converted_results])
+    if redactor.count:
+        console.print(
+            f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
+            "local files are unchanged[/yellow]"
+        )
 
     eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -160,6 +160,18 @@ def push_eval_results_to_hub(
 
     api_client = APIClient()
     redactor = Redactor(known_secrets(api_client.api_key))
+    # Everything from here on is what the platform receives: redact it all up front. A
+    # secret inside an identifier makes the request fail rather than leak it.
+    env_name, model, job_id, resolved_env_slug, resolved_env_id, metadata, results_samples = (
+        redactor.value(
+            [env_name, model, job_id, resolved_env_slug, resolved_env_id, metadata, results_samples]
+        )
+    )
+    if redactor.count:
+        console.print(
+            f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
+            "local files are unchanged[/yellow]"
+        )
 
     if resolved_env_id:
         environments = [{"id": resolved_env_id}]
@@ -189,14 +201,6 @@ def push_eval_results_to_hub(
         }
         for sample in results_samples
     ]
-    eval_metadata, metrics, converted_results = redactor.value(
-        [eval_metadata, metrics, converted_results]
-    )
-    if redactor.count:
-        console.print(
-            f"[yellow]Redacted {redactor.count} occurrence(s) of known secrets; "
-            "local files are unchanged[/yellow]"
-        )
 
     eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -208,7 +212,7 @@ def push_eval_results_to_hub(
         model_name=model,
         dataset=env_name,
         framework="verifiers",
-        task_type=eval_metadata.get("task_type"),
+        task_type=metadata.get("task_type"),
         metadata=eval_metadata,
         metrics=metrics,
         is_public=False,  # Private by default - only visible to the user who created it

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -30,20 +30,27 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
 def url_credentials(value: str) -> Iterator[str]:
-    """The password — or the bare user token — inside a `scheme://user:password@host`
-    value, as written and percent-decoded the way a client uses it. A username next to a
-    password is a name, not a secret (`postgres`), so a token placed there beside a dummy
-    password (GitHub's legacy `token:x-oauth-basic`) is not recognised."""
+    """The credentials inside a URL, as written and percent-decoded the way a client uses
+    them: the password — or the bare user token — of `scheme://user:password@host`, and
+    credential-named query values (`?token=…`). A username next to a password is a name,
+    not a secret (`postgres`), so a token placed there beside a dummy password (GitHub's
+    legacy `token:x-oauth-basic`) is not recognised. Prose is never a URL here: the
+    value must start with `scheme://host`."""
     try:
         parts = urlsplit(value)
     except ValueError:
         return
-    if "@" not in parts.netloc:
+    if not (parts.scheme and parts.netloc):
         return
-    # With a password slot, even an empty one, the username is a name, not a token.
-    userinfo = parts.username if parts.password is None else parts.password
-    if userinfo:
-        yield from {userinfo, unquote(userinfo)}
+    if "@" in parts.netloc:
+        # With a password slot, even an empty one, the username is a name, not a token.
+        userinfo = parts.username if parts.password is None else parts.password
+        if userinfo:
+            yield from {userinfo, unquote(userinfo)}
+    for pair in parts.query.split("&"):
+        name, _, raw = pair.partition("=")
+        if raw and SECRET_NAME.search(name):
+            yield from {raw, unquote(raw)}
 
 
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -1,0 +1,77 @@
+"""Keep known secret values out of uploads.
+
+Redaction is exact-match only: a known value is replaced with `[REDACTED]` wherever it
+appears inside a JSON string, and nothing is guessed from the shape of the text, so
+ordinary content is never rewritten. Values come from the process environment
+(variables whose names look like credentials), the Prime API key, and `--secret`
+arguments. Local files are never modified.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+REDACTED = "[REDACTED]"
+MIN_SECRET_LENGTH = 8
+SECRET_NAME = re.compile(
+    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
+    re.IGNORECASE,
+)
+"""Variable names whose values are credentials."""
+JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:
+    """Credential-named environment values, the given values, and `--secret` arguments
+    (a literal, or the path of a file with one secret per line). Environment values
+    shorter than `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary
+    text; explicit values are taken as given."""
+    secrets = {
+        value
+        for name, value in os.environ.items()
+        if SECRET_NAME.search(name) and len(value) >= MIN_SECRET_LENGTH
+    }
+    secrets.update(value for value in values if value)
+    for arg in secret_args:
+        path = Path(arg)
+        lines = path.read_text().splitlines() if path.is_file() else [arg]
+        secrets.update(line.strip() for line in lines)
+    return {secret for secret in secrets if secret}
+
+
+class Redactor:
+    """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
+
+    def __init__(self, secrets: Iterable[str]) -> None:
+        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
+        # a string (a tool result) it is escaped twice. Match every spelling.
+        forms = set(secrets)
+        for _ in range(2):
+            forms |= {
+                json.dumps(form, ensure_ascii=escape)[1:-1]
+                for form in list(forms)
+                for escape in (True, False)
+            }
+        alternatives = "|".join(re.escape(form) for form in sorted(forms, key=len, reverse=True))
+        self.pattern = re.compile(alternatives) if forms else None
+        self.count = 0
+
+    def json(self, text: str) -> str:
+        """Redact one JSON document (or JSONL line) given as text; structure and
+        non-string values stay."""
+        pattern = self.pattern
+        if pattern is None:
+            return text
+
+        def string(match: re.Match[str]) -> str:
+            inner, hits = pattern.subn(REDACTED, match.group(1))
+            self.count += hits
+            return f'"{inner}"'
+
+        return JSON_STRING.sub(string, text)
+
+    def value(self, value: Any) -> Any:
+        """Redact a JSON-compatible value (parsed `metadata.json`, results rows)."""
+        return json.loads(self.json(json.dumps(value)))

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -49,7 +49,7 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {userinfo, unquote(userinfo)}
     for pair in parts.query.split("&"):
         name, _, raw = pair.partition("=")
-        if raw and SECRET_NAME.search(name):
+        if raw and SECRET_NAME.search(unquote(name)):
             yield from {raw, unquote(raw)}
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -54,21 +54,6 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {raw, unquote(raw), unquote_plus(raw)}
 
 
-def overlaps_marker(secret: str) -> bool:
-    """Whether replacing with the marker could leave or form `secret`: one sits inside the
-    other (`REDACTED`, `foo[REDACTED]bar`), or `secret` begins with the marker's tail
-    (`]bar`) or ends with its head (`foo[`). Such a value is a placeholder or a
-    pathological input, never a credential."""
-    return (
-        secret in REDACTED
-        or REDACTED in secret
-        or any(
-            secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
-            for n in range(1, len(REDACTED) + 1)
-        )
-    )
-
-
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping: every value under a credential-like
     name, and the URL credentials in any value whatever its name (`DATABASE_URL`,
@@ -97,11 +82,13 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
         # Taken as given: only a file entry's line terminator goes.
         explicit.update(Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg])
     explicit.discard("")
-    # No fixed marker can hide a value that overlaps it. A discovered one is a sanitized
-    # placeholder (`API_TOKEN=REDACTED`) and is skipped; a requested one is refused.
-    if colliding := sorted(secret for secret in explicit if overlaps_marker(secret)):
-        raise ValueError(f"cannot redact {colliding}: overlaps the {REDACTED} marker")
-    return {secret for secret in discovered if not overlaps_marker(secret)} | explicit
+    # The marker must not contain a secret. A discovered value inside it is a sanitized
+    # placeholder (`API_TOKEN=REDACTED`) and is skipped; a requested one is refused. A
+    # secret that merely contains or borders the marker is kept: leaving it out would
+    # upload it for certain, while a replacement can only form it around another secret.
+    if inside_marker := sorted(secret for secret in explicit if secret in REDACTED):
+        raise ValueError(f"cannot redact {inside_marker}: part of the {REDACTED} marker")
+    return {secret for secret in discovered if secret not in REDACTED} | explicit
 
 
 class Redactor:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -63,21 +63,22 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
     `--secret` arguments (a literal, or the path of a file with one secret per line).
     Environment values shorter than `MIN_SECRET_LENGTH` are dropped — redacting them
     would rewrite ordinary text; explicit values are taken as given."""
-    secrets = {
+    discovered = {
         credential
         for credential in env_credentials(os.environ)
         if len(credential) >= MIN_SECRET_LENGTH
     }
-    secrets.update(value for value in values if value)
+    discovered.update(value for value in values if value)
+    explicit: set[str] = set()
     for arg in secret_args:
-        # `os.path.isfile` is False for anything that cannot be a path, a long literal included.
         # Taken as given: only a file entry's line terminator goes.
-        secrets.update(Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg])
-    secrets.discard("")
-    # No fixed marker can hide a value it contains; refuse rather than upload it.
-    if inside_marker := sorted(secret for secret in secrets if secret in REDACTED):
+        explicit.update(Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg])
+    explicit.discard("")
+    # No fixed marker can hide a value it contains. A discovered one is a sanitized
+    # placeholder (`API_TOKEN=REDACTED`) and is skipped; a requested one is refused.
+    if inside_marker := sorted(secret for secret in explicit if secret in REDACTED):
         raise ValueError(f"cannot redact {inside_marker}: part of the {REDACTED} marker")
-    return secrets
+    return {secret for secret in discovered if secret not in REDACTED} | explicit
 
 
 class Redactor:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -17,15 +17,16 @@ from urllib.parse import unquote, unquote_plus, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?:(?<![A-Za-z0-9])"
+    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable names whose values are credentials: a credential word as a whole segment
-(`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
-`TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
-so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
+(`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`), so `KEYCLOAK_REALM`,
+`OAUTH_CLIENT_ID`, or `TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN,
+SECRET, or PASSWORD, so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -66,8 +66,8 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
     secrets.update(value for value in values if value)
     for arg in secret_args:
         # `os.path.isfile` is False for anything that cannot be a path, a long literal included.
-        lines = Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg]
-        secrets.update(line.strip() for line in lines)
+        # Taken as given: only a file entry's line terminator goes.
+        secrets.update(Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg])
     secrets.discard("")
     # No fixed marker can hide a value it contains; refuse rather than upload it.
     if inside_marker := sorted(secret for secret in secrets if secret in REDACTED):

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -18,15 +18,16 @@ REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
     r"(?:(?<![A-Za-z0-9])"
-    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG)"
+    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable names whose values are credentials: a credential word as a whole segment
-(`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`), so `KEYCLOAK_REALM`,
-`OAUTH_CLIENT_ID`, or `TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN,
-SECRET, or PASSWORD, so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
+(`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so
+`KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, `PYTHONPATH`, or `TOKENIZERS_PARALLELISM` is not one.
+No other word ends in TOKEN, SECRET, or PASSWORD, so those may also end a segment
+(`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -63,7 +63,11 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
         # `os.path.isfile` is False for anything that cannot be a path, a long literal included.
         lines = Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg]
         secrets.update(line.strip() for line in lines)
-    return {secret for secret in secrets if secret}
+    secrets.discard("")
+    # No fixed marker can hide a value it contains; refuse rather than upload it.
+    if inside_marker := sorted(secret for secret in secrets if secret in REDACTED):
+        raise ValueError(f"cannot redact {inside_marker}: part of the {REDACTED} marker")
+    return secrets
 
 
 class Redactor:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -12,7 +12,7 @@ import os
 import re
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping, Optional
-from urllib.parse import unquote, urlsplit
+from urllib.parse import unquote, unquote_plus, urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -50,7 +50,17 @@ def url_credentials(value: str) -> Iterator[str]:
     for pair in parts.query.split("&"):
         name, _, raw = pair.partition("=")
         if raw and SECRET_NAME.search(unquote(name)):
-            yield from {raw, unquote(raw)}
+            yield from {raw, unquote(raw), unquote_plus(raw)}
+
+
+def overlaps_marker(secret: str) -> bool:
+    """Whether replacing with the marker could leave or form `secret`: it sits inside
+    `[REDACTED]`, or begins with the marker's tail (`]bar`) or ends with its head
+    (`foo[`). Such a value is a placeholder or a pathological input, never a credential."""
+    return secret in REDACTED or any(
+        secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
+        for n in range(1, len(REDACTED) + 1)
+    )
 
 
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
@@ -81,11 +91,11 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
         # Taken as given: only a file entry's line terminator goes.
         explicit.update(Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg])
     explicit.discard("")
-    # No fixed marker can hide a value it contains. A discovered one is a sanitized
+    # No fixed marker can hide a value that overlaps it. A discovered one is a sanitized
     # placeholder (`API_TOKEN=REDACTED`) and is skipped; a requested one is refused.
-    if inside_marker := sorted(secret for secret in explicit if secret in REDACTED):
-        raise ValueError(f"cannot redact {inside_marker}: part of the {REDACTED} marker")
-    return {secret for secret in discovered if secret not in REDACTED} | explicit
+    if colliding := sorted(secret for secret in explicit if overlaps_marker(secret)):
+        raise ValueError(f"cannot redact {colliding}: overlaps the {REDACTED} marker")
+    return {secret for secret in discovered if not overlaps_marker(secret)} | explicit
 
 
 class Redactor:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -3,15 +3,16 @@
 Redaction is exact-match only: a known value is replaced with `[REDACTED]` wherever it
 appears inside a JSON string, and nothing is guessed from the shape of the text, so
 ordinary content is never rewritten. Values come from the process environment
-(variables whose names look like credentials), the Prime API key, and `--secret`
-arguments. Local files are never modified.
+(credential-like variable names, and the password inside connection URLs), the Prime
+API key, and `--secret` arguments. Local files are never modified.
 """
 
 import json
 import os
 import re
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Iterator, Mapping, Optional
+from urllib.parse import urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -23,15 +24,32 @@ SECRET_NAME = re.compile(
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
+def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
+    """The credentials in an environment-like mapping: every value under a credential-like
+    name, and the password — or the bare user token — inside a `scheme://user:password@host`
+    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`)."""
+    for name, value in mapping.items():
+        if not isinstance(value, str):
+            continue
+        if SECRET_NAME.search(name):
+            yield value
+        try:
+            parts = urlsplit(value)
+        except ValueError:
+            continue
+        if "@" in parts.netloc and (userinfo := parts.password or parts.username):
+            yield userinfo
+
+
 def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:
-    """Credential-named environment values, the given values, and `--secret` arguments
-    (a literal, or the path of a file with one secret per line). Environment values
-    shorter than `MIN_SECRET_LENGTH` are dropped — redacting them would rewrite ordinary
-    text; explicit values are taken as given."""
+    """The process environment's credentials (`env_credentials`), the given values, and
+    `--secret` arguments (a literal, or the path of a file with one secret per line).
+    Environment values shorter than `MIN_SECRET_LENGTH` are dropped — redacting them
+    would rewrite ordinary text; explicit values are taken as given."""
     secrets = {
-        value
-        for name, value in os.environ.items()
-        if SECRET_NAME.search(name) and len(value) >= MIN_SECRET_LENGTH
+        credential
+        for credential in env_credentials(os.environ)
+        if len(credential) >= MIN_SECRET_LENGTH
     }
     secrets.update(value for value in values if value)
     for arg in secret_args:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -58,16 +58,27 @@ def url_credentials(value: str) -> Iterator[str]:
             yield from {raw, unquote(raw), unquote_plus(raw)}
 
 
-def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
-    """The credentials in an environment-like mapping: every value under a credential-like
-    name, and the URL credentials in any value whatever its name (`DATABASE_URL`,
-    `HTTP_PROXY`)."""
+def env_credentials(mapping: Mapping[Any, Any]) -> Iterator[str]:
+    """The credentials in an environment-like mapping (variables, headers): every value
+    under a credential-like name, the URL credentials in any value whatever its name
+    (`DATABASE_URL`, `HTTP_PROXY`), and the same again inside a value that is a JSON
+    object (`DOCKER_AUTH_CONFIG`, a service-account blob), which is a mapping too."""
     for name, value in mapping.items():
+        if isinstance(value, Mapping):
+            yield from env_credentials(value)
+            continue
         if not isinstance(value, str):
             continue
         if SECRET_NAME.search(name):
             yield value
         yield from url_credentials(value)
+        if value.startswith("{"):
+            try:
+                nested = json.loads(value)
+            except ValueError:
+                continue
+            if isinstance(nested, Mapping):
+                yield from env_credentials(nested)
 
 
 def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -40,7 +40,11 @@ def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
             parts = urlsplit(value)
         except ValueError:
             continue
-        if "@" in parts.netloc and (userinfo := parts.password or parts.username):
+        if "@" not in parts.netloc:
+            continue
+        # With a password slot, even an empty one, the username is a name, not a token.
+        userinfo = parts.username if parts.password is None else parts.password
+        if userinfo:
             yield from {userinfo, unquote(userinfo)}
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -17,13 +17,15 @@ from urllib.parse import unquote, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"(?<![A-Za-z0-9])"
-    r"(?:API_?KEYS?|KEYS?|TOKENS?|SECRETS?|PASSW(?:OR)?DS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?:(?<![A-Za-z0-9])(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 """Variable names whose values are credentials: a credential word as a whole segment
-(`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` is not one."""
+(`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, or
+`TOKENIZERS_PARALLELISM` is not one. No other word ends in TOKEN, SECRET, or PASSWORD,
+so those may also end a segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -45,32 +45,30 @@ class Redactor:
     """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
 
     def __init__(self, secrets: Iterable[str]) -> None:
-        # The string itself is decoded before matching. A JSON document quoted inside it
-        # (a tool result) is escaped once per nesting level, by an encoder that may also
-        # escape `/`: match those spellings too.
-        forms = set(secrets)
-        forms |= {form.replace("/", r"\/") for form in forms}
-        for _ in range(2):
-            forms |= {
-                json.dumps(form, ensure_ascii=escape)[1:-1]
-                for form in list(forms)
-                for escape in (True, False)
-            }
-        alternatives = "|".join(re.escape(form) for form in sorted(forms, key=len, reverse=True))
-        self.pattern = re.compile(alternatives) if forms else None
+        secrets = set(secrets)
+        alternatives = "|".join(
+            re.escape(secret) for secret in sorted(secrets, key=len, reverse=True)
+        )
+        self.pattern = re.compile(alternatives) if secrets else None
         self.count = 0
 
     def json(self, text: str) -> str:
         """Redact one JSON document (or JSONL line) given as text; structure and
-        non-string values stay, and so do the bytes of every string without a hit."""
+        non-string values stay, and so do the bytes of every string without a hit. Each
+        string is decoded before matching and searched again for quoted JSON inside it
+        (a tool result), so every escape spelling at every nesting depth is matched."""
         pattern = self.pattern
         if pattern is None:
             return text
 
         def string(match: re.Match[str]) -> str:
             token = match.group(0)
-            redacted, hits = pattern.subn(REDACTED, json.loads(token))
-            if not hits:
+            try:
+                value = json.loads(token)
+            except ValueError:  # quotes in prose, not a JSON string
+                return token
+            redacted, hits = pattern.subn(REDACTED, self.json(value))
+            if redacted == value:
                 return token
             self.count += hits
             return json.dumps(redacted, ensure_ascii=token.isascii())

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -18,19 +18,19 @@ REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
     r"(?:(?<![A-Za-z0-9])"
-    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|SIGNATURES?|SIG|PATS?)"
+    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
-    r"(?![A-Za-z0-9])"
-    r"|(?<![A-Za-z0-9])AUTH$",
+    r"(?:[_-][0-9]+)?$",
     re.IGNORECASE,
 )
-"""Variable names whose values are credentials: a credential word as a whole segment
-(`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so
-`KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, `PYTHONPATH`, or `TOKENIZERS_PARALLELISM` is not one.
-AUTH counts only as the last segment (`BASIC_AUTH`, `X-Auth`): elsewhere it says what a
-variable is about, not what it holds (`AUTH_TYPE`, `SSH_AUTH_SOCK`). No other word ends
-in TOKEN, SECRET, or PASSWORD, so those may also end a segment (`PGPASSWORD`,
-`ACCESSTOKEN`)."""
+"""Variable and header names whose values are credentials: the name's last word is a
+credential word (`HF_TOKEN`, `X-Api-Key`, `PGPASSWORD`), optionally numbered
+(`API_KEY_2`). Compound names are head-final, so `TOKEN_URL`, `COOKIE_DOMAIN`,
+`KEY_FILE`, `AUTHORIZATION_URL`, and `SSH_AUTH_SOCK` name metadata about a credential
+rather than one, and `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` never named one. A
+name whose head word is not a credential word (`SECRET_KEY_BASE`) is missed on
+purpose. No other word ends in TOKEN, SECRET, or PASSWORD, so those may also end a
+segment (`PGPASSWORD`, `ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -18,16 +18,19 @@ REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
     r"(?:(?<![A-Za-z0-9])"
-    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH|SIGNATURES?|SIG|PATS?)"
+    r"(?:API_?KEYS?|KEYS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|SIGNATURES?|SIG|PATS?)"
     r"|TOKENS?|SECRETS?|PASSW(?:OR)?DS?)"
-    r"(?![A-Za-z0-9])",
+    r"(?![A-Za-z0-9])"
+    r"|(?<![A-Za-z0-9])AUTH$",
     re.IGNORECASE,
 )
 """Variable names whose values are credentials: a credential word as a whole segment
 (`HF_TOKEN`, `X-Api-Key`, a signed URL's `sig`/`X-Amz-Signature`, `GITHUB_PAT`), so
 `KEYCLOAK_REALM`, `OAUTH_CLIENT_ID`, `PYTHONPATH`, or `TOKENIZERS_PARALLELISM` is not one.
-No other word ends in TOKEN, SECRET, or PASSWORD, so those may also end a segment
-(`PGPASSWORD`, `ACCESSTOKEN`)."""
+AUTH counts only as the last segment (`BASIC_AUTH`, `X-Auth`): elsewhere it says what a
+variable is about, not what it holds (`AUTH_TYPE`, `SSH_AUTH_SOCK`). No other word ends
+in TOKEN, SECRET, or PASSWORD, so those may also end a segment (`PGPASSWORD`,
+`ACCESSTOKEN`)."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -20,7 +20,7 @@ SECRET_NAME = re.compile(
     re.IGNORECASE,
 )
 """Variable names whose values are credentials."""
-JSON_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
 def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:
@@ -45,9 +45,9 @@ class Redactor:
     """Replaces every occurrence of the secrets inside JSON strings, counting hits."""
 
     def __init__(self, secrets: Iterable[str]) -> None:
-        # Inside a JSON string a secret is escaped; inside a JSON document quoted within
-        # a string (a tool result) it is escaped twice. Encoders other than Python's
-        # also escape `/`. Match every spelling.
+        # The string itself is decoded before matching. A JSON document quoted inside it
+        # (a tool result) is escaped once per nesting level, by an encoder that may also
+        # escape `/`: match those spellings too.
         forms = set(secrets)
         forms |= {form.replace("/", r"\/") for form in forms}
         for _ in range(2):
@@ -62,15 +62,18 @@ class Redactor:
 
     def json(self, text: str) -> str:
         """Redact one JSON document (or JSONL line) given as text; structure and
-        non-string values stay."""
+        non-string values stay, and so do the bytes of every string without a hit."""
         pattern = self.pattern
         if pattern is None:
             return text
 
         def string(match: re.Match[str]) -> str:
-            inner, hits = pattern.subn(REDACTED, match.group(1))
+            token = match.group(0)
+            redacted, hits = pattern.subn(REDACTED, json.loads(token))
+            if not hits:
+                return token
             self.count += hits
-            return f'"{inner}"'
+            return json.dumps(redacted, ensure_ascii=token.isascii())
 
         return JSON_STRING.sub(string, text)
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -24,28 +24,33 @@ SECRET_NAME = re.compile(
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 
+def url_credentials(value: str) -> Iterator[str]:
+    """The password — or the bare user token — inside a `scheme://user:password@host`
+    value, as written and percent-decoded the way a client uses it. A username next to a
+    password is a name, not a secret (`postgres`), so a token placed there beside a dummy
+    password (GitHub's legacy `token:x-oauth-basic`) is not recognised."""
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return
+    if "@" not in parts.netloc:
+        return
+    # With a password slot, even an empty one, the username is a name, not a token.
+    userinfo = parts.username if parts.password is None else parts.password
+    if userinfo:
+        yield from {userinfo, unquote(userinfo)}
+
+
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping: every value under a credential-like
-    name, and the password — or the bare user token — inside a `scheme://user:password@host`
-    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`), as written and percent-decoded
-    the way a client uses it. A username next to a password
-    is a name, not a secret (`postgres`), so a token placed there beside a dummy password
-    (GitHub's legacy `token:x-oauth-basic`) is not recognised."""
+    name, and the URL credentials in any value whatever its name (`DATABASE_URL`,
+    `HTTP_PROXY`)."""
     for name, value in mapping.items():
         if not isinstance(value, str):
             continue
         if SECRET_NAME.search(name):
             yield value
-        try:
-            parts = urlsplit(value)
-        except ValueError:
-            continue
-        if "@" not in parts.netloc:
-            continue
-        # With a password slot, even an empty one, the username is a name, not a token.
-        userinfo = parts.username if parts.password is None else parts.password
-        if userinfo:
-            yield from {userinfo, unquote(userinfo)}
+        yield from url_credentials(value)
 
 
 def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -46,8 +46,10 @@ class Redactor:
 
     def __init__(self, secrets: Iterable[str]) -> None:
         # Inside a JSON string a secret is escaped; inside a JSON document quoted within
-        # a string (a tool result) it is escaped twice. Match every spelling.
+        # a string (a tool result) it is escaped twice. Encoders other than Python's
+        # also escape `/`. Match every spelling.
         forms = set(secrets)
+        forms |= {form.replace("/", r"\/") for form in forms}
         for _ in range(2):
             forms |= {
                 json.dumps(form, ensure_ascii=escape)[1:-1]

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -12,7 +12,7 @@ import os
 import re
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping, Optional
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
@@ -27,7 +27,8 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping: every value under a credential-like
     name, and the password — or the bare user token — inside a `scheme://user:password@host`
-    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`). A username next to a password
+    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`), as written and percent-decoded
+    the way a client uses it. A username next to a password
     is a name, not a secret (`postgres`), so a token placed there beside a dummy password
     (GitHub's legacy `token:x-oauth-basic`) is not recognised."""
     for name, value in mapping.items():
@@ -40,7 +41,7 @@ def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
         except ValueError:
             continue
         if "@" in parts.netloc and (userinfo := parts.password or parts.username):
-            yield userinfo
+            yield from {userinfo, unquote(userinfo)}
 
 
 def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> set[str]:
@@ -55,8 +56,8 @@ def known_secrets(*values: Optional[str], secret_args: Iterable[str] = ()) -> se
     }
     secrets.update(value for value in values if value)
     for arg in secret_args:
-        path = Path(arg)
-        lines = path.read_text().splitlines() if path.is_file() else [arg]
+        # `os.path.isfile` is False for anything that cannot be a path, a long literal included.
+        lines = Path(arg).read_text().splitlines() if os.path.isfile(arg) else [arg]
         secrets.update(line.strip() for line in lines)
     return {secret for secret in secrets if secret}
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -54,12 +54,17 @@ def url_credentials(value: str) -> Iterator[str]:
 
 
 def overlaps_marker(secret: str) -> bool:
-    """Whether replacing with the marker could leave or form `secret`: it sits inside
-    `[REDACTED]`, or begins with the marker's tail (`]bar`) or ends with its head
-    (`foo[`). Such a value is a placeholder or a pathological input, never a credential."""
-    return secret in REDACTED or any(
-        secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
-        for n in range(1, len(REDACTED) + 1)
+    """Whether replacing with the marker could leave or form `secret`: one sits inside the
+    other (`REDACTED`, `foo[REDACTED]bar`), or `secret` begins with the marker's tail
+    (`]bar`) or ends with its head (`foo[`). Such a value is a placeholder or a
+    pathological input, never a credential."""
+    return (
+        secret in REDACTED
+        or REDACTED in secret
+        or any(
+            secret.startswith(REDACTED[-n:]) or secret.endswith(REDACTED[:n])
+            for n in range(1, len(REDACTED) + 1)
+        )
     )
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -72,7 +72,7 @@ def env_credentials(mapping: Mapping[Any, Any]) -> Iterator[str]:
         if SECRET_NAME.search(name):
             yield value
         yield from url_credentials(value)
-        if value.startswith("{"):
+        if value.lstrip().startswith("{"):
             try:
                 nested = json.loads(value)
             except ValueError:

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -17,10 +17,13 @@ from urllib.parse import unquote, urlsplit
 REDACTED = "[REDACTED]"
 MIN_SECRET_LENGTH = 8
 SECRET_NAME = re.compile(
-    r"KEY|TOKEN|SECRET|PASSW|CREDENTIAL|COOKIE|AUTHORIZATION|(?:^|[_-])AUTH(?:[_-]|$)",
+    r"(?<![A-Za-z0-9])"
+    r"(?:API_?KEYS?|KEYS?|TOKENS?|SECRETS?|PASSW(?:OR)?DS?|CREDENTIALS?|COOKIES?|AUTHORIZATION|AUTH)"
+    r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
-"""Variable names whose values are credentials."""
+"""Variable names whose values are credentials: a credential word as a whole segment
+(`HF_TOKEN`, `X-Api-Key`), so `KEYCLOAK_REALM` or `TOKENIZERS_PARALLELISM` is not one."""
 JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 
 

--- a/packages/prime/src/prime_cli/utils/redact.py
+++ b/packages/prime/src/prime_cli/utils/redact.py
@@ -27,7 +27,9 @@ JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
 def env_credentials(mapping: Mapping[str, object]) -> Iterator[str]:
     """The credentials in an environment-like mapping: every value under a credential-like
     name, and the password — or the bare user token — inside a `scheme://user:password@host`
-    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`)."""
+    value whatever its name (`DATABASE_URL`, `HTTP_PROXY`). A username next to a password
+    is a name, not a secret (`postgres`), so a token placed there beside a dummy password
+    (GitHub's legacy `token:x-oauth-basic`) is not recognised."""
     for name, value in mapping.items():
         if not isinstance(value, str):
             continue

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -368,8 +368,11 @@ class TestPushSingleEval:
         monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
-        _push_single_eval(str(tmp_path), None, None, None, secrets=["literal-0001"])
+        _push_single_eval(
+            str(tmp_path), None, None, None, name="run literal-0001", secrets=["literal-0001"]
+        )
 
+        assert captured["name"] == "run [REDACTED]"
         assert captured["metadata"]["note"] == "[REDACTED]"
         assert captured["samples"][0]["completion"] == "[REDACTED] [REDACTED] [REDACTED] keep"
         assert json.loads((tmp_path / "results.jsonl").read_text()) == sample

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -16,6 +16,10 @@ from typing_extensions import cast
 runner = CliRunner()
 
 
+class _StubAPIClient:
+    api_key = "stub-api-key-0001"
+
+
 class TestHasEvalFiles:
     """Tests for _has_eval_files function"""
 
@@ -151,7 +155,7 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_push_single_eval(config_path, env_slug, run_id, eval_id, is_public, name):
+    def fake_push_single_eval(config_path, env_slug, run_id, eval_id, is_public, name, secrets):
         captured.update(
             {
                 "config_path": config_path,
@@ -236,7 +240,7 @@ def test_push_eval_cli_supports_old_prime_evals_client(monkeypatch, tmp_path):
             return {}
 
     monkeypatch.setattr("prime_cli.commands.evals.console", TerminalConsole())
-    monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
     monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", OldEvalsClient)
 
     (tmp_path / "metadata.json").write_text(
@@ -303,7 +307,7 @@ class TestPushSingleEval:
                 captured["finalized_evaluation_id"] = evaluation_id
                 captured["finalized_metrics"] = metrics
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
         eval_id = _push_single_eval(str(tmp_path), None, None, None)
@@ -312,10 +316,11 @@ class TestPushSingleEval:
         assert captured["is_public"] is False
         assert captured["environments"] == [{"slug": "owner/gsm8k"}]
 
-    def test_create_evaluation_requires_pushed_environment(self, tmp_path, capsys):
+    def test_create_evaluation_requires_pushed_environment(self, tmp_path, capsys, monkeypatch):
         metadata = {"env": "gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
 
         with pytest.raises(typer.Exit) as exc_info:
             _push_single_eval(str(tmp_path), None, None, None)
@@ -325,6 +330,49 @@ class TestPushSingleEval:
         assert "Evaluation uploads require a pushed environment" in output
         assert "prime env push gsm8k" in output
         assert "--env <owner>/gsm8k" in output
+
+    def test_push_redacts_known_secrets_before_upload(self, tmp_path, monkeypatch):
+        """Values from --secret, credential-named environment variables, and the API key
+        are replaced in every outgoing field; the local files keep them."""
+        monkeypatch.setenv("JUDGE_API_KEY", "judge-key-0001-abcd")
+        metadata = {
+            "env": "owner/gsm8k",
+            "model": "gpt-4",
+            "avg_reward": 0.5,
+            "note": "judge-key-0001-abcd",
+        }
+        sample = {
+            "id": 1,
+            "reward": 1.0,
+            "completion": "stub-api-key-0001 judge-key-0001-abcd literal-0001 keep",
+        }
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text(json.dumps(sample) + "\n")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def push_samples(self, evaluation_id, samples):
+                captured["samples"] = samples
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                pass
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        _push_single_eval(str(tmp_path), None, None, None, secrets=["literal-0001"])
+
+        assert captured["metadata"]["note"] == "[REDACTED]"
+        assert captured["samples"][0]["completion"] == "[REDACTED] [REDACTED] [REDACTED] keep"
+        assert json.loads((tmp_path / "results.jsonl").read_text()) == sample
 
     def test_create_evaluation_passes_public_flag(self, tmp_path, monkeypatch):
         metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
@@ -345,7 +393,7 @@ class TestPushSingleEval:
                 captured["finalized_evaluation_id"] = evaluation_id
                 captured["finalized_metrics"] = metrics
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
         eval_id = _push_single_eval(str(tmp_path), None, None, None, is_public=True)
@@ -372,7 +420,7 @@ class TestPushSingleEval:
                 captured["finalized_evaluation_id"] = evaluation_id
                 captured["finalized_metrics"] = metrics
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
         eval_id = _push_single_eval(str(tmp_path), None, None, None, name="explicit override")
@@ -402,7 +450,7 @@ class TestPushSingleEval:
                 captured["finalized_evaluation_id"] = evaluation_id
                 captured["finalized_metrics"] = metrics
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
         eval_id = _push_single_eval(str(tmp_path), None, None, "eval-123", name="explicit override")
@@ -430,7 +478,7 @@ class TestPushSingleEval:
                     "viewer_url": "https://app.primeintellect.ai/dashboard/evaluations/eval-123"
                 }
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
         monkeypatch.setattr(
             "prime_cli.commands.evals.get_eval_viewer_url",
@@ -462,7 +510,7 @@ class TestPushSingleEval:
                 assert metrics == {}
                 return {}
 
-        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", _StubAPIClient)
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
         monkeypatch.setattr(
             "prime_cli.commands.evals.get_eval_viewer_url",

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -369,9 +369,15 @@ class TestPushSingleEval:
         monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
 
         _push_single_eval(
-            str(tmp_path), None, None, None, name="run literal-0001", secrets=["literal-0001"]
+            str(tmp_path),
+            None,
+            "run-literal-0001",
+            None,
+            name="run literal-0001",
+            secrets=["literal-0001"],
         )
 
+        assert captured["run_id"] == "run-[REDACTED]"
         assert captured["name"] == "run [REDACTED]"
         assert captured["metadata"]["note"] == "[REDACTED]"
         assert captured["samples"][0]["completion"] == "[REDACTED] [REDACTED] [REDACTED] keep"

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -64,6 +64,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("NOTE", "see ?token=prose-token-0001")  # prose, not a URL
     monkeypatch.setenv("ODD_URL", "https://h.example/?to%6ben=encoded-name-0001")  # encoded name
     monkeypatch.setenv("FORM_URL", "https://h.example/?token=plus+sep+0001")  # form encoding
+    monkeypatch.setenv("SAS_URL", "https://a.blob.core.windows.net/c?sv=2020&sig=sas-sig-000001")
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -93,6 +94,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "encoded-name-0001",
         "plus+sep+0001",
         "plus sep 0001",  # as a form-decoding client uses it
+        "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -73,6 +73,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("ODD_URL", "https://h.example/?to%6ben=encoded-name-0001")  # encoded name
     monkeypatch.setenv("FORM_URL", "https://h.example/?token=plus+sep+0001")  # form encoding
     monkeypatch.setenv("SAS_URL", "https://a.blob.core.windows.net/c?sv=2020&sig=sas-sig-000001")
+    monkeypatch.setenv("GITHUB_PAT", "ghp_pat_000000000001")  # PAT is a credential word
+    monkeypatch.setenv("PYTHONPATH", "/opt/keep/this/path")  # PATH is not
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -103,6 +105,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "plus+sep+0001",
         "plus sep 0001",  # as a form-decoding client uses it
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
+        "ghp_pat_000000000001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -117,6 +120,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "/home/user/.pgpass",
             "[REDACTED]",
             "prose-token-0001",
+            "/opt/keep/this/path",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -50,6 +50,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
+    monkeypatch.setenv("RO_URL", "postgres://readonly_user:@db")  # empty password: a name
     secrets_file = tmp_path / "secrets"
     secrets_file.write_text("from-file-0001\n\n  spaced  \n")
 
@@ -70,4 +71,13 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "p@ss-000001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
-    assert not {"short", "Some Author Name", "", "postgres://app:db-pass-000001@db/x"} & found
+    assert (
+        not {
+            "short",
+            "Some Author Name",
+            "",
+            "postgres://app:db-pass-000001@db/x",
+            "readonly_user",
+        }
+        & found
+    )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -36,7 +36,7 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
         assert redactor.count == 8
 
 
-@pytest.mark.parametrize("value", ["REDACTED", "]bar", "foo[", "ED]tail"])
+@pytest.mark.parametrize("value", ["REDACTED", "]bar", "foo[", "ED]tail", "foo[REDACTED]bar"])
 def test_known_secrets_refuses_values_that_overlap_the_marker(value):
     with pytest.raises(ValueError, match="REDACTED"):
         known_secrets(secret_args=[value])

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -47,6 +47,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("X-Auth", "hyphenated-auth-0001")
     monkeypatch.setenv("MY_SHORT_KEY", "short")  # too short to redact safely
     monkeypatch.setenv("GIT_AUTHOR_NAME", "Some Author Name")  # AUTHOR is not AUTH
+    monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
+    monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     secrets_file = tmp_path / "secrets"
     secrets_file.write_text("from-file-0001\n\n  spaced  \n")
 
@@ -59,5 +61,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "literal",
         "from-file-0001",
         "spaced",
+        "db-pass-000001",
+        "ghp_token_000000001",
     } <= found
-    assert not {"short", "Some Author Name", ""} & found
+    assert not {"short", "Some Author Name", "", "postgres://app:db-pass-000001@db/x"} & found

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -1,5 +1,6 @@
 """Exact-match redaction: a known value disappears from JSON strings in every spelling
-(plain, escaped, escaped again inside a quoted JSON document) and nothing else changes."""
+(plain, escaped, escaped again inside quoted JSON documents at any depth, with the `\\/`
+and uppercase-hex escapes other encoders emit) and nothing else changes."""
 
 import json
 
@@ -12,6 +13,8 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
         "plain": 'pa"ss\\word-0001 and ünïcode-secret',
         "nested": json.dumps({"k": 'pa"ss\\word-0001', "u": "ünïcode-secret"}),
         "slashes": '{"url": "hooks\\/abc\\/def"}',  # a JS/PHP-style encoder escapes `/`
+        "upper": '{"u": "\\u00FCn\\u00EFcode-secret"}',  # uppercase hex escapes
+        "deep": json.dumps({"log": json.dumps({"k": 'pa"ss\\word-0001', "n": 1})}),
         "number": 12345678,  # a JSON number is not a string: untouched
         "text": "12345678",
         "keep": "ordinary text",
@@ -23,11 +26,13 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
             "plain": "[REDACTED] and [REDACTED]",
             "nested": json.dumps({"k": "[REDACTED]", "u": "[REDACTED]"}),
             "slashes": '{"url": "[REDACTED]"}',
+            "upper": '{"u": "[REDACTED]"}',
+            "deep": json.dumps({"log": json.dumps({"k": "[REDACTED]", "n": 1})}),
             "number": 12345678,
             "text": "[REDACTED]",
             "keep": "ordinary text",
         }
-        assert redactor.count == 6
+        assert redactor.count == 8
 
 
 def test_redactor_without_secrets_leaves_text_untouched():

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -7,10 +7,11 @@ from prime_cli.utils.redact import Redactor, known_secrets
 
 
 def test_redactor_replaces_every_spelling_inside_strings_only():
-    redactor = Redactor({'pa"ss\\word-0001', "12345678", "ünïcode-secret"})
+    redactor = Redactor({'pa"ss\\word-0001', "12345678", "ünïcode-secret", "hooks/abc/def"})
     doc = {
         "plain": 'pa"ss\\word-0001 and ünïcode-secret',
         "nested": json.dumps({"k": 'pa"ss\\word-0001', "u": "ünïcode-secret"}),
+        "slashes": '{"url": "hooks\\/abc\\/def"}',  # a JS/PHP-style encoder escapes `/`
         "number": 12345678,  # a JSON number is not a string: untouched
         "text": "12345678",
         "keep": "ordinary text",
@@ -21,11 +22,12 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
         assert out == {
             "plain": "[REDACTED] and [REDACTED]",
             "nested": json.dumps({"k": "[REDACTED]", "u": "[REDACTED]"}),
+            "slashes": '{"url": "[REDACTED]"}',
             "number": 12345678,
             "text": "[REDACTED]",
             "keep": "ordinary text",
         }
-        assert redactor.count == 5
+        assert redactor.count == 6
 
 
 def test_redactor_without_secrets_leaves_text_untouched():

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -59,6 +59,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("PGPASSWORD", "pg-pass-000001")  # and PGPASSWORD a password
     monkeypatch.setenv("PGPASSFILE", "/home/user/.pgpass")  # a path, not a password
     monkeypatch.setenv("LEGACY_API_KEY", "[REDACTED]")  # a sanitized placeholder: skipped
+    monkeypatch.setenv("BROWSER_URL", "wss://b.example/devtools?token=query-token-0001&v=2")
+    monkeypatch.setenv("NOTE", "see ?token=prose-token-0001")  # prose, not a URL
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -84,6 +86,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "p@ss-000001",
         "apikey-nosep-0001",
         "pg-pass-000001",
+        "query-token-0001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -97,6 +100,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "/home/user/config",
             "/home/user/.pgpass",
             "[REDACTED]",
+            "prose-token-0001",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -36,10 +36,18 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
         assert redactor.count == 8
 
 
-@pytest.mark.parametrize("value", ["REDACTED", "]bar", "foo[", "ED]tail", "foo[REDACTED]bar"])
-def test_known_secrets_refuses_values_that_overlap_the_marker(value):
+@pytest.mark.parametrize("value", ["REDACTED", "[REDACTED", "ED]"])
+def test_known_secrets_refuses_values_inside_the_marker(value):
     with pytest.raises(ValueError, match="REDACTED"):
         known_secrets(secret_args=[value])
+
+
+def test_known_secrets_keeps_values_that_contain_or_border_the_marker(monkeypatch):
+    """Skipping these would upload a real credential for certain; a replacement can only
+    form one of them around another registered secret."""
+    monkeypatch.setenv("SERVICE_PASSWORD", "live[REDACTED]pass-123")
+    found = known_secrets(secret_args=["]bar", "foo["])
+    assert {"live[REDACTED]pass-123", "]bar", "foo["} <= found
 
 
 def test_redactor_without_secrets_leaves_text_untouched():

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -53,6 +53,9 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("X-Auth", "hyphenated-auth-0001")
     monkeypatch.setenv("MY_SHORT_KEY", "short")  # too short to redact safely
     monkeypatch.setenv("GIT_AUTHOR_NAME", "Some Author Name")  # AUTHOR is not AUTH
+    monkeypatch.setenv("KEYCLOAK_REALM", "production-realm")  # KEYCLOAK is not KEY
+    monkeypatch.setenv("COOKIECUTTER_CONFIG", "/home/user/config")  # nor COOKIE
+    monkeypatch.setenv("OPENAI_APIKEY", "apikey-nosep-0001")  # but APIKEY is a key
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -76,6 +79,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "ghp_token_000000001",
         "p%40ss-000001",
         "p@ss-000001",
+        "apikey-nosep-0001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -85,6 +89,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "",
             "postgres://app:db-pass-000001@db/x",
             "readonly_user",
+            "production-realm",
+            "/home/user/config",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -58,6 +58,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_APIKEY", "apikey-nosep-0001")  # but APIKEY is a key
     monkeypatch.setenv("PGPASSWORD", "pg-pass-000001")  # and PGPASSWORD a password
     monkeypatch.setenv("PGPASSFILE", "/home/user/.pgpass")  # a path, not a password
+    monkeypatch.setenv("LEGACY_API_KEY", "[REDACTED]")  # a sanitized placeholder: skipped
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -95,6 +96,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "production-realm",
             "/home/user/config",
             "/home/user/.pgpass",
+            "[REDACTED]",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -4,6 +4,7 @@ and uppercase-hex escapes other encoders emit) and nothing else changes."""
 
 import json
 
+import pytest
 from prime_cli.utils.redact import Redactor, known_secrets
 
 
@@ -33,6 +34,11 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
             "keep": "ordinary text",
         }
         assert redactor.count == 8
+
+
+def test_known_secrets_refuses_values_the_marker_would_keep():
+    with pytest.raises(ValueError, match="REDACTED"):
+        known_secrets(secret_args=["REDACTED"])
 
 
 def test_redactor_without_secrets_leaves_text_untouched():

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -36,9 +36,10 @@ def test_redactor_replaces_every_spelling_inside_strings_only():
         assert redactor.count == 8
 
 
-def test_known_secrets_refuses_values_the_marker_would_keep():
+@pytest.mark.parametrize("value", ["REDACTED", "]bar", "foo[", "ED]tail"])
+def test_known_secrets_refuses_values_that_overlap_the_marker(value):
     with pytest.raises(ValueError, match="REDACTED"):
-        known_secrets(secret_args=["REDACTED"])
+        known_secrets(secret_args=[value])
 
 
 def test_redactor_without_secrets_leaves_text_untouched():
@@ -62,6 +63,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("BROWSER_URL", "wss://b.example/devtools?token=query-token-0001&v=2")
     monkeypatch.setenv("NOTE", "see ?token=prose-token-0001")  # prose, not a URL
     monkeypatch.setenv("ODD_URL", "https://h.example/?to%6ben=encoded-name-0001")  # encoded name
+    monkeypatch.setenv("FORM_URL", "https://h.example/?token=plus+sep+0001")  # form encoding
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -89,6 +91,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "pg-pass-000001",
         "query-token-0001",
         "encoded-name-0001",
+        "plus+sep+0001",
+        "plus sep 0001",  # as a form-decoding client uses it
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -75,6 +75,9 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("SAS_URL", "https://a.blob.core.windows.net/c?sv=2020&sig=sas-sig-000001")
     monkeypatch.setenv("GITHUB_PAT", "ghp_pat_000000000001")  # PAT is a credential word
     monkeypatch.setenv("PYTHONPATH", "/opt/keep/this/path")  # PATH is not
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123")  # about auth, not auth
+    monkeypatch.setenv("AUTH_TYPE", "oauth2_pkce")
+    monkeypatch.setenv("BASIC_AUTH", "basic-auth-0001")  # is the credential
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -106,6 +109,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "plus sep 0001",  # as a form-decoding client uses it
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "ghp_pat_000000000001",
+        "basic-auth-0001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -121,6 +125,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "[REDACTED]",
             "prose-token-0001",
             "/opt/keep/this/path",
+            "/tmp/ssh-agent/agent.123",
+            "oauth2_pkce",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -56,6 +56,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("KEYCLOAK_REALM", "production-realm")  # KEYCLOAK is not KEY
     monkeypatch.setenv("COOKIECUTTER_CONFIG", "/home/user/config")  # nor COOKIE
     monkeypatch.setenv("OPENAI_APIKEY", "apikey-nosep-0001")  # but APIKEY is a key
+    monkeypatch.setenv("PGPASSWORD", "pg-pass-000001")  # and PGPASSWORD a password
+    monkeypatch.setenv("PGPASSFILE", "/home/user/.pgpass")  # a path, not a password
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -80,6 +82,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "p%40ss-000001",
         "p@ss-000001",
         "apikey-nosep-0001",
+        "pg-pass-000001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -91,6 +94,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "readonly_user",
             "production-realm",
             "/home/user/config",
+            "/home/user/.pgpass",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -61,6 +61,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("LEGACY_API_KEY", "[REDACTED]")  # a sanitized placeholder: skipped
     monkeypatch.setenv("BROWSER_URL", "wss://b.example/devtools?token=query-token-0001&v=2")
     monkeypatch.setenv("NOTE", "see ?token=prose-token-0001")  # prose, not a URL
+    monkeypatch.setenv("ODD_URL", "https://h.example/?to%6ben=encoded-name-0001")  # encoded name
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -87,6 +88,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "apikey-nosep-0001",
         "pg-pass-000001",
         "query-token-0001",
+        "encoded-name-0001",
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -78,6 +78,10 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123")  # about auth, not auth
     monkeypatch.setenv("AUTH_TYPE", "oauth2_pkce")
     monkeypatch.setenv("BASIC_AUTH", "basic-auth-0001")  # is the credential
+    monkeypatch.setenv("AUTHORIZATION_URL", "https://idp.example/authorize")  # metadata
+    monkeypatch.setenv("COOKIE_DOMAIN", "cookies.example.com")
+    monkeypatch.setenv("TLS_KEY_FILE", "/etc/tls/server.key")
+    monkeypatch.setenv("API_KEY_2", "numbered-key-0002")  # a numbered credential still counts
     monkeypatch.setenv(  # a JSON-valued variable is a mapping too
         "DOCKER_AUTH_CONFIG",
         json.dumps(
@@ -116,6 +120,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "ghp_pat_000000000001",
         "basic-auth-0001",
+        "numbered-key-0002",
         "dXNlcjpwYXNzd29yZA==",  # Docker's registry auth, inside a JSON-valued variable
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
@@ -135,6 +140,9 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "/tmp/ssh-agent/agent.123",
             "oauth2_pkce",
             "a@b.example",
+            "https://idp.example/authorize",
+            "cookies.example.com",
+            "/etc/tls/server.key",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -58,10 +58,10 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
     monkeypatch.setenv("RO_URL", "postgres://readonly_user:@db")  # empty password: a name
     secrets_file = tmp_path / "secrets"
-    secrets_file.write_text("from-file-0001\n\n  spaced  \n")
+    secrets_file.write_text("from-file-0001\r\n\n  spaced  \n")
 
     found = known_secrets(
-        "api-key-0001", None, secret_args=["literal", str(secrets_file), "j" * 400]
+        "api-key-0001", None, secret_args=["literal", "lit ", str(secrets_file), "j" * 400]
     )
 
     assert {
@@ -69,8 +69,9 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "hyphenated-auth-0001",
         "api-key-0001",
         "literal",
-        "from-file-0001",
-        "spaced",
+        "lit ",  # explicit values keep their whitespace
+        "from-file-0001",  # a CRLF file entry loses only its terminator
+        "  spaced  ",
         "db-pass-000001",
         "ghp_token_000000001",
         "p%40ss-000001",

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -84,7 +84,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("API_KEY_2", "numbered-key-0002")  # a numbered credential still counts
     monkeypatch.setenv(  # a JSON-valued variable is a mapping too
         "DOCKER_AUTH_CONFIG",
-        json.dumps(
+        " "
+        + json.dumps(  # leading whitespace is valid JSON
             {"auths": {"r.example": {"auth": "dXNlcjpwYXNzd29yZA==", "email": "a@b.example"}}}
         ),
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -49,10 +49,13 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("GIT_AUTHOR_NAME", "Some Author Name")  # AUTHOR is not AUTH
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
+    monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
     secrets_file = tmp_path / "secrets"
     secrets_file.write_text("from-file-0001\n\n  spaced  \n")
 
-    found = known_secrets("api-key-0001", None, secret_args=["literal", str(secrets_file)])
+    found = known_secrets(
+        "api-key-0001", None, secret_args=["literal", str(secrets_file), "j" * 400]
+    )
 
     assert {
         "env-key-value-0001",
@@ -63,5 +66,8 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "spaced",
         "db-pass-000001",
         "ghp_token_000000001",
+        "p%40ss-000001",
+        "p@ss-000001",
+        "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert not {"short", "Some Author Name", "", "postgres://app:db-pass-000001@db/x"} & found

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -78,6 +78,12 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
     monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent/agent.123")  # about auth, not auth
     monkeypatch.setenv("AUTH_TYPE", "oauth2_pkce")
     monkeypatch.setenv("BASIC_AUTH", "basic-auth-0001")  # is the credential
+    monkeypatch.setenv(  # a JSON-valued variable is a mapping too
+        "DOCKER_AUTH_CONFIG",
+        json.dumps(
+            {"auths": {"r.example": {"auth": "dXNlcjpwYXNzd29yZA==", "email": "a@b.example"}}}
+        ),
+    )
     monkeypatch.setenv("DATABASE_URL", "postgres://app:db-pass-000001@db/x")  # URL password
     monkeypatch.setenv("GIT_REMOTE", "https://ghp_token_000000001@github.com/o/r")  # bare token
     monkeypatch.setenv("PG_URL", "postgres://app:p%40ss-000001@db")  # percent-encoded password
@@ -110,6 +116,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
         "sas-sig-000001",  # a signed URL's signature is its bearer credential
         "ghp_pat_000000000001",
         "basic-auth-0001",
+        "dXNlcjpwYXNzd29yZA==",  # Docker's registry auth, inside a JSON-valued variable
         "j" * 400,  # longer than a filesystem name: a literal, not a file to probe
     } <= found
     assert (
@@ -127,6 +134,7 @@ def test_known_secrets_sources(monkeypatch, tmp_path):
             "/opt/keep/this/path",
             "/tmp/ssh-agent/agent.123",
             "oauth2_pkce",
+            "a@b.example",
         }
         & found
     )

--- a/packages/prime/tests/test_redact.py
+++ b/packages/prime/tests/test_redact.py
@@ -1,0 +1,56 @@
+"""Exact-match redaction: a known value disappears from JSON strings in every spelling
+(plain, escaped, escaped again inside a quoted JSON document) and nothing else changes."""
+
+import json
+
+from prime_cli.utils.redact import Redactor, known_secrets
+
+
+def test_redactor_replaces_every_spelling_inside_strings_only():
+    redactor = Redactor({'pa"ss\\word-0001', "12345678", "ünïcode-secret"})
+    doc = {
+        "plain": 'pa"ss\\word-0001 and ünïcode-secret',
+        "nested": json.dumps({"k": 'pa"ss\\word-0001', "u": "ünïcode-secret"}),
+        "number": 12345678,  # a JSON number is not a string: untouched
+        "text": "12345678",
+        "keep": "ordinary text",
+    }
+    for ensure_ascii in (True, False):
+        redactor.count = 0
+        out = json.loads(redactor.json(json.dumps(doc, ensure_ascii=ensure_ascii)))
+        assert out == {
+            "plain": "[REDACTED] and [REDACTED]",
+            "nested": json.dumps({"k": "[REDACTED]", "u": "[REDACTED]"}),
+            "number": 12345678,
+            "text": "[REDACTED]",
+            "keep": "ordinary text",
+        }
+        assert redactor.count == 5
+
+
+def test_redactor_without_secrets_leaves_text_untouched():
+    line = '{"a": "b"}\n'
+    redactor = Redactor(set())
+    assert redactor.json(line) is line
+    assert redactor.value({"a": "b"}) == {"a": "b"}
+
+
+def test_known_secrets_sources(monkeypatch, tmp_path):
+    monkeypatch.setenv("MY_API_KEY", "env-key-value-0001")
+    monkeypatch.setenv("X-Auth", "hyphenated-auth-0001")
+    monkeypatch.setenv("MY_SHORT_KEY", "short")  # too short to redact safely
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Some Author Name")  # AUTHOR is not AUTH
+    secrets_file = tmp_path / "secrets"
+    secrets_file.write_text("from-file-0001\n\n  spaced  \n")
+
+    found = known_secrets("api-key-0001", None, secret_args=["literal", str(secrets_file)])
+
+    assert {
+        "env-key-value-0001",
+        "hyphenated-auth-0001",
+        "api-key-0001",
+        "literal",
+        "from-file-0001",
+        "spaced",
+    } <= found
+    assert not {"short", "Some Author Name", ""} & found

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -3,6 +3,7 @@
 of silently falling back to the SDK's static config."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from prime_cli.commands import traces as traces_cmd
@@ -290,10 +291,11 @@ def _summary(**overrides):
 class FakeTracesClient:
     def __init__(self):
         self.calls: dict = {}
+        self.client = SimpleNamespace(api_key="fake-api-key-0001")
         self.receipt = UploadReceipt(upload_id="a" * 64, status="committed")
 
-    def upload_file(self, path, **kwargs):
-        self.calls["upload_file"] = {"path": path, **kwargs}
+    def upload_lines(self, lines, **kwargs):
+        self.calls["upload_lines"] = {"lines": b"".join(lines), **kwargs}
         on_batch = kwargs.get("on_batch")
         batch = Batch(data=b"{}\n", digest="a" * 64, num_lines=1, first_line_number=1)
         if on_batch is not None:
@@ -342,7 +344,8 @@ def test_upload_command_table_output(fake_client, tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "Uploaded 1 batch(es)" in result.output
-    call = fake_client.calls["upload_file"]
+    call = fake_client.calls["upload_lines"]
+    assert call["lines"] == b'{"id":"a"}\n'  # nothing to redact: bytes are untouched
     assert call["context"] == {"source": "hosted_eval", "suite": "s1"}
     assert call["compress"] is True
     assert call["line_format"].value == "trace"
@@ -361,9 +364,51 @@ def test_upload_command_episodes_json_output(fake_client, tmp_path):
     payload = json.loads(result.output)
     assert payload["num_batches"] == 1
     assert payload["receipts"][0]["status"] == "committed"
-    call = fake_client.calls["upload_file"]
+    assert payload["redacted"] == 0
+    call = fake_client.calls["upload_lines"]
     assert call["line_format"].value == "episode"
     assert call["compress"] is False
+
+
+def test_upload_command_redacts_known_secrets(fake_client, tmp_path, monkeypatch):
+    """Secrets from the environment, the API key, and --secret (a literal or a file) are
+    replaced inside JSON strings before the bytes leave the machine — including a copy
+    quoted inside a JSON tool result. Numbers, ordinary text, and the file itself stay."""
+    monkeypatch.setenv("HOST_HF_TOKEN", "hf_host_token_00000001")
+    secrets_file = tmp_path / "secrets.txt"
+    secrets_file.write_text("from-file-secret-0001\n\n")
+    traces_file = tmp_path / "traces.jsonl"
+    original = (
+        b'{"id":"a","messages":[{"content":"hf_host_token_00000001 fake-api-key-0001 '
+        b'literal-secret-0001 from-file-secret-0001 {\\"k\\": \\"literal-secret-0001\\"} '
+        b'plain"}],"n":12345678}\n'
+    )
+    traces_file.write_bytes(original)
+
+    result = runner.invoke(
+        main_app,
+        [
+            "traces",
+            "upload",
+            str(traces_file),
+            "--secret",
+            "literal-secret-0001",
+            "--secret",
+            str(secrets_file),
+            "--secret",
+            "12345678",
+            "-o",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["redacted"] == 5
+    assert fake_client.calls["upload_lines"]["lines"] == (
+        b'{"id":"a","messages":[{"content":"[REDACTED] [REDACTED] [REDACTED] [REDACTED] '
+        b'{\\"k\\": \\"[REDACTED]\\"} plain"}],"n":12345678}\n'
+    )
+    assert traces_file.read_bytes() == original
 
 
 def test_upload_command_rejects_malformed_context(fake_client, tmp_path):
@@ -373,7 +418,7 @@ def test_upload_command_rejects_malformed_context(fake_client, tmp_path):
     result = runner.invoke(main_app, ["traces", "upload", str(traces_file), "-c", "no-equals"])
 
     assert result.exit_code == 1
-    assert "upload_file" not in fake_client.calls
+    assert "upload_lines" not in fake_client.calls
 
 
 def test_unexpected_error_does_not_dump_sdk_locals(fake_client, tmp_path):
@@ -385,7 +430,7 @@ def test_unexpected_error_does_not_dump_sdk_locals(fake_client, tmp_path):
         assert secret_trace
         raise RuntimeError("malformed receipt")
 
-    fake_client.upload_file = fail_upload
+    fake_client.upload_lines = fail_upload
     result = runner.invoke(main_app, ["traces", "upload", str(traces_file)])
 
     assert result.exit_code == 1

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -397,13 +397,16 @@ def test_upload_command_redacts_known_secrets(fake_client, tmp_path, monkeypatch
             str(secrets_file),
             "--secret",
             "12345678",
+            "-c",
+            "note=literal-secret-0001",
             "-o",
             "json",
         ],
     )
 
     assert result.exit_code == 0, result.output
-    assert json.loads(result.output)["redacted"] == 5
+    assert json.loads(result.output)["redacted"] == 6
+    assert fake_client.calls["upload_lines"]["context"] == {"note": "[REDACTED]"}
     assert fake_client.calls["upload_lines"]["lines"] == (
         b'{"id":"a","messages":[{"content":"[REDACTED] [REDACTED] [REDACTED] [REDACTED] '
         b'{\\"k\\": \\"[REDACTED]\\"} plain"}],"n":12345678}\n'

--- a/transfer-bulk-failures.jsonl
+++ b/transfer-bulk-failures.jsonl
@@ -1,1 +1,0 @@
-{"source": "a/app-a:v1", "platform": "linux/amd64"}

--- a/transfer-bulk-failures.jsonl
+++ b/transfer-bulk-failures.jsonl
@@ -1,0 +1,1 @@
+{"source": "a/app-a:v1", "platform": "linux/amd64"}


### PR DESCRIPTION
## Overview

Replaces #882 with a from-scratch, minimal implementation of the same goal: secrets do not leave the machine on upload. One ~75-line util in the CLI instead of a 973-line preflight module plus SDK changes.

## What it does

`prime traces upload`, `prime eval push`, and the auto-push after `prime eval run` replace every known secret value with `[REDACTED]` before the bytes go out — in the JSONL lines and `--context` values, in the eval data and `--name`, and in the auto-push's metadata, metrics, and task type. Known values are:
- the process environment's credentials: values under credential-like names (`KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|AUTHORIZATION|AUTH|SIGNATURE|SIG|PAT` as the name's last word, optionally numbered — compound names are head-final, so `HF_TOKEN`, `X-Api-Key`, `PGPASSWORD`, `API_KEY_2` are credentials while `TOKEN_URL`, `COOKIE_DOMAIN`, `KEY_FILE`, `SSH_AUTH_SOCK`, `KEYCLOAK_REALM` are not), plus, for any value that is a URL (`scheme://host…`, never prose), the password (or bare user token) of its userinfo and its credential-named query values (`DATABASE_URL`, an authenticated `HTTP_PROXY`, `wss://…?token=…`); a value that is a JSON object is a mapping too and gets the same rules inside it (`DOCKER_AUTH_CONFIG`, a service-account blob); 8+ chars
- the Prime API key
- `--secret <value>` or `--secret <file with one per line>`, repeatable, on `traces upload` and `eval push`

Matching is exact, over the serialized JSON text: each JSON string is decoded and then searched again for quoted JSON inside it, recursively, so any escape spelling (`\/`, uppercase hex, …) at any nesting depth is matched. Only JSON strings are touched, so numbers and structure cannot be corrupted, ordinary text is never rewritten, and a line with no hit is uploaded byte-identical, so content-addressed receipts still replay on rerun. Local files are never modified. The command reports how many occurrences were replaced (`.redacted` in JSON output).

## Deliberately not carried over from #882

- **Shape-based detection** (provider key regexes, header/cookie/assignment grammars, OpenAPI and JSON-schema awareness). Every review round grew the pattern set and its false-positive guards (`token_usage`, `oauth`, `BearerAuth`, …). That is a scanner's job: run trufflehog over the file before uploading if you want it. The CLI redacts what it knows, which is also [pi-share-hf](https://github.com/badlogic/pi-share-hf)'s position.
- **SDK-level auto-redaction, `push_evaluation`, exact batching and async upload rewrites, the fingerprint API** in prime-evals. The SDKs stay transports; redaction is a CLI concern, so no prime-evals release is needed and verifiers keeps no dependency on it.
- **Temp-file staging** for `traces upload`: `TracesClient.upload_lines` already exists, so lines are redacted in a generator on the way to the batcher.

## Companion

PrimeIntellect-ai/verifiers#2508 handles what only verifiers knows (client headers, harness env, resolved API keys, per-rollout tokens) with the same redactor. The two copies are intentionally independent so neither repo waits on the other's release.

## Tests

`test_redact.py` covers escaping at several depths (including `\/` and uppercase hex), the number/structure guarantee, and the secret sources. `test_traces_command.py` and `test_eval_push.py` check the commands end to end through Typer with stubbed clients: bytes untouched when nothing matches, secrets from env / API key / `--secret` literal / `--secret` file / `--context` / `--name` gone, local files unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what leaves the machine on upload (security-sensitive); redaction is best-effort on known values only, so missed secrets or edge-case false negatives remain possible despite extensive tests.
> 
> **Overview**
> Adds a small **`redact`** helper and wires it into **`prime traces upload`**, **`prime eval push`**, and the post-run eval auto-push so outbound payloads are scrubbed before they hit the platform.
> 
> **Secret sources** are credential-like env vars (plus URL/JSON-nested credentials), the Prime API key, and repeatable **`--secret`** (literal or one-per-line file). Matches are **exact** inside JSON strings only (including nested quoted JSON), replaced with **`[REDACTED]`**; local files stay unchanged. Commands print a yellow notice and JSON output includes **`redacted`** counts where applicable.
> 
> **Traces** now stream through **`upload_lines`** with per-line redaction instead of uploading the raw file bytes unchanged. **Eval push** redacts loaded eval data and CLI fields such as **`run_id`** and **`name`** so secrets in identifiers cannot leak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4475fcd8faad5d6fb2742f651727bfa4d3575e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->