### PR TITLE
fix(sandboxes): retry transient background-job status timeouts

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -51,7 +51,7 @@ from tenacity import (
 )
 
 from ._connectrpc import GOOGLE_PROTOBUF_BINARY_CODEC
-from .core import APIClient, APIError, AsyncAPIClient
+from .core import APIClient, APIError, APITimeoutError, AsyncAPIClient
 from .exceptions import (
     BatchStatusUnsupportedError,
     CommandTimeoutError,
@@ -144,6 +144,15 @@ class _BatchItemError:
     """An error for one key in an otherwise successful transport batch."""
 
     error: Exception
+
+
+class _BackgroundJobStatusLookupError(APIError):
+    """A typed per-job status error returned by the VM runtime backend."""
+
+    def __init__(self, sandbox_id: str, job_id: str, code: str, message: str) -> None:
+        super().__init__(f"Background job batch status failed: {sandbox_id}/{job_id}: {message}")
+        self.code = code
+        self.message = message
 
 
 class _BatcherClosedError(RuntimeError):
@@ -410,6 +419,29 @@ BACKGROUND_JOB_OUTPUT_CACHE_BYTES = 64 * 1024 * 1024
 # adding a persistent worker to the client lifecycle.
 MAX_STATUS_BATCH_SIZE = 100
 STATUS_BATCH_WINDOW_SECONDS = 0.025
+
+# The command is already running when its status lookup fails, so retrying this
+# idempotent read is safe and avoids duplicating command side effects.
+_BACKGROUND_JOB_STATUS_MAX_ATTEMPTS = 4
+_BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS = 1.0
+_BACKGROUND_JOB_STATUS_RETRY_MAX_DELAY_SECONDS = 4.0
+_VM_RUNTIME_STATUS_TIMEOUT_MESSAGE = "Timed out reading background job status from the VM runtime"
+
+
+def _background_job_status_retry_delay(failures: int) -> float:
+    return min(
+        _BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS * (2 ** (failures - 1)),
+        _BACKGROUND_JOB_STATUS_RETRY_MAX_DELAY_SECONDS,
+    )
+
+
+def _is_retryable_background_job_status_error(error: Exception) -> bool:
+    return isinstance(error, APITimeoutError) or (
+        isinstance(error, _BackgroundJobStatusLookupError)
+        and error.code == "RUNTIME_ERROR"
+        and _VM_RUNTIME_STATUS_TIMEOUT_MESSAGE in error.message
+    )
+
 
 # Creation status-poll pacing. Sandbox creation is polled with exponential
 # backoff plus jitter rather than at a fixed interval
@@ -2976,7 +3008,12 @@ class SandboxClient:
             exc = (
                 BatchStatusUnsupportedError(details)
                 if error.code == "NOT_VM"
-                else APIError(f"Background job batch status failed: {details}")
+                else _BackgroundJobStatusLookupError(
+                    error.sandbox_id,
+                    error.job_id,
+                    error.code,
+                    error.message,
+                )
             )
             results[key] = _BatchItemError(exc)
 
@@ -3028,11 +3065,26 @@ class SandboxClient:
         job = self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
+        status_failures = 0
         while time.monotonic() < deadline:
-            if use_batch_status:
-                snapshot = self._background_job_status_batcher.get((sandbox_id, job.job_id))
-            else:
-                snapshot = self.get_background_job_status(sandbox_id, job)
+            try:
+                if use_batch_status:
+                    snapshot = self._background_job_status_batcher.get((sandbox_id, job.job_id))
+                else:
+                    snapshot = self.get_background_job_status(sandbox_id, job)
+            except Exception as error:  # noqa: BLE001 - classify SDK status errors below
+                status_failures += 1
+                if (
+                    not _is_retryable_background_job_status_error(error)
+                    or status_failures >= _BACKGROUND_JOB_STATUS_MAX_ATTEMPTS
+                ):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(_background_job_status_retry_delay(status_failures), remaining))
+                continue
+            status_failures = 0
             if snapshot.completed:
                 assert snapshot.exit_code is not None
                 return self._background_job_output_coordinator.get(job, snapshot.exit_code, None)
@@ -4696,7 +4748,12 @@ class AsyncSandboxClient:
             exc = (
                 BatchStatusUnsupportedError(details)
                 if error.code == "NOT_VM"
-                else APIError(f"Background job batch status failed: {details}")
+                else _BackgroundJobStatusLookupError(
+                    error.sandbox_id,
+                    error.job_id,
+                    error.code,
+                    error.message,
+                )
             )
             results[key] = _BatchItemError(exc)
 
@@ -4755,11 +4812,30 @@ class AsyncSandboxClient:
         job = await self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = await self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
+        status_failures = 0
         while time.monotonic() < deadline:
