### PR TITLE
Protect run config uploads with typed summaries

### DIFF
--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -21,7 +21,7 @@ run = pr.init(
     environments=["gsm8k"],      # hub names (get-or-create) or owner/name slugs
     model="Qwen/Qwen3-8B",
     framework="verifiers",
-    config="eval.toml",          # the launched file, stored byte for byte
+    config={"num_tasks": 100, "sampling": {"temperature": 0.6}},
 )
 print(run.url)                   # https://app.primeintellect.ai/dashboard/evaluations/...
 
@@ -39,9 +39,21 @@ the platform's id; `run.url` is the handle. A `with run:` block finishes for
 you: an exception marks the run `failed`, Ctrl-C `cancelled`, and a process
 that exits without finishing is reported `crashed` by an atexit hook.
 
-`config=` takes the path to the launched file (kept verbatim under
-`config_source`, comments and all) or a mapping stored as given; put a file
-under `pr.CONFIG_SOURCE_KEY` in the mapping to send both. Nothing is redacted.
+`config=` accepts a mapping or a local file path. The run retains the original
+in memory (`run.config` / `run.config_source`); it uploads only a summary of
+supported numeric/boolean controls, sampling settings, client type, and serving
+pool controls. Source text and filenames are never uploaded. To record controls
+alongside a local source, include them in a mapping with `pr.CONFIG_SOURCE_KEY`.
+
+Unknown fields, task data, harness environment values, headers, URLs, paths and
+commands are omitted instead of attempting to mask arbitrary secrets. This also
+applies on updates and failure finalization. A file alone supplies no remote
+config controls; pass a mapping for a dashboard summary. External training
+config additionally supports numeric training controls, including `trainer.lr`.
+
+This policy covers config metadata, not run identity, metrics, samples or traces.
+Choose publishable `name`, `model`, `environments`, tags and descriptions, and keep
+credentials out of the data passed to `log_*()`.
 
 ## Training runs
 

--- a/packages/prime-runs/README.md
+++ b/packages/prime-runs/README.md
@@ -51,6 +51,10 @@ applies on updates and failure finalization. A file alone supplies no remote
 config controls; pass a mapping for a dashboard summary. External training
 config additionally supports numeric training controls, including `trainer.lr`.
 
+`state_columns` identifies published sample fields by their exact names, including
+spaces, punctuation and Unicode. Summaries retain non-empty names of at most 128
+characters from the first 128 entries; they do not copy the sample values.
+
 This policy covers config metadata, not run identity, metrics, samples or traces.
 Choose publishable `name`, `model`, `environments`, tags and descriptions, and keep
 credentials out of the data passed to `log_*()`.

--- a/packages/prime-runs/src/prime_runs/backend.py
+++ b/packages/prime-runs/src/prime_runs/backend.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Protocol
 
 from ._http import PlatformClient
+from .config_privacy import metadata_summary, training_config_summary
 from .exceptions import APIError, ConfigurationError, EnvironmentResolutionError
 from .models import EnvironmentRef, RunHandle, RunSpec, RunStatus, TrainingSpec
 
@@ -85,7 +86,7 @@ class EvalsBackend:
         _set_if(payload, "dataset", _first_environment_name(spec))  # the env under another name
         _set_if(payload, "framework", spec.framework)
         _set_if(payload, "description", spec.description)
-        _set_if(payload, "metadata", spec.config or None)
+        _set_if(payload, "metadata", metadata_summary(spec.config) or None)
         _set_if(payload, "team_id", spec.team_id or self._team_id)
 
         # Not replayable: a retry after a lost response would create a second run.
@@ -121,7 +122,8 @@ class EvalsBackend:
         summary: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {}
-        _set_if(payload, "metadata", config or None)
+        if config is not None:
+            payload["metadata"] = metadata_summary(config)
         _set_if(payload, "metrics", summary or None)
         if payload:
             self._client.put(f"/evaluations/{run_id}", json_body=payload)
