### PR TITLE
fix(sandboxes): detach background launch output streams

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -2703,9 +2703,11 @@ class SandboxClient:
 
         # mkdir is the launch's idempotency guard: after an ambiguous timeout, only one attempt
         # can create it and run the user command.
+        # Redirect the entire group so its shell cannot keep the launch output streams open.
         bg_cmd = (
-            f"mkdir {shlex.quote(launch_dir)} && "
-            f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
+            f"{{ mkdir {shlex.quote(launch_dir)} && "
+            f"nohup sh -c {quoted_sh_command}; "
+            "} < /dev/null > /dev/null 2>&1 &"
         )
         for attempt in range(_BACKGROUND_JOB_LAUNCH_ATTEMPTS):
             try:
@@ -4422,9 +4424,11 @@ class AsyncSandboxClient:
 
         # mkdir is the launch's idempotency guard: after an ambiguous timeout, only one attempt
         # can create it and run the user command.
+        # Redirect the entire group so its shell cannot keep the launch output streams open.
         bg_cmd = (
-            f"mkdir {shlex.quote(launch_dir)} && "
-            f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
+            f"{{ mkdir {shlex.quote(launch_dir)} && "
+            f"nohup sh -c {quoted_sh_command}; "
+            "} < /dev/null > /dev/null 2>&1 &"
         )
         for attempt in range(_BACKGROUND_JOB_LAUNCH_ATTEMPTS):
             try:

--- a/packages/prime-sandboxes/tests/test_background_job_launch_retry.py
+++ b/packages/prime-sandboxes/tests/test_background_job_launch_retry.py
@@ -36,7 +36,7 @@ class TestSyncLaunchRetry:
         job = client.start_background_job("sb", "rm -rf x")
         assert len(commands) == 2
         assert commands[0] == commands[1]
-        assert commands[0].startswith(f"mkdir /tmp/job_{job.job_id}.launch && nohup")
+        assert commands[0].startswith(f"{{ mkdir /tmp/job_{job.job_id}.launch && nohup")
         assert job.job_id
 
     def test_gives_up_after_max_attempts(self, monkeypatch):
@@ -71,7 +71,7 @@ class TestAsyncLaunchRetry:
         job = await client.start_background_job("sb", "rm -rf x")
         assert len(commands) == 2
         assert commands[0] == commands[1]
-        assert commands[0].startswith(f"mkdir /tmp/job_{job.job_id}.launch && nohup")
+        assert commands[0].startswith(f"{{ mkdir /tmp/job_{job.job_id}.launch && nohup")
         assert job.job_id
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Background job launches can keep the launch command's output streams open until the job finishes or the 30-second launch timeout expires, even though the job is already running. This delays callers that need a job handle before continuing service startup.

Redirect the entire `mkdir && nohup` background shell group in both SDK clients. The intermediate shell otherwise inherits the launch command's pipes while waiting for the worker. Grouping the redirections lets the launch return promptly while preserving the atomic retry guard, separate job logs, and exit-code capture.

`run_background_job()` continues to wait for job completion through polling. Foreground command streaming and completion semantics are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow shell-invocation change for background launches only; job execution and polling semantics are unchanged aside from faster launch return.
> 
> **Overview**
> Fixes **background job launch** blocking until the worker finishes or the 30s launch timeout by changing how the launch shell command is built in **sync and async** `start_background_job`.
> 
> Previously only `nohup` was redirected to `/dev/null`, so the outer launch shell could stay tied to the gateway exec streams. The launch string now wraps `{ mkdir … && nohup sh -c …; }` and applies `< /dev/null > /dev/null 2>&1` to that **whole group**, so `execute_command` can return with a job handle while the job keeps running. The **`mkdir` idempotency guard**, per-job log files, and exit-code capture are unchanged.
> 
> Launch-retry tests were updated to expect the new `{ mkdir …` command prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bafc42ec5c7f2084e23cf986146e40c6386dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->