### PR TITLE
ci(release): harden the prime Docker image job against PyPI CDN lag

### DIFF
--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -220,6 +220,8 @@ jobs:
       contents: read
       packages: write
     strategy:
+      # One matrix leg hitting a transient PyPI error must not cancel the others.
+      fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
@@ -248,11 +250,26 @@ jobs:
           IMAGE_PATH=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/$IMAGE_PATH"
           PY_TAG="py${PYTHON_VERSION}"
-          docker build --build-arg PRIME_VERSION="$VERSION" \
-            --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
-            -t "$IMAGE:$VERSION-$PY_TAG" \
-            -t "$IMAGE:v$VERSION-$PY_TAG" \
-            -t "$IMAGE:$PY_TAG" .
+          # pip resolves the wheel's dependencies from PyPI inside the build. Even after
+          # await-sdk-releases has seen a freshly published SDK, a later request can still be
+          # served a stale index by the PyPI CDN, so retry the build before giving up. Layers
+          # before the pip install stay cached, so each retry only repeats the install step.
+          MAX_ATTEMPTS=6
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if docker build --build-arg PRIME_VERSION="$VERSION" \
+              --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
+              -t "$IMAGE:$VERSION-$PY_TAG" \
+              -t "$IMAGE:v$VERSION-$PY_TAG" \
+              -t "$IMAGE:$PY_TAG" .; then
+              break
+            fi
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::docker build failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            echo "docker build failed (attempt $attempt/$MAX_ATTEMPTS); retrying in 30s"
+            sleep 30
+          done
           docker push "$IMAGE:$VERSION-$PY_TAG"
           docker push "$IMAGE:v$VERSION-$PY_TAG"
           docker push "$IMAGE:$PY_TAG"


### PR DESCRIPTION
## Summary

- Set `fail-fast: false` on the `docker-images` matrix so one flaky leg no longer cancels the other Python versions.
- Retry `docker build` up to 6 times, 30s apart, when it fails. pip resolves the wheel's dependencies from PyPI inside the build, and a request can still be served a stale index by the PyPI CDN shortly after an SDK publish. Layers before the pip install stay cached, so each retry only repeats the install step.

## Context

The v0.6.32 release run ([33899010669](https://github.com/PrimeIntellect-ai/prime/actions/runs/33899010669)) published to PyPI and created the GitHub release, but `docker-images (3.12)` failed with:

```
ERROR: No matching distribution found for prime-sandboxes>=0.2.41
```

That was about two minutes after prime-sandboxes 0.2.41 landed on PyPI, and after `await-sdk-releases` had already confirmed it installable. Fail-fast then cancelled the 3.11 and 3.13 legs, so no 0.6.32 images were pushed to GHCR. The run was recovered by re-running only the failed jobs, which reuses the `dist` artifact and the `release_created` output.

## Test plan

- [x] Workflow YAML parses; `bash -n` passes on the extracted build step.
- [ ] Next release run exercises the job. The retry loop is a no-op when the first build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKQV3HLAnmxURyiR3dRpAy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with no runtime, auth, or application code impact; worst case is slightly longer release jobs on repeated build failures.
> 
> **Overview**
> Hardens the **release-prime** `docker-images` job so transient PyPI index lag does not block publishing all GHCR tags for a release.
> 
> The matrix strategy now sets **`fail-fast: false`**, so a failure on one Python version (3.11/3.12/3.13) no longer cancels the other legs. The **build-and-push** step wraps `docker build` in a loop of up to **6 attempts** with **30s** backoff when the build fails—targeting cases where `pip install` inside the image still cannot see a newly published SDK despite `await-sdk-releases` having passed. Push steps run only after a successful build; behavior is unchanged when the first build succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31540f53f7ed9cad6c30e8611768cb170c070675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->