@@ -288,7 +290,7 @@ class RftBackend:
         _set_if(payload, "batch_size", training.batch_size)
         _set_if(payload, "rollouts_per_example", training.rollouts_per_example)
         _set_if(payload, "seq_len", training.seq_len)
-        _set_if(payload, "run_config", spec.config or None)
+        _set_if(payload, "run_config", training_config_summary(spec.config) or None)
         _set_if(payload, "wandb_project", training.wandb_project)
         _set_if(payload, "wandb_entity", training.wandb_entity)
         _set_if(payload, "wandb_run_name", training.wandb_run_name)

--- a/packages/prime-runs/src/prime_runs/config_privacy.py
+++ b/packages/prime-runs/src/prime_runs/config_privacy.py
@@ -8,7 +8,7 @@ dashboard's evaluationConfig projection; none trusts another to sanitize input.
 """
 
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 NUMBER_FIELDS = (
@@ -127,11 +127,13 @@ def metadata_summary(value: Any) -> dict[str, Any]:
             finished_at = terminal.get("finished_at")
             if isinstance(finished_at, str):
                 try:
-                    result["prime_runs"]["finished_at"] = datetime.fromisoformat(
-                        finished_at.replace("Z", "+00:00")
-                    ).isoformat()
-                except ValueError:
-                    # Untrusted, invalid timestamps are omitted from the summary.
+                    parsed = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
+                    if parsed.utcoffset() is not None:
+                        result["prime_runs"]["finished_at"] = parsed.astimezone(
+                            timezone.utc
+                        ).isoformat()
+                except (ValueError, OverflowError):
+                    # Invalid or out-of-range timestamps are omitted from the summary.
                     pass
     return result
 

--- a/packages/prime-runs/src/prime_runs/config_privacy.py
+++ b/packages/prime-runs/src/prime_runs/config_privacy.py
@@ -8,7 +8,6 @@ dashboard's evaluationConfig projection; none trusts another to sanitize input.
 """
 
 import math
-import re
 from datetime import datetime
 from typing import Any
 
@@ -116,10 +115,9 @@ def metadata_summary(value: Any) -> dict[str, Any]:
     result.update(_numbers(value, ("avg_reward", "avg_score")))
     columns = value.get("state_columns")
     if isinstance(columns, list):
+        # These are exact published sample keys, not Python identifiers.
         result["state_columns"] = [
-            column
-            for column in columns[:128]
-            if isinstance(column, str) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,127}", column)
+            column for column in columns[:128] if isinstance(column, str) and 0 < len(column) <= 128
         ]
     terminal = value.get("prime_runs")
     if isinstance(terminal, dict):
@@ -133,6 +131,7 @@ def metadata_summary(value: Any) -> dict[str, Any]:
                         finished_at.replace("Z", "+00:00")
                     ).isoformat()
                 except ValueError:
+                    # Untrusted, invalid timestamps are omitted from the summary.
                     pass
     return result
 

