### PR TITLE
release: cli 0.6.35

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.34"
+__version__ = "0.6.35"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

Releases prime CLI **0.6.35** (0.6.34 → 0.6.35).

Unreleased changes on `main` since v0.6.34 included in this release:

- #911 — `prime traces` now defaults `traces_url` to the Prime Traces service instead of falling back to the platform API `base_url`, which does not serve `/api/v1/traces`. Resolution order is env (`PRIME_TRACES_URL`) → config file → `prime_traces.DEFAULT_TRACES_URL`. Raises the `prime-traces` floor to `>=0.0.4`.

That is the only change to `packages/prime` since v0.6.34. Dependency floors: `prime-traces>=0.0.4` is published on PyPI (latest is 0.0.4); `prime-sandboxes>=0.2.41` and `prime-tunnel>=0.1.11` are unchanged.

Tagging and PyPI publishing are handled automatically by CI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPfQcWiGApH8vtS42rGKdf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only a version string change with no runtime or dependency edits in this PR.
> 
> **Overview**
> **Release bump** for the Prime CLI: updates `__version__` in `prime_cli` from **0.6.34** to **0.6.35** so CI can tag and publish the new package to PyPI on merge.
> 
> No other code changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43adf309410e1f26be8bcea3d76e525c4cbc71ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->