### PR TITLE
release: prime-sandboxes 0.2.42

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -80,7 +80,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.41"
+__version__ = "0.2.42"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
Releases `prime-sandboxes 0.2.42` with #900 and #905. Background launches now detach their inherited streams, and completion polling backs off to reduce status traffic while staying bounded by the caller timeout. Merging triggers the sandbox tag and PyPI workflow.
