### PR TITLE
Add prime slurm command for managing Slurm clusters

### DIFF
--- a/packages/prime/src/prime_cli/api/slurm.py
+++ b/packages/prime/src/prime_cli/api/slurm.py
@@ -18,21 +18,6 @@ class SlurmClusterSummary(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-class SlurmClusterDetail(BaseModel):
-    id: str
-    prime_cluster_id: str = Field(alias="primeClusterId")
-    display_name: str = Field(alias="displayName")
-    status: str
-    gpu_type: Optional[str] = Field(None, alias="gpuType")
-    gpu_count: int = Field(alias="gpuCount")
-    connectable: bool
-    ssh_host: Optional[str] = Field(None, alias="sshHost")
-    ssh_port: Optional[int] = Field(None, alias="sshPort")
-    created_at: str = Field(alias="createdAt")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
 class SlurmClusterMember(BaseModel):
     username: str
     uid: int
@@ -46,40 +31,6 @@ class SlurmClusterMember(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-class ThroughputPoint(BaseModel):
-    day: str
-    completed: int = 0
-    failed: int = 0
-    cancelled: int = 0
-
-
-class QueueWaitPoint(BaseModel):
-    day: str
-    median_seconds: float
-
-
-class GpuHoursRow(BaseModel):
-    user: str
-    gpu_hours: float
-
-
-class OutcomeRow(BaseModel):
-    outcome: str
-    count: int
-
-
-class SlurmAccounting(BaseModel):
-    # Backend response is snake_case (not aliased) — see
-    # platform backend/app/packages/jobs/schemas.py TeamSlurmAccountingResponse.
-    available: bool
-    days: int = 0
-    total_jobs: int = 0
-    throughput: List[ThroughputPoint] = Field(default_factory=list)
-    queue_wait: List[QueueWaitPoint] = Field(default_factory=list)
-    gpu_hours_by_user: List[GpuHoursRow] = Field(default_factory=list)
-    outcomes: List[OutcomeRow] = Field(default_factory=list)
-
-
 class SlurmClustersClient:
     def __init__(self, client: APIClient) -> None:
         self.client = client
@@ -87,10 +38,6 @@ class SlurmClustersClient:
     def list(self, team_id: str) -> List[SlurmClusterSummary]:
         response = self.client.get(f"/slurm-clusters/{team_id}")
         return [SlurmClusterSummary.model_validate(c) for c in response.get("data", [])]
-
-    def get(self, team_id: str, cluster_id: str) -> SlurmClusterDetail:
-        response = self.client.get(f"/slurm-clusters/{team_id}/{cluster_id}")
-        return SlurmClusterDetail.model_validate(response)
 
     def list_members(self, team_id: str, cluster_id: str) -> List[SlurmClusterMember]:
         response = self.client.get(f"/slurm-clusters/{team_id}/{cluster_id}/members")
@@ -113,37 +60,10 @@ class SlurmClustersClient:
     def remove_member(self, team_id: str, cluster_id: str, username: str) -> None:
         self.client.delete(f"/slurm-clusters/{team_id}/{cluster_id}/members/{username}")
 
-    def set_sudo(
-        self, team_id: str, cluster_id: str, username: str, enabled: bool
-    ) -> SlurmClusterMember:
-        response = self.client.patch(
-            f"/slurm-clusters/{team_id}/{cluster_id}/members/{username}/sudo",
-            json={"enabled": enabled},
-        )
-        return SlurmClusterMember.model_validate(response)
-
-    def rename(self, team_id: str, cluster_id: str, display_name: str) -> Optional[str]:
-        response = self.client.patch(
-            f"/slurm-clusters/{team_id}/{cluster_id}", json={"displayName": display_name}
-        )
-        return response.get("displayName")
-
-    def delete(self, team_id: str, cluster_id: str, force: bool = False) -> None:
-        params = {"force": "true"} if force else None
-        self.client.delete(f"/slurm-clusters/{team_id}/{cluster_id}", params=params)
-
-    def accounting(self, team_id: str, cluster_id: str, days: int = 30) -> SlurmAccounting:
-        response = self.client.get(
-            f"/slurm-clusters/{team_id}/{cluster_id}/accounting", params={"days": days}
-        )
-        return SlurmAccounting.model_validate(response)
-
 
 __all__ = [
     "SlurmClustersClient",
     "SlurmClusterSummary",
-    "SlurmClusterDetail",
     "SlurmClusterMember",
-    "SlurmAccounting",
     "APIError",
 ]

--- a/packages/prime/src/prime_cli/api/slurm.py
+++ b/packages/prime/src/prime_cli/api/slurm.py
@@ -5,33 +5,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from prime_cli.core import APIClient, APIError
 
 
-class CordonedNode(BaseModel):
-    name: str
-    reason: str
-    automated: bool
-
-
-class NodeHealth(BaseModel):
-    total_nodes: int = Field(alias="totalNodes")
-    healthy_nodes: int = Field(alias="healthyNodes")
-    cordoned_nodes: List[CordonedNode] = Field(alias="cordonedNodes")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class GpuNode(BaseModel):
-    name: str
-    ready: bool
-    is_cordoned: bool = Field(alias="isCordoned")
-    cordon_reason: Optional[str] = Field(None, alias="cordonReason")
-    allocatable_gpus: int = Field(alias="allocatableGpus")
-    used_gpus: int = Field(alias="usedGpus")
-    free_gpus: int = Field(alias="freeGpus")
-    slurm_states: Optional[List[str]] = Field(None, alias="slurmStates")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
 class SlurmClusterSummary(BaseModel):
     id: str
     prime_cluster_id: str = Field(alias="primeClusterId")
@@ -39,11 +12,6 @@ class SlurmClusterSummary(BaseModel):
     status: str
     gpu_type: Optional[str] = Field(None, alias="gpuType")
     gpu_count: int = Field(alias="gpuCount")
-    total_gpus: Optional[int] = Field(None, alias="totalGpus")
-    free_gpus: Optional[int] = Field(None, alias="freeGpus")
-    total_nodes: int = Field(alias="totalNodes")
-    healthy_nodes: int = Field(alias="healthyNodes")
-    cordoned_node_count: int = Field(alias="cordonedNodeCount")
     created_at: str = Field(alias="createdAt")
     started_at: Optional[str] = Field(None, alias="startedAt")
 
@@ -60,8 +28,6 @@ class SlurmClusterDetail(BaseModel):
     connectable: bool
     ssh_host: Optional[str] = Field(None, alias="sshHost")
     ssh_port: Optional[int] = Field(None, alias="sshPort")
-    node_health: NodeHealth = Field(alias="nodeHealth")
-    nodes: List[GpuNode]
     created_at: str = Field(alias="createdAt")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -112,11 +78,6 @@ class SlurmAccounting(BaseModel):
     queue_wait: List[QueueWaitPoint] = Field(default_factory=list)
     gpu_hours_by_user: List[GpuHoursRow] = Field(default_factory=list)
     outcomes: List[OutcomeRow] = Field(default_factory=list)
-
-
-class UtilizationPoint(BaseModel):
-    timestamp: float
-    value: float
 
 
 class SlurmClustersClient:
@@ -177,25 +138,12 @@ class SlurmClustersClient:
         )
         return SlurmAccounting.model_validate(response)
 
-    def utilization(
-        self, team_id: str, cluster_id: str, range_seconds: int = 21_600
-    ) -> List[UtilizationPoint]:
-        response = self.client.get(
-            f"/slurm-clusters/{team_id}/{cluster_id}/utilization",
-            params={"range_seconds": range_seconds},
-        )
-        return [UtilizationPoint.model_validate(p) for p in response.get("gpuUtil", [])]
-
 
 __all__ = [
     "SlurmClustersClient",
     "SlurmClusterSummary",
     "SlurmClusterDetail",
     "SlurmClusterMember",
-    "NodeHealth",
-    "GpuNode",
-    "CordonedNode",
     "SlurmAccounting",
-    "UtilizationPoint",
     "APIError",
 ]

--- a/packages/prime/src/prime_cli/api/slurm.py
+++ b/packages/prime/src/prime_cli/api/slurm.py
@@ -1,0 +1,199 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from prime_cli.core import APIClient, APIError
+
+
+class CordonedNode(BaseModel):
+    name: str
+    reason: str
+    automated: bool
+
+
+class NodeHealth(BaseModel):
+    total_nodes: int = Field(alias="totalNodes")
+    healthy_nodes: int = Field(alias="healthyNodes")
+    cordoned_nodes: List[CordonedNode] = Field(alias="cordonedNodes")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class GpuNode(BaseModel):
+    name: str
+    ready: bool
+    is_cordoned: bool = Field(alias="isCordoned")
+    cordon_reason: Optional[str] = Field(None, alias="cordonReason")
+    allocatable_gpus: int = Field(alias="allocatableGpus")
+    used_gpus: int = Field(alias="usedGpus")
+    free_gpus: int = Field(alias="freeGpus")
+    slurm_states: Optional[List[str]] = Field(None, alias="slurmStates")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SlurmClusterSummary(BaseModel):
+    id: str
+    prime_cluster_id: str = Field(alias="primeClusterId")
+    display_name: str = Field(alias="displayName")
+    status: str
+    gpu_type: Optional[str] = Field(None, alias="gpuType")
+    gpu_count: int = Field(alias="gpuCount")
+    total_gpus: Optional[int] = Field(None, alias="totalGpus")
+    free_gpus: Optional[int] = Field(None, alias="freeGpus")
+    total_nodes: int = Field(alias="totalNodes")
+    healthy_nodes: int = Field(alias="healthyNodes")
+    cordoned_node_count: int = Field(alias="cordonedNodeCount")
+    created_at: str = Field(alias="createdAt")
+    started_at: Optional[str] = Field(None, alias="startedAt")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SlurmClusterDetail(BaseModel):
+    id: str
+    prime_cluster_id: str = Field(alias="primeClusterId")
+    display_name: str = Field(alias="displayName")
+    status: str
+    gpu_type: Optional[str] = Field(None, alias="gpuType")
+    gpu_count: int = Field(alias="gpuCount")
+    connectable: bool
+    ssh_host: Optional[str] = Field(None, alias="sshHost")
+    ssh_port: Optional[int] = Field(None, alias="sshPort")
+    node_health: NodeHealth = Field(alias="nodeHealth")
+    nodes: List[GpuNode]
+    created_at: str = Field(alias="createdAt")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SlurmClusterMember(BaseModel):
+    username: str
+    sudo: bool
+    status: str
+    linked_user_id: Optional[str] = Field(None, alias="linkedUserId")
+    linked_user_name: Optional[str] = Field(None, alias="linkedUserName")
+    linked_user_email: Optional[str] = Field(None, alias="linkedUserEmail")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ThroughputPoint(BaseModel):
+    day: str
+    completed: int = 0
+    failed: int = 0
+    cancelled: int = 0
+
+
+class QueueWaitPoint(BaseModel):
+    day: str
+    median_seconds: float
+
+
+class GpuHoursRow(BaseModel):
+    user: str
+    gpu_hours: float
+
+
+class OutcomeRow(BaseModel):
+    outcome: str
+    count: int
+
+
+class SlurmAccounting(BaseModel):
+    # Backend response is snake_case (not aliased) — see
+    # platform backend/app/packages/jobs/schemas.py TeamSlurmAccountingResponse.
+    available: bool
+    days: int = 0
+    total_jobs: int = 0
+    throughput: List[ThroughputPoint] = Field(default_factory=list)
+    queue_wait: List[QueueWaitPoint] = Field(default_factory=list)
+    gpu_hours_by_user: List[GpuHoursRow] = Field(default_factory=list)
+    outcomes: List[OutcomeRow] = Field(default_factory=list)
+
+
+class UtilizationPoint(BaseModel):
+    timestamp: float
+    value: float
+
+
+class SlurmClustersClient:
+    def __init__(self, client: APIClient) -> None:
+        self.client = client
+
+    def list(self, team_id: str) -> List[SlurmClusterSummary]:
+        response = self.client.get(f"/slurm-clusters/{team_id}")
+        return [SlurmClusterSummary.model_validate(c) for c in response.get("data", [])]
+
+    def get(self, team_id: str, cluster_id: str) -> SlurmClusterDetail:
+        response = self.client.get(f"/slurm-clusters/{team_id}/{cluster_id}")
+        return SlurmClusterDetail.model_validate(response)
+
+    def list_members(self, team_id: str, cluster_id: str) -> List[SlurmClusterMember]:
+        response = self.client.get(f"/slurm-clusters/{team_id}/{cluster_id}/members")
+        return [SlurmClusterMember.model_validate(m) for m in response.get("data", [])]
+
+    def add_member(
+        self,
+        team_id: str,
+        cluster_id: str,
+        username: str,
+        ssh_authorized_keys: List[str],
+        linked_user_id: Optional[str] = None,
+    ) -> SlurmClusterMember:
+        body = {"username": username, "sshAuthorizedKeys": ssh_authorized_keys}
+        if linked_user_id:
+            body["linkedUserId"] = linked_user_id
+        response = self.client.post(f"/slurm-clusters/{team_id}/{cluster_id}/members", json=body)
+        return SlurmClusterMember.model_validate(response)
+
+    def remove_member(self, team_id: str, cluster_id: str, username: str) -> None:
+        self.client.delete(f"/slurm-clusters/{team_id}/{cluster_id}/members/{username}")
+
+    def set_sudo(
+        self, team_id: str, cluster_id: str, username: str, enabled: bool
+    ) -> SlurmClusterMember:
+        response = self.client.patch(
+            f"/slurm-clusters/{team_id}/{cluster_id}/members/{username}/sudo",
+            json={"enabled": enabled},
+        )
+        return SlurmClusterMember.model_validate(response)
+
+    def rename(self, team_id: str, cluster_id: str, display_name: str) -> Optional[str]:
+        response = self.client.patch(
+            f"/slurm-clusters/{team_id}/{cluster_id}", json={"displayName": display_name}
+        )
+        return response.get("displayName")
+
+    def delete(self, team_id: str, cluster_id: str, force: bool = False) -> None:
+        params = {"force": "true"} if force else None
+        self.client.delete(f"/slurm-clusters/{team_id}/{cluster_id}", params=params)
+
+    def accounting(self, team_id: str, cluster_id: str, days: int = 30) -> SlurmAccounting:
+        response = self.client.get(
+            f"/slurm-clusters/{team_id}/{cluster_id}/accounting", params={"days": days}
+        )
+        return SlurmAccounting.model_validate(response)
+
+    def utilization(
+        self, team_id: str, cluster_id: str, range_seconds: int = 21_600
+    ) -> List[UtilizationPoint]:
+        response = self.client.get(
+            f"/slurm-clusters/{team_id}/{cluster_id}/utilization",
+            params={"range_seconds": range_seconds},
+        )
+        return [UtilizationPoint.model_validate(p) for p in response.get("gpuUtil", [])]
+
+
+__all__ = [
+    "SlurmClustersClient",
+    "SlurmClusterSummary",
+    "SlurmClusterDetail",
+    "SlurmClusterMember",
+    "NodeHealth",
+    "GpuNode",
+    "CordonedNode",
+    "SlurmAccounting",
+    "UtilizationPoint",
+    "APIError",
+]

--- a/packages/prime/src/prime_cli/api/slurm.py
+++ b/packages/prime/src/prime_cli/api/slurm.py
@@ -69,6 +69,8 @@ class SlurmClusterDetail(BaseModel):
 
 class SlurmClusterMember(BaseModel):
     username: str
+    uid: int
+    ssh_authorized_keys: List[str] = Field(alias="sshAuthorizedKeys")
     sudo: bool
     status: str
     linked_user_id: Optional[str] = Field(None, alias="linkedUserId")

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -1,0 +1,530 @@
+import os
+import subprocess
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import typer
+from rich.table import Table
+from rich.text import Text
+
+from prime_cli.core import APIClient, APIError, Config
+
+from ..api.slurm import SlurmClusterMember, SlurmClustersClient
+from ..utils import (
+    PlainTyper,
+    confirm_or_skip,
+    get_console,
+    json_output_help,
+    output_data_as_json,
+    status_color,
+    validate_output_format,
+)
+from ..utils.display import SLURM_CLUSTER_STATUS_COLORS
+
+app = PlainTyper(help="Manage Slurm clusters", no_args_is_help=True)
+console = get_console()
+
+LIST_CLUSTERS_JSON_HELP = json_output_help(
+    ".data[] = {id, prime_cluster_id, display_name, status, gpu_type, gpu_count, "
+    "total_gpus, free_gpus, total_nodes, healthy_nodes, cordoned_node_count, "
+    "created_at, started_at?}",
+)
+
+CLUSTER_DETAIL_JSON_HELP = json_output_help(
+    ". = {id, prime_cluster_id, display_name, status, gpu_type, gpu_count, "
+    "connectable, ssh_host?, ssh_port?, node_health, nodes[]}",
+)
+
+MEMBERS_JSON_HELP = json_output_help(
+    ".data[] = {username, sudo, status, linked_user_id?, linked_user_name?, linked_user_email?}",
+)
+
+ACCOUNTING_JSON_HELP = json_output_help(
+    ". = {available, days, total_jobs, throughput[], queue_wait[], "
+    "gpu_hours_by_user[], outcomes[]}",
+)
+
+
+def _resolve_team_id(team_id: Optional[str]) -> str:
+    resolved = team_id or Config().team_id
+    if not resolved:
+        console.print(
+            "[red]Error: No team selected. "
+            "Use --team-id or set a team with 'prime config set-team-id'[/red]"
+        )
+        raise typer.Exit(1)
+    return resolved
+
+
+def _slurm_client() -> SlurmClustersClient:
+    return SlurmClustersClient(APIClient())
+
+
+_TEAM_ID_OPTION = typer.Option(
+    None, "--team-id", help="Team ID (uses config team_id if not specified)"
+)
+
+
+@app.command(name="list", epilog=LIST_CLUSTERS_JSON_HELP)
+def list_clusters(
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List your team's Slurm clusters."""
+    validate_output_format(output, console)
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        clusters = _slurm_client().list(resolved_team_id)
+
+        if output == "json":
+            output_data_as_json({"data": [c.model_dump() for c in clusters]}, console)
+            return
+
+        table = Table(title=f"Slurm Clusters (Total: {len(clusters)})", show_lines=True)
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Name", style="blue")
+        table.add_column("Status", style="yellow")
+        table.add_column("GPU Type", style="magenta")
+        table.add_column("Free/Total GPUs", style="green")
+        table.add_column("Nodes (healthy/total)", style="blue")
+
+        for c in clusters:
+            gpu_col = (
+                f"{c.free_gpus}/{c.total_gpus}"
+                if c.free_gpus is not None and c.total_gpus is not None
+                else "N/A"
+            )
+            table.add_row(
+                c.id,
+                c.display_name,
+                Text(c.status, style=status_color(c.status, SLURM_CLUSTER_STATUS_COLORS)),
+                c.gpu_type or "N/A",
+                gpu_col,
+                f"{c.healthy_nodes}/{c.total_nodes}",
+            )
+        console.print(table)
+        console.print(
+            "\n[blue]Use 'prime slurm connect <cluster-id> <username>' to SSH in, "
+            "or 'prime slurm get <cluster-id>' for details[/blue]"
+        )
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="get", no_args_is_help=True, epilog=CLUSTER_DETAIL_JSON_HELP)
+def get_cluster(
+    cluster_id: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Get connection info, health, and node details for a Slurm cluster."""
+    validate_output_format(output, console)
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        cluster = _slurm_client().get(resolved_team_id, cluster_id)
+
+        if output == "json":
+            output_data_as_json(cluster.model_dump(), console)
+            return
+
+        table = Table(title=f"Cluster: {cluster.display_name}")
+        table.add_column("Property", style="cyan")
+        table.add_column("Value", style="white")
+        table.add_row(
+            "Status",
+            Text(cluster.status, style=status_color(cluster.status, SLURM_CLUSTER_STATUS_COLORS)),
+        )
+        table.add_row("GPU Type", cluster.gpu_type or "N/A")
+        table.add_row("GPU Count", str(cluster.gpu_count))
+        if cluster.connectable and cluster.ssh_host and cluster.ssh_port:
+            table.add_row(
+                "SSH",
+                f"ssh -p {cluster.ssh_port} <username>@{cluster.ssh_host}  "
+                f"(or: prime slurm connect {cluster_id} <username>)",
+            )
+        else:
+            table.add_row("SSH", "Not connectable (cluster is not RUNNING)")
+        table.add_row(
+            "Node health",
+            f"{cluster.node_health.healthy_nodes}/{cluster.node_health.total_nodes} healthy",
+        )
+        console.print(table)
+
+        if cluster.node_health.cordoned_nodes:
+            cordoned_table = Table(title="Cordoned Nodes")
+            cordoned_table.add_column("Name", style="cyan")
+            cordoned_table.add_column("Reason", style="yellow")
+            for n in cluster.node_health.cordoned_nodes:
+                cordoned_table.add_row(n.name, n.reason)
+            console.print("\n")
+            console.print(cordoned_table)
+
+        if cluster.nodes:
+            nodes_table = Table(title="Nodes")
+            nodes_table.add_column("Name", style="cyan")
+            nodes_table.add_column("Ready", style="white")
+            nodes_table.add_column("Free/Allocatable GPUs", style="green")
+            nodes_table.add_column("Slurm State", style="blue")
+            for n in cluster.nodes:
+                nodes_table.add_row(
+                    n.name,
+                    "yes" if n.ready else "no",
+                    f"{n.free_gpus}/{n.allocatable_gpus}",
+                    ",".join(n.slurm_states) if n.slurm_states else "N/A",
+                )
+            console.print("\n")
+            console.print(nodes_table)
+
+        console.print(
+            f"\n[blue]Use 'prime slurm members {cluster_id}' to see who has access[/blue]"
+        )
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="connect", no_args_is_help=True)
+@app.command(name="ssh", no_args_is_help=True)
+def connect(
+    cluster_id: str,
+    username: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    identity_file: Optional[str] = typer.Option(
+        None,
+        "--identity",
+        "-i",
+        help="Path to SSH private key (uses configured ssh_key_path if not specified)",
+    ),
+) -> None:
+    """SSH into a Slurm cluster's login node as the given member."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        cluster = _slurm_client().get(resolved_team_id, cluster_id)
+
+        if not cluster.connectable or not cluster.ssh_host or not cluster.ssh_port:
+            console.print(
+                f"[red]Cluster {cluster_id} is not connectable (status: {cluster.status}).[/red]"
+            )
+            raise typer.Exit(1)
+
+        ssh_key_path = identity_file or Config().ssh_key_path
+        if not os.path.exists(ssh_key_path):
+            console.print(f"[red]SSH key not found at {ssh_key_path}[/red]")
+            raise typer.Exit(1)
+
+        console.print(f"[blue]Connecting to {cluster.display_name} as {username}...[/blue]")
+        ssh_command = [
+            "ssh",
+            "-i",
+            ssh_key_path,
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-p",
+            str(cluster.ssh_port),
+            f"{username}@{cluster.ssh_host}",
+        ]
+        try:
+            subprocess.run(ssh_command)
+        except subprocess.CalledProcessError as e:
+            console.print(f"[red]SSH connection failed: {str(e)}[/red]")
+            raise typer.Exit(1)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="members", no_args_is_help=True, epilog=MEMBERS_JSON_HELP)
+def list_members(
+    cluster_id: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """List members with SSH access to a Slurm cluster."""
+    validate_output_format(output, console)
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        members = _slurm_client().list_members(resolved_team_id, cluster_id)
+
+        if output == "json":
+            output_data_as_json({"data": [m.model_dump() for m in members]}, console)
+            return
+
+        table = Table(title=f"Members (Total: {len(members)})", show_lines=True)
+        table.add_column("Username", style="cyan")
+        table.add_column("Sudo", style="white")
+        table.add_column("Status", style="yellow")
+        table.add_column("Linked User", style="blue")
+        for m in members:
+            table.add_row(
+                m.username,
+                "yes" if m.sudo else "no",
+                m.status,
+                m.linked_user_email or m.linked_user_name or "N/A",
+            )
+        console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+def _print_member(m: SlurmClusterMember) -> None:
+    console.print(f"Username: {m.username}")
+    console.print(f"Sudo: {'yes' if m.sudo else 'no'}")
+    console.print(f"Status: {m.status}")
+
+
+@app.command(name="add-member", no_args_is_help=True)
+def add_member(
+    cluster_id: str,
+    username: str,
+    ssh_key: List[str] = typer.Option(
+        ..., "--ssh-key", help="Authorized SSH public key line. Repeatable."
+    ),
+    link_user: Optional[str] = typer.Option(
+        None, "--link-user", help="Prime user ID to link this member to"
+    ),
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+) -> None:
+    """Add a member with SSH access to a Slurm cluster. Requires team admin."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        with console.status("[bold blue]Adding member...", spinner="dots"):
+            member = _slurm_client().add_member(
+                resolved_team_id, cluster_id, username, ssh_key, link_user
+            )
+        console.print(
+            f"[green]Successfully added {member.username} to cluster {cluster_id}[/green]"
+        )
+        _print_member(member)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="remove-member", no_args_is_help=True)
+def remove_member(
+    cluster_id: str,
+    username: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Remove a member's SSH access from a Slurm cluster. Requires team admin."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    if not confirm_or_skip(f"Remove {username}'s access to cluster {cluster_id}?", yes):
+        console.print("Cancelled")
+        raise typer.Exit(0)
+
+    try:
+        with console.status("[bold blue]Removing member...", spinner="dots"):
+            _slurm_client().remove_member(resolved_team_id, cluster_id, username)
+        console.print(f"[green]Successfully removed {username} from cluster {cluster_id}[/green]")
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="sudo", no_args_is_help=True)
+def set_sudo(
+    cluster_id: str,
+    username: str,
+    on: bool = typer.Option(..., "--on/--off", help="Grant or revoke sudo"),
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+) -> None:
+    """Grant or revoke sudo for a cluster member. Requires team admin."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        with console.status("[bold blue]Updating sudo...", spinner="dots"):
+            member = _slurm_client().set_sudo(resolved_team_id, cluster_id, username, on)
+        verb = "Granted" if on else "Revoked"
+        console.print(f"[green]{verb} sudo for {member.username} on cluster {cluster_id}[/green]")
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="rename", no_args_is_help=True)
+def rename(
+    cluster_id: str,
+    name: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+) -> None:
+    """Rename a Slurm cluster. Requires team admin."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        with console.status("[bold blue]Renaming cluster...", spinner="dots"):
+            display_name = _slurm_client().rename(resolved_team_id, cluster_id, name)
+        console.print(f"[green]Cluster {cluster_id} renamed to '{display_name}'[/green]")
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="delete", no_args_is_help=True)
+def delete(
+    cluster_id: str,
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Delete even if the cluster has active Slurm jobs (or accounting can't verify)",
+    ),
+) -> None:
+    """Delete a Slurm cluster. Destructive — requires team admin."""
+    resolved_team_id = _resolve_team_id(team_id)
+
+    if not confirm_or_skip(
+        f"Delete Slurm cluster {cluster_id}? This is destructive and permanently "
+        "removes all data and any running jobs on it.",
+        yes,
+    ):
+        console.print("Cancelled")
+        raise typer.Exit(0)
+
+    try:
+        with console.status("[bold blue]Deleting cluster...", spinner="dots"):
+            _slurm_client().delete(resolved_team_id, cluster_id, force=force)
+        console.print(f"[green]Delete started for cluster {cluster_id}[/green]")
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        if "active" in str(e).lower() or "force" in str(e).lower():
+            console.print("[yellow]Retry with --force to delete anyway.[/yellow]")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="accounting", no_args_is_help=True, epilog=ACCOUNTING_JSON_HELP)
+def accounting(
+    cluster_id: str,
+    days: int = typer.Option(30, "--days", help="Number of days to include (1-90)"),
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Show accounting rollups (throughput, queue wait, GPU-hours) for a Slurm cluster."""
+    validate_output_format(output, console)
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        rollup = _slurm_client().accounting(resolved_team_id, cluster_id, days=days)
+
+        if output == "json":
+            output_data_as_json(rollup.model_dump(), console)
+            return
+
+        if not rollup.available:
+            console.print("[yellow]Accounting is currently unavailable for this cluster.[/yellow]")
+            return
+
+        console.print(f"[bold]Accounting for the last {rollup.days} day(s)[/bold]")
+        console.print(f"Total jobs: {rollup.total_jobs}")
+
+        if rollup.gpu_hours_by_user:
+            table = Table(title="GPU-Hours by User")
+            table.add_column("User", style="cyan")
+            table.add_column("GPU-Hours", style="green")
+            for row in rollup.gpu_hours_by_user:
+                table.add_row(row.user, f"{row.gpu_hours:.2f}")
+            console.print(table)
+
+        if rollup.outcomes:
+            table = Table(title="Outcomes")
+            table.add_column("Outcome", style="cyan")
+            table.add_column("Count", style="white")
+            for row in rollup.outcomes:
+                table.add_row(row.outcome, str(row.count))
+            console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)
+
+
+@app.command(name="utilization", no_args_is_help=True)
+def utilization(
+    cluster_id: str,
+    range_seconds: int = typer.Option(
+        21_600, "--range-seconds", help="Time range to query, in seconds"
+    ),
+    team_id: Optional[str] = _TEAM_ID_OPTION,
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Show GPU utilization over time for a Slurm cluster."""
+    validate_output_format(output, console)
+    resolved_team_id = _resolve_team_id(team_id)
+
+    try:
+        points = _slurm_client().utilization(
+            resolved_team_id, cluster_id, range_seconds=range_seconds
+        )
+
+        if output == "json":
+            output_data_as_json({"gpu_util": [p.model_dump() for p in points]}, console)
+            return
+
+        if not points:
+            console.print("[yellow]No utilization data available for this range.[/yellow]")
+            return
+
+        table = Table(title=f"GPU Utilization (last {range_seconds}s)")
+        table.add_column("Time", style="cyan")
+        table.add_column("Utilization %", style="green")
+        for p in points:
+            timestamp = datetime.fromtimestamp(p.timestamp, tz=timezone.utc).strftime(
+                "%Y-%m-%d %H:%M:%S UTC"
+            )
+            table.add_row(timestamp, f"{p.value:.1f}")
+        console.print(table)
+
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {str(e)}")
+        raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -239,6 +239,14 @@ def connect(
         if result.returncode != 0:
             raise typer.Exit(result.returncode)
 
+    except typer.Exit:
+        # typer.Exit subclasses Exception, so without this it falls into
+        # the generic handler below: the exit code from a failed ssh
+        # (or the "not connectable" / "key not found" cases above, each
+        # already printed its own message before raising) gets stomped
+        # to 1 and a bogus "Unexpected error: <code>" line gets printed
+        # on top of it.
+        raise
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from datetime import datetime, timezone
 from typing import List, Optional
 
 import typer
@@ -26,13 +25,12 @@ console = get_console()
 
 LIST_CLUSTERS_JSON_HELP = json_output_help(
     ".data[] = {id, prime_cluster_id, display_name, status, gpu_type, gpu_count, "
-    "total_gpus, free_gpus, total_nodes, healthy_nodes, cordoned_node_count, "
     "created_at, started_at?}",
 )
 
 CLUSTER_DETAIL_JSON_HELP = json_output_help(
     ". = {id, prime_cluster_id, display_name, status, gpu_type, gpu_count, "
-    "connectable, ssh_host?, ssh_port?, node_health, nodes[]}",
+    "connectable, ssh_host?, ssh_port?}",
 )
 
 MEMBERS_JSON_HELP = json_output_help(
@@ -87,22 +85,15 @@ def list_clusters(
         table.add_column("Name", style="blue")
         table.add_column("Status", style="yellow")
         table.add_column("GPU Type", style="magenta")
-        table.add_column("Free/Total GPUs", style="green")
-        table.add_column("Nodes (healthy/total)", style="blue")
+        table.add_column("GPU Count", style="green")
 
         for c in clusters:
-            gpu_col = (
-                f"{c.free_gpus}/{c.total_gpus}"
-                if c.free_gpus is not None and c.total_gpus is not None
-                else "N/A"
-            )
             table.add_row(
                 c.id,
                 c.display_name,
                 Text(c.status, style=status_color(c.status, SLURM_CLUSTER_STATUS_COLORS)),
                 c.gpu_type or "N/A",
-                gpu_col,
-                f"{c.healthy_nodes}/{c.total_nodes}",
+                str(c.gpu_count),
             )
         console.print(table)
         console.print(
@@ -124,7 +115,7 @@ def get_cluster(
     team_id: Optional[str] = _TEAM_ID_OPTION,
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """Get connection info, health, and node details for a Slurm cluster."""
+    """Get connection info for a Slurm cluster."""
     validate_output_format(output, console)
     resolved_team_id = _resolve_team_id(team_id)
 
@@ -152,36 +143,7 @@ def get_cluster(
             )
         else:
             table.add_row("SSH", "Not connectable (cluster is not RUNNING)")
-        table.add_row(
-            "Node health",
-            f"{cluster.node_health.healthy_nodes}/{cluster.node_health.total_nodes} healthy",
-        )
         console.print(table)
-
-        if cluster.node_health.cordoned_nodes:
-            cordoned_table = Table(title="Cordoned Nodes")
-            cordoned_table.add_column("Name", style="cyan")
-            cordoned_table.add_column("Reason", style="yellow")
-            for n in cluster.node_health.cordoned_nodes:
-                cordoned_table.add_row(n.name, n.reason)
-            console.print("\n")
-            console.print(cordoned_table)
-
-        if cluster.nodes:
-            nodes_table = Table(title="Nodes")
-            nodes_table.add_column("Name", style="cyan")
-            nodes_table.add_column("Ready", style="white")
-            nodes_table.add_column("Free/Allocatable GPUs", style="green")
-            nodes_table.add_column("Slurm State", style="blue")
-            for n in cluster.nodes:
-                nodes_table.add_row(
-                    n.name,
-                    "yes" if n.ready else "no",
-                    f"{n.free_gpus}/{n.allocatable_gpus}",
-                    ",".join(n.slurm_states) if n.slurm_states else "N/A",
-                )
-            console.print("\n")
-            console.print(nodes_table)
 
         console.print(
             f"\n[blue]Use 'prime slurm members {cluster_id}' to see who has access[/blue]"
@@ -515,50 +477,6 @@ def accounting(
             for row in rollup.outcomes:
                 table.add_row(row.outcome, str(row.count))
             console.print(table)
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="utilization", no_args_is_help=True)
-def utilization(
-    cluster_id: str,
-    range_seconds: int = typer.Option(
-        21_600, "--range-seconds", help="Time range to query, in seconds"
-    ),
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """Show GPU utilization over time for a Slurm cluster."""
-    validate_output_format(output, console)
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        points = _slurm_client().utilization(
-            resolved_team_id, cluster_id, range_seconds=range_seconds
-        )
-
-        if output == "json":
-            output_data_as_json({"gpu_util": [p.model_dump() for p in points]}, console)
-            return
-
-        if not points:
-            console.print("[yellow]No utilization data available for this range.[/yellow]")
-            return
-
-        table = Table(title=f"GPU Utilization (last {range_seconds}s)")
-        table.add_column("Time", style="cyan")
-        table.add_column("Utilization %", style="green")
-        for p in points:
-            timestamp = datetime.fromtimestamp(p.timestamp, tz=timezone.utc).strftime(
-                "%Y-%m-%d %H:%M:%S UTC"
-            )
-            table.add_row(timestamp, f"{p.value:.1f}")
-        console.print(table)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -79,7 +79,7 @@ def list_clusters(
         for c in clusters:
             table.add_row(
                 c.id,
-                escape(c.display_name),
+                Text(c.display_name),
                 Text(c.status, style=status_color(c.status, SLURM_CLUSTER_STATUS_COLORS)),
                 c.gpu_type or "N/A",
                 str(c.gpu_count),
@@ -123,10 +123,11 @@ def list_members(
             table.add_row(
                 m.username,
                 str(m.uid),
-                "\n".join(escape(_truncate_ssh_key(k)) for k in m.ssh_authorized_keys) or "N/A",
+                Text("\n").join(Text(_truncate_ssh_key(k)) for k in m.ssh_authorized_keys)
+                or Text("N/A"),
                 "yes" if m.sudo else "no",
                 m.status,
-                escape(m.linked_user_email or m.linked_user_name or "N/A"),
+                Text(m.linked_user_email or m.linked_user_name or "N/A"),
             )
         console.print(table)
 

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -36,7 +36,8 @@ CLUSTER_DETAIL_JSON_HELP = json_output_help(
 )
 
 MEMBERS_JSON_HELP = json_output_help(
-    ".data[] = {username, sudo, status, linked_user_id?, linked_user_name?, linked_user_email?}",
+    ".data[] = {username, uid, ssh_authorized_keys[], sudo, status, "
+    "linked_user_id?, linked_user_name?, linked_user_email?}",
 )
 
 ACCOUNTING_JSON_HELP = json_output_help(
@@ -274,12 +275,16 @@ def list_members(
 
         table = Table(title=f"Members (Total: {len(members)})", show_lines=True)
         table.add_column("Username", style="cyan")
+        table.add_column("UID", style="magenta")
+        table.add_column("SSH Keys", style="green")
         table.add_column("Sudo", style="white")
         table.add_column("Status", style="yellow")
         table.add_column("Linked User", style="blue")
         for m in members:
             table.add_row(
                 m.username,
+                str(m.uid),
+                "\n".join(_truncate_ssh_key(k) for k in m.ssh_authorized_keys) or "N/A",
                 "yes" if m.sudo else "no",
                 m.status,
                 m.linked_user_email or m.linked_user_name or "N/A",
@@ -294,10 +299,19 @@ def list_members(
         raise typer.Exit(1)
 
 
+def _truncate_ssh_key(key: str, max_len: int = 60) -> str:
+    """Shorten a full authorized_keys line for table display. Full value
+    is always available via --output json."""
+    return key if len(key) <= max_len else f"{key[:max_len]}..."
+
+
 def _print_member(m: SlurmClusterMember) -> None:
     console.print(f"Username: {m.username}")
+    console.print(f"UID: {m.uid}")
     console.print(f"Sudo: {'yes' if m.sudo else 'no'}")
     console.print(f"Status: {m.status}")
+    for key in m.ssh_authorized_keys:
+        console.print(f"SSH Key: {key}")
 
 
 @app.command(name="add-member", no_args_is_help=True)

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 from typing import List, Optional
 
 import typer
@@ -20,7 +18,7 @@ from ..utils import (
 )
 from ..utils.display import SLURM_CLUSTER_STATUS_COLORS
 
-app = PlainTyper(help="Manage Slurm clusters", no_args_is_help=True)
+app = PlainTyper(help="Manage Slurm cluster member access", no_args_is_help=True)
 console = get_console()
 
 LIST_CLUSTERS_JSON_HELP = json_output_help(
@@ -28,19 +26,9 @@ LIST_CLUSTERS_JSON_HELP = json_output_help(
     "created_at, started_at?}",
 )
 
-CLUSTER_DETAIL_JSON_HELP = json_output_help(
-    ". = {id, prime_cluster_id, display_name, status, gpu_type, gpu_count, "
-    "connectable, ssh_host?, ssh_port?}",
-)
-
 MEMBERS_JSON_HELP = json_output_help(
     ".data[] = {username, uid, ssh_authorized_keys[], sudo, status, "
     "linked_user_id?, linked_user_name?, linked_user_email?}",
-)
-
-ACCOUNTING_JSON_HELP = json_output_help(
-    ". = {available, days, total_jobs, throughput[], queue_wait[], "
-    "gpu_hours_by_user[], outcomes[]}",
 )
 
 
@@ -96,120 +84,8 @@ def list_clusters(
                 str(c.gpu_count),
             )
         console.print(table)
-        console.print(
-            "\n[blue]Use 'prime slurm connect <cluster-id> <username>' to SSH in, "
-            "or 'prime slurm get <cluster-id>' for details[/blue]"
-        )
+        console.print("\n[blue]Use 'prime slurm members <cluster-id>' to see who has access[/blue]")
 
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="get", no_args_is_help=True, epilog=CLUSTER_DETAIL_JSON_HELP)
-def get_cluster(
-    cluster_id: str,
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """Get connection info for a Slurm cluster."""
-    validate_output_format(output, console)
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        cluster = _slurm_client().get(resolved_team_id, cluster_id)
-
-        if output == "json":
-            output_data_as_json(cluster.model_dump(), console)
-            return
-
-        table = Table(title=f"Cluster: {cluster.display_name}")
-        table.add_column("Property", style="cyan")
-        table.add_column("Value", style="white")
-        table.add_row(
-            "Status",
-            Text(cluster.status, style=status_color(cluster.status, SLURM_CLUSTER_STATUS_COLORS)),
-        )
-        table.add_row("GPU Type", cluster.gpu_type or "N/A")
-        table.add_row("GPU Count", str(cluster.gpu_count))
-        if cluster.connectable and cluster.ssh_host and cluster.ssh_port:
-            table.add_row(
-                "SSH",
-                f"ssh -p {cluster.ssh_port} <username>@{cluster.ssh_host}  "
-                f"(or: prime slurm connect {cluster_id} <username>)",
-            )
-        else:
-            table.add_row("SSH", "Not connectable (cluster is not RUNNING)")
-        console.print(table)
-
-        console.print(
-            f"\n[blue]Use 'prime slurm members {cluster_id}' to see who has access[/blue]"
-        )
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="connect", no_args_is_help=True)
-@app.command(name="ssh", no_args_is_help=True)
-def connect(
-    cluster_id: str,
-    username: str,
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-    identity_file: Optional[str] = typer.Option(
-        None,
-        "--identity",
-        "-i",
-        help="Path to SSH private key (uses configured ssh_key_path if not specified)",
-    ),
-) -> None:
-    """SSH into a Slurm cluster's login node as the given member."""
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        cluster = _slurm_client().get(resolved_team_id, cluster_id)
-
-        if not cluster.connectable or not cluster.ssh_host or not cluster.ssh_port:
-            console.print(
-                f"[red]Cluster {cluster_id} is not connectable (status: {cluster.status}).[/red]"
-            )
-            raise typer.Exit(1)
-
-        ssh_key_path = identity_file or Config().ssh_key_path
-        if not os.path.exists(ssh_key_path):
-            console.print(f"[red]SSH key not found at {ssh_key_path}[/red]")
-            raise typer.Exit(1)
-
-        console.print(f"[blue]Connecting to {cluster.display_name} as {username}...[/blue]")
-        ssh_command = [
-            "ssh",
-            "-i",
-            ssh_key_path,
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-p",
-            str(cluster.ssh_port),
-            f"{username}@{cluster.ssh_host}",
-        ]
-        result = subprocess.run(ssh_command)
-        if result.returncode != 0:
-            raise typer.Exit(result.returncode)
-
-    except typer.Exit:
-        # typer.Exit subclasses Exception, so without this it falls into
-        # the generic handler below: the exit code from a failed ssh
-        # (or the "not connectable" / "key not found" cases above, each
-        # already printed its own message before raising) gets stomped
-        # to 1 and a bogus "Unexpected error: <code>" line gets printed
-        # on top of it.
-        raise
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")
         raise typer.Exit(1)
@@ -327,156 +203,6 @@ def remove_member(
         with console.status("[bold blue]Removing member...", spinner="dots"):
             _slurm_client().remove_member(resolved_team_id, cluster_id, username)
         console.print(f"[green]Successfully removed {username} from cluster {cluster_id}[/green]")
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="sudo", no_args_is_help=True)
-def set_sudo(
-    cluster_id: str,
-    username: str,
-    on: bool = typer.Option(..., "--on/--off", help="Grant or revoke sudo"),
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-) -> None:
-    """Grant or revoke sudo for a cluster member. Requires team admin."""
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        with console.status("[bold blue]Updating sudo...", spinner="dots"):
-            member = _slurm_client().set_sudo(resolved_team_id, cluster_id, username, on)
-        verb = "Granted" if on else "Revoked"
-        console.print(f"[green]{verb} sudo for {member.username} on cluster {cluster_id}[/green]")
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="rename", no_args_is_help=True)
-def rename(
-    cluster_id: str,
-    name: str,
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-) -> None:
-    """Rename a Slurm cluster. Requires team admin."""
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        with console.status("[bold blue]Renaming cluster...", spinner="dots"):
-            display_name = _slurm_client().rename(resolved_team_id, cluster_id, name)
-        console.print(f"[green]Cluster {cluster_id} renamed to '{display_name}'[/green]")
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="delete", no_args_is_help=True)
-def delete(
-    cluster_id: str,
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        help="Delete even if the cluster has active Slurm jobs (or accounting can't verify)",
-    ),
-) -> None:
-    """Delete a Slurm cluster. Destructive — requires team admin."""
-    resolved_team_id = _resolve_team_id(team_id)
-
-    if not confirm_or_skip(
-        f"Delete Slurm cluster {cluster_id}? This is destructive and permanently "
-        "removes all data and any running jobs on it.",
-        yes,
-    ):
-        console.print("Cancelled")
-        raise typer.Exit(0)
-
-    try:
-        with console.status("[bold blue]Deleting cluster...", spinner="dots"):
-            _slurm_client().delete(resolved_team_id, cluster_id, force=force)
-        console.print(f"[green]Delete started for cluster {cluster_id}[/green]")
-
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {str(e)}")
-        if "active" in str(e).lower() or "force" in str(e).lower():
-            console.print("[yellow]Retry with --force to delete anyway.[/yellow]")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {str(e)}")
-        raise typer.Exit(1)
-
-
-@app.command(name="accounting", no_args_is_help=True, epilog=ACCOUNTING_JSON_HELP)
-def accounting(
-    cluster_id: str,
-    days: int = typer.Option(30, "--days", help="Number of days to include (1-90)"),
-    team_id: Optional[str] = _TEAM_ID_OPTION,
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """Show accounting rollups (throughput, queue wait, GPU-hours) for a Slurm cluster."""
-    validate_output_format(output, console)
-    resolved_team_id = _resolve_team_id(team_id)
-
-    try:
-        rollup = _slurm_client().accounting(resolved_team_id, cluster_id, days=days)
-
-        if output == "json":
-            output_data_as_json(rollup.model_dump(), console)
-            return
-
-        if not rollup.available:
-            console.print("[yellow]Accounting is currently unavailable for this cluster.[/yellow]")
-            return
-
-        console.print(f"[bold]Accounting for the last {rollup.days} day(s)[/bold]")
-        console.print(f"Total jobs: {rollup.total_jobs}")
-
-        if rollup.throughput:
-            table = Table(title="Throughput")
-            table.add_column("Day", style="cyan")
-            table.add_column("Completed", style="green")
-            table.add_column("Failed", style="red")
-            table.add_column("Cancelled", style="yellow")
-            for row in rollup.throughput:
-                table.add_row(row.day, str(row.completed), str(row.failed), str(row.cancelled))
-            console.print(table)
-
-        if rollup.queue_wait:
-            table = Table(title="Queue Wait")
-            table.add_column("Day", style="cyan")
-            table.add_column("Median Wait", style="green")
-            for row in rollup.queue_wait:
-                table.add_row(row.day, f"{row.median_seconds:.0f}s")
-            console.print(table)
-
-        if rollup.gpu_hours_by_user:
-            table = Table(title="GPU-Hours by User")
-            table.add_column("User", style="cyan")
-            table.add_column("GPU-Hours", style="green")
-            for row in rollup.gpu_hours_by_user:
-                table.add_row(row.user, f"{row.gpu_hours:.2f}")
-            console.print(table)
-
-        if rollup.outcomes:
-            table = Table(title="Outcomes")
-            table.add_column("Outcome", style="cyan")
-            table.add_column("Count", style="white")
-            for row in rollup.outcomes:
-                table.add_row(row.outcome, str(row.count))
-            console.print(table)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -235,11 +235,9 @@ def connect(
             str(cluster.ssh_port),
             f"{username}@{cluster.ssh_host}",
         ]
-        try:
-            subprocess.run(ssh_command)
-        except subprocess.CalledProcessError as e:
-            console.print(f"[red]SSH connection failed: {str(e)}[/red]")
-            raise typer.Exit(1)
+        result = subprocess.run(ssh_command)
+        if result.returncode != 0:
+            raise typer.Exit(result.returncode)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {str(e)}")
@@ -461,6 +459,24 @@ def accounting(
 
         console.print(f"[bold]Accounting for the last {rollup.days} day(s)[/bold]")
         console.print(f"Total jobs: {rollup.total_jobs}")
+
+        if rollup.throughput:
+            table = Table(title="Throughput")
+            table.add_column("Day", style="cyan")
+            table.add_column("Completed", style="green")
+            table.add_column("Failed", style="red")
+            table.add_column("Cancelled", style="yellow")
+            for row in rollup.throughput:
+                table.add_row(row.day, str(row.completed), str(row.failed), str(row.cancelled))
+            console.print(table)
+
+        if rollup.queue_wait:
+            table = Table(title="Queue Wait")
+            table.add_column("Day", style="cyan")
+            table.add_column("Median Wait", style="green")
+            for row in rollup.queue_wait:
+                table.add_row(row.day, f"{row.median_seconds:.0f}s")
+            console.print(table)
 
         if rollup.gpu_hours_by_user:
             table = Table(title="GPU-Hours by User")

--- a/packages/prime/src/prime_cli/commands/slurm.py
+++ b/packages/prime/src/prime_cli/commands/slurm.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -78,7 +79,7 @@ def list_clusters(
         for c in clusters:
             table.add_row(
                 c.id,
-                c.display_name,
+                escape(c.display_name),
                 Text(c.status, style=status_color(c.status, SLURM_CLUSTER_STATUS_COLORS)),
                 c.gpu_type or "N/A",
                 str(c.gpu_count),
@@ -122,10 +123,10 @@ def list_members(
             table.add_row(
                 m.username,
                 str(m.uid),
-                "\n".join(_truncate_ssh_key(k) for k in m.ssh_authorized_keys) or "N/A",
+                "\n".join(escape(_truncate_ssh_key(k)) for k in m.ssh_authorized_keys) or "N/A",
                 "yes" if m.sudo else "no",
                 m.status,
-                m.linked_user_email or m.linked_user_name or "N/A",
+                escape(m.linked_user_email or m.linked_user_name or "N/A"),
             )
         console.print(table)
 
@@ -149,7 +150,7 @@ def _print_member(m: SlurmClusterMember) -> None:
     console.print(f"Sudo: {'yes' if m.sudo else 'no'}")
     console.print(f"Status: {m.status}")
     for key in m.ssh_authorized_keys:
-        console.print(f"SSH Key: {key}")
+        console.print(f"SSH Key: {escape(key)}")
 
 
 @app.command(name="add-member", no_args_is_help=True)

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -24,6 +24,7 @@ from .commands.registry import app as registry_app
 from .commands.rl import app as train_app
 from .commands.sandbox import app as sandbox_app
 from .commands.secrets import app as secret_app
+from .commands.slurm import app as slurm_app
 from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.traces import app as traces_app
@@ -68,6 +69,7 @@ app.add_typer(availability_app, name="availability", rich_help_panel="Compute")
 app.add_typer(disks_app, name="disks", rich_help_panel="Compute")
 app.add_typer(pods_app, name="pods", rich_help_panel="Compute")
 app.add_typer(sandbox_app, name="sandbox", rich_help_panel="Compute")
+app.add_typer(slurm_app, name="slurm", rich_help_panel="Compute")
 app.add_typer(images_app, name="images", rich_help_panel="Compute")
 app.add_typer(registry_app, name="registry", rich_help_panel="Compute")
 app.add_typer(tunnel_app, name="tunnel", rich_help_panel="Compute")

--- a/packages/prime/src/prime_cli/utils/display.py
+++ b/packages/prime/src/prime_cli/utils/display.py
@@ -101,3 +101,15 @@ DEPLOYMENT_STATUS_COLORS = {
     "DEPLOY_FAILED": "red",
     "UNLOAD_FAILED": "red",
 }
+
+SLURM_CLUSTER_STATUS_COLORS = {
+    "PENDING": "yellow",
+    "DEPLOYING": "yellow",
+    "RUNNING": "green",
+    "TERMINATING": "yellow",
+    "COMPLETED": "white",
+    "FAILED": "red",
+    "STOPPED": "blue",
+    "UNKNOWN": "white",
+    "TOMBSTONED": "white",
+}


### PR DESCRIPTION
## Summary
- New `prime slurm` command group: `list`, `members`, `add-member`, `remove-member`
- Backed by the platform's new `/api/v1/slurm-clusters/*` API (see companion PR)
- Deliberately narrow: roster management only, meant to be safe for a scoped token held by a human admin or an automated agent

## Notes
- Depends on the platform PR shipping the backing API
- Verified manually against a live cluster: list, members, add-member, and remove-member all round-tripped correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin-facing surface that grants or revokes SSH access to Slurm clusters; impact depends on platform authorization and correct key handling, though scope is limited to member roster APIs.
> 
> **Overview**
> Adds a new **Compute** command group, `prime slurm`, for listing team Slurm clusters and managing who has SSH access—scoped to roster operations only (no cluster lifecycle).
> 
> A new `SlurmClustersClient` talks to `/slurm-clusters/{team_id}` endpoints with Pydantic models for cluster summaries and members. Commands include **`list`** and **`members`** (table or `--output json`), plus admin **`add-member`** (repeatable `--ssh-key`, optional `--link-user`) and **`remove-member`** (confirmation unless `-y`). Team context comes from config or `--team-id`, matching other CLI commands.
> 
> `main.py` registers the typer app under **Compute**, and cluster status colors are added for Rich tables on `prime slurm list`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d998d5de919045517f3950cc874904f457e4e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->