### PR TITLE
release: cli 0.6.33

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.32"
+__version__ = "0.6.33"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

Releases prime CLI **0.6.33** (0.6.32 → 0.6.33).

Unreleased changes on `main` since v0.6.32 included in this release:

- #898 — `--page` option on `prime traces list`
- #899 — model catalog details in `prime inference models` (adaptive columns: display name, cache pricing, context window, max output tokens, reasoning; ids fold in narrow terminals)

Not included (per request): prime-sandboxes 0.2.42 (the #900 fix) — will ride a later sandboxes release. The CLI's dependency floor `prime-sandboxes>=0.2.41` is already published and unchanged.

Tagging and PyPI publishing are handled automatically by CI on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version constant change with no runtime or dependency edits in this PR.
> 
> **Overview**
> Bumps the published **prime CLI** version from `0.6.32` to **`0.6.33`** in `prime_cli.__init__` so CI can tag and publish the release on merge.
> 
> This diff is only the version string; the release bundles work already on `main` (e.g. `--page` on `prime traces list` and richer `prime inference models` output). The sandboxes **0.2.42** fix is intentionally excluded from this cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbe2e90f02b468393651549b4ef57fa071ea533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->