### PR TITLE
fix(sandboxes): retry upload response read errors

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -2204,13 +2204,16 @@ class SandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    def _should_retry_upload_error(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
-        """Check if a transient error (408/5xx) on an idempotent upload should be retried."""
-        status = error.response.status_code
-        if status != 408 and status not in RETRYABLE_5XX_STATUSES:
-            return False
-        if _is_gateway_sandbox_not_found(error.response):
-            return False
+    def _should_retry_upload_error(
+        self, error: httpx.HTTPStatusError | httpx.ReadError, attempt: int
+    ) -> bool:
+        """Retry transient HTTP or read errors on an idempotent upload."""
+        if isinstance(error, httpx.HTTPStatusError):
+            status = error.response.status_code
+            if status != 408 and status not in RETRYABLE_5XX_STATUSES:
+                return False
+            if _is_gateway_sandbox_not_found(error.response):
+                return False
         if attempt < MAX_409_RETRIES - 1:
             time.sleep(RETRY_409_BASE_DELAY * (2**attempt))
             return True
@@ -3309,6 +3312,9 @@ class SandboxClient:
                 )
                 raise APIError(f"Upload failed: {error_details}") from e
             except httpx.RequestError as e:
+                if isinstance(e, httpx.ReadError) and self._should_retry_upload_error(e, attempt):
+                    attempt += 1
+                    continue
                 req = getattr(e, "request", None)
                 method = getattr(req, "method", "?")
                 u = getattr(req, "url", "?")
@@ -3338,7 +3344,7 @@ class SandboxClient:
         effective_timeout = timeout if timeout is not None else 300
 
         reauthed = False
-        # `attempt` counts only transient (409/5xx/408) retries, capped by the
+        # `attempt` counts only transient (409/5xx/408/ReadError) retries, capped by the
         # helpers at MAX_409_RETRIES; the single 401 re-auth is bounded by
         # `reauthed`. The loop bound is a backstop sized for both budgets.
         attempt = 0
@@ -3370,7 +3376,10 @@ class SandboxClient:
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")
             except Exception as e:
-                raise APIError(f"Upload failed: {str(e)}")
+                if isinstance(e, httpx.ReadError) and self._should_retry_upload_error(e, attempt):
+                    attempt += 1
+                    continue
+                raise APIError(f"Upload failed: {e.__class__.__name__}: {e}") from e
 
         raise APIError("Upload failed after retries")
 
@@ -3727,13 +3736,16 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    async def _should_retry_upload_error(self, error: httpx.HTTPStatusError, attempt: int) -> bool:
-        """Check if a transient 408/5xx on an idempotent upload should be retried (async)."""
-        status = error.response.status_code
-        if status != 408 and status not in RETRYABLE_5XX_STATUSES:
-            return False
-        if _is_gateway_sandbox_not_found(error.response):
-            return False
+    async def _should_retry_upload_error(
+        self, error: httpx.HTTPStatusError | httpx.ReadError, attempt: int
+    ) -> bool:
+        """Retry transient HTTP or read errors on an idempotent upload (async)."""
+        if isinstance(error, httpx.HTTPStatusError):
+            status = error.response.status_code
+            if status != 408 and status not in RETRYABLE_5XX_STATUSES:
+                return False
+            if _is_gateway_sandbox_not_found(error.response):
+                return False
         if attempt < MAX_409_RETRIES - 1:
             await asyncio.sleep(RETRY_409_BASE_DELAY * (2**attempt))
             return True
@@ -5054,6 +5066,11 @@ class AsyncSandboxClient:
                 )
                 raise APIError(f"Upload failed: {error_details}") from e
             except httpx.RequestError as e:
+                if isinstance(e, httpx.ReadError) and await self._should_retry_upload_error(
+                    e, attempt
+                ):
+                    attempt += 1
+                    continue
                 req = getattr(e, "request", None)
                 method = getattr(req, "method", "?")
                 u = getattr(req, "url", "?")
@@ -5116,7 +5133,12 @@ class AsyncSandboxClient:
                 error_details = f"HTTP {e.response.status_code}: {e.response.text}"
                 raise APIError(f"Upload failed: {error_details}")
             except Exception as e:
-                raise APIError(f"Upload failed: {str(e)}")
+                if isinstance(e, httpx.ReadError) and await self._should_retry_upload_error(
+                    e, attempt
+                ):
+                    attempt += 1
+                    continue
+                raise APIError(f"Upload failed: {e.__class__.__name__}: {e}") from e
 
         raise APIError("Upload failed after retries")
 

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -1,7 +1,9 @@
 """Tests for retry logic on transient connection errors."""
 
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, call
 
 import httpx
 import pytest
