### PR TITLE
fix(env): ignore extra-guarded verifiers requirements when deriving the push runtime hint

### DIFF
--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -27,7 +27,10 @@ VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
 _RUNTIME_OPTIONS = {"v0": VERIFIERS_V0, "v1": VERIFIERS_V1}
 
+# packaging serializes markers canonically (bare variables, quoted values), so
+# quoted literals are blanked before looking for the `extra` variable.
 _EXTRA_MARKER = re.compile(r"\bextra\b")
+_QUOTED_LITERAL = re.compile(r"\"[^\"]*\"|'[^']*'")
 
 
 def parse_runtime_option(value: Optional[str]) -> Optional[str]:
@@ -47,7 +50,7 @@ def _is_extra_guarded(requirement: Requirement) -> bool:
     """True when only an ``extra`` pulls the requirement in (its marker is
     false with no extra selected). Markers without ``extra`` are not judged."""
     marker = requirement.marker
-    if marker is None or not _EXTRA_MARKER.search(str(marker)):
+    if marker is None or not _EXTRA_MARKER.search(_QUOTED_LITERAL.sub('""', str(marker))):
         return False
     try:
         return not marker.evaluate({"extra": ""})

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -3,9 +3,7 @@
 The Hub stores whatever the CLI declares (``--runtime v0|v1``) as the package's
 runtime. Without the flag, the package's own ``verifiers`` requirement decides:
 v1 shipped as verifiers 0.2.0, so a lower bound at or above 0.2.0 declares v1
-and any other pin declares v0. Entries that only apply under an ``extra``
-(``verifiers>=0.3; extra == "rl"``) are optional dependency groups a plain
-install never resolves, so they say nothing about the runtime and are ignored.
+and any other pin declares v0. Entries only an ``extra`` pulls in are ignored.
 No verifiers requirement (or a URL pin, which says nothing about the API) means
 no hint is sent and the Hub lists the package as Unclassified until its owner
 sets the runtime.
@@ -29,9 +27,6 @@ VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
 _RUNTIME_OPTIONS = {"v0": VERIFIERS_V0, "v1": VERIFIERS_V1}
 
-# Markers that mention the ``extra`` variable are evaluated as a plain install
-# sees them (no extra selected); ``packaging`` normalizes markers to a canonical
-# string, so a word-boundary match finds the variable exactly.
 _EXTRA_MARKER = re.compile(r"\bextra\b")
 
 
@@ -49,26 +44,21 @@ def parse_runtime_option(value: Optional[str]) -> Optional[str]:
 
 
 def _is_extra_guarded(requirement: Requirement) -> bool:
-    """True when the requirement is not part of a plain (no-extra) install.
-
-    Only markers that mention ``extra`` are judged, evaluated with no extra
-    selected: ``extra == "rl"`` is false there and the entry is dropped, while
-    ``extra != "rl"`` or ``extra == "rl" or python_version >= "3.10"`` hold and
-    the entry counts. Other markers are left as best-effort floors.
-    """
+    """True when only an ``extra`` pulls the requirement in (its marker is
+    false with no extra selected). Markers without ``extra`` are not judged."""
     marker = requirement.marker
     if marker is None or not _EXTRA_MARKER.search(str(marker)):
         return False
     try:
         return not marker.evaluate({"extra": ""})
-    except Exception:  # pragma: no cover - defensive: unknown marker variable
+    except Exception:  # pragma: no cover
         return True
 
 
 def find_verifiers_requirement(requirement_strings: Iterable[str]) -> Optional[Requirement]:
-    """Effective ``verifiers`` requirement: entries that only apply under an
-    ``extra`` are ignored, unconditional entries beat marker-guarded ones, and
-    among those the highest floor wins (repeated entries intersect)."""
+    """Effective ``verifiers`` requirement: extra-only entries are ignored,
+    unconditional entries beat marker-guarded ones, and among those the highest
+    floor wins (repeated entries intersect)."""
     requirements: List[Requirement] = []
     for text in requirement_strings:
         try:

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -14,8 +14,9 @@ Mirrors the server's fallback (platform ``backend/app/utils/environment_runtime.
 from __future__ import annotations
 
 import re
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
+from packaging.markers import Marker, Variable
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
 
@@ -27,8 +28,8 @@ VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
 _RUNTIME_OPTIONS = {"v0": VERIFIERS_V0, "v1": VERIFIERS_V1}
 
-# packaging serializes markers canonically (bare variables, quoted values), so
-# quoted literals are blanked before looking for the `extra` variable.
+# Fallback only, when packaging exposes no parsed marker tree: the serialized
+# form is lossy (embedded double quotes are not re-escaped), so the tree wins.
 _EXTRA_MARKER = re.compile(r"\bextra\b")
 _QUOTED_LITERAL = re.compile(r"\"[^\"]*\"|'[^']*'")
 
@@ -46,11 +47,29 @@ def parse_runtime_option(value: Optional[str]) -> Optional[str]:
     return runtime
 
 