-            if use_batch_status:
-                snapshot = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
-            else:
-                snapshot = await self.get_background_job_status(sandbox_id, job)
+            try:
+                if use_batch_status:
+                    snapshot = await self._background_job_status_batcher.get(
+                        (sandbox_id, job.job_id)
+                    )
+                else:
+                    snapshot = await self.get_background_job_status(sandbox_id, job)
+            except Exception as error:  # noqa: BLE001 - classify SDK status errors below
+                status_failures += 1
+                if (
+                    not _is_retryable_background_job_status_error(error)
+                    or status_failures >= _BACKGROUND_JOB_STATUS_MAX_ATTEMPTS
+                ):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                await asyncio.sleep(
+                    min(_background_job_status_retry_delay(status_failures), remaining)
+                )
+                continue
+            status_failures = 0
             if snapshot.completed:
                 assert snapshot.exit_code is not None
                 return await self._background_job_output_coordinator.get(

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, cast
 import pytest
 
 from prime_sandboxes import BatchStatusUnsupportedError
+from prime_sandboxes import sandbox as sandbox_module
 from prime_sandboxes.core.client import APIClient, APIError
 from prime_sandboxes.models import (
     BackgroundJob,
@@ -107,14 +108,27 @@ class _SyncBackgroundJobPlatformClient:
         self,
         reject_as_container: bool = False,
         error_job_id: Optional[str] = None,
+        transient_failures: int = 0,
     ) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
         self.reject_as_container = reject_as_container
         self.error_job_id = error_job_id
+        self.transient_failures = transient_failures
 
     def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
         jobs = kwargs["json"]["jobs"]
+        if len(self.calls) <= self.transient_failures:
+            return {
+                "statuses": [],
+                "errors": [
+                    {
+                        **jobs[0],
+                        "code": "RUNTIME_ERROR",
+                        "message": "Timed out reading background job status from the VM runtime",
+                    }
+                ],
+            }
         if self.reject_as_container:
             return {
                 "statuses": [],
@@ -157,13 +171,26 @@ class _AsyncBackgroundJobPlatformClient:
         self,
         error_job_id: Optional[str] = None,
         complete_all: bool = False,
+        transient_failures: int = 0,
     ) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
         self.error_job_id = error_job_id
         self.complete_all = complete_all
+        self.transient_failures = transient_failures
 
     async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
+        if len(self.calls) <= self.transient_failures:
+            return {
+                "statuses": [],
+                "errors": [
+                    {
+                        **kwargs["json"]["jobs"][0],
+                        "code": "RUNTIME_ERROR",
+                        "message": "Timed out reading background job status from the VM runtime",
+                    }
+                ],
+            }
         return {
             "statuses": [
                 {
@@ -718,6 +745,136 @@ async def test_async_background_batch_errors_only_fail_the_matching_waiter() -> 
     assert isinstance(results[1], APIError)
     assert "sandbox-b/cafebabe" in str(results[1])
     assert len(platform.calls) == 1
+
+
+def test_sync_run_background_job_retries_transient_vm_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncBackgroundJobPlatformClient(transient_failures=1)
+    cast(Any, client).client = platform
+    cast(Any, client)._auth_cache = _SyncVMAuthCache()
+    job = _job("sandbox-a", "feedface")
+    launches = 0
+
+    def start_background_job(*_args: Any, **_kwargs: Any) -> BackgroundJob:
+        nonlocal launches
+        launches += 1
+        return job
+
+    def read_file(
+        _sandbox_id: str,
+        path: str,
+        **_kwargs: Any,
+    ) -> ReadFileResponse:
+        content = "stdout" if path.endswith("stdout.log") else "stderr"
+        return ReadFileResponse(content=content, size=len(content), truncated=False)
+
+    cast(Any, client).start_background_job = start_background_job
+    cast(Any, client).read_file = read_file
+    monkeypatch.setattr(sandbox_module, "_BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS", 0)
+    status = client.run_background_job("sandbox-a", "echo ok")
+
+    assert status.completed
+    assert status.exit_code == 7
+    assert status.stdout == "stdout"
+    assert len(platform.calls) == 2
+    assert launches == 1
+
+
+def test_sync_run_background_job_does_not_retry_other_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncBackgroundJobPlatformClient(error_job_id="deadbeef")
+    cast(Any, client).client = platform
+    cast(Any, client)._auth_cache = _SyncVMAuthCache()
+    launches = 0
+
+    def start_background_job(*_args: Any, **_kwargs: Any) -> BackgroundJob:
+        nonlocal launches
+        launches += 1
+        return _job("sandbox-a", "deadbeef")
+
+    cast(Any, client).start_background_job = start_background_job
+    monkeypatch.setattr(sandbox_module, "_BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS", 0)
+
+    with pytest.raises(APIError, match="Runtime lookup failed"):
+        client.run_background_job("sandbox-a", "echo ok")
+
+    assert len(platform.calls) == 1
+    assert launches == 1
+
+
+@pytest.mark.asyncio
+async def test_async_run_background_job_retries_transient_vm_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncBackgroundJobPlatformClient(complete_all=True, transient_failures=1)
+    cast(Any, client).client = platform
+    cast(Any, client)._auth_cache = _AsyncVMAuthCache()
+    job = _job("sandbox-a", "deadbeef")
+    launches = 0
+
+    async def start_background_job(*_args: Any, **_kwargs: Any) -> BackgroundJob:
+        nonlocal launches
+        launches += 1
+        return job
+
+    async def read_file(
+        _sandbox_id: str,
+        path: str,
+        **_kwargs: Any,
+    ) -> ReadFileResponse:
+        content = "stdout" if path.endswith("stdout.log") else "stderr"
+        return ReadFileResponse(content=content, size=len(content), truncated=False)
+
+    cast(Any, client).start_background_job = start_background_job
+    cast(Any, client).read_file = read_file
+    monkeypatch.setattr(sandbox_module, "_BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS", 0)
+    try:
+        status = await client.run_background_job("sandbox-a", "echo ok")
+    finally:
+        await client.aclose()
+
+    assert status.completed
+    assert status.exit_code == 0
+    assert status.stdout == "stdout"
+    assert len(platform.calls) == 2
+    assert launches == 1
+
+
+@pytest.mark.asyncio
+async def test_async_run_background_job_bounds_transient_vm_status_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncBackgroundJobPlatformClient(complete_all=True, transient_failures=10)
+    cast(Any, client).client = platform
+    cast(Any, client)._auth_cache = _AsyncVMAuthCache()
+    launches = 0
+
+    async def start_background_job(*_args: Any, **_kwargs: Any) -> BackgroundJob:
+        nonlocal launches
+        launches += 1
+        return _job("sandbox-a", "deadbeef")
+
+    cast(Any, client).start_background_job = start_background_job
+    monkeypatch.setattr(sandbox_module, "_BACKGROUND_JOB_STATUS_RETRY_INITIAL_DELAY_SECONDS", 0)
+    monkeypatch.setattr(sandbox_module, "_BACKGROUND_JOB_STATUS_MAX_ATTEMPTS", 3)
+    try:
+        with pytest.raises(APIError, match="Timed out reading background job status"):
+            await client.run_background_job("sandbox-a", "echo ok")
+    finally:
+        await client.aclose()
+
+    assert len(platform.calls) == 3
+    assert launches == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retry transient background-job status reads after the VM runtime or SDK HTTP layer times out
- keep background-command launch exactly once; only the idempotent status read is retried
- apply the same bounded behavior to sync and async clients
- retry only the known VM-runtime timeout response; unrelated runtime errors still fail immediately

## Motivation

Production RL workloads intermittently received structured per-job errors while polling commands that were already running:

```text
Background job batch status failed: <sandbox>/<job>: Timed out reading background job status from the VM runtime
```

Surfacing that transient status-read failure immediately aborts the rollout even though relaunching the command would be unsafe and the original command may complete normally. This change retries the read instead, allowing four consecutive status attempts with 1s/2s/4s backoff. A successful poll resets that consecutive-failure budget, and all polling remains bounded by the caller's existing command deadline.

This does not retry sandbox creation, command launch, rate limits, egress failures, or persistent runtime errors.

## Live A/B result

We ran two simultaneous, launch-order-reversed waves against the active service using the production `prime-sandboxes==0.2.39` client. Each arm used four VMs and ran 800 commands total over the same service windows.

| Variant | Successful commands | Success rate | Terminal status failures | Raw VM status-timeout items | Recovered | Command launches |
|---|---:|---:|---:|---:|---:|---:|
| Stock | 796/800 | 99.50% | 4 | 4 | 0 | 800 |
| Retry patch | 800/800 | 100% | 0 | 5 | 5 | 800 |

The headline 99.50% to 100% success-rate difference might just be noise: the Wilson 95% intervals overlap (stock 98.72–99.81%, patched 99.52–100%) and a two-sided Fisher exact test gives `p=0.125`. It is still interesting because the patched arm actually saw slightly more raw backend timeout items and recovered all five, while preserving exactly one launch per command. That instrumented recovery path is stronger evidence for the behavior than the aggregate score alone.

The timeout items were correlated status-batch events: stock fanout was `2 + 2`, while patched fanout was `3 + 2`. Median/p95 command latency was 1.357s/11.044s for stock and 1.309s/10.645s for patched. The sample is too small to attribute the latency difference to this patch.

The live A/B used the exact production 0.2.39 implementation. This PR ports the same behavior onto current `main` / `prime-sandboxes` 0.2.41 and narrows the classifier to the exact structured timeout message.

## Validation

- `uv run pytest packages/prime-sandboxes/tests/test_batch_status.py -q` — 43 passed
- `uv run pre-commit run --all-files` — passed
- broader sandbox package run — 263 passed, 4 skipped; the remaining 10 failures and 22 errors were live integration tests without `PRIME_API_KEY`

Tests cover sync and async recovery, bounded exhaustion, exactly-once command launch, and immediate failure for unrelated `RUNTIME_ERROR` responses.
