### PR TITLE
fix(sandboxes): forward working_dir to the background-job launcher exec

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -2702,6 +2702,7 @@ class SandboxClient:
                     sandbox_id,
                     bg_cmd,
                     timeout=_BACKGROUND_JOB_LAUNCH_TIMEOUT_SECONDS,
+                    working_dir=working_dir,
                     user=user,
                 )
                 break
@@ -4392,6 +4393,7 @@ class AsyncSandboxClient:
                     sandbox_id,
                     bg_cmd,
                     timeout=_BACKGROUND_JOB_LAUNCH_TIMEOUT_SECONDS,
+                    working_dir=working_dir,
                     user=user,
                 )
                 break

--- a/packages/prime-sandboxes/tests/test_background_job_working_dir.py
+++ b/packages/prime-sandboxes/tests/test_background_job_working_dir.py
@@ -1,0 +1,40 @@
+"""Background-job launcher execs honor start_background_job's working_dir."""
+
+from typing import Any, List, cast
+
+import pytest
+
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.models import CommandResponse
+from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
+
+_OK = CommandResponse(stdout="", stderr="", exit_code=0)
+
+
+def test_sync_launcher_exec_passes_working_dir():
+    client = SandboxClient(APIClient(api_key="test-key"))
+    seen: List[Any] = []
+
+    def execute(_sandbox_id, _command, **kwargs):
+        seen.append(kwargs.get("working_dir", "<absent>"))
+        return _OK
+
+    cast(Any, client).execute_command = execute
+    client.start_background_job("sb", "pwd", working_dir="/")
+    client.start_background_job("sb", "pwd")
+    assert seen == ["/", None]
+
+
+@pytest.mark.asyncio
+async def test_async_launcher_exec_passes_working_dir():
+    client = AsyncSandboxClient(APIClient(api_key="test-key"))
+    seen: List[Any] = []
+
+    async def execute(_sandbox_id, _command, **kwargs):
+        seen.append(kwargs.get("working_dir", "<absent>"))
+        return _OK
+
+    cast(Any, client).execute_command = execute
+    await client.start_background_job("sb", "pwd", working_dir="/")
+    await client.start_background_job("sb", "pwd")
+    assert seen == ["/", None]


### PR DESCRIPTION
## Description

`start_background_job()` accepts a `working_dir` but only used it as a `cd` prefix inside the eventual background command. The internal launcher exec (the `nohup` submission) called `execute_command()` without forwarding `working_dir`, so the gateway launched from the image's default cwd. When that directory no longer exists (e.g. a VM image whose `/app` was removed/replaced), the launch itself fails with `cwd '/app' does not exist` before the requested `cd` can ever run.

This forwards `working_dir` to the internal launcher `execute_command()` call in both the sync and async implementations. Foreground `execute_command()` already accepts and honors `working_dir` on both transports (Connect-RPC `command_spec.cwd`, REST payload), so the launcher now starts in the requested directory too.

Fixes #890

## Why

Any consumer that removes or replaces the image-default working directory and then starts a background job with an explicit `working_dir` currently gets a hard launch failure even though the requested directory exists. The `working_dir` parameter was effectively dead for the launch step.

## Verification

- before, on current `main`: `uv run pytest tests/test_background_job_working_dir.py` in `packages/prime-sandboxes`: both tests fail, launcher `execute_command` receives no `working_dir` kwarg (matches the issue's reproduction: launch from missing image-default cwd)
- after: same command, 2 passed; launcher exec carries `working_dir='/'` and defaults to `None` when unset, on both `SandboxClient` and `AsyncSandboxClient`
- `uv run pytest tests/test_background_job_working_dir.py tests/test_background_job_launch_retry.py tests/test_background_job_timeout.py tests/test_command_transport_selection.py tests/test_batch_status.py tests/test_client_retry.py tests/test_gateway_error_mapping.py`: 123 passed (hermetic unit tests; the live-API suites in this package need `PRIME_API_KEY`/`PRIME_TEAM_ID` and were not run)