+def _marker_mentions_extra(marker: Marker) -> bool:
+    """True when the marker compares the ``extra`` *variable* anywhere. Walks the
+    parsed tree (nested ``(Variable, Op, Value)`` triples joined by and/or), so a
+    value containing the word never counts, however it is quoted."""
+    tree = getattr(marker, "_markers", None)
+    if tree is None:
+        return bool(_EXTRA_MARKER.search(_QUOTED_LITERAL.sub('""', str(marker))))
+
+    def walk(node: Any) -> bool:
+        if isinstance(node, list):
+            return any(walk(child) for child in node)
+        if isinstance(node, tuple):
+            return any(isinstance(o, Variable) and o.value == "extra" for o in node)
+        return False
+
+    return walk(tree)
+
+
 def _is_extra_guarded(requirement: Requirement) -> bool:
     """True when only an ``extra`` pulls the requirement in (its marker is
     false with no extra selected). Markers without ``extra`` are not judged."""
     marker = requirement.marker
-    if marker is None or not _EXTRA_MARKER.search(_QUOTED_LITERAL.sub('""', str(marker))):
+    if marker is None or not _marker_mentions_extra(marker):
         return False
     try:
         return not marker.evaluate({"extra": ""})

--- a/packages/prime/src/prime_cli/utils/environment_runtime.py
+++ b/packages/prime/src/prime_cli/utils/environment_runtime.py
@@ -3,15 +3,19 @@
 The Hub stores whatever the CLI declares (``--runtime v0|v1``) as the package's
 runtime. Without the flag, the package's own ``verifiers`` requirement decides:
 v1 shipped as verifiers 0.2.0, so a lower bound at or above 0.2.0 declares v1