--- a/packages/prime-runs/src/prime_runs/config_privacy.py
+++ b/packages/prime-runs/src/prime_runs/config_privacy.py
@@ -1,0 +1,160 @@
+"""The config summary prime-runs may upload.
+
+This is a summary, not a replayable config. Unknown fields are omitted, including
+source files, URLs, paths, commands, task data, headers and harness environment
+values. A credential-name denylist cannot make arbitrary configuration public.
+Keep the evaluation wire policy aligned with platform's config_privacy module and the
+dashboard's evaluationConfig projection; none trusts another to sanitize input.
+"""
+
+import math
+import re
+from datetime import datetime
+from typing import Any
+
+NUMBER_FIELDS = (
+    "num_examples",
+    "rollouts_per_example",
+    "num_tasks",
+    "num_rollouts",
+    "max_concurrent",
+    "max_retries",
+    "timeout_minutes",
+    "max_tokens",
+    "temperature",
+    "top_k",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "repetition_penalty",
+    "seed",
+)
+BOOL_FIELDS = (
+    "auto_max_concurrent",
+    "independent_scoring",
+    "verbose",
+    "shuffle",
+    "push",
+    "allow_sandbox_access",
+    "allow_instances_access",
+    "allow_tunnel_access",
+    "use_platform_billing",
+)
+SAMPLING_FIELDS = (
+    "max_tokens",
+    "temperature",
+    "top_k",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "repetition_penalty",
+    "seed",
+    "min_p",
+)
+
+
+def _numbers(source: dict, fields: tuple[str, ...]) -> dict[str, Any]:
+    return {
+        key: value
+        for key in fields
+        if type(value := source.get(key)) in (int, float)
+        and -(2**53) < value < 2**53
+        and math.isfinite(value)
+    }
+
+
+def config_summary(value: Any) -> dict[str, Any]:
+    """Copy only supported, correctly typed controls. Never parse raw files."""
+    if not isinstance(value, dict):
+        return {}
+    result = _numbers(value, NUMBER_FIELDS)
+    result.update({key: value[key] for key in BOOL_FIELDS if type(value.get(key)) is bool})
+    for key in ("sampling", "sampling_args"):
+        sampling = value.get(key)
+        if isinstance(sampling, dict):
+            projected = _numbers(sampling, SAMPLING_FIELDS)
+            effort = sampling.get("reasoning_effort")
+            if isinstance(effort, str) and effort in (
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+            ):
+                projected["reasoning_effort"] = effort
+            if projected:
+                result[key] = projected
+    client = value.get("client")
+    if isinstance(client, dict) and client.get("type") in ("eval", "train"):
+        result["client"] = {"type": client["type"]}
+    serve = value.get("serve")
+    if isinstance(serve, dict):
+        projected = _numbers(serve, ("max_concurrent",))
+        pool = serve.get("pool")
+        if isinstance(pool, dict):
+            projected_pool = _numbers(pool, ("num_workers", "max_workers", "multiplex"))
+            if pool.get("type") in ("static", "elastic"):
+                projected_pool["type"] = pool["type"]
+            if projected_pool:
+                projected["pool"] = projected_pool
+        if projected:
+            result["serve"] = projected
+    return result
+
+
+def metadata_summary(value: Any) -> dict[str, Any]:
+    """Config controls plus the typed metadata used by statistics and columns.
+
+    Run identity belongs in the API's name/model/environment fields, not arbitrary
+    metadata strings. Column names identify published sample fields; their values
+    are never copied here. Producer errors may contain credentials and are omitted.
+    """
+    result = config_summary(value)
+    if not isinstance(value, dict):
+        return result
+    result.update(_numbers(value, ("avg_reward", "avg_score")))
+    columns = value.get("state_columns")
+    if isinstance(columns, list):
+        result["state_columns"] = [
+            column
+            for column in columns[:128]
+            if isinstance(column, str) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,127}", column)
+        ]
+    terminal = value.get("prime_runs")
+    if isinstance(terminal, dict):
+        status = terminal.get("status")
+        if status in ("running", "completed", "failed", "cancelled", "crashed"):
+            result["prime_runs"] = {"status": status}
+            finished_at = terminal.get("finished_at")
+            if isinstance(finished_at, str):
+                try:
+                    result["prime_runs"]["finished_at"] = datetime.fromisoformat(
+                        finished_at.replace("Z", "+00:00")
+                    ).isoformat()
+                except ValueError:
+                    pass
+    return result
+
+
+def training_config_summary(value: Any) -> dict[str, Any]:
+    """External training metadata is also a summary, never a full config file."""
+    result = config_summary(value)
+    if not isinstance(value, dict):
+        return result
+    fields = (
+        "max_steps",
+        "batch_size",
+        "seq_len",
+        "lr",
+        "learning_rate",
+        "weight_decay",
+        "warmup_steps",
+    )
+    result.update(_numbers(value, fields))
+    trainer = value.get("trainer")
+    if isinstance(trainer, dict):
+        projected = _numbers(trainer, fields)
+        if projected:
+            result["trainer"] = projected
+    return result

