### PR TITLE
chore: add akirillo as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper @kennethnym
+* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper @kennethnym @akirillo


### PR DESCRIPTION
Adds `@akirillo` to the repository-wide CODEOWNERS rule while preserving all existing owners.
