### PR TITLE
Make background job polling adaptive

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -3043,7 +3043,7 @@ class SandboxClient:
         use_batch_status = self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
         poll_delay = min(float(poll_interval), BACKGROUND_JOB_POLL_MAX_DELAY)
-        while time.monotonic() < deadline:
+        while True:
             if use_batch_status:
                 snapshot = self._background_job_status_batcher.get((sandbox_id, job.job_id))
             else:
@@ -3051,7 +3051,10 @@ class SandboxClient:
             if snapshot.completed:
                 assert snapshot.exit_code is not None
                 return self._background_job_output_coordinator.get(job, snapshot.exit_code, None)
-            time.sleep(poll_delay)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(poll_delay, remaining))
             poll_delay = _next_background_job_poll_delay(poll_delay)
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
@@ -4773,7 +4776,7 @@ class AsyncSandboxClient:
         use_batch_status = await self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
         poll_delay = min(float(poll_interval), BACKGROUND_JOB_POLL_MAX_DELAY)
-        while time.monotonic() < deadline:
+        while True:
             if use_batch_status:
                 snapshot = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
             else:
@@ -4783,7 +4786,10 @@ class AsyncSandboxClient:
                 return await self._background_job_output_coordinator.get(
                     job, snapshot.exit_code, None
                 )
-            await asyncio.sleep(poll_delay)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(poll_delay, remaining))
             poll_delay = _next_background_job_poll_delay(poll_delay)
         raise CommandTimeoutError(sandbox_id, command, timeout)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -411,6 +411,11 @@ BACKGROUND_JOB_OUTPUT_CACHE_BYTES = 64 * 1024 * 1024
 MAX_STATUS_BATCH_SIZE = 100
 STATUS_BATCH_WINDOW_SECONDS = 0.025
 
+# Background-job completion polling starts with the caller-selected interval,
+# then backs off after each non-terminal status to reduce load from older jobs.
+BACKGROUND_JOB_POLL_MAX_DELAY = 20.0
+BACKGROUND_JOB_POLL_BACKOFF_FACTOR = 1.5
+
 # Creation status-poll pacing. Sandbox creation is polled with exponential
 # backoff plus jitter rather than at a fixed interval
 CREATION_POLL_INITIAL_DELAY = 1.0
@@ -2074,6 +2079,14 @@ def _is_waiting_for_image_build(sandbox: Sandbox | SandboxStatusSnapshot) -> boo
     return sandbox.status == "PENDING" and bool(getattr(sandbox, "pending_image_build_id", None))
 
 
+def _background_job_poll_delay(initial_interval: float, poll_index: int) -> float:
+    """Return the adaptive delay after the Nth non-terminal status poll."""
+    return min(
+        initial_interval * (BACKGROUND_JOB_POLL_BACKOFF_FACTOR**poll_index),
+        BACKGROUND_JOB_POLL_MAX_DELAY,
+    )
+
+
 class SandboxClient:
     """Client for sandbox API operations"""
 
@@ -3017,7 +3030,8 @@ class SandboxClient:
             timeout: Maximum seconds to wait for completion
             working_dir: Working directory for command execution
             env: Environment variables
-            poll_interval: Seconds between status polls
+            poll_interval: Initial seconds between status polls. The interval
+                backs off to a maximum of 20 seconds as the job ages.
 
         Returns:
             BackgroundJobStatus with exit_code, stdout, stderr
@@ -3028,6 +3042,7 @@ class SandboxClient:
         job = self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
+        poll_index = 0
         while time.monotonic() < deadline:
             if use_batch_status:
                 snapshot = self._background_job_status_batcher.get((sandbox_id, job.job_id))
@@ -3036,7 +3051,8 @@ class SandboxClient:
             if snapshot.completed:
                 assert snapshot.exit_code is not None
                 return self._background_job_output_coordinator.get(job, snapshot.exit_code, None)
