### PR TITLE
release: cli 0.6.32 + sandboxes 0.2.41 + tunnel 0.1.11

### DIFF
--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -15,35 +15,41 @@ on:
         type: string
 
 jobs:
-  await-sandboxes-release:
+  await-sdk-releases:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       # The CLI image installs the wheel with its dependencies resolved from PyPI, and
-      # release-sandboxes.yml runs independently of this workflow. Tagging or publishing
-      # before prime-sandboxes is installable would strand the release: the CLI tag
-      # already exists, so a rerun skips it, and every image build fails.
-      - name: Wait for the required prime-sandboxes version on PyPI
+      # SDK release workflows run independently. Publishing before a required SDK is
+      # installable would strand the release: reruns skip the existing CLI tag while
+      # every image build continues to fail dependency resolution.
+      - name: Wait for required SDK versions on PyPI
         run: |
-          FLOOR=$(sed -nE 's/.*"prime-sandboxes>=([^"]+)".*/\1/p' packages/prime/pyproject.toml | head -n1)
-          if [ -z "$FLOOR" ]; then
-            echo "::error::Unable to parse the prime-sandboxes floor from packages/prime/pyproject.toml"
-            exit 1
-          fi
-          echo "Waiting for prime-sandboxes==$FLOOR to become installable"
-          for _ in $(seq 1 40); do
-            if python3 -m pip download --quiet --no-deps --no-cache-dir --dest /tmp/floor-check "prime-sandboxes==$FLOOR"; then
-              echo "prime-sandboxes $FLOOR is installable"
-              exit 0
+          for PACKAGE in prime-sandboxes prime-tunnel; do
+            FLOOR=$(sed -nE "s/.*\"${PACKAGE}>=([^\"]+)\".*/\1/p" packages/prime/pyproject.toml | head -n1)
+            if [ -z "$FLOOR" ]; then
+              echo "::error::Unable to parse the $PACKAGE floor from packages/prime/pyproject.toml"
+              exit 1
             fi
-            sleep 15
+            echo "Waiting for $PACKAGE==$FLOOR to become installable"
+            AVAILABLE=false
+            for _ in $(seq 1 40); do
+              if python3 -m pip download --quiet --no-deps --no-cache-dir --dest /tmp/floor-check "$PACKAGE==$FLOOR"; then
+                echo "$PACKAGE $FLOOR is installable"
+                AVAILABLE=true
+                break
+              fi
+              sleep 15
+            done
+            if [ "$AVAILABLE" != true ]; then
+              echo "::error::$PACKAGE $FLOOR is still not on PyPI after 10 minutes; check its release workflow"
+              exit 1
+            fi
           done
-          echo "::error::prime-sandboxes $FLOOR is still not on PyPI after 10 minutes; check the Release prime-sandboxes workflow"
-          exit 1
 
   tag-and-release:
-    needs: await-sandboxes-release
+    needs: await-sdk-releases
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Tagging and publishing to PyPI is handled automatically by CI.
 
 #### Version sync considerations:
 
-When releasing `prime`, consider whether `prime-sandboxes` should also be bumped, as `prime` depends on `prime-sandboxes`. The packages can be released independently or together depending on what changed.
+When releasing `prime`, consider whether `prime-sandboxes` or `prime-tunnel` should also be bumped, as `prime` depends on both. The packages can be released independently or together depending on what changed.
 
 ## License
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -80,7 +80,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.40"
+__version__ = "0.2.41"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -1,6 +1,6 @@
 """Prime Tunnel SDK - Expose local services via secure tunnels."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 from prime_tunnel.core import Config, TunnelClient
 from prime_tunnel.exceptions import (

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,10 +10,10 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.40",
+    "prime-sandboxes>=0.2.41",
     "prime-evals>=0.2.3",
     "prime-traces>=0.0.1",
-    "prime-tunnel>=0.1.9",
+    "prime-tunnel>=0.1.11",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "typer>=0.9.0,<0.26",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.31"
+__version__ = "0.6.32"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/tests/test_tunnel_cli.py
+++ b/packages/prime/tests/test_tunnel_cli.py
@@ -22,9 +22,10 @@ def test_prime_requires_runtime_sdks_with_cli_feature_support() -> None:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
+    assert "prime-sandboxes>=0.2.41" in pyproject["project"]["dependencies"]
     assert "prime-evals>=0.2.3" in pyproject["project"]["dependencies"]
     assert "prime-traces>=0.0.1" in pyproject["project"]["dependencies"]
-    assert "prime-tunnel>=0.1.9" in pyproject["project"]["dependencies"]
+    assert "prime-tunnel>=0.1.11" in pyproject["project"]["dependencies"]
 
 
 def test_tunnel_start_cli_passes_labels_to_sdk(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dev-dependencies = [
     "ty>=0.0.1a21",
     "pre-commit>=3.5.0"
 ]
-override-dependencies = ["prime-tunnel>=0.1.6"]
 
 [tool.uv.exclude-newer-package]
 # Fast-track trusted first-party / partner-published packages past the

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,6 @@ members = [
     "prime-traces",
     "prime-tunnel",
 ]
-overrides = [{ name = "prime-tunnel", editable = "packages/prime-tunnel" }]
 
 [manifest.dependency-groups]
 dev = [


### PR DESCRIPTION
Releases `prime` 0.6.32, `prime-sandboxes` 0.2.41, and `prime-tunnel` 0.1.11. The CLI now requires the SDK versions that carry its runtime behavior, and its release workflow waits for both exact SDK floors on PyPI before tagging or publishing.

Included changes:

- #883 by @mikasenghaas prevents sandbox polling and deletion teardown races.
- #862 by @DamianB-BitFlipper bounds background-job output retrieval and preserves completed job state when output retrieval fails.
- #886 by @DamianB-BitFlipper applies temporary contexts across CLI, sandbox, and tunnel clients.
- #867 by @akirillo makes live-process Start, input, and signal retries idempotent.
- #885 by @xeophon aligns the release E2E default with `openai/gpt-5.6-luna`.

The sandboxd prerequisites for #867 are deployed. Its live idempotency suite passed against dev and prod. The obsolete workspace `prime-tunnel>=0.1.6` override is removed because the CLI now owns the required `>=0.1.11` contract.