### PR TITLE
feat(inference): show model catalog details in prime inference models

### DIFF
--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -24,12 +24,43 @@ app = PlainTyper(
 console = get_console()
 
 MODELS_JSON_HELP = json_output_help(
-    "Typical OpenAI schema: .object?, .data[] = {id, created, pricing?}",
+    "Typical OpenAI schema: .object?, .data[] = {id, display_name?, created, pricing?, specs?}",
     "Compatibility fallback: .models[] may be present instead of .data[]",
 )
 
 _SORT_KEYS = ("id", "input", "output")
 _ORDER_KEYS = ("asc", "desc")
+
+_MODALITY_CODES = {"text": "t", "image": "i", "audio": "a", "video": "v", "file": "f"}
+
+
+def _format_token_count(value: Any) -> str:
+    """Compact token counts for table cells: 200000 -> '200k', 1048576 -> '1.05M'."""
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return "—"
+    if v <= 0:
+        return "—"
+    if v >= 1_000_000:
+        return f"{v / 1_000_000:.2f}".rstrip("0").rstrip(".") + "M"
+    if v >= 1_000:
+        return f"{v / 1_000:.1f}".rstrip("0").rstrip(".") + "k"
+    return str(v)
+
+
+def _format_modalities(specs: Dict[str, Any]) -> str:
+    """Compact modality codes: {'input': ['text','image'], 'output': ['text']} -> 't+i→t'."""
+    modalities = (specs or {}).get("modalities") or {}
+    inputs = [str(x) for x in (modalities.get("input") or [])]
+    outputs = [str(x) for x in (modalities.get("output") or [])]
+    if not inputs and not outputs:
+        return "—"
+
+    def codes(values: List[str]) -> str:
+        return "+".join(_MODALITY_CODES.get(x, x[:1].lower()) for x in values) or "?"
+
+    return f"{codes(inputs)}→{codes(outputs)}"
 
 
 def _price(m: Dict[str, Any], key: str) -> Optional[float]:
@@ -117,23 +148,63 @@ def list_models(
             return
 
         table = Table(title="Prime Inference — Models")
+        # Catalog columns appear only when the endpoint serves the data, so
+        # the table stays slim against older /models responses.
+        show_name = any(m.get("display_name") for m in models)
+        show_cache = any(
+            (m.get("pricing") or {}).get("cache_read_usd_per_mtok") is not None
+            or (m.get("pricing") or {}).get("cache_write_usd_per_mtok") is not None
+            for m in models
+        )
+        show_specs = any(m.get("specs") for m in models)
+
         table.add_column("id", style="cyan")
+        if show_name:
+            table.add_column("name")
         table.add_column("input $/1M tok", style="green", justify="right")
         table.add_column("output $/1M tok", style="green", justify="right")
+        if show_cache:
+            table.add_column("cache r/w $/1M tok", style="green", justify="right")
+        if show_specs:
+            table.add_column("context", justify="right")
+            table.add_column("max out", justify="right")
+            table.add_column("modalities")
+            table.add_column("reasoning")
 
         for m in models:
             mid = str(m.get("id", ""))
             pricing = m.get("pricing") or {}
-            pin = pricing.get("input_usd_per_mtok")
-            pout = pricing.get("output_usd_per_mtok")
+            specs = m.get("specs") or {}
 
-            table.add_row(
-                mid,
-                format_price_per_mtok(pin),
-                format_price_per_mtok(pout),
-            )
+            row: List[str] = [mid]
+            if show_name:
+                row.append(str(m.get("display_name") or "—"))
+            row.append(format_price_per_mtok(pricing.get("input_usd_per_mtok")))
+            row.append(format_price_per_mtok(pricing.get("output_usd_per_mtok")))
+            if show_cache:
+                cache_read = pricing.get("cache_read_usd_per_mtok")
+                cache_write = pricing.get("cache_write_usd_per_mtok")
+                if cache_read is None and cache_write is None:
+                    row.append("—")
+                else:
+                    cache_cell = (
+                        f"{format_price_per_mtok(cache_read)} /"
+                        f" {format_price_per_mtok(cache_write)}"
+                    )
+                    row.append(cache_cell)
+            if show_specs:
+                row.append(_format_token_count(specs.get("context_window")))
+                row.append(_format_token_count(specs.get("max_output_tokens")))
+                row.append(_format_modalities(specs))
+                row.append("✓" if specs.get("supports_reasoning") else "—")
+            table.add_row(*row)
 
         console.print(table)
+        if show_specs:
+            console.print(
+                "[dim]modalities: t=text i=image a=audio v=video f=file (in→out) · "
+                "reasoning ✓ = supports reasoning effort[/dim]"
+            )
 
     except InferenceAPIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List, Optional, cast
 
 import typer
 from rich.table import Table
+from rich.text import Text
 
 from ..api.inference import InferenceAPIError, InferenceClient
 from ..utils import (
@@ -165,9 +166,13 @@ def list_models(
             pricing = m.get("pricing") or {}
             specs = m.get("specs") or {}
 
-            row: List[str] = [mid]
+            # Catalog values (id, display_name) are untrusted upstream data —
+            # Text cells render them verbatim, so Rich markup in a name can
+            # neither restyle the table nor raise MarkupError.
+            row: List[Any] = [Text(mid)]
             if show_name:
-                row.append(str(m.get("display_name") or "—"))
+                name = m.get("display_name")
+                row.append(Text(str(name)) if name else "—")
             row.append(format_price_per_mtok(pricing.get("input_usd_per_mtok")))
             row.append(format_price_per_mtok(pricing.get("output_usd_per_mtok")))
             if show_cache:

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -31,8 +31,6 @@ MODELS_JSON_HELP = json_output_help(
 _SORT_KEYS = ("id", "input", "output")
 _ORDER_KEYS = ("asc", "desc")
 
-_MODALITY_CODES = {"text": "t", "image": "i", "audio": "a", "video": "v", "file": "f"}
-
 
 def _format_token_count(value: Any) -> str:
     """Compact token counts for table cells: 200000 -> '200k', 1048576 -> '1.05M'."""
@@ -47,20 +45,6 @@ def _format_token_count(value: Any) -> str:
     if v >= 1_000:
         return f"{v / 1_000:.1f}".rstrip("0").rstrip(".") + "k"
     return str(v)
-
-
-def _format_modalities(specs: Dict[str, Any]) -> str:
-    """Compact modality codes: {'input': ['text','image'], 'output': ['text']} -> 't+i→t'."""
-    modalities = (specs or {}).get("modalities") or {}
-    inputs = [str(x) for x in (modalities.get("input") or [])]
-    outputs = [str(x) for x in (modalities.get("output") or [])]
-    if not inputs and not outputs:
-        return "—"
-
-    def codes(values: List[str]) -> str:
-        return "+".join(_MODALITY_CODES.get(x, x[:1].lower()) for x in values) or "?"
-
-    return f"{codes(inputs)}→{codes(outputs)}"
 
 
 def _price(m: Dict[str, Any], key: str) -> Optional[float]:
@@ -168,7 +152,6 @@ def list_models(
         if show_specs:
             table.add_column("context", justify="right")
             table.add_column("max out", justify="right")
-            table.add_column("modalities")
             table.add_column("reasoning")
 
         for m in models:
@@ -195,16 +178,12 @@ def list_models(
             if show_specs:
                 row.append(_format_token_count(specs.get("context_window")))
                 row.append(_format_token_count(specs.get("max_output_tokens")))
-                row.append(_format_modalities(specs))
                 row.append("✓" if specs.get("supports_reasoning") else "—")
             table.add_row(*row)
 
         console.print(table)
         if show_specs:
-            console.print(
-                "[dim]modalities: t=text i=image a=audio v=video f=file (in→out) · "
-                "reasoning ✓ = supports reasoning effort[/dim]"
-            )
+            console.print("[dim]reasoning ✓ = supports reasoning effort[/dim]")
 
     except InferenceAPIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -32,6 +32,12 @@ _SORT_KEYS = ("id", "input", "output")
 _ORDER_KEYS = ("asc", "desc")
 
 
+def _format_cache_price(value: Any) -> str:
+    """Render one side of the cache read/write pair. None means "no data"
+    (renders as an em-dash); 0 is a real price (free) and renders normally."""
+    return format_price_per_mtok(value) if value is not None else "—"
+
+
 def _format_token_count(value: Any) -> str:
     """Compact token counts for table cells: 200000 -> '200k', 1048576 -> '1.05M'."""
     try:
@@ -142,7 +148,7 @@ def list_models(
         )
         show_specs = any(m.get("specs") for m in models)
 
-        table.add_column("id", style="cyan")
+        table.add_column("id", style="cyan", overflow="fold")
         if show_name:
             table.add_column("name")
         table.add_column("input $/1M tok", style="green", justify="right")
@@ -171,8 +177,7 @@ def list_models(
                     row.append("—")
                 else:
                     cache_cell = (
-                        f"{format_price_per_mtok(cache_read)} /"
-                        f" {format_price_per_mtok(cache_write)}"
+                        f"{_format_cache_price(cache_read)} / {_format_cache_price(cache_write)}"
                     )
                     row.append(cache_cell)
             if show_specs:

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -300,6 +300,29 @@ def test_models_table_shows_catalog_columns(monkeypatch: pytest.MonkeyPatch) -> 
     assert "reasoning ✓" in out
 
 
+def test_models_table_renders_markup_in_catalog_names_literally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "object": "list",
+        "data": [
+            {
+                "id": "vendor/model",
+                "display_name": "Weird [/red] Name",
+                "pricing": {"input_usd_per_mtok": 1.0, "output_usd_per_mtok": 2.0},
+            }
+        ],
+    }
+    _patch_models(monkeypatch, payload)
+
+    result = CliRunner().invoke(app, ["inference", "models"], env=TEST_ENV)
+
+    # An unmatched closing tag must not raise MarkupError (exit 1) nor
+    # restyle the table — catalog names render verbatim.
+    assert result.exit_code == 0, result.output
+    assert "Weird [/red] Name" in result.output
+
+
 def test_models_table_folds_ids_in_narrow_terminals(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_models(monkeypatch, _catalog_fixture())
 

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -261,6 +261,14 @@ def _catalog_fixture() -> Dict[str, Any]:
                     "cache_write_usd_per_mtok": 0.11,
                 },
             },
+            {
+                "id": "partial/cache-read-only",
+                "pricing": {
+                    "input_usd_per_mtok": 0.3,
+                    "output_usd_per_mtok": 0.6,
+                    "cache_read_usd_per_mtok": 0.03,
+                },
+            },
         ],
     }
 
@@ -286,8 +294,22 @@ def test_models_table_shows_catalog_columns(monkeypatch: pytest.MonkeyPatch) -> 
     # Second model has no specs -> em-dash cells, but cache pricing still shown.
     assert "prime/hosted-model" in out
     assert "$0.099 / $0.11" in out
+    # Partial cache pricing marks the missing side explicitly.
+    assert "$0.03 / —" in out
     # Legend explains the reasoning column.
     assert "reasoning ✓" in out
+
+
+def test_models_table_folds_ids_in_narrow_terminals(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _catalog_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models"], env={**TEST_ENV, "COLUMNS": "80"})
+
+    assert result.exit_code == 0, result.output
+    # The id column folds (wraps) instead of truncating, so the identifier's
+    # tail stays visible and copyable even when catalog columns squeeze the
+    # table (truncation would render 'anthrop…' and drop the tail).
+    assert "u-4.5" in result.output
 
 
 def test_models_table_omits_catalog_columns_for_legacy_payload(

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -276,15 +276,18 @@ def test_models_table_shows_catalog_columns(monkeypatch: pytest.MonkeyPatch) -> 
     assert "context" in out
     assert "200k" in out
     assert "64k" in out
-    assert "t+i+f→t" in out
     assert "✓" in out
+    # Modalities are upstream model data, not a productized gateway feature —
+    # never rendered even when the endpoint serves them.
+    assert "modalities" not in out
+    assert "t+i+f" not in out
     # Cache read/write cell for the first model.
     assert "$0.1 / $1.25" in out
     # Second model has no specs -> em-dash cells, but cache pricing still shown.
     assert "prime/hosted-model" in out
     assert "$0.099 / $0.11" in out
-    # Legend explains the compact modality codes.
-    assert "t=text" in out
+    # Legend explains the reasoning column.
+    assert "reasoning ✓" in out
 
 
 def test_models_table_omits_catalog_columns_for_legacy_payload(
@@ -299,7 +302,6 @@ def test_models_table_omits_catalog_columns_for_legacy_payload(
     # No model carries catalog data -> slim table, unchanged from before.
     assert "name" not in out
     assert "context" not in out
-    assert "modalities" not in out
     assert "reasoning" not in out
     assert "cache" not in out
 

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -230,3 +230,88 @@ def test_models_json_output_applies_search_and_sort(monkeypatch: pytest.MonkeyPa
     )
     assert all(p >= 0 for p in positions)
     assert positions == sorted(positions)
+
+
+def _catalog_fixture() -> Dict[str, Any]:
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "anthropic/claude-haiku-4.5",
+                "display_name": "Claude Haiku 4.5",
+                "pricing": {
+                    "input_usd_per_mtok": 1.0,
+                    "output_usd_per_mtok": 5.0,
+                    "cache_read_usd_per_mtok": 0.1,
+                    "cache_write_usd_per_mtok": 1.25,
+                },
+                "specs": {
+                    "context_window": 200000,
+                    "max_output_tokens": 64000,
+                    "modalities": {"input": ["text", "image", "file"], "output": ["text"]},
+                    "supports_reasoning": True,
+                },
+            },
+            {
+                "id": "prime/hosted-model",
+                "pricing": {
+                    "input_usd_per_mtok": 0.11,
+                    "output_usd_per_mtok": 0.44,
+                    "cache_read_usd_per_mtok": 0.099,
+                    "cache_write_usd_per_mtok": 0.11,
+                },
+            },
+        ],
+    }
+
+
+def test_models_table_shows_catalog_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_models(monkeypatch, _catalog_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Claude Haiku 4.5" in out
+    assert "context" in out
+    assert "200k" in out
+    assert "64k" in out
+    assert "t+i+f→t" in out
+    assert "✓" in out
+    # Cache read/write cell for the first model.
+    assert "$0.1 / $1.25" in out
+    # Second model has no specs -> em-dash cells, but cache pricing still shown.
+    assert "prime/hosted-model" in out
+    assert "$0.099 / $0.11" in out
+    # Legend explains the compact modality codes.
+    assert "t=text" in out
+
+
+def test_models_table_omits_catalog_columns_for_legacy_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_models(monkeypatch, _models_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # No model carries catalog data -> slim table, unchanged from before.
+    assert "name" not in out
+    assert "context" not in out
+    assert "modalities" not in out
+    assert "reasoning" not in out
+    assert "cache" not in out
+
+
+def test_models_json_output_passes_catalog_fields_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_models(monkeypatch, _catalog_fixture())
+
+    result = CliRunner().invoke(app, ["inference", "models", "--output", "json"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert '"display_name": "Claude Haiku 4.5"' in result.output
+    assert '"context_window": 200000' in result.output
+    assert '"cache_read_usd_per_mtok": 0.1' in result.output


### PR DESCRIPTION
## Summary

Extends `prime inference models` to surface the model catalog data that the `/models` endpoint now serves (platform PR: platform#5086 + the specs release):

| Column | Source |
|---|---|
| `name` | `display_name` (OpenRouter catalog name, vendor prefix stripped, or route override) |
| `cache r/w $/1M tok` | `pricing.cache_read_usd_per_mtok` / `cache_write_usd_per_mtok` (prime-hosted models / overrides) |
| `context` | `specs.context_window` (compact: `200k`, `1.05M`) |
| `max out` | `specs.max_output_tokens` (compact) |
| `reasoning` | `specs.supports_reasoning` (`✓` / `—`, with a legend line) |

**Modalities are deliberately NOT rendered.** They are upstream model data (from the OpenRouter catalog), not a productized gateway feature — showing them would imply support we don't test or guarantee. The field remains available in `--output json` for consumers that want it.

**Columns are adaptive** — each appears only when at least one returned model carries that data, so the table stays exactly as slim as before against endpoints that don't serve the catalog fields yet (verified live against dev, which currently serves specs but not display_name/cache pricing):

```
$ prime inference models --plain
id                  input $/1M tok  output $/1M tok  context  max out  reasoning
anthropic/claude-…              $1               $5     200k      64k  ✓
deepseek/deepseek…            $0.5             $1.5   163.8k    16.4k  —
```

## Test plan

- [x] New tests: catalog columns render (name, cache cell, compact counts, reasoning + legend), modalities never rendered even when the endpoint serves them, legacy payload keeps the slim table (no new columns), JSON passthrough of `display_name`/`specs`/cache pricing
- [x] `pytest packages/prime/tests/test_inference_models.py` — 14 passed; ruff check + format clean; pre-commit hooks pass
- [x] Live smoke test against dev: specs columns render, absent fields correctly hidden, no modalities column

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation and test coverage; no changes to inference auth, billing, or API calls beyond displaying extra response fields.
> 
> **Overview**
> Extends **`prime inference models`** table output to surface new `/models` catalog fields when the API provides them, while keeping the same slim layout for legacy responses.
> 
> **Adaptive columns** appear only if any model has the data: **name** (`display_name`), **cache r/w $/1M tok** (read/write pair with em-dash for missing sides), and **context** / **max out** / **reasoning** from `specs` (compact `k`/`M` counts, ✓ for reasoning plus a dim legend). Modalities in `specs` are intentionally not shown in the table.
> 
> Rendering hardening: model **id** and **display_name** use Rich **`Text`** so upstream markup cannot break or restyle the table; the **id** column uses **`overflow="fold"`** for narrow terminals. JSON mode and help text are updated to document optional `display_name` and `specs`.
> 
> New tests cover catalog rendering, legacy slim table, JSON passthrough, markup safety, and folded ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5631ec32c05742cc0debc7575fcc2f6be5f51086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->