-and any other pin declares v0. No verifiers requirement (or a URL pin, which
-says nothing about the API) means no hint is sent and the Hub lists the
-package as Unclassified until its owner sets the runtime.
+and any other pin declares v0. Entries that only apply under an ``extra``
+(``verifiers>=0.3; extra == "rl"``) are optional dependency groups a plain
+install never resolves, so they say nothing about the runtime and are ignored.
+No verifiers requirement (or a URL pin, which says nothing about the API) means
+no hint is sent and the Hub lists the package as Unclassified until its owner
+sets the runtime.
 
 Mirrors the server's fallback (platform ``backend/app/utils/environment_runtime.py``).
 """
 
 from __future__ import annotations
 
+import re
 from typing import Iterable, List, Optional
 
 from packaging.requirements import InvalidRequirement, Requirement
@@ -24,6 +28,11 @@ VERIFIERS_V1 = "VERIFIERS_V1"
 VERIFIERS_V1_MIN_VERSION = Version("0.2.0")
 
 _RUNTIME_OPTIONS = {"v0": VERIFIERS_V0, "v1": VERIFIERS_V1}
+
+# Markers that mention the ``extra`` variable are evaluated as a plain install
+# sees them (no extra selected); ``packaging`` normalizes markers to a canonical
+# string, so a word-boundary match finds the variable exactly.
+_EXTRA_MARKER = re.compile(r"\bextra\b")
 
 
 def parse_runtime_option(value: Optional[str]) -> Optional[str]:
@@ -39,16 +48,34 @@ def parse_runtime_option(value: Optional[str]) -> Optional[str]:
     return runtime
 
 
+def _is_extra_guarded(requirement: Requirement) -> bool:
+    """True when the requirement is not part of a plain (no-extra) install.
+
+    Only markers that mention ``extra`` are judged, evaluated with no extra
+    selected: ``extra == "rl"`` is false there and the entry is dropped, while
+    ``extra != "rl"`` or ``extra == "rl" or python_version >= "3.10"`` hold and
+    the entry counts. Other markers are left as best-effort floors.
+    """
+    marker = requirement.marker
+    if marker is None or not _EXTRA_MARKER.search(str(marker)):
+        return False
+    try:
+        return not marker.evaluate({"extra": ""})
+    except Exception:  # pragma: no cover - defensive: unknown marker variable
+        return True
+
+
 def find_verifiers_requirement(requirement_strings: Iterable[str]) -> Optional[Requirement]:
-    """Effective ``verifiers`` requirement: unconditional entries beat marker-guarded
-    ones, and among those the highest floor wins (repeated entries intersect)."""
+    """Effective ``verifiers`` requirement: entries that only apply under an
+    ``extra`` are ignored, unconditional entries beat marker-guarded ones, and
+    among those the highest floor wins (repeated entries intersect)."""
     requirements: List[Requirement] = []
     for text in requirement_strings:
         try:
             requirement = Requirement(text.strip())
         except InvalidRequirement:
             continue
-        if requirement.name.lower() == "verifiers":
+        if requirement.name.lower() == "verifiers" and not _is_extra_guarded(requirement):
             requirements.append(requirement)
     if not requirements:
         return None

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -25,12 +25,11 @@ from typer.testing import CliRunner
         (["verifiers>=0.1", "verifiers>=0.2"], VERIFIERS_V1),
         (["verifiers==0.2.*"], VERIFIERS_V1),
         (["not a requirement", "verifiers~=0.3.0"], VERIFIERS_V1),
-        # An entry that only applies under an extra is an optional dependency
-        # group a plain install never resolves: it declares nothing.
+        # Extra-only entries declare nothing.
         (['verifiers<0.4,>=0.3; extra == "rl"'], None),
         (['verifiers>=0.3; python_version >= "3.11" and extra == "rl"'], None),
         (["verifiers>=0.1.5,<0.2", 'verifiers>=0.3; extra == "rl"'], VERIFIERS_V0),
-        # Markers that hold without an extra still count.
+        # Markers that hold without an extra count.
         (['verifiers>=0.2; extra != "rl"'], VERIFIERS_V1),
         (['verifiers>=0.2; extra == "rl" or python_version >= "3"'], VERIFIERS_V1),
     ],

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -25,6 +25,14 @@ from typer.testing import CliRunner
         (["verifiers>=0.1", "verifiers>=0.2"], VERIFIERS_V1),
         (["verifiers==0.2.*"], VERIFIERS_V1),
         (["not a requirement", "verifiers~=0.3.0"], VERIFIERS_V1),
+        # An entry that only applies under an extra is an optional dependency
+        # group a plain install never resolves: it declares nothing.
+        (['verifiers<0.4,>=0.3; extra == "rl"'], None),
+        (['verifiers>=0.3; python_version >= "3.11" and extra == "rl"'], None),
+        (["verifiers>=0.1.5,<0.2", 'verifiers>=0.3; extra == "rl"'], VERIFIERS_V0),
+        # Markers that hold without an extra still count.
+        (['verifiers>=0.2; extra != "rl"'], VERIFIERS_V1),
+        (['verifiers>=0.2; extra == "rl" or python_version >= "3"'], VERIFIERS_V1),
     ],
 )
 def test_classify_from_metadata(requirements, expected):

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -29,6 +29,9 @@ from typer.testing import CliRunner
         (['verifiers<0.4,>=0.3; extra == "rl"'], None),
         (['verifiers>=0.3; python_version >= "3.11" and extra == "rl"'], None),
         (["verifiers>=0.1.5,<0.2", 'verifiers>=0.3; extra == "rl"'], VERIFIERS_V0),
+        # "extra" inside a quoted value is not the extra variable.
+        (['verifiers>=0.3; platform_release == "6.8.0-extra"'], VERIFIERS_V1),
+        (['verifiers>=0.2; extra == "extra"'], None),
         # Markers that hold without an extra count.
         (['verifiers>=0.2; extra != "rl"'], VERIFIERS_V1),
         (['verifiers>=0.2; extra == "rl" or python_version >= "3"'], VERIFIERS_V1),

--- a/packages/prime/tests/test_env_runtime_hint.py
+++ b/packages/prime/tests/test_env_runtime_hint.py
@@ -31,6 +31,8 @@ from typer.testing import CliRunner
         (["verifiers>=0.1.5,<0.2", 'verifiers>=0.3; extra == "rl"'], VERIFIERS_V0),
         # "extra" inside a quoted value is not the extra variable.
         (['verifiers>=0.3; platform_release == "6.8.0-extra"'], VERIFIERS_V1),
+        # str(marker) is lossy for embedded double quotes; the parsed tree is not.
+        (["verifiers>=0.3; platform_release == '6.8.0-\"extra\"'"], VERIFIERS_V1),
         (['verifiers>=0.2; extra == "extra"'], None),
         # Markers that hold without an extra count.
         (['verifiers>=0.2; extra != "rl"'], VERIFIERS_V1),


### PR DESCRIPTION
`prime env push` derives its runtime hint from the wheel's `verifiers` requirement when `--runtime` is not given. A requirement that only an extra pulls in (`verifiers>=0.3; extra == "rl"`) is never installed by default, so it should not count. Right now it does, which made the CLI publish a v0 environment on the Hub as v1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI metadata classification fix with expanded unit tests; no auth, data, or deployment path changes.
> 
> **Overview**
> Fixes **`prime env push`** mis-labeling environments on the Hub when metadata includes a **`verifiers`** pin that only applies under an optional extra (e.g. `verifiers>=0.3; extra == "rl"`). Those lines are now **excluded** from runtime inference so the hint follows the default-install requirement instead of treating an RL-only pin as v1.
> 
> Detection walks **`packaging`** marker trees so the word `extra` inside quoted platform strings does not false-positive, and requirements whose markers can still be true without an extra (e.g. `extra != "rl"` or `extra == "rl" or python_version >= "3"`) still count. **`test_env_runtime_hint.py`** adds cases for extra-only pins, mixed pins, and marker edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17a76cc998b26c3b9eb60f9dc002f2caba15e93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->