### PR TITLE
release: prime-runs 0.1.2

### DIFF
--- a/packages/prime-runs/src/prime_runs/__init__.py
+++ b/packages/prime-runs/src/prime_runs/__init__.py
@@ -28,7 +28,7 @@ from .models import (
 )
 from .run import MODE_ENV, Run, init
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "init",


### PR DESCRIPTION
Bumps `prime-runs` to 0.1.2 so `release-runs.yml` publishes the one change since 0.1.1:

- #913 `feat(runs): attach eval runs to an evaluation a launcher already created` — `init(id=...)` attaches eval runs the way it already attached training runs: no create, sinks keyed to the launcher's id, finalize on a clean finish, failure marking left to the launcher, no `metadata` overwrite. Consumed by verifiers' `run.attach` and the platform's v1 hosted-eval runner (ENG-5781).

**Merge order: #913 first, then this.** The branch is cut from `main` and carries only the one-line version bump, so it has nothing to release until #913 lands; merging it first would publish 0.1.2 without the attach path. `check-version-bump` passes either way.

Version-only change; the workspace lock is unaffected (the editable member carries no pinned version). Merging publishes 0.1.2 through OIDC and tags `prime-runs-v0.1.2`.

Follow-up once 0.1.2 is on PyPI: the verifiers PR pins `prime-runs>=0.1.2` and relocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrcqANSZ24BALuWS9MciYv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version bump with no runtime or API changes in this diff.
> 
> **Overview**
> **Bumps `prime-runs` from 0.1.1 to 0.1.2** in `packages/prime-runs/src/prime_runs/__init__.py` so the release workflow can publish and tag the package on merge.
> 
> This PR contains **no functional code changes**—only the version string. It is meant to ship **after** the attach-eval-runs work (#913) is on `main`, so PyPI 0.1.2 includes `init(id=...)` for eval runs alongside the existing training attach path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e320abcdf992d577fb0431ec42bb2cd79222b7b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->