### PR TITLE
feat(traces): add --page to 'prime traces list'

### DIFF
--- a/packages/prime/src/prime_cli/commands/traces.py
+++ b/packages/prime/src/prime_cli/commands/traces.py
@@ -189,7 +189,10 @@ def list_traces(
         1,
         "--page",
         "-p",
-        help="Page number; later pages are reached by walking the pages before them",
+        help=(
+            "Page number; each run walks the pages before it from the current top, so"
+            " boundaries shift as traces arrive (use --cursor for a fixed boundary)"
+        ),
     ),
     limit: int = typer.Option(20, "--limit", help="Max results per page (up to 100)"),
     cursor: Optional[str] = typer.Option(
@@ -271,7 +274,7 @@ def list_traces(
     console.print(table)
 
     # A cursor resume has no page number to report, so it keeps the raw
-    # cursor hint; page mode mirrors the other list commands' footer.
+    # cursor hint alone; page mode mirrors the other list commands' footer.
     if cursor is not None:
         if result.next_cursor:
             console.print(f"[dim]More results: --cursor {escape(result.next_cursor)}[/dim]")
@@ -281,7 +284,14 @@ def list_traces(
         end = (page - 1) * limit + len(result.items)
         console.print(f"[dim]Page {page} • showing {start}-{end}[/dim]")
     if result.next_cursor:
+        # `--page N+1` re-walks from the current top in a fresh process, so a
+        # trace that arrives in between shifts every boundary and the row
+        # that fell off this page shows up again on the next. The cursor
+        # pins the boundary to this exact row, so it stays on offer.
         console.print(f"[dim]Use --page {page + 1} to see more.[/dim]")
+        console.print(
+            f"[dim]Or resume from this exact boundary: --cursor {escape(result.next_cursor)}[/dim]"
+        )
 
 
 @app.command("get", epilog=GET_TRACE_JSON_HELP)

--- a/packages/prime/src/prime_cli/commands/traces.py
+++ b/packages/prime/src/prime_cli/commands/traces.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import click
 import typer
@@ -10,6 +10,7 @@ from prime_traces import (
     NotFoundError,
     PaymentRequiredError,
     PrimeTracesError,
+    TraceListPage,
     TracesClient,
     UnauthorizedError,
     UploadReceipt,
@@ -145,6 +146,27 @@ def upload_traces(
         console.print(f"[green]Uploaded {len(receipts)} batch(es) from {escape(str(file))}[/green]")
 
 
+def _list_page(
+    fetch: Callable[[Optional[str]], TraceListPage],
+    *,
+    page: int,
+    cursor: Optional[str],
+) -> TraceListPage:
+    """Fetch one page, walking the pages before it when it is not the first.
+
+    The service paginates by cursor only, so page N costs N requests. Every
+    hop asks for the same page size, which keeps the page boundaries lined
+    up; a walk that runs out of pages early yields an empty page rather than
+    the last real one.
+    """
+    for _ in range(page - 1):
+        hop = fetch(cursor)
+        if not hop.next_cursor:
+            return TraceListPage(items=[], next_cursor=None)
+        cursor = hop.next_cursor
+    return fetch(cursor)
+
+
 @app.command("list", epilog=LIST_TRACES_JSON_HELP)
 def list_traces(
     run_id: Optional[str] = typer.Option(None, "--run-id", help="Filter by run ID"),
@@ -163,28 +185,48 @@ def list_traces(
     sort: Optional[str] = typer.Option(
         None, "--sort", help="Sort key: created_at (default, newest first), reward, duration_ms"
     ),
+    page: int = typer.Option(
+        1,
+        "--page",
+        "-p",
+        help="Page number; later pages are reached by walking the pages before them",
+    ),
     limit: int = typer.Option(20, "--limit", help="Max results per page (up to 100)"),
-    cursor: Optional[str] = typer.Option(None, "--cursor", help="Cursor from a previous page"),
+    cursor: Optional[str] = typer.Option(
+        None,
+        "--cursor",
+        help="Resume from a cursor returned by a previous page (cannot be combined with --page)",
+    ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """List trace summaries, newest first."""
     validate_output_format(output, error_console)
+    if page < 1:
+        error_console.print("[red]Error:[/red] --page must be at least 1")
+        raise typer.Exit(1)
+    if cursor is not None and page > 1:
+        error_console.print("[red]Error:[/red] --page cannot be combined with --cursor")
+        raise typer.Exit(1)
     try:
         client = _traces_client()
-        page = client.list(
-            run_id=run_id,
-            task_id=task_id,
-            model_id=model_id,
-            outcome=outcome,
-            has_error=has_error,
-            reward_min=reward_min,
-            reward_max=reward_max,
-            created_after=created_after,
-            created_before=created_before,
-            sort=sort,
-            limit=limit,
-            cursor=cursor,
-        )
+
+        def fetch(page_cursor: Optional[str]) -> TraceListPage:
+            return client.list(
+                run_id=run_id,
+                task_id=task_id,
+                model_id=model_id,
+                outcome=outcome,
+                has_error=has_error,
+                reward_min=reward_min,
+                reward_max=reward_max,
+                created_after=created_after,
+                created_before=created_before,
+                sort=sort,
+                limit=limit,
+                cursor=page_cursor,
+            )
+
+        result = _list_page(fetch, page=page, cursor=cursor)
     except typer.Exit:
         raise
     except UnauthorizedError as e:
@@ -202,7 +244,7 @@ def list_traces(
         raise typer.Exit(1)
 
     if output == "json":
-        output_data_as_json(page.model_dump(mode="json"), console)
+        output_data_as_json(result.model_dump(mode="json"), console)
         return
 
     table = Table(title="Traces")
@@ -213,7 +255,7 @@ def list_traces(
     table.add_column("Outcome")
     table.add_column("Created")
 
-    for summary in page.items:
+    for summary in result.items:
         reward = summary.score.reward
         table.add_row(
             escape(summary.trace_id),
@@ -223,9 +265,23 @@ def list_traces(
             escape(summary.score.outcome or "-"),
             escape(summary.created_at.isoformat()),
         )
+    if not result.items and page > 1:
+        console.print(f"[yellow]No traces on page {page}.[/yellow]")
+        console.print("Try [bold]--page 1[/bold] to start from the beginning.")
     console.print(table)
-    if page.next_cursor:
-        console.print(f"[dim]More results: --cursor {escape(page.next_cursor)}[/dim]")
+
+    # A cursor resume has no page number to report, so it keeps the raw
+    # cursor hint; page mode mirrors the other list commands' footer.
+    if cursor is not None:
+        if result.next_cursor:
+            console.print(f"[dim]More results: --cursor {escape(result.next_cursor)}[/dim]")
+        return
+    if result.items and (result.next_cursor or page > 1):
+        start = (page - 1) * limit + 1
+        end = (page - 1) * limit + len(result.items)
+        console.print(f"[dim]Page {page} • showing {start}-{end}[/dim]")
+    if result.next_cursor:
+        console.print(f"[dim]Use --page {page + 1} to see more.[/dim]")
 
 
 @app.command("get", epilog=GET_TRACE_JSON_HELP)

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -402,7 +402,8 @@ def test_list_command_forwards_filters_and_renders_table(fake_client):
     assert result.exit_code == 0, result.output
     assert "8d3f1a2b" in result.output
     assert "Use --page 2 to see more." in result.output
-    assert "cursor-1" not in result.output  # page mode hides the raw cursor
+    # The exact-boundary resume stays on offer next to the page hint.
+    assert "--cursor cursor-1" in result.output
     call = fake_client.calls["list"]
     assert call["run_id"] == "run_9f3k2m"
     assert call["reward_min"] == 0.5
@@ -478,7 +479,7 @@ def test_list_command_page_with_more_pages_hints_the_next_page(fake_client):
     assert result.exit_code == 0, result.output
     assert "Page 2 • showing 3-4" in result.output
     assert "Use --page 3 to see more." in result.output
-    assert "c2" not in result.output
+    assert "--cursor c2" in result.output
 
 
 def test_list_command_page_past_the_end_stops_walking(fake_client):

--- a/packages/prime/tests/test_traces_command.py
+++ b/packages/prime/tests/test_traces_command.py
@@ -401,11 +401,136 @@ def test_list_command_forwards_filters_and_renders_table(fake_client):
 
     assert result.exit_code == 0, result.output
     assert "8d3f1a2b" in result.output
-    assert "cursor-1" in result.output  # next-page hint
+    assert "Use --page 2 to see more." in result.output
+    assert "cursor-1" not in result.output  # page mode hides the raw cursor
     call = fake_client.calls["list"]
     assert call["run_id"] == "run_9f3k2m"
     assert call["reward_min"] == 0.5
     assert call["limit"] == 10
+    assert call["cursor"] is None
+
+
+def test_list_command_first_page_without_more_has_no_footer(fake_client):
+    fake_client.list = lambda **kwargs: TraceListPage(items=[_summary()], next_cursor=None)
+
+    result = runner.invoke(main_app, ["traces", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "Page 1" not in result.output
+    assert "--page" not in result.output
+
+
+def test_list_command_cursor_resume_keeps_cursor_hint(fake_client):
+    result = runner.invoke(main_app, ["traces", "list", "--cursor", "cursor-0"])
+
+    assert result.exit_code == 0, result.output
+    assert fake_client.calls["list"]["cursor"] == "cursor-0"
+    assert "More results: --cursor cursor-1" in result.output
+    assert "--page" not in result.output
+
+
+def _paged_client(fake_client, pages):
+    """Serve ``pages`` keyed by the cursor that reaches them; records each call."""
+    calls = []
+
+    def list_(**kwargs):
+        calls.append(kwargs)
+        items, next_cursor = pages[kwargs.get("cursor")]
+        return TraceListPage(items=items, next_cursor=next_cursor)
+
+    fake_client.list = list_
+    return calls
+
+
+def test_list_command_page_walks_cursors_to_the_requested_page(fake_client):
+    calls = _paged_client(
+        fake_client,
+        {
+            None: ([_summary(trace_id="p1a"), _summary(trace_id="p1b")], "c1"),
+            "c1": ([_summary(trace_id="p2a"), _summary(trace_id="p2b")], "c2"),
+            "c2": ([_summary(trace_id="p3a")], None),
+        },
+    )
+
+    result = runner.invoke(main_app, ["traces", "list", "--page", "3", "--limit", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert [call["cursor"] for call in calls] == [None, "c1", "c2"]
+    assert all(call["limit"] == 2 for call in calls)
+    assert "p3a" in result.output
+    assert "p1a" not in result.output
+    assert "p2a" not in result.output
+    assert "Page 3 • showing 5-5" in result.output
+    assert "--page 4" not in result.output
+
+
+def test_list_command_page_with_more_pages_hints_the_next_page(fake_client):
+    _paged_client(
+        fake_client,
+        {
+            None: ([_summary(trace_id="p1a"), _summary(trace_id="p1b")], "c1"),
+            "c1": ([_summary(trace_id="p2a"), _summary(trace_id="p2b")], "c2"),
+        },
+    )
+
+    result = runner.invoke(main_app, ["traces", "list", "-p", "2", "--limit", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert "Page 2 • showing 3-4" in result.output
+    assert "Use --page 3 to see more." in result.output
+    assert "c2" not in result.output
+
+
+def test_list_command_page_past_the_end_stops_walking(fake_client):
+    calls = _paged_client(
+        fake_client,
+        {
+            None: ([_summary(trace_id="p1a")], "c1"),
+            "c1": ([_summary(trace_id="p2a")], None),
+        },
+    )
+
+    result = runner.invoke(main_app, ["traces", "list", "--page", "5"])
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 2  # stops at the last real page instead of requesting five
+    assert "No traces on page 5." in result.output
+    assert "--page 1" in result.output
+    assert "p2a" not in result.output
+    assert "showing" not in result.output
+
+
+def test_list_command_page_json_output_is_the_requested_page(fake_client):
+    _paged_client(
+        fake_client,
+        {
+            None: ([_summary(trace_id="p1a")], "c1"),
+            "c1": ([_summary(trace_id="p2a")], "c2"),
+        },
+    )
+
+    result = runner.invoke(main_app, ["traces", "list", "--page", "2", "-o", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [item["trace_id"] for item in payload["items"]] == ["p2a"]
+    assert payload["next_cursor"] == "c2"
+
+
+def test_list_command_rejects_page_with_cursor(fake_client):
+    result = runner.invoke(main_app, ["traces", "list", "--page", "2", "--cursor", "c1"])
+
+    assert result.exit_code == 1
+    assert "--page cannot be combined with --cursor" in result.output
+    assert "list" not in fake_client.calls
+
+
+def test_list_command_rejects_page_below_one(fake_client):
+    result = runner.invoke(main_app, ["traces", "list", "--page", "0"])
+
+    assert result.exit_code == 1
+    assert "--page must be at least 1" in result.output
+    assert "list" not in fake_client.calls
 
 
 def test_list_command_renders_full_trace_id(fake_client):


### PR DESCRIPTION
## Summary

`prime traces list` paginated only by an opaque keyset cursor, so its next-page hint was a long base64 token rather than the page footer that `prime sandbox list` and `prime images list` print. This adds `--page`/`-p` so the traces list reads the same way:

```
Page 2 • showing 21-40
Use --page 3 to see more.
Or resume from this exact boundary: --cursor eyJ2IjoxLCJz…
```

The traces service is cursor-only and that is deliberate (a cursor pins the page boundary to a specific `created_at` + trace ID, so a trace uploaded mid-pagination shifts nothing). Rather than add offset pagination server-side, the CLI walks the cursors of the earlier pages under the hood and requests the same `--limit` on every hop so page boundaries line up.

## Behavior

- `--page N` costs N requests, each about the cost of page 1. That is fine interactively. The help text says so.
- Each `--page N` invocation re-walks from the current top, so page boundaries shift as traces arrive, exactly like the offset-paginated lists. Traces arrive continuously during a run, so the footer keeps the next cursor on offer as a second line: `--cursor` resumes from the exact row this page ended on and never repeats or skips. The `--page` help text says which to use when.
- A page past the end stops walking at the last real page (no wasted requests) and prints `No traces on page N. Try --page 1 to start from the beginning.`
- `--cursor` keeps working unchanged for scripts and SDK users. A cursor resume has no page number to report, so it prints only the raw `More results: --cursor …` hint.
- `--page` and `--cursor` are mutually exclusive; `--page 0` is rejected. Both mirror the validation in the other list commands.
- `-o json` output shape is unchanged (`items`, `next_cursor`); `--page N` just makes it page N's payload.

## Not in this PR

The `of 883 trace(s)` total that the images footer shows needs a `total` field from the traces service. The list query already runs a dedup pass over the owner's key range before filtering, so a count can ride along in the same query nearly for free (the runs aggregate already counts this way). Once that field exists the footer can pick it up in a follow-up.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check src/` clean
- [x] `packages/prime` suite: 1055 passed, 5 skipped
- [x] New tests cover: cursor walk reaches the requested page with the same limit per hop, footer text for middle and last pages including the cursor line, past-the-end stops early, JSON on `--page 2`, `--cursor` resume keeps the cursor hint, and both rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yUXQVXhYWRPMDazbnb9uV