-            time.sleep(poll_interval)
+            time.sleep(_background_job_poll_delay(poll_interval, poll_index))
+            poll_index += 1
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     def wait_for_creation(
@@ -4744,7 +4760,8 @@ class AsyncSandboxClient:
             timeout: Maximum seconds to wait for completion
             working_dir: Working directory for command execution
             env: Environment variables
-            poll_interval: Seconds between status polls
+            poll_interval: Initial seconds between status polls. The interval
+                backs off to a maximum of 20 seconds as the job ages.
 
         Returns:
             BackgroundJobStatus with exit_code, stdout, stderr
@@ -4755,6 +4772,7 @@ class AsyncSandboxClient:
         job = await self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = await self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
+        poll_index = 0
         while time.monotonic() < deadline:
             if use_batch_status:
                 snapshot = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
@@ -4765,7 +4783,8 @@ class AsyncSandboxClient:
                 return await self._background_job_output_coordinator.get(
                     job, snapshot.exit_code, None
                 )
-            await asyncio.sleep(poll_interval)
+            await asyncio.sleep(_background_job_poll_delay(poll_interval, poll_index))
+            poll_index += 1
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     async def wait_for_creation(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -2079,10 +2079,10 @@ def _is_waiting_for_image_build(sandbox: Sandbox | SandboxStatusSnapshot) -> boo
     return sandbox.status == "PENDING" and bool(getattr(sandbox, "pending_image_build_id", None))
 
 
-def _background_job_poll_delay(initial_interval: float, poll_index: int) -> float:
-    """Return the adaptive delay after the Nth non-terminal status poll."""
+def _next_background_job_poll_delay(current_interval: float) -> float:
+    """Increase a background-job poll delay without exponentiating its age."""
     return min(
-        initial_interval * (BACKGROUND_JOB_POLL_BACKOFF_FACTOR**poll_index),
+        current_interval * BACKGROUND_JOB_POLL_BACKOFF_FACTOR,
         BACKGROUND_JOB_POLL_MAX_DELAY,
     )
 
@@ -3042,7 +3042,7 @@ class SandboxClient:
         job = self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
-        poll_index = 0
+        poll_delay = min(float(poll_interval), BACKGROUND_JOB_POLL_MAX_DELAY)
         while time.monotonic() < deadline:
             if use_batch_status:
                 snapshot = self._background_job_status_batcher.get((sandbox_id, job.job_id))
@@ -3051,8 +3051,8 @@ class SandboxClient:
             if snapshot.completed:
                 assert snapshot.exit_code is not None
                 return self._background_job_output_coordinator.get(job, snapshot.exit_code, None)
-            time.sleep(_background_job_poll_delay(poll_interval, poll_index))
-            poll_index += 1
+            time.sleep(poll_delay)
+            poll_delay = _next_background_job_poll_delay(poll_delay)
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     def wait_for_creation(
@@ -4772,7 +4772,7 @@ class AsyncSandboxClient:
         job = await self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
         use_batch_status = await self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
-        poll_index = 0
+        poll_delay = min(float(poll_interval), BACKGROUND_JOB_POLL_MAX_DELAY)
         while time.monotonic() < deadline:
             if use_batch_status:
                 snapshot = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
@@ -4783,8 +4783,8 @@ class AsyncSandboxClient:
                 return await self._background_job_output_coordinator.get(
                     job, snapshot.exit_code, None
                 )
-            await asyncio.sleep(_background_job_poll_delay(poll_interval, poll_index))
-            poll_index += 1
+            await asyncio.sleep(poll_delay)
+            poll_delay = _next_background_job_poll_delay(poll_delay)
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
     async def wait_for_creation(

--- a/packages/prime-sandboxes/tests/test_background_job_polling.py
+++ b/packages/prime-sandboxes/tests/test_background_job_polling.py
@@ -1,9 +1,15 @@
 """Adaptive pacing tests for background-job completion polling."""
 
+from typing import Any, cast
+
 import pytest
 
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.models import BackgroundJob, BackgroundJobStatus
 from prime_sandboxes.sandbox import (
     BACKGROUND_JOB_POLL_MAX_DELAY,
+    AsyncSandboxClient,
+    SandboxClient,
     _next_background_job_poll_delay,
 )
 
@@ -15,6 +21,16 @@ def _poll_delays(initial_interval: float, count: int) -> list[float]:
         delays.append(delay)
         delay = _next_background_job_poll_delay(delay)
     return delays
+
+
+def _job() -> BackgroundJob:
+    return BackgroundJob(
+        job_id="job",
+        sandbox_id="sandbox",
+        stdout_log_file="/tmp/job.stdout",
+        stderr_log_file="/tmp/job.stderr",
+        exit_file="/tmp/job.exit",
+    )
 
 
 def test_background_job_polling_backs_off_from_default_interval() -> None:
@@ -33,3 +49,85 @@ def test_background_job_polling_stays_capped_for_very_old_jobs() -> None:
     delays = _poll_delays(3, 1_752)
 
     assert delays[-2:] == [20, 20]
+
+
+def test_sync_background_job_polling_checks_status_at_timeout(monkeypatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    clock = 0.0
+    sleeps = []
+    snapshots = iter(
+        [
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=True, exit_code=0),
+        ]
+    )
+    result = BackgroundJobStatus(job_id="job", completed=True, exit_code=0, stdout="done")
+
+    def sleep(delay: float) -> None:
+        nonlocal clock
+        sleeps.append(delay)
+        clock += delay
+
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.monotonic", lambda: clock)
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.sleep", sleep)
+    monkeypatch.setattr(client, "start_background_job", lambda *_args, **_kwargs: _job())
+    monkeypatch.setattr(cast(Any, client)._auth_cache, "is_vm", lambda _sandbox_id: False)
+    monkeypatch.setattr(
+        client,
+        "get_background_job_status",
+        lambda *_args, **_kwargs: next(snapshots),
+    )
+    monkeypatch.setattr(
+        cast(Any, client)._background_job_output_coordinator,
+        "get",
+        lambda *_args, **_kwargs: result,
+    )
+
+    assert client.run_background_job("sandbox", "command", timeout=10) is result
+    assert sleeps == pytest.approx([3, 4.5, 2.5])
+
+
+@pytest.mark.asyncio
+async def test_async_background_job_polling_checks_status_at_timeout(monkeypatch) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    clock = 0.0
+    sleeps = []
+    snapshots = iter(
+        [
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=False),
+            BackgroundJobStatus(job_id="job", completed=True, exit_code=0),
+        ]
+    )
+    result = BackgroundJobStatus(job_id="job", completed=True, exit_code=0, stdout="done")
+
+    async def sleep(delay: float) -> None:
+        nonlocal clock
+        sleeps.append(delay)
+        clock += delay
+
+    async def start_background_job(*_args, **_kwargs) -> BackgroundJob:
+        return _job()
+
+    async def is_vm(_sandbox_id: str) -> bool:
+        return False
+
+    async def get_status(*_args, **_kwargs) -> BackgroundJobStatus:
+        return next(snapshots)
+
+    async def get_output(*_args, **_kwargs) -> BackgroundJobStatus:
+        return result
+
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.monotonic", lambda: clock)
+    monkeypatch.setattr("prime_sandboxes.sandbox.asyncio.sleep", sleep)
+    monkeypatch.setattr(client, "start_background_job", start_background_job)
+    monkeypatch.setattr(cast(Any, client)._auth_cache, "is_vm", is_vm)
+    monkeypatch.setattr(client, "get_background_job_status", get_status)
+    monkeypatch.setattr(cast(Any, client)._background_job_output_coordinator, "get", get_output)
+
+    assert await client.run_background_job("sandbox", "command", timeout=10) is result
+    assert sleeps == pytest.approx([3, 4.5, 2.5])

--- a/packages/prime-sandboxes/tests/test_background_job_polling.py
+++ b/packages/prime-sandboxes/tests/test_background_job_polling.py
@@ -2,16 +2,34 @@
 
 import pytest
 
-from prime_sandboxes.sandbox import _background_job_poll_delay
+from prime_sandboxes.sandbox import (
+    BACKGROUND_JOB_POLL_MAX_DELAY,
+    _next_background_job_poll_delay,
+)
+
+
+def _poll_delays(initial_interval: float, count: int) -> list[float]:
+    delay = min(initial_interval, BACKGROUND_JOB_POLL_MAX_DELAY)
+    delays = []
+    for _ in range(count):
+        delays.append(delay)
+        delay = _next_background_job_poll_delay(delay)
+    return delays
 
 
 def test_background_job_polling_backs_off_from_default_interval() -> None:
-    delays = [_background_job_poll_delay(3, poll_index) for poll_index in range(8)]
+    delays = _poll_delays(3, 8)
 
     assert delays == pytest.approx([3, 4.5, 6.75, 10.125, 15.1875, 20, 20, 20])
 
 
 def test_background_job_poll_interval_override_sets_initial_delay_and_still_backs_off() -> None:
-    delays = [_background_job_poll_delay(5, poll_index) for poll_index in range(6)]
+    delays = _poll_delays(5, 6)
 
     assert delays == pytest.approx([5, 7.5, 11.25, 16.875, 20, 20])
+
+
+def test_background_job_polling_stays_capped_for_very_old_jobs() -> None:
+    delays = _poll_delays(3, 1_752)
+
+    assert delays[-2:] == [20, 20]

--- a/packages/prime-sandboxes/tests/test_background_job_polling.py
+++ b/packages/prime-sandboxes/tests/test_background_job_polling.py
@@ -1,0 +1,17 @@
+"""Adaptive pacing tests for background-job completion polling."""
+
+import pytest
+
+from prime_sandboxes.sandbox import _background_job_poll_delay
+
+
+def test_background_job_polling_backs_off_from_default_interval() -> None:
+    delays = [_background_job_poll_delay(3, poll_index) for poll_index in range(8)]
+
+    assert delays == pytest.approx([3, 4.5, 6.75, 10.125, 15.1875, 20, 20, 20])
+
+
+def test_background_job_poll_interval_override_sets_initial_delay_and_still_backs_off() -> None:
+    delays = [_background_job_poll_delay(5, poll_index) for poll_index in range(6)]
+
+    assert delays == pytest.approx([5, 7.5, 11.25, 16.875, 20, 20])


### PR DESCRIPTION
## Summary
- back off background-job status polling by 1.5x after each non-terminal response
- preserve `poll_interval` as the caller-selected initial delay
- cap sync and async polling intervals at 20 seconds
- add focused coverage for default and overridden initial intervals

## Testing
- `pytest -q packages/prime-sandboxes/tests/test_background_job_polling.py packages/prime-sandboxes/tests/test_batch_status.py`
- `ruff check packages/prime-sandboxes/src/prime_sandboxes/sandbox.py packages/prime-sandboxes/tests/test_background_job_polling.py`
- `ruff format --check packages/prime-sandboxes/src/prime_sandboxes/sandbox.py packages/prime-sandboxes/tests/test_background_job_polling.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only polling pacing change; timeouts and completion semantics stay the same, with slightly slower detection of job finish on long waits.
> 
> **Overview**
> **`run_background_job`** on sync and async sandbox clients no longer polls completion at a fixed interval. After each non-terminal status check, the wait grows by **1.5×**, capped at **20 seconds**, starting from the caller’s **`poll_interval`** (still default **3s**).
> 
> Polling loops now sleep only up to the remaining **`timeout`** before the next status check, matching creation-wait deadline handling. A small **`_next_background_job_poll_delay`** helper and module constants define the backoff.
> 
> New tests in **`test_background_job_polling.py`** cover the delay sequence, overrides, cap behavior, and that the final sleep respects the overall timeout for both clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a857da6e4624c949bf38a492a84f54933ba9942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->