@@ -9,11 +11,73 @@ import pytest
 from prime_sandboxes.core.client import APIClient, APIError, AsyncAPIClient
 from prime_sandboxes.models import CreateSandboxRequest
 from prime_sandboxes.sandbox import (
+    MAX_409_RETRIES,
+    RETRY_409_BASE_DELAY,
     AsyncSandboxAuthCache,
     AsyncSandboxClient,
     SandboxAuthCache,
     SandboxClient,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_type", [SandboxClient, AsyncSandboxClient])
+@pytest.mark.parametrize("upload_method", ["upload_file", "upload_bytes"])
+@pytest.mark.parametrize(
+    "failures, first_status", [(1, None), (MAX_409_RETRIES, None), (MAX_409_RETRIES, 503)]
+)
+async def test_upload_retries_read_error(
+    monkeypatch, tmp_path, client_type, upload_method, failures, first_status
+):
+    payload = bytes(range(256)) * 256
+    local_path = tmp_path / "upload.pdf"
+    local_path.write_bytes(payload)
+    destination = "/workspace/upload.pdf"
+    request = httpx.Request("POST", "https://gateway.example/upload")
+    errors = [httpx.ReadError("", request=request) for _ in range(failures)]
+    if first_status:
+        errors[0] = httpx.HTTPStatusError(
+            "temporary error",
+            request=request,
+            response=httpx.Response(first_status, request=request),
+        )
+    response = httpx.Response(
+        200,
+        request=request,
+        json={
+            "success": True,
+            "path": destination,
+            "size": len(payload),
+            "timestamp": "2026-01-01T00:00:00Z",
+        },
+    )
+    is_async = client_type is AsyncSandboxClient
+    mock_type = AsyncMock if is_async else Mock
+    sleep = mock_type()
+    monkeypatch.setattr(
+        "prime_sandboxes.sandbox.asyncio.sleep"
+        if is_async
+        else "prime_sandboxes.sandbox.time.sleep",
+        sleep,
+    )
+    client = client_type.__new__(client_type)
+    client._auth_cache = SimpleNamespace(get_or_refresh=mock_type(return_value=_auth_response()))
+    client._gateway_post = mock_type(side_effect=[*errors, response])
+    args = (str(local_path),) if upload_method == "upload_file" else (payload, local_path.name)
+    exhausted = failures == MAX_409_RETRIES
+    with pytest.raises(APIError, match="ReadError") if exhausted else nullcontext() as error:
+        result = getattr(client, upload_method)("sandbox-1", destination, *args)
+        if is_async:
+            result = await result
+        assert result.success
+    if exhausted:
+        assert error.value.__cause__ is errors[-1]
+    attempts = min(failures + 1, MAX_409_RETRIES)
+    assert client._gateway_post.call_count == attempts
+    assert sleep.call_args_list == [call(RETRY_409_BASE_DELAY * 2**i) for i in range(attempts - 1)]
+    for attempt in client._gateway_post.call_args_list:
+        assert attempt.kwargs["files"]["file"] == (local_path.name, payload)
+        assert attempt.kwargs["params"] == {"path": destination, "sandbox_id": "sandbox-1"}
 
 
 class FailThenSucceedTransport(httpx.BaseTransport):


### PR DESCRIPTION
File uploads now recover from transient response-read failures instead of immediately aborting sandbox setup. Both synchronous and asynchronous file and bytes uploads retry `httpx.ReadError` using the existing four-attempt upload budget and exponential backoff.

Retries resend the same bytes to the same destination and share the budget with existing transient HTTP retries. The generic POST retry policy remains unchanged. If a bytes upload ultimately fails, its error includes the exception type and preserves the original cause.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Idempotent upload retries only; behavior change is limited to recovering transient network/read failures without altering auth, 409, or generic POST retry policies.
> 
> **Overview**
> **Sandbox uploads** now treat transient `httpx.ReadError` (failures while reading the gateway response) like existing **408/5xx** retries, instead of failing immediately.
> 
> Sync and async **`upload_file`** and **`upload_bytes`** route `ReadError` through `_should_retry_upload_error`, which shares the same **`MAX_409_RETRIES`** attempt counter and exponential backoff as other transient upload errors. **`upload_bytes`** also surfaces failures with the exception type and chains the original cause when retries are exhausted.
> 
> New parametrized tests cover sync/async clients, file vs bytes uploads, and exhaustion after the retry budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf14b906ed0a7b3e5586eb8c805edcd0b028cb06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->