--- a/packages/prime-runs/src/prime_runs/models.py
+++ b/packages/prime-runs/src/prime_runs/models.py
@@ -72,7 +72,7 @@ class EnvironmentRef:
 
 
 CONFIG_SOURCE_KEY = "config_source"
-"""Where a config file lands inside a run's config, as a ``ConfigSource`` dict."""
+"""The local config source key; excluded from uploaded config summaries."""
 
 MAX_CONFIG_SOURCE_BYTES = 256 * 1024
 
@@ -81,8 +81,8 @@ _CONFIG_SOURCE_FORMATS = {".toml": "toml", ".json": "json", ".yaml": "yaml", ".y
 
 @dataclass
 class ConfigSource:
-    """The config file a run was started from, kept byte for byte. Nothing is
-    redacted: keep credentials in the environment, not the file."""
+    """The local launch file, kept byte for byte on the Run. Source text and
+    filenames are never included in uploaded config summaries."""
 
     text: str
     format: str = "toml"

--- a/packages/prime-runs/src/prime_runs/run.py
+++ b/packages/prime-runs/src/prime_runs/run.py
@@ -416,9 +416,11 @@ def init(
 
     ``mode`` defaults to ``$PRIME_RUNS_MODE``, else online when there is an API
     key and disabled (with a warning) when there is not. ``config`` is the path
-    to the file the run was launched from (stored byte for byte under
-    ``config_source``) or a mapping taken as given. ``finish_timeout`` bounds
-    the drain in :meth:`Run.finish`.
+    to the file the run was launched from (kept locally under ``config_source``)
+    or a mapping. Only supported, typed summary fields are uploaded; source
+    files, unknown fields, URLs, paths, commands, headers and environment values
+    stay local. The name/model/environment arguments remain published run identity.
+    ``finish_timeout`` bounds the drain in :meth:`Run.finish`.
 
     ``kind="train"`` opens an external training run: ``model`` is the base
     model, ``environments`` the hub ids, ``training`` the display fields, and a

--- a/packages/prime-runs/tests/data/config_privacy.json
+++ b/packages/prime-runs/tests/data/config_privacy.json
@@ -71,7 +71,11 @@
     },
     "state_columns": [
       "info",
-      "answer"
+      "answer",
+      "tool-output",
+      "grader.score",
+      "ground truth",
+      "答案"
     ],
     "avg_reward": 0.75,
     "custom_notes": "PRIVATE_NOTES"
@@ -125,7 +129,11 @@
     },
     "state_columns": [
       "info",
-      "answer"
+      "answer",
+      "tool-output",
+      "grader.score",
+      "ground truth",
+      "答案"
     ],
     "avg_reward": 0.75
   }

