### PR TITLE
release: cli 0.6.34

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.33"
+__version__ = "0.6.34"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

Releases prime CLI **0.6.34** (0.6.33 → 0.6.34).

Unreleased changes on `main` since v0.6.33 included in this release:

- #877 — `prime env push --runtime v0|v1`: the CLI declares which verifiers API a package targets (defaulting to the package's `verifiers` requirement) and sends it as `runtime_hint` on both uploads; the Hub stores it as the version's runtime (ENG-5767)
- #889 — `prime config view` shows the user's name next to the id (merged to `main` after this PR was opened and before it merged, so it is in this release)
- #908 — retire `prime env action` / `prime env actions` and the Environment Actions preflight on `prime train run`, following the removal of the Hub's Actions CI (ENG-5968)

Nothing else on `main` since v0.6.33 touches `packages/prime` (#905 and #907 are prime-sandboxes; #906 and #909 are CODEOWNERS). Dependency floors are unchanged: `prime-sandboxes>=0.2.41` and `prime-tunnel>=0.1.11` are both published.

This release unblocks the `research-environments` bulk push to the Hub (ENG-5771), which uses `--runtime v1`.

Tagging and PyPI publishing are handled automatically by CI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEiudSbyXfGR7cYxjKwbwR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the published version string changes; no runtime or logic edits in this PR.
> 
> **Overview**
> **Release prime CLI 0.6.34** by updating `__version__` in `prime_cli/__init__.py` from `0.6.33` to `0.6.34`.
> 
> This is a version-only change so CI can tag and publish the package; behavior on `main` is unchanged by this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cdca8fba55de0b1a0d2f6421d0d0a2c036ed059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
