### PR TITLE
chore: add mrmoxon as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper @kennethnym @akirillo
+* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper @kennethnym @akirillo @mrmoxon


### PR DESCRIPTION
## Summary
- Add @mrmoxon (Oscar Moxon) to the default owners list in `.github/CODEOWNERS`, following the same pattern as #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqZCcqAHNwgLBGttBiS1Qu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub CODEOWNERS metadata; no application or runtime behavior changes.
> 
> **Overview**
> Adds **@mrmoxon** to the repository-wide default owner rule in `.github/CODEOWNERS`, so they are included on review requests for all changes under `*`, consistent with the existing default owners list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d9f0fbe2c12ea58a2a2aa7e64b158f185bf8ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->