--- a/packages/prime-runs/tests/data/config_privacy.json
+++ b/packages/prime-runs/tests/data/config_privacy.json
@@ -1,0 +1,132 @@
+{
+  "input": {
+    "num_examples": 12,
+    "num_rollouts": 4,
+    "shuffle": false,
+    "max_concurrent": 8,
+    "model": "PRIVATE_MODEL_PATH",
+    "env": {
+      "agent": {
+        "harness": {
+          "env": {
+            "OPENAI_API_KEY": "SECRET_HARNESS"
+          }
+        },
+        "client": {
+          "headers": {
+            "Authorization": "Bearer SECRET_NESTED"
+          }
+        }
+      },
+      "taskset": {
+        "args": {
+          "email": "PRIVATE_EMAIL"
+        }
+      }
+    },
+    "config_source": {
+      "format": "toml",
+      "text": "# SECRET_COMMENT\n[client]\nbase_url=\"https://user:SECRET_URL@example.invalid\"\nCookie=\"SECRET_COOKIE\"",
+      "filename": "PRIVATE_FILENAME.toml"
+    },
+    "api_key": "SECRET_TOP",
+    "output_dir": "PRIVATE_PATH",
+    "env_args": {
+      "password": "SECRET_ENV_ARG"
+    },
+    "extra_env_kwargs": {
+      "key": "SECRET_EXTRA"
+    },
+    "start_command": "echo SECRET_COMMAND",
+    "sampling": {
+      "temperature": 0.6,
+      "max_tokens": 2048,
+      "reasoning_effort": "high",
+      "extra_body": {
+        "credential": "SECRET_SAMPLING"
+      }
+    },
+    "client": {
+      "type": "eval",
+      "base_url": "https://user:SECRET_URL@example.invalid",
+      "headers": {
+        "Cookie": "SECRET_COOKIE"
+      },
+      "api_key_var": "PRIVATE_VAR"
+    },
+    "serve": {
+      "max_concurrent": 32,
+      "address": "PRIVATE_ADDRESS",
+      "pool": {
+        "type": "elastic",
+        "max_workers": 4,
+        "multiplex": 128,
+        "password": "SECRET_POOL"
+      }
+    },
+    "prime_runs": {
+      "status": "failed",
+      "finished_at": "2026-09-11T00:00:00+00:00",
+      "error": "SECRET_ERROR"
+    },
+    "state_columns": [
+      "info",
+      "answer"
+    ],
+    "avg_reward": 0.75,
+    "custom_notes": "PRIVATE_NOTES"
+  },
+  "config": {
+    "num_examples": 12,
+    "num_rollouts": 4,
+    "max_concurrent": 8,
+    "shuffle": false,
+    "sampling": {
+      "temperature": 0.6,
+      "max_tokens": 2048,
+      "reasoning_effort": "high"
+    },
+    "client": {
+      "type": "eval"
+    },
+    "serve": {
+      "max_concurrent": 32,
+      "pool": {
+        "type": "elastic",
+        "max_workers": 4,
+        "multiplex": 128
+      }
+    }
+  },
+  "metadata": {
+    "num_examples": 12,
+    "num_rollouts": 4,
+    "max_concurrent": 8,
+    "shuffle": false,
+    "sampling": {
+      "temperature": 0.6,
+      "max_tokens": 2048,
+      "reasoning_effort": "high"
+    },
+    "client": {
+      "type": "eval"
+    },
+    "serve": {
+      "max_concurrent": 32,
+      "pool": {
+        "type": "elastic",
+        "max_workers": 4,
+        "multiplex": 128
+      }
+    },
+    "prime_runs": {
+      "status": "failed",
+      "finished_at": "2026-09-11T00:00:00+00:00"
+    },
+    "state_columns": [
+      "info",
+      "answer"
+    ],
+    "avg_reward": 0.75
+  }
+}

