### PR TITLE
fix(release-e2e): retry the temporary environment delete

### DIFF
--- a/packages/prime/scripts/release_e2e.py
+++ b/packages/prime/scripts/release_e2e.py
@@ -513,6 +513,31 @@ def remote_script(config: RemoteConfig) -> str:
                     )
 
 
+        def best_effort_delete_remote_environment(slug: str, attempts: int = 3) -> None:
+            # A fast-failing run deletes the environment seconds after pushing it,
+            # while the hub may still be post-processing the version. A transient
+            # failure here must not leave the temporary environment behind.
+            for attempt in range(1, attempts + 1):
+                try:
+                    run(["prime", "env", "delete", slug, "--force"], timeout=180)
+                    return
+                except Exception as exc:
+                    if attempt == attempts:
+                        print(
+                            f"Warning: failed to delete temporary environment "
+                            f"{slug} after {attempts} attempts: {exc}",
+                            file=sys.stderr,
+                        )
+                        return
+                    delay = 10 * attempt
+                    print(
+                        f"Retrying delete of {slug} in {delay}s "
+                        f"(attempt {attempt}/{attempts} failed: {exc})",
+                        flush=True,
+                    )
+                    time.sleep(delay)
+
+
         def hosted_eval_checks() -> None:
             if CONFIG["hosted_mode"] == "skip":
                 print("Skipping hosted eval checks by request.", flush=True)
@@ -691,18 +716,7 @@ def remote_script(config: RemoteConfig) -> str:
                 if HOSTED_EVAL_IDS:
                     best_effort_cancel_hosted_evals()
                 if REMOTE_ENV_SLUG and CONFIG["cleanup_remote_env"]:
-                    try:
-                        run(
-                            ["prime", "env", "delete", REMOTE_ENV_SLUG, "--force"],
-                            check=False,
-                            timeout=180,
-                        )
-                    except Exception as exc:
-                        print(
-                            f"Warning: failed to delete temporary environment "
-                            f"{REMOTE_ENV_SLUG}: {exc}",
-                            file=sys.stderr,
-                        )
+                    best_effort_delete_remote_environment(REMOTE_ENV_SLUG)
 
 
         if __name__ == "__main__":

--- a/packages/prime/tests/test_release_e2e_script.py
+++ b/packages/prime/tests/test_release_e2e_script.py
@@ -89,6 +89,10 @@ def test_remote_script_compiles_and_keeps_cleanup_best_effort(tmp_path):
     assert "prime_tunnel.Tunnel must accept labels" in script
     assert "old prime-evals push_samples compatibility failed" in script
     assert "Warning: failed to delete temporary environment" in script
+    # The cleanup delete is retried instead of being a single check=False call.
+    assert "def best_effort_delete_remote_environment(slug: str, attempts: int = 3)" in script
+    assert 'run(["prime", "env", "delete", slug, "--force"], timeout=180)' in script
+    assert "best_effort_delete_remote_environment(REMOTE_ENV_SLUG)" in script
     assert 'line.rsplit(":", 1)[-1]' in script
     assert (
         "install_candidate_cli()\n"


### PR DESCRIPTION
## Summary

The release e2e deletes its temporary Environment Hub environment in a `finally` block with a single `check=False` call. On Sep 1 two of those deletes returned 500 (a platform-side deadlock between the delete and the still-running unpack of the just-pushed version, fixed in PrimeIntellect-ai/platform#5095), the script only printed a warning, and both `prime-cli-test/prime-e2e-*` environments are still sitting in the prod hub.

This came out of the investigation for PrimeIntellect-ai/platform#5090: on the 0.6.30/0.6.31 release PRs the eval step failed instantly, so the cleanup delete landed ~11s after push, inside the hub's post-processing window. That timing exposed two platform bugs (both now have PRs) and this gap in the e2e cleanup.

## Change

`best_effort_delete_remote_environment` retries `prime env delete <slug> --force` up to three times with a 10s/20s backoff before giving up with the existing warning. Cleanup stays best-effort and still never masks the original test failure.

## Testing

- `ruff format` / `ruff check` clean.
- `pytest packages/prime/tests/test_release_e2e_script.py`: 6 passed. The remote-script test now asserts the retry helper is defined and wired into the `finally` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WpxaxgZUnN6CmuzH8tHUU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation cleanup only; no product runtime or auth paths affected.
> 
> **Overview**
> Release e2e cleanup no longer issues a single best-effort `prime env delete` in the `finally` block. It now routes through **`best_effort_delete_remote_environment`**, which retries `prime env delete <slug> --force` up to three times with **10s / 20s** backoff when the hub may still be post-processing a just-pushed version.
> 
> Failed deletes still only emit a warning and do not change the test exit code. **`test_release_e2e_script`** asserts the helper is embedded in the generated remote script and wired to `REMOTE_ENV_SLUG` cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f66bf0b89507920b1e094cf8cb6b3eaa776b51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->