--- a/packages/prime-runs/tests/test_config_privacy.py
+++ b/packages/prime-runs/tests/test_config_privacy.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+import pytest
+from conftest import RecordingHandler
+
+from prime_runs.backend import EvalsBackend, RftBackend
+from prime_runs.config_privacy import config_summary, metadata_summary
+from prime_runs.models import EnvironmentRef, RunSpec, RunStatus
+
+FIXTURE = json.loads((Path(__file__).parent / "data/config_privacy.json").read_text())
+
+
+def test_shared_wire_contract_does_not_mutate_config():
+    before = json.dumps(FIXTURE["input"])
+    assert config_summary(FIXTURE["input"]) == FIXTURE["config"]
+    assert metadata_summary(FIXTURE["input"]) == FIXTURE["metadata"]
+    assert json.dumps(FIXTURE["input"]) == before
+
+
+def test_eval_create_update_and_failure_only_send_summaries(make_platform_client, eval_routes):
+    handler = RecordingHandler(eval_routes)
+    backend = EvalsBackend(make_platform_client(handler), frontend_url="https://example.invalid")
+    source = FIXTURE["input"]
+    spec = RunSpec(
+        name="public identity", environments=[EnvironmentRef(id="env-123")], config=source
+    )
+    handle = backend.create(spec)
+    backend.update(handle.id, config=source)
+    backend.finalize(handle.id, status=RunStatus.FAILED, error="SECRET_ERROR", config=source)
+    for request in handler.requests:
+        assert b"SECRET" not in request.content
+        assert b"PRIVATE" not in request.content
+    created = handler.bodies_for("/api/v1/evaluations/")[0]
+    assert created["metadata"] == FIXTURE["metadata"]
+    assert handler.bodies_for("/api/v1/evaluations/eval-abc")[0]["metadata"] == FIXTURE["metadata"]
+    assert source["env"]["agent"]["harness"]["env"]["OPENAI_API_KEY"] == "SECRET_HARNESS"
+
+
+def test_an_empty_summary_replaces_old_metadata(make_platform_client, eval_routes):
+    handler = RecordingHandler(eval_routes)
+    backend = EvalsBackend(make_platform_client(handler), frontend_url="https://example.invalid")
+    backend.update("eval-abc", config={"config_source": {"text": "SECRET"}})
+    assert handler.bodies_for("/api/v1/evaluations/eval-abc") == [{"metadata": {}}]
+
+
+def test_training_config_does_not_bypass_source_protection(make_platform_client, rft_routes):
+    handler = RecordingHandler(rft_routes)
+    backend = RftBackend(
+        make_platform_client(handler), frontend_url="https://example.invalid", team_id="team-1"
+    )
+    backend.create(
+        RunSpec(
+            kind="train",
+            model="public/model",
+            config={
+                **FIXTURE["input"],
+                "trainer": {"lr": 1e-6, "env": {"key": "SECRET_TRAINER"}},
+            },
+        )
+    )
+    assert b"SECRET" not in handler.requests[0].content
+    assert b"PRIVATE" not in handler.requests[0].content
+    assert handler.bodies_for("/api/v1/rft/external-runs")[0]["run_config"]["trainer"] == {
+        "lr": 1e-6
+    }
+
+
+@pytest.mark.parametrize(
+    "value", [None, {}, [], "SECRET", True, float("inf"), float("nan"), 2**100]
+)
+def test_numeric_controls_reject_opaque_values(value):
+    assert config_summary({"max_tokens": value, "sampling": {"temperature": value}}) == {}

--- a/packages/prime-runs/tests/test_config_privacy.py
+++ b/packages/prime-runs/tests/test_config_privacy.py
@@ -71,3 +71,14 @@ def test_training_config_does_not_bypass_source_protection(make_platform_client,
 )
 def test_numeric_controls_reject_opaque_values(value):
     assert config_summary({"max_tokens": value, "sampling": {"temperature": value}}) == {}
+
+
+def test_state_columns_preserve_exact_keys_with_bounded_names_and_count():
+    columns = ["tool-output", "grader.score", "ground truth", "答案", "😀" * 128]
+    assert metadata_summary(
+        {"state_columns": [*columns, "", "x" * 129, "😀" * 129, None, {"key": "SECRET"}]}
+    ) == {"state_columns": columns}
+    many_columns = [f"column {index}" for index in range(129)]
+    assert metadata_summary({"state_columns": many_columns}) == {
+        "state_columns": many_columns[:128]
+    }

--- a/packages/prime-runs/tests/test_config_privacy.py
+++ b/packages/prime-runs/tests/test_config_privacy.py
@@ -82,3 +82,25 @@ def test_state_columns_preserve_exact_keys_with_bounded_names_and_count():
     assert metadata_summary({"state_columns": many_columns}) == {
         "state_columns": many_columns[:128]
     }
+
+
+@pytest.mark.parametrize(
+    ("finished_at", "expected"),
+    [
+        ("2026-09-11", None),
+        ("2026-09-11T12:34:56", None),
+        ("2026-09-11T07:04:56Z", "2026-09-11T07:04:56+00:00"),
+        ("2026-09-11T12:34:56+05:30", "2026-09-11T07:04:56+00:00"),
+        ("2026-09-11T12:34:56+05:30:15", "2026-09-11T07:04:41+00:00"),
+        ("0001-01-01T00:00:00+01:00", None),
+    ],
+)
+def test_terminal_timestamps_require_a_timezone_and_normalize_to_utc(finished_at, expected):
+    terminal = metadata_summary(
+        {"prime_runs": {"status": "completed", "finished_at": finished_at}}
+    )["prime_runs"]
+    assert terminal == (
+        {"status": "completed", "finished_at": expected}
+        if expected is not None
+        else {"status": "completed"}
+    )

--- a/packages/prime-runs/tests/test_config_source.py
+++ b/packages/prime-runs/tests/test_config_source.py
@@ -131,7 +131,7 @@ def online(monkeypatch, make_platform_client, eval_routes):
     return _init
 
 
-def test_an_online_run_sends_the_source_in_create_metadata(tmp_path, online):
+def test_an_online_run_keeps_the_source_local(tmp_path, online):
     path = tmp_path / "eval.toml"
     path.write_text(EVAL_TOML)
 
@@ -139,17 +139,16 @@ def test_an_online_run_sends_the_source_in_create_metadata(tmp_path, online):
     run.finish()
 
     create = next(r for r in handler.requests if r.url.path == "/api/v1/evaluations/")
-    metadata = json.loads(create.content)["metadata"]
-    assert metadata[CONFIG_SOURCE_KEY]["text"] == EVAL_TOML
-    assert metadata[CONFIG_SOURCE_KEY]["format"] == "toml"
-    assert metadata[CONFIG_SOURCE_KEY]["filename"] == "eval.toml"
+    assert "metadata" not in json.loads(create.content)
+    assert run.config_source.text == EVAL_TOML
+    assert path.read_text() == EVAL_TOML
 
 
 def test_extra_values_can_be_merged_onto_a_launch_file(tmp_path, online):
     path = tmp_path / "eval.toml"
     path.write_text(EVAL_TOML)
     config = {
-        "model": "deepseek/deepseek-v4-flash",
+        "num_rollouts": 4,
         CONFIG_SOURCE_KEY: ConfigSource.from_file(path).to_dict(),
     }
 
@@ -158,8 +157,8 @@ def test_extra_values_can_be_merged_onto_a_launch_file(tmp_path, online):
 
     create = next(r for r in handler.requests if r.url.path == "/api/v1/evaluations/")
     metadata = json.loads(create.content)["metadata"]
-    assert metadata["model"] == "deepseek/deepseek-v4-flash"
-    assert metadata[CONFIG_SOURCE_KEY]["text"] == EVAL_TOML
+    assert metadata == {"num_rollouts": 4}
+    assert run.config_source.text == EVAL_TOML
     assert run.config_source.filename == "eval.toml"
 
 
@@ -189,5 +188,6 @@ def test_the_source_survives_the_failure_fallback(tmp_path, online):
     run.fail("something broke")
 
     update = handler.bodies_for("/api/v1/evaluations/eval-abc")[-1]
-    assert update["metadata"][CONFIG_SOURCE_KEY]["text"] == EVAL_TOML
+    assert CONFIG_SOURCE_KEY not in update["metadata"]
+    assert run.config_source.text == EVAL_TOML
     assert update["metadata"]["prime_runs"]["status"] == "failed"

--- a/packages/prime-runs/tests/test_evals_backend.py
+++ b/packages/prime-runs/tests/test_evals_backend.py
@@ -162,7 +162,7 @@ def test_a_failed_run_is_recorded_in_metadata(make_platform_client, eval_routes,
     assert "POST /api/v1/evaluations/eval-abc/finalize" not in handler.paths()
     terminal = handler.bodies_for("/api/v1/evaluations/eval-abc")[0]["metadata"]["prime_runs"]
     assert terminal["status"] == "failed"
-    assert terminal["error"] == "boom"
+    assert "error" not in terminal
     assert "keep showing as running" in caplog.text
 
 
@@ -198,5 +198,5 @@ def test_the_failure_fallback_preserves_the_run_config(make_platform_client, eva
 
     metadata = handler.bodies_for("/api/v1/evaluations/eval-abc")[0]["metadata"]
     assert metadata["num_rollouts"] == 4
-    assert metadata["model"] == "Qwen3-8B"
+    assert "model" not in metadata
     assert metadata["prime_runs"]["status"] == "failed"


### PR DESCRIPTION
## What this changes

prime-runs no longer uploads run configs verbatim. A launch file's comments, credentials, internal URLs, harness environment values or private task data could otherwise be stored as run metadata. The SDK keeps the original in the process (`run.config` / `run.config_source`) and sends only a typed summary.

## What reaches the dashboard

**Shown when present and correctly typed:**
- Run controls (numbers): `num_examples`, `rollouts_per_example`, `num_tasks`, `num_rollouts`, `max_concurrent`, `max_retries`, `timeout_minutes`, `max_tokens`, `temperature`, `top_k`, `top_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `seed`
- Flags (booleans): `auto_max_concurrent`, `independent_scoring`, `verbose`, `shuffle`, `push`, `allow_sandbox_access`, `allow_instances_access`, `allow_tunnel_access`, `use_platform_billing`
- `sampling` / `sampling_args`: `max_tokens`, `temperature`, `top_k`, `top_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `seed`, `min_p`, `enable_thinking` (bool), `reasoning_effort` (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`)
- `client.type` (`eval` or `train`); `serve.max_concurrent` and `serve.pool` (`type`, `num_workers`, `max_workers`, `multiplex`)
- Metadata: `avg_reward`, `avg_score`; `state_columns` names only (first 128 entries, each up to 128 characters); `prime_runs.status` and `prime_runs.finished_at` (must carry a timezone, shown in UTC)
- External training registration: the same controls plus `max_steps`, `batch_size`, `seq_len`, `lr`, `learning_rate`, `weight_decay`, `warmup_steps` (top level and under `trainer`)

## What never leaves the process

- Launch file text and filenames, URLs, paths, commands
- Task, harness and environment data, headers, harness `env` values
- Any key not listed above, including custom strings
- Values with the wrong type under a known key (a string under `max_tokens`, an object under `seed`): dropped, not coerced

A run that fails or is cancelled is closed through the status API with the message passed to `run.fail`; no config values travel with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what evaluation and training runs persist remotely and may leave dashboards with less config detail until callers pass summary mappings; mitigated by allowlists and broad test coverage of wire bodies.
> 
> **Overview**
> **Run config is no longer sent verbatim to the platform.** Eval create/update/failure paths and external training registration now pass **`metadata_summary` / `training_config_summary`** filters so only allowlisted numeric/boolean controls, sampling settings, client type, serve/pool fields, bounded `state_columns` names, and sanitized terminal `prime_runs` timestamps reach the API. Launch file text, `config_source`, URLs, paths, harness env, headers, and other unknown keys stay on the client in `run.config` / `run.config_source`.
> 
> This is a **breaking contract change** for dashboard metadata: a file-only `config=` path uploads no remote controls unless callers merge summary fields in a mapping (README example updated). **`EvalsBackend.update`** always sends `metadata` (including `{}`) when config is provided so stale full configs can be cleared.
> 
> New **`config_privacy`** module plus fixture-driven tests assert request bodies never contain secret-like payloads and that training `trainer.lr` still projects safely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a79451a2d3d286a66d5763cbc9f20b